### PR TITLE
fix os x build

### DIFF
--- a/journal/consensus/poet/poet_enclave_simulator/wait_timer.cpp
+++ b/journal/consensus/poet/poet_enclave_simulator/wait_timer.cpp
@@ -19,6 +19,9 @@
 #else
     #include <sys/time.h>
 #endif
+#ifdef __APPLE__
+    #include <random>
+#endif
 #include <algorithm>
 #include <time.h>
 #include <stdlib.h>


### PR DESCRIPTION
On OS X (at least 10.11) <random> needs to be included to successfully
run setup.py build.