### PR TITLE
add requests to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(name='sawtooth-core',
       url='http://www.intel.com',
       packages=find_packages(),
       install_requires=['cbor>=0.1.23', 'colorlog', 'pybitcointools',
-                        'twisted', 'enum'],
+                        'twisted', 'enum', 'requests'],
       ext_modules=[enclavemod, ecdsamod],
       py_modules=['journal.consensus.poet.poet_enclave_simulator'
                   '.poet_enclave_simulator',


### PR DESCRIPTION
```sawtooth-validator``` requires ```requests``` 

It is installed by ```sawtooth-dev-tools``` but was not included in the ```install_requires``` of ```setup.py```
