### PR TITLE
Extend the sawtooth CLI to support for listing blocks

### DIFF
--- a/sawtooth/client.py
+++ b/sawtooth/client.py
@@ -570,7 +570,19 @@ class LedgerWebClient(object):
             blockid - get the state of the store following the validation of
                 blockid
         """
-        url = self.ledger_url + '/store' + txntype.TransactionTypeName
+        return self.store_url_by_name(txntype.TransactionTypeName,
+                                      key, blockid, delta)
+
+    def store_url_by_name(self,
+                          txntypename='',
+                          key='',
+                          blockid='',
+                          delta=False):
+        if txntypename == '':
+            url = self.ledger_url + '/store'
+            return url
+
+        url = self.ledger_url + '/store' + txntypename
         if key:
             url += '/' + key
         url = urlparse.urljoin(url,
@@ -705,6 +717,14 @@ class LedgerWebClient(object):
             key -- a specific identifier to retrieve
         """
         return self._geturl(self.store_url(txntype, key, blockid, delta))
+
+    def get_store_by_name(self,
+                          txntypename='',
+                          key='',
+                          blockid='',
+                          delta=False):
+        return self._geturl(self.store_url_by_name(txntypename, key,
+                                                   blockid, delta))
 
     def get_block(self, blockid, field=None):
         """

--- a/tests/test_ledger_web_client.py
+++ b/tests/test_ledger_web_client.py
@@ -56,6 +56,39 @@ class TestLedgerWebCLient(unittest.TestCase):
             "http://localhost:8800/store/EndpointRegistryTransaction/t1"
             "?blockid=b3&delta=1")
 
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction"),
+            "http://localhost:8800/store/EndpointRegistryTransaction")
+
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction", 't1'),
+            "http://localhost:8800/store/EndpointRegistryTransaction/t1")
+
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction",
+                                  blockid='b2'),
+            "http://localhost:8800/store/EndpointRegistryTransaction"
+            "?blockid=b2")
+
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction", 't1',
+                                  'b2'),
+            "http://localhost:8800/store/EndpointRegistryTransaction/t1"
+            "?blockid=b2")
+
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction", 't1',
+                                  delta=True),
+            "http://localhost:8800/store/EndpointRegistryTransaction/t1"
+            "?delta=1")
+
+        self.assertEquals(
+            lwc.store_url_by_name("/EndpointRegistryTransaction", 't1',
+                                  blockid='b3',
+                                  delta=True),
+            "http://localhost:8800/store/EndpointRegistryTransaction/t1"
+            "?blockid=b3&delta=1")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#10
This pr implements "sawtooth block list|show [--url URL]"

The command '''#sawtooth block list''' lists the committed block IDs
The command '''#sawtooth block show blockID''' shows the contents of the block 

Signed-off-by: feihujiang <jiangfeihu@huawei.com>