### PR TITLE
Let preparetransaction not request stored transactions

### DIFF
--- a/validator/journal/journal_core.py
+++ b/validator/journal/journal_core.py
@@ -1144,8 +1144,15 @@ class Journal(gossip_core.Gossip):
                 # there are no loops in the dependencies but not doing that
                 # right now
                 deptxn = self.TransactionStore.get(dependencyID)
-                if deptxn and self._preparetransaction(addtxns, deltxns, store,
-                                                       deptxn):
+                if deptxn:
+                    if not self._preparetransaction(addtxns, deltxns,
+                                                    store, deptxn):
+                        if dependencyID in deltxns:
+                            logger.info('txnid: %s - depends on '
+                                        'deleted transaction %s',
+                                        txn.Identifier[:8], dependencyID[:8])
+                            deltxns.append(txn.Identifier)
+                        ready = False
                     continue
 
                 # at this point we cannot find the dependency so send out a


### PR DESCRIPTION
Signed-off-by: feihujiang jiangfeihu@huawei.com

Let the `_preparetransaction()` function not request stored dependent transactions, and handle the case that the dependency is added to deltxns by `_preparetransaction` function.
