### PR TITLE
install_requires as the one place for requirements

### DIFF
--- a/extensions/mktplace/setup.py
+++ b/extensions/mktplace/setup.py
@@ -77,7 +77,7 @@ setup(
     author='Mic Bowman, Intel Labs',
     url='http://www.intel.com',
     packages=find_packages(),
-    install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog', 'PyYAML'],
+    install_requires=['sawtooth-core', 'colorlog', 'pybitcointools', 'PyYAML'],
     entry_points={
         'console_scripts': [
             'mktclient = mktmain.client_cli:main'

--- a/tools/bootstrap.d/30-python-lib-install.sh
+++ b/tools/bootstrap.d/30-python-lib-install.sh
@@ -2,16 +2,27 @@
 
 set -e
 
-pip install cbor
-pip install pybitcointools
-pip install colorlog
-pip install coverage
-pip install nose2
-pip install cov-core
-pip install pylint
-pip install setuptools-lint
-pip install pep8
-pip install networkx
-pip install daemonize
-pip install psutil
-pip install demjson
+function install_requires {
+    cat $1 \
+        | grep -v "sawtooth-core" \
+        | pip install -r /dev/stdin
+}
+
+# Packages for testing
+pip install -r /project/sawtooth-core/tools/requirements-testing.txt
+
+# sawtooth-core/core
+(cd /project/sawtooth-core/core/ && python setup.py egg_info)
+pip install -r /project/sawtooth-core/core/sawtooth_core.egg-info/requires.txt
+
+# sawtooth-core/validator
+(cd /project/sawtooth-core/validator/ && python setup.py egg_info)
+install_requires /project/sawtooth-core/validator/sawtooth_validator.egg-info/requires.txt
+
+# sawtooth-core/extensions/mktplace
+(cd /project/sawtooth-core/extensions/mktplace/ && python setup.py egg_info)
+install_requires /project/sawtooth-core/extensions/mktplace/sawtooth_mktplace.egg-info/requires.txt
+
+# sawtooth-core/extensions/arcade
+(cd /project/sawtooth-core/extensions/arcade/ && python setup.py egg_info)
+install_requires /project/sawtooth-core/extensions/arcade/sawtooth_arcade.egg-info/requires.txt

--- a/tools/requirements-testing.txt
+++ b/tools/requirements-testing.txt
@@ -1,0 +1,7 @@
+pep8
+coverage
+nose2
+cov-core
+pylint
+setuptools-lint
+demjson

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -113,8 +113,8 @@ setup(
     author='Mic Bowman, Intel Labs',
     url='http://www.intel.com',
     packages=find_packages(),
-    install_requires=['sawtooth-core', 'cbor>=0.1.23', 'colorlog',
-                      'twisted', 'PyYAML', 'psutil', 'numpy'],
+    install_requires=['sawtooth-core', 'colorlog', 'twisted', 'PyYAML', 'psutil',
+                      'numpy', 'networkx', 'daemonize'],
     data_files=data_files,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Merge the different places where Python dependencies are specified
into one (DRY) place. This should make it easier to maintain the list
since there is only one place where they are specified.

The different Sawtooth packages should now correctly specify their own dependencies
which means that with this patch using ```pip install -e .``` or ```python setup.py
develop``` should also work correctly.

For example using the following ```requirements.txt``` placed in ```sawtooth-core``` as ```requirements-dev-venv.txt```:
```
-e core/
-e validator/
-e extensions/mktplace
-e extensions/arcade
```

Sawtooth will install in a virtualenv on OSX.

```
$ virtualenv venv
$ source venv/bin/activate
$ pip install -r requirements-dev-venv.txt
```

Passing the tests

```
$ cd core
$ nose2
...

----------------------------------------------------------------------
Ran 121 tests in 45.751s

OK
---------- coverage: platform darwin, python 2.7.12-final-0 ----------
Coverage HTML written to dir htmlcov
$ cd ../validator
$ nose2

----------------------------------------------------------------------
Ran 34 tests in 249.776s

OK (skipped=10)
---------- coverage: platform darwin, python 2.7.12-final-0 ----------
Coverage HTML written to dir htmlcov

$ cd ../extensions/mktplace
$ nose2
...
----------------------------------------------------------------------
Ran 30 tests in 0.011s

OK (skipped=10)
---------- coverage: platform darwin, python 2.7.12-final-0 ----------
Coverage HTML written to dir htmlcov
```
