### PR TITLE
Fix the bug of marketplace name must be unique

### DIFF
--- a/extensions/mktplace/mktplace/transactions/account_update.py
+++ b/extensions/mktplace/mktplace/transactions/account_update.py
@@ -83,6 +83,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/asset_type_update.py
+++ b/extensions/mktplace/mktplace/transactions/asset_type_update.py
@@ -86,6 +86,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/asset_update.py
+++ b/extensions/mktplace/mktplace/transactions/asset_update.py
@@ -113,6 +113,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/exchange_offer_update.py
+++ b/extensions/mktplace/mktplace/transactions/exchange_offer_update.py
@@ -193,6 +193,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/holding_update.py
+++ b/extensions/mktplace/mktplace/transactions/holding_update.py
@@ -139,6 +139,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/liability_update.py
+++ b/extensions/mktplace/mktplace/transactions/liability_update.py
@@ -139,6 +139,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID

--- a/extensions/mktplace/mktplace/transactions/market_place_object_update.py
+++ b/extensions/mktplace/mktplace/transactions/market_place_object_update.py
@@ -147,7 +147,17 @@ class Register(object):
 
         return True
 
+    def _get_absolute_name(self, store):
+        if not self.Name.startswith('//'):
+            name = "{0}{1}".format(store.i2n(self.CreatorID), self.Name)
+        else:
+            name = self.Name
+        return name
+
     def apply(self, store):
+        name = self._get_absolute_name(store)
+        store.bind(name, self.ObjectID)
+        logger.info('apply Market Register store._namemap: %s', store._namemap)
         pass
 
     def dump(self):
@@ -199,6 +209,8 @@ class Unregister(object):
         return True
 
     def apply(self, store):
+        name = self._get_absolute_name(store)
+        store.unbind(name)
         del store[self.ObjectID]
 
     def dump(self):

--- a/extensions/mktplace/mktplace/transactions/participant_update.py
+++ b/extensions/mktplace/mktplace/transactions/participant_update.py
@@ -105,7 +105,15 @@ class Register(market_place_object_update.Register):
 
         return True
 
+    def _get_absolute_name(self, store):
+        if not self.Name.startswith('//'):
+            name = "//{0}".format(self.Name)
+        else:
+            name = self.Name
+        return name
+
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = ParticipantObject(self.ObjectID)
         pobj.Address = self.OriginatorID
         pobj.Description = self.Description

--- a/extensions/mktplace/mktplace/transactions/sell_offer_update.py
+++ b/extensions/mktplace/mktplace/transactions/sell_offer_update.py
@@ -166,6 +166,7 @@ class Register(market_place_object_update.Register):
         return True
 
     def apply(self, store):
+        super(Register, self).apply(store)
         pobj = self.ObjectType(self.ObjectID)
 
         pobj.CreatorID = self.CreatorID


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

[Here](https://github.com/hyperledger/sawtooth-core/blob/master/extensions/mktplace/mktplace/transactions/market_place_object_update.py#L120) checks that names must be unique, but when transactions apply, the store don't bind name to the transaction identifier,  this is a bug. This PR fixes this bug.