### PR TITLE
Fix too many replicated warnings are throwed

### DIFF
--- a/extensions/mktplace/mktmain/client_cli.py
+++ b/extensions/mktplace/mktmain/client_cli.py
@@ -1496,6 +1496,8 @@ def get_configuration(args, os_name=os.name, config_files_required=True):
 
     return cfg
 
+globalClog = None
+
 
 def log_configuration(cfg):
     if 'LogConfigFile' in cfg and len(cfg['LogConfigFile']) > 0:
@@ -1525,11 +1527,14 @@ def log_configuration(cfg):
             sys.exit(1)
 
     else:
-        clog = logging.StreamHandler()
-        clog.setFormatter(logging.Formatter(
-            '[%(asctime)s %(name)s %(levelname)s] %(message)s', "%H:%M:%S"))
-        clog.setLevel(logging.WARN)
-        logging.getLogger().addHandler(clog)
+        global globalClog
+        if not globalClog:
+            globalClog = logging.StreamHandler()
+            globalClog.setFormatter(logging.Formatter(
+                '[%(asctime)s %(name)s %(levelname)s] %(message)s',
+                "%H:%M:%S"))
+            globalClog.setLevel(logging.WARN)
+            logging.getLogger().addHandler(globalClog)
 
 
 def read_key_file(keyfile):


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Everytime we invoke [client_cli.main()](https://github.com/hyperledger/sawtooth-core/blob/master/extensions/mktplace/tests/integration/test_all_transactions.py#L65), Logger().addHandler(clog) [here](https://github.com/hyperledger/sawtooth-core/blob/master/extensions/mktplace/mktmain/client_cli.py#L1532), too many handlers are added. So test_transactions_reg() throws two replicated warnings,  test_transactions_unr() throws three replicated warnings etc. This PR fixes the bug.