### PR TITLE
Fix the bug of posting unknown message

### DIFF
--- a/validator/txnserver/web_pages/forward_page.py
+++ b/validator/txnserver/web_pages/forward_page.py
@@ -38,6 +38,11 @@ class ForwardPage(BasePage):
         """
         data = request.content.getvalue()
         msg = self._get_message(request)
+
+        # if it is an error response message, returns it immediately
+        if isinstance(msg, dict) and 'status' in msg:
+            return msg
+
         if self.validator.config.get("LocalValidation", True):
             # determine if the message contains a valid transaction before
             # we send the message to the network

--- a/validator/txnserver/web_pages/prevalidation_page.py
+++ b/validator/txnserver/web_pages/prevalidation_page.py
@@ -79,6 +79,11 @@ class PrevalidationPage(BasePage):
 
         data = request.content.getvalue()
         msg = self._get_message(request)
+
+        # if it is an error response message, returns it immediately
+        if isinstance(msg, dict) and 'status' in msg:
+            return msg
+
         mymsg = copy.deepcopy(msg)
 
         if hasattr(mymsg, 'Transaction') and mymsg.Transaction is not None:


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

if [error response](https://github.com/hyperledger/sawtooth-core/blob/master/validator/txnserver/web_pages/base_page.py#L164) or [another error response](https://github.com/hyperledger/sawtooth-core/blob/master/validator/txnserver/web_pages/base_page.py#L171) returned, we need to return these messages immediately. And I add an integration test.