### PR TITLE
Rename signingkey and SignatureKey

### DIFF
--- a/validator/gossip/message.py
+++ b/validator/gossip/message.py
@@ -203,7 +203,7 @@ class Message(SignedObject):
         """
         if minfo is None:
             minfo = {}
-        super(Message, self).__init__(minfo, signkey='__SIGNATURE__')
+        super(Message, self).__init__(minfo, sig_dict_key='__SIGNATURE__')
 
         self.Nonce = minfo.get('__NONCE__', time.time())
 

--- a/validator/gossip/signed_object.py
+++ b/validator/gossip/signed_object.py
@@ -108,24 +108,25 @@ class SignedObject(object):
 
     Attributes:
         Signature (str): The signature used to sign the object.
-        SignatureKey (str): The name of the key related to the signature.
-            Used to build dict return types.
+        SignatureDictKey (str): The key in the serialized dict containing the
+            signature. Used to build dict return types.
 
     """
     signature_cache = LruCache()
 
-    def __init__(self, minfo=None, signkey='Signature'):
+    def __init__(self, minfo=None, sig_dict_key='Signature'):
         """Constructor for the SignedObject class.
 
         Args:
             minfo (dict): object data
-            signkey (str): the field name for the signature within the
+            sig_dict_key (str): the field name for the signature within the
                 object data
         """
         if minfo is None:
             minfo = {}
-        self.Signature = minfo.get(signkey)
-        self.SignatureKey = signkey
+
+        self.Signature = minfo.get(sig_dict_key)
+        self.SignatureDictKey = sig_dict_key
         self.public_key = minfo.get("PublicKey")
         self._identifier = hashlib.sha256(
             self.Signature).hexdigest() if self.Signature else None
@@ -260,30 +261,30 @@ class SignedObject(object):
         self._identifier = hashlib.sha256(self.Signature).hexdigest()
 
     def serialize(self, signable=False):
-        """Generates a CBOR serialized dict containing the a SignatureKey
+        """Generates a CBOR serialized dict containing the SignatureDictKey
         to Signature mapping.
 
         Args:
-            signable (bool): if signable is True, self.SignatureKey is
+            signable (bool): if signable is True, self.SignatureDictKey is
                 removed from the dict prior to serialization to CBOR.
 
         Returns:
-            bytes: a CBOR representation of a SignatureKey to Signature
+            bytes: a CBOR representation of a SignatureDictKey to Signature
                 mapping.
         """
         dump = self.dump()
 
-        if signable and self.SignatureKey in dump:
-            del dump[self.SignatureKey]
+        if signable and self.SignatureDictKey in dump:
+            del dump[self.SignatureDictKey]
 
         return dict2cbor(dump)
 
     def dump(self):
-        """Builds a dict containing a mapping of SignatureKey to Signature.
+        """Builds a dict containing a mapping of SignatureDictKey to Signature.
 
         Returns:
-            dict: a map containing SignatureKey:Signature.
+            dict: a map containing SignatureDictKey:Signature.
         """
-        result = {self.SignatureKey: self.Signature}
+        result = {self.SignatureDictKey: self.Signature}
         result["PublicKey"] = self.public_key
         return result

--- a/validator/tests/unit/test_signed_object.py
+++ b/validator/tests/unit/test_signed_object.py
@@ -36,10 +36,9 @@ class TestSignedObject(unittest.TestCase):
     def test_init(self):
         # Trival test creates a SignedObject
         # check that everything initalizes as expected
-        signkey = SigObj.generate_signing_key()
-        temp = SignedObject({signkey: "test"}, signkey)
-        self.assertEquals(temp.SignatureKey, signkey)
-        self.assertEquals(temp.dump(), {signkey: "test", "PublicKey": None})
+        temp = SignedObject({"TestSignatureDictKey": "test"}, "TestSignatureDictKey")
+        self.assertEquals(temp.SignatureDictKey, "TestSignatureDictKey")
+        self.assertEquals(temp.dump(), {"TestSignatureDictKey": "test", "PublicKey": None})
         self.assertEquals(temp.__repr__(), temp.serialize())
         self.assertIsNotNone(temp.Identifier)
         temp._identifier = None
@@ -49,8 +48,7 @@ class TestSignedObject(unittest.TestCase):
         # Verify that is_valid only returns true if working with a valid
         # Signed Object
         # test a valid signature
-        signkey = SigObj.generate_signing_key()
-        temp = SignedObject({signkey: "test"}, signkey)
+        temp = SignedObject({"TestSignatureDictKey": "test"}, "TestSignatureDictKey")
         self.assertTrue(temp.is_valid("unused"))
 
         # test OriginatorID
@@ -78,8 +76,7 @@ class TestSignedObject(unittest.TestCase):
         # Verify that signed_node and sign_object does not invalidate the
         # signed object and can be returned to original
         # create initial signed object
-        signkey = SigObj.generate_signing_key()
-        temp = SignedObject({signkey: "test"}, signkey)
+        temp = SignedObject({"TestSignatureDictKey": "test"}, "TestSignatureDictKey")
         # save origanl OriginatorID before creating node
         idBeforeNode = temp.OriginatorID
 
@@ -103,8 +100,7 @@ class TestSignedObject(unittest.TestCase):
         # Test that an assertion error is thrown when a node is passed
         # that does not have a Signingkey
         # create SignedObject
-        signkey = SigObj.generate_signing_key()
-        temp = SignedObject({signkey: "test"}, signkey)
+        temp = SignedObject({"TestSignatureDictKey": "test"}, "TestSignatureDictKey")
         # create a Node that does not have a signingKey
         testNode = Node(name="badNode")
         try:
@@ -119,8 +115,7 @@ class TestSignedObject(unittest.TestCase):
         # Test that serilazation returns the correct dictionary and that
         # it can be retrieved.
         # create SignedObject
-        signkey = SigObj.generate_signing_key()
-        temp = SignedObject({signkey: "test"}, signkey)
+        temp = SignedObject({"TestSignatureDictKey": "test"}, "TestSignatureDictKey")
         # serlize SignedObject
         cbor = temp.serialize()
         # check that the unserilized serilized dictinary is the same


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

I think [signingkey](https://github.com/hyperledger/sawtooth-core/blob/master/validator/gossip/signed_object.py#L117) and [SignatureKey](https://github.com/hyperledger/sawtooth-core/blob/master/validator/gossip/signed_object.py#L128) here isn't really a signing key, it is just the name of the key related to the signature. I renamed them to avoid confusing and fixed the wrong case in test_signed_object.