### PR TITLE
Print more linted files when using 'run_lint -n' command

### DIFF
--- a/bin/run_lint
+++ b/bin/run_lint
@@ -127,7 +127,8 @@ do
 done
 
 if [ "$DRY_RUN" = "1" ]; then
-    for dir in core validator extensions/mktplace extensions/arcade
+    for dir in core signing validator sdk/python sdk/examples/intkey_python \
+        extensions/bond extensions/mktplace extensions/arcade
     do
         for package in $(find_packages "$dir" "$SINCE")
         do


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Print linted files from missed module  when using 'run_lint -n' command
