### PR TITLE
Add module option in run_tests

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -1,4 +1,28 @@
 #!/bin/bash
+#
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+usage() {
+    echo "Usage:"
+    echo "  $0 [-m Module]"
+    echo
+    echo "Options:"
+    echo "  -h          print usage and exit"
+    echo "  -m Module   only run tests of specified module <core, signing, validator, mktplace, bond, arcade>"
+}
 
 set -e
 
@@ -7,64 +31,132 @@ top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 PATH=$top_dir/bin:$PATH
 export PATH
 
-PYTHONPATH=$top_dir/core
-export PYTHONPATH
-cd core
-nose2 -v
-cd ..
+test_core() {
+	PYTHONPATH=$top_dir/core
+	export PYTHONPATH
+	cd core
+	nose2 -v
+	cd ..
+}
 
-PYTHONPATH=$top_dir
-PYTHONPATH=$PYTHONPATH:$top_dir/signing
-PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
-export PYTHONPATH
-cd signing
-nose2 -v
-cd ..
+test_signing() {
+	PYTHONPATH=$top_dir
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
+	export PYTHONPATH
+	cd signing
+	nose2 -v
+	cd ..
+}
 
-PYTHONPATH=$top_dir
-PYTHONPATH=$PYTHONPATH:$top_dir/signing
-PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
-PYTHONPATH=$PYTHONPATH:$top_dir/core
-PYTHONPATH=$PYTHONPATH:$top_dir/validator
-PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
-export PYTHONPATH
-cd validator
-nose2 -v unit
+test_validator() {
+	PYTHONPATH=$top_dir
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/core
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
+	export PYTHONPATH
+	cd validator
+	nose2 -v unit
 
-# Disable nose2-3 within docker container until bugs can be resolved.
-if [ "$DOCKER_CONTAINER_ID" = "" ]; then
-    nose2-3 -v unit3
-fi
+	# Disable nose2-3 within docker container until bugs can be resolved.
+	if [ "$DOCKER_CONTAINER_ID" = "" ]; then
+	    nose2-3 -v unit3
+	fi
+	
+	export RUN_TEST_SUITES=1
+	nose2 -v sawtooth_suites.ts_pr_dev_mode.DevModeTestSuite
+	nose2 -v sawtooth_suites.ts_pr_poet0.Poet0TestSuite
+	unset RUN_TEST_SUITES
+	cd ..
+}
 
-export RUN_TEST_SUITES=1
-nose2 -v sawtooth_suites.ts_pr_dev_mode.DevModeTestSuite
-nose2 -v sawtooth_suites.ts_pr_poet0.Poet0TestSuite
-unset RUN_TEST_SUITES
-cd ..
+test_mktplace() {
+	PYTHONPATH=$top_dir
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/core
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/extensions/mktplace
+	export PYTHONPATH
+	cd extensions/mktplace
+	nose2 -v unit
+	export RUN_TEST_SUITES=1
+	nose2 -v sawtooth_suites.ts_pr_mkt_poet0.Poet0MktTestSuite
+	unset RUN_TEST_SUITES
+	cd ../..
+}
 
-PYTHONPATH=$top_dir
-PYTHONPATH=$PYTHONPATH:$top_dir/signing
-PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
-PYTHONPATH=$PYTHONPATH:$top_dir/core
-PYTHONPATH=$PYTHONPATH:$top_dir/validator
-PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
-PYTHONPATH=$PYTHONPATH:$top_dir/extensions/mktplace
-export PYTHONPATH
-cd extensions/mktplace
-nose2 -v unit
-export RUN_TEST_SUITES=1
-nose2 -v sawtooth_suites.ts_pr_mkt_poet0.Poet0MktTestSuite
-unset RUN_TEST_SUITES
-cd ../..
+test_bond() {
+	PYTHONPATH=$top_dir
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing
+	PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/core
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/extensions/bond
+	export PYTHONPATH
+	cd extensions/bond
+	nose2 -v
+	cd ../..
+}
 
-PYTHONPATH=$top_dir
-PYTHONPATH=$PYTHONPATH:$top_dir/signing
-PYTHONPATH=$PYTHONPATH:$top_dir/signing/build/lib.linux-x86_64-2.7
-PYTHONPATH=$PYTHONPATH:$top_dir/core
-PYTHONPATH=$PYTHONPATH:$top_dir/validator
-PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
-PYTHONPATH=$PYTHONPATH:$top_dir/extensions/bond
-export PYTHONPATH
-cd extensions/bond
-nose2 -v
-cd ../..
+test_arcade() { 
+	PYTHONPATH=$top_dir/core
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator
+	PYTHONPATH=$PYTHONPATH:$top_dir/validator/build/lib.linux-x86_64-2.7
+	PYTHONPATH=$PYTHONPATH:$top_dir/extensions/arcade
+	export PYTHONPATH
+	cd extensions/arcade
+	nose2 -v
+	cd ../..
+}
+
+MODULE="all"
+while getopts :m:h opt
+do
+    case $opt in
+        h)
+            usage
+            exit 0
+            ;;
+        m)
+            MODULE=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case $MODULE in
+    all)
+        test_core
+        test_signing
+        test_validator
+        test_mktplace
+        test_bond
+        test_arcade
+        ;;
+    core)
+        test_core
+        ;;
+    signing)
+        test_signing
+        ;;
+    validator)
+        test_validator
+        ;;
+    mktplace)
+        test_mktplace
+        ;;
+    bond)
+        test_bond
+        ;;
+    arcade)
+        test_arcade
+        ;;
+esac


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Usage:
  ./bin/run_tests [-m Module]
Options:
  -h          print usage and exit
  -m Module   only run tests of module, <core, validator, mktplace, bond, arcade>
