### PR TITLE
Add logger warning when signed object has no pub key and addr

### DIFF
--- a/validator/gossip/signed_object.py
+++ b/validator/gossip/signed_object.py
@@ -229,6 +229,9 @@ class SignedObject(object):
         try:
             # force validation of the signature
             recovered_id = self.OriginatorID
+            if self.public_key is None and originatorid is None:
+                logger.warning("Identifier %s of SignedObject has no public "
+                    "key and addr used to verify signature", self.Identifier)
             return (self.public_key is None or self.public_key ==
                     self.originator_public_key) and \
                 (originatorid is None or recovered_id == originatorid)


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

If signed object has no pub key and addr, verifying its signature always return true. We should add logger warning when such case occurs.