### PR TITLE
Remove duplicate logger info messages

### DIFF
--- a/validator/journal/journal_core.py
+++ b/validator/journal/journal_core.py
@@ -753,10 +753,6 @@ class Journal(object):
 
         new_block.TransactionIDs = txn_list
 
-        logger.info('build transaction block to extend %s with %s '
-                    'transactions',
-                    self.most_recent_committed_block_id[:8], len(txn_list))
-
         self.consensus.initialize_block(self, new_block)
 
         # fire the build block event handlers


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

The removed logger info is duplicate of [here](https://github.com/hyperledger/sawtooth-core/blob/master/validator/journal/journal_core.py#L747)