### PR TITLE
Fix NoneType object has no attribute 'has_expired'

### DIFF
--- a/validator/journal/journal_core.py
+++ b/validator/journal/journal_core.py
@@ -554,7 +554,6 @@ class Journal(object):
         """
         logger.debug('blkid: %s - processing incoming transaction block',
                      tblock.Identifier[:8])
-
         # Make sure this is a valid block, for now this will just check the
         # signature... more later
         if not tblock.verify_signature():
@@ -1434,7 +1433,8 @@ class Journal(object):
                         time.time() if remaining_transactions > 0 else None
 
         with self._txn_lock:
-            if self.pending_block and \
+            if self.pending_block and self.pending_block.Status != \
+                    transaction_block.Status.invalid and\
                     self.consensus.check_claim_block(
                         self,
                         self.pending_block,


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Fix the following AttributeError:
~~~
[19:34:37 [MainThread] gossip.event_handler ERROR] event handler MessageDispatcher.on_heartbeat failed
Traceback (most recent call last):
  File "/root/projects/sawtooth-core/validator/gossip/event_handler.py", line 56, in __call__
    if not handler(*args, **keywargs) is True:
  File "/root/projects/sawtooth-core/validator/journal/journal_core.py", line 1447, in _check_claim_block
    now):
  File "/root/projects/sawtooth-core/validator/sawtooth_validator/consensus/poet1/poet_consensus.py", line 222, in check_claim_block
    return block.wait_timer_has_expired(now)
  File "/root/projects/sawtooth-core/validator/sawtooth_validator/consensus/poet1/poet_transaction_block.py", line 272, in wait_timer_has_expired
    return self.wait_timer.has_expired(now)
AttributeError: 'NoneType' object has no attribute 'has_expired'
~~~