### PR TITLE
set keyfile config for validator tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -115,7 +115,7 @@ and run the following commands:
 
    $ /project/sawtooth-core/docs/source/tutorial/genesis.sh
    $ cd /project/sawtooth-core
-   $ ./bin/txnvalidator -v -F ledger.transaction.integer_key --config /home/ubuntu/sawtooth/v0.json
+   $ ./bin/txnvalidator -v -F ledger.transaction.integer_key --config /home/ubuntu/sawtooth/v0.json --keyfile /home/ubuntu/sawtooth/keys/base000.wif
 
 This will start txnvalidator and logging output will be printed to the
 terminal window.


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

When we use poet1, if we don't use a registered validator, we get an error ```Cannot validate wait certificate because cannot retrieve PoET public key for validator with ID=1MJYJNLiN9m2zbPkK21BW4nMn5RfsDQKzs``` and ```block test failed```. We need to use the registered validator.