### PR TITLE
Add head parameter, update /state endpoint

### DIFF
--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -74,12 +74,6 @@ def add_block_parser(subparsers, parent_parser):
 
 
 def do_block(args):
-    subcommands = ['list', 'show']
-    if args.subcommand not in subcommands:
-        print('Unknown sub-command, expecting one of {0}'.format(
-            subcommands))
-        return
-
     rest_client = RestClient(args.url)
 
     def print_json(data):
@@ -114,7 +108,6 @@ def do_block(args):
 
         if args.format == 'default':
             print('{:<3}  {:88.88}  {:<7}  {:<4}  {:20.20}'.format(*headers))
-
             for block in blocks:
                 print('{:<3}  {:88.88}  {:<7}  {:<4}  {:17.17}...'.format(
                     *get_block_data(block)))
@@ -142,7 +135,7 @@ def do_block(args):
         else:
             raise CliException('unknown format: {}'.format(args.format))
 
-    elif args.subcommand == 'show':
+    if args.subcommand == 'show':
         block = rest_client.get_block(args.block_id)
 
         if args.key:

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -33,6 +33,8 @@ from sawtooth_cli.config import add_config_parser
 from sawtooth_cli.config import do_config
 from sawtooth_cli.block import add_block_parser
 from sawtooth_cli.block import do_block
+from sawtooth_cli.state import add_state_parser
+from sawtooth_cli.state import do_state
 
 
 def create_console_handler(verbose_level):
@@ -91,6 +93,7 @@ def create_parser(prog_name):
     add_admin_parser(subparsers, parent_parser)
     add_config_parser(subparsers, parent_parser)
     add_block_parser(subparsers, parent_parser)
+    add_state_parser(subparsers, parent_parser)
 
     return parser
 
@@ -115,6 +118,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
         do_config(args)
     elif args.command == 'block':
         do_block(args)
+    elif args.command == 'state':
+        do_state(args)
     else:
         raise AssertionError("invalid command: {}".format(args.command))
 

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -1,0 +1,151 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import sys
+from base64 import b64decode
+
+import csv
+import json
+import yaml
+
+from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli.exceptions import CliException
+
+
+def add_state_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('state')
+
+    grand_parsers = parser.add_subparsers(title='grandchildcommands',
+                                          dest='subcommand')
+
+    epilog = '''
+    details:
+        Lists leaves on the merkle tree, storing state. List can be
+        narrowed using the address of a subtree.
+    '''
+
+    list_parser = grand_parsers.add_parser('list', epilog=epilog)
+    list_parser.add_argument(
+        'subtree',
+        type=str,
+        nargs='?',
+        default=None,
+        help='the address of a subtree to filter list by')
+    list_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    list_parser.add_argument(
+        '--head',
+        action='store',
+        default=None,
+        help='the id of the block to set as the chain head')
+    list_parser.add_argument(
+        '--format',
+        action='store',
+        default='default',
+        help='the format of the output, options: csv, json or yaml')
+
+    epilog = '''
+    details:
+        Shows the data for a single leaf on the merkle tree.
+    '''
+    show_parser = grand_parsers.add_parser('show', epilog=epilog)
+    show_parser.add_argument(
+        'address',
+        type=str,
+        help='the address of the leaf')
+    show_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    show_parser.add_argument(
+        '--head',
+        action='store',
+        default=None,
+        help='the id of the block to set as the chain head')
+
+
+def do_state(args):
+    rest_client = RestClient(args.url)
+
+    def print_json(data):
+        print(json.dumps(
+            data,
+            indent=2,
+            separators=(',', ': '),
+            sort_keys=True))
+
+    def print_yaml(data):
+        print(yaml.dump(data, default_flow_style=False)[0:-1])
+
+    if args.subcommand == 'list':
+        response = rest_client.list_state(args.subtree, args.head)
+        leaves = response['data']
+        head = response['head']
+
+        keys = ('address', 'size', 'data')
+        headers = (k.upper() for k in keys)
+        max_data_width = 15
+        format_string = '{{:{addr}.{addr}}} {{:<4}} {{!s:.{data}}}'.format(
+            addr=len(leaves[0]['address']) if len(leaves) > 0 else 30,
+            data=max_data_width)
+
+        def get_leaf_data(leaf, use_decoded=True):
+            data = leaf['data']
+            decoded_data = b64decode(data)
+            return (
+                leaf['address'],
+                len(decoded_data),
+                decoded_data if use_decoded else data)
+
+        if args.format == 'default':
+            print(format_string.format(*headers))
+            for leaf in leaves:
+                print_string = format_string.format(*get_leaf_data(leaf))
+                if len(str(leaf['data'])) > max_data_width:
+                    print_string += '...'
+                print(print_string)
+            print('HEAD BLOCK: "{}"'.format(head))
+
+        elif args.format == 'csv':
+            try:
+                writer = csv.writer(sys.stdout)
+                writer.writerow(headers)
+                for leaf in leaves:
+                    writer.writerow(get_leaf_data(leaf))
+            except csv.Error:
+                raise CliException('Error writing CSV.')
+            print('(data for head block: "{}")'.format(head))
+
+        elif args.format == 'json' or args.format == 'yaml':
+            state_data = {
+                'head': head,
+                'data': list(map(
+                    lambda b: dict(zip(keys, get_leaf_data(b, False))),
+                    leaves))}
+
+            if args.format == 'json':
+                print_json(state_data)
+            else:
+                print_yaml(state_data)
+
+        else:
+            raise CliException('Unknown format: {}'.format(args.format))
+
+    if args.subcommand == 'show':
+        leaf = rest_client.get_leaf(args.address, args.head)
+        print('DATA: "{}"'.format(b64decode(leaf['data'])))
+        print('HEAD: "{}"'.format(leaf['head']))

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -100,7 +100,7 @@ class TestIntkeySmoke(unittest.TestCase):
 
     def verify_empty_state(self):
         LOGGER.debug('Verifying empty state')
-        self.assertRaises(urllib.error.HTTPError, _get_state)
+        self.assertEqual([], _get_state())
 
     # utilities
 
@@ -124,22 +124,14 @@ def _get_data():
     return data
 
 def _get_state():
-    root = _get_root()
-    response = _query_rest_api('/state/{}'.format(root))
-    state = json.loads(response)['entries']
-    return state
-
-def _get_root():
     response = _query_rest_api('/state')
-    data = json.loads(response)
-    root = data['merkleRoot']
-    return root
+    return response['data']
 
 def _query_rest_api(suffix='', data=None, headers={}):
     url = 'http://rest_api:8080' + suffix
     request = urllib.request.Request(url, data, headers)
     response = urllib.request.urlopen(request).read().decode('utf-8')
-    return response
+    return json.loads(response)
 
 # separate file?
 

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -50,72 +50,80 @@ message ClientStateCurrentResponse {
     }
     Status status = 1;
     string merkle_root = 2;
-
 }
 
-// A request from a client for a particular address's data, for a given merkle root
-message ClientStateGetRequest {
-    string merkle_root = 1;
-    string address = 2;
-}
-
-// The response to a GetRequest from the client. NORESOURCE means that either the
-// merkle root is not a merkle root in State or the address doesn't exist
-// under a valid merkle root. NONLEAF means that the address isn't a valid
-// leaf address in the merkle tree, this would probably mean that the address
-// is a prefix (truncated). ERROR is a general internal error, like the protobuf
-// sent by the client didn't deserialize correctly.
-message ClientStateGetResponse {
-    enum Status {
-        OK = 0;
-        NORESOURCE = 1;
-        NONLEAF = 2;
-        ERROR = 3;
-    }
-    Status status = 1;
-    bytes value = 2;
-}
-
-// A request to list the Entries under a given prefix (could be the root prefix ('')
-// which would give everything in State under a given merkle root) or (since the
-// merkle trie implementation requires addresses and prefixes to be length % 2 == 0)
-// any length % 2 == 0 prefix namespace.
+// A request to list every entry under a given merkle root or head block.
 message ClientStateListRequest {
     string merkle_root = 1;
-    string prefix = 2;
+    string subtree = 2;
 }
 
-// A response that lists the Entries under a given prefix (subtree). NORESOURCE means
-// that the merkle_root supplied isn't in the merkle trie or there aren't any leaves
-// under the given prefix. ERROR is a general internal error, like the protobuf sent
-// by the client didn't deserialize correctly.
+// A response that lists the Entries under a given merkle root.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * ERROR - general internal error, such as protobuf failing to deserialize
+//   * NOGENESIS - the validate has not been configrued with a genesis block
+//   * NOROOT - the merkle_root specified was not found
+//   * NORESOURCE - the root sprecidied is valid, but contains no data
+
 message ClientStateListResponse {
     enum Status {
         OK = 0;
-        NORESOURCE = 1;
-        ERROR = 2;
+        ERROR = 1;
+        NOROOT = 3;
+        NORESOURCE = 2;
+        NOGENESIS = 4;
     }
     Status status = 1;
     repeated Entry entries = 2;
 }
 
-// A request to return a list of blocks from the validator
-// May include the id of a particular block to be the `head` of the chain being
-// requested. In that case the list will include that block (if found), and all
-// blocks previous to it on the chain.
+// A request from a client for a particular address's data, or for a given
+// merkle root or head block
+message ClientStateGetRequest {
+    string merkle_root = 1;
+    string address = 2;
+}
+
+// The response to a GetRequest from the client.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * ERROR - general internal error, such as protobuf failing to deserialize
+//   * NOGENESIS - the validate has not been configrued with a genesis block
+//   * NOROOT - the head block or merkle_root specified was not found
+//   * NORESOURCE - the address specified doesn't exist
+//   * NONLEAF - the address isn't a valid, i.e. it is a subtree (truncated)
+message ClientStateGetResponse {
+    enum Status {
+        OK = 0;
+        ERROR = 1;
+        NORESOURCE = 2;
+        NOROOT = 3;
+        NOGENESIS = 4;
+        NONLEAF = 5;
+    }
+    Status status = 1;
+    bytes value = 2;
+}
+
+// A request to return a list of blocks from the validator.
 message ClientBlockListRequest {
-    string head = 1;
 }
 
 // A response that lists a chain of blocks with the newest at the end, and the
-// oldest (genesis) block at the beginning. NORESOURCE indicates that no blocks
-// were found, likely because the id specified in the `head` of the request was
-// not found on the chain.
+// oldest (genesis) block at the beginning.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * ERROR - general internal error, such as protobuf failing to deserialize
+//   * NOGENESIS - the validate has not been configrued with a genesis block
 message ClientBlockListResponse {
     enum Status {
         OK = 0;
-        NORESOURCE = 1;
-        ERROR = 2;
+        ERROR = 1;
+        NOGENESIS = 3;
     }
     Status status = 1;
     repeated Block blocks = 2;
@@ -129,15 +137,16 @@ message ClientBlockGetRequest {
 }
 
 // A response that returns the block specified by a ClientBlockGetRequest.
-// NORESOURCE indicates that no block with the specified id was found.
-// ERROR indicates that there was some sort of internal error, such as the
-// Protobuf failing to deserialize. OK indicates the block has been returned
-// successfully.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * ERROR - general internal error, such as protobuf failing to deserialize
+//   * NORESOURCE - no block with the specified id exists
 message ClientBlockGetResponse {
     enum Status {
         OK = 0;
-        NORESOURCE = 1;
-        ERROR = 2;
+        ERROR = 1;
+        NORESOURCE = 2;
     }
     Status status = 1;
     Block block = 2;

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -19,9 +19,14 @@ option java_multiple_files = true;
 option java_package = "sawtooth.sdk.protobuf";
 
 import "batch.proto";
-import "state_context.proto";
 import "block.proto";
 
+
+// An entry in the State
+message Leaf {
+    string address = 1;
+    bytes data = 2;
+}
 
 // Corresponds to messagetype CLIENT_BATCH_SUBMIT_REQUEST
 message ClientBatchSubmitRequest {
@@ -31,7 +36,7 @@ message ClientBatchSubmitRequest {
 message ClientBatchSubmitResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
+        INTERNAL_ERROR = 1;
     }
     Status status = 1;
 }
@@ -39,77 +44,102 @@ message ClientBatchSubmitResponse {
 message ClientStateCurrentRequest {
 }
 
-// This is a response to a request from a client (including the rest api)
-// for the current merkle root. There will always be a current merkle root
-// (if genesis has happened)
-// so there is only the general ERROR status response or OK.
+// This is a response to a request from a client for the current merkle root.
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+
 message ClientStateCurrentResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
     }
     Status status = 1;
     string merkle_root = 2;
 }
 
-// A request to list every entry under a given merkle root or head block.
+// A request to list every entry in the merkle tree. Defaults to the most
+// current tree, but can fetch older state by specifying either a merkle root
+// or a previous head block's id. Results can be further filtered by
+// specifying a subtree with a partial address.
 message ClientStateListRequest {
-    string merkle_root = 1;
-    string subtree = 2;
+    oneof root_key {
+        string merkle_root = 1;
+        string head_id = 2;
+    }
+    string address = 3;
 }
 
-// A response that lists the Entries under a given merkle root.
+// A response that lists the data Entries from the state's merkle tree,
+// filtered by merkle root, head id, or subtree address according to the
+// request. Returns the chain head id used to facilitate future requests.
 //
 // Statuses:
 //   * OK - everything worked as expected
-//   * ERROR - general internal error, such as protobuf failing to deserialize
-//   * NOGENESIS - the validate has not been configrued with a genesis block
-//   * NOROOT - the merkle_root specified was not found
-//   * NORESOURCE - the root sprecidied is valid, but contains no data
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block or merkle_root specified was not found
+//   * NO_RESOURCE - the head/root sprecidied is valid, but contains no data
 
 message ClientStateListResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
-        NOROOT = 3;
-        NORESOURCE = 2;
-        NOGENESIS = 4;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_ROOT = 3;
+        NO_RESOURCE = 4;
     }
     Status status = 1;
-    repeated Entry entries = 2;
+    repeated Leaf leaves = 2;
+    string head_id = 3;
 }
 
-// A request from a client for a particular address's data, or for a given
-// merkle root or head block
+// A request from a client for a particular entry in the merkle tree.
+// Like State List, it defaults to the newest state, but a merkle root
+// or head block id can be used to specify older data. Unlike State List
+// the request must be provided with a full address that corresponds to
+// a single entry.
 message ClientStateGetRequest {
-    string merkle_root = 1;
-    string address = 2;
+    oneof root_key {
+        string merkle_root = 1;
+        string head_id = 2;
+    }
+    string address = 3;
 }
 
-// The response to a GetRequest from the client.
+// The response to a State Get Request from the client. Sends back just
+// the data stored at the entry, not the address. Also sends back the
+// head block id used to facilitate further requests.
 //
 // Statuses:
 //   * OK - everything worked as expected
-//   * ERROR - general internal error, such as protobuf failing to deserialize
-//   * NOGENESIS - the validate has not been configrued with a genesis block
-//   * NOROOT - the head block or merkle_root specified was not found
-//   * NORESOURCE - the address specified doesn't exist
-//   * NONLEAF - the address isn't a valid, i.e. it is a subtree (truncated)
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block or merkle_root specified was not found
+//   * NO_RESOURCE - the address specified doesn't exist
+//   * INVALID_ADDRESS - address isn't a valid, i.e. it's a subtree (truncated)
 message ClientStateGetResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
-        NORESOURCE = 2;
-        NOROOT = 3;
-        NOGENESIS = 4;
-        NONLEAF = 5;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_ROOT = 3;
+        NO_RESOURCE = 4;
+        INVALID_ADDRESS = 5;
     }
     Status status = 1;
     bytes value = 2;
+    string head_id = 3;
 }
 
-// A request to return a list of blocks from the validator.
+// A request to return a list of blocks from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include that block (if found), and all blocks previous
+// to it on the chain.
 message ClientBlockListRequest {
+    string head_id = 1;
 }
 
 // A response that lists a chain of blocks with the newest at the end, and the
@@ -117,21 +147,23 @@ message ClientBlockListRequest {
 //
 // Statuses:
 //   * OK - everything worked as expected
-//   * ERROR - general internal error, such as protobuf failing to deserialize
-//   * NOGENESIS - the validate has not been configrued with a genesis block
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
 message ClientBlockListResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
-        NOGENESIS = 3;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_ROOT = 3;
     }
     Status status = 1;
     repeated Block blocks = 2;
+    string head_id = 3;
 }
 
-// A request to return a specific block from the validator.
-// Requires the block to be specified by its unique id, which
-// in this case is the block's header signature
+// A request to return a specific block from the validator. The block must be
+// specified by its unique id, in this case the block's header signature
 message ClientBlockGetRequest {
     string block_id = 1;
 }
@@ -140,13 +172,14 @@ message ClientBlockGetRequest {
 //
 // Statuses:
 //   * OK - everything worked as expected
-//   * ERROR - general internal error, such as protobuf failing to deserialize
-//   * NORESOURCE - no block with the specified id exists
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no block with the specified id exists
 message ClientBlockGetResponse {
     enum Status {
         OK = 0;
-        ERROR = 1;
-        NORESOURCE = 2;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_RESOURCE = 4;
     }
     Status status = 1;
     Block block = 2;

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -1,0 +1,85 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from aiohttp import web
+from sawtooth_rest_api.protobuf import client_pb2 as client
+
+
+class _ErrorTrap(object):
+    """
+    ErrorTraps are particular handlers for a common pattern the REST API
+    encounters: translating Protobuf statuses sent over ZMQ, into HTTP errors
+    to be raised and sent to the client. Traps take a status as a "trigger"
+    (either hard-coded or at instantiation), and provide a "check" method
+    which will check the trigger against a status, raising a preset
+    HTTP Error if there is a match.
+
+    Args:
+        trigger: a Protobuf enum status to match against
+        error: the type of error to raise
+        message: a message raise the error with
+    """
+    def __init__(self, trigger, error, message=None):
+        self._trigger = trigger
+        self._error = error(reason=message)
+
+    def check(self, status):
+        if status == self._trigger:
+            raise self._error
+
+
+class Unknown(_ErrorTrap):
+    def __init__(self, trigger):
+        error = web.HTTPInternalServerError
+        message = 'An unknown error occured with your request'
+        super().__init__(trigger, error, message)
+
+
+class NotReady(_ErrorTrap):
+    def __init__(self, trigger):
+        error = web.HTTPServiceUnavailable
+        message = 'The validator is not yet ready to be queried'
+        super().__init__(trigger, error, message)
+
+
+class MissingHead(_ErrorTrap):
+    def __init__(self, trigger):
+        error = web.HTTPNotFound
+        message = 'There is no block with that head id'
+        super().__init__(trigger, error, message)
+
+
+class MissingLeaf(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientStateGetResponse.NORESOURCE,
+            error=web.HTTPNotFound,
+            message='There is no leaf at that address')
+
+
+class MissingBlock(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBlockGetResponse.NORESOURCE,
+            error=web.HTTPNotFound,
+            message='There is no block with that id')
+
+
+class BadAddress(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientStateGetResponse.NONLEAF,
+            error=web.HTTPBadRequest,
+            message='Expected a leaf address, but received a subtree instead')

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -64,7 +64,7 @@ class MissingHead(_ErrorTrap):
 class MissingLeaf(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientStateGetResponse.NORESOURCE,
+            trigger=client.ClientStateGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no leaf at that address')
 
@@ -72,7 +72,7 @@ class MissingLeaf(_ErrorTrap):
 class MissingBlock(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientBlockGetResponse.NORESOURCE,
+            trigger=client.ClientBlockGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no block with that id')
 
@@ -80,6 +80,6 @@ class MissingBlock(_ErrorTrap):
 class BadAddress(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientStateGetResponse.NONLEAF,
+            trigger=client.ClientStateGetResponse.INVALID_ADDRESS,
             error=web.HTTPBadRequest,
             message='Expected a leaf address, but received a subtree instead')

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from aiohttp import web
+
+
+class WrongBodyType(web.HTTPBadRequest):
+    def __init__(self):
+        message = 'Expected an octet-stream encoded Protobuf binary'
+        super().__init__(reason=message)
+
+
+class ValidatorUnavailable(web.HTTPServiceUnavailable):
+    def __init__(self):
+        message = 'Could not reach validator, validator timed out'
+        super().__init__(reason=message)

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -36,7 +36,7 @@ paths:
           description: Callback url
       responses:
         202:
-          description: Successfully submitted the BatchList
+          description: Successfully submitted BatchList
           schema:
             properties:
               link:
@@ -63,7 +63,7 @@ paths:
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully retrieved the list of batches
+          description: Successfully retrieved batches
           schema:
             properties:
               data:
@@ -87,14 +87,13 @@ paths:
     parameters:
       - $ref: "#/parameters/batch_id"
     get:
-      summary: Fetches the protobuf representation of a particular batch
+      summary: Fetches a particular batch
       parameters:
-        - $ref: "#/parameters/head"
         - $ref: "#/parameters/fields"
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully retrieved the batch
+          description: Successfully retrieved batch
           schema:
             properties:
               data:
@@ -117,7 +116,7 @@ paths:
       summary: Fetches a list of the committed statuses for a set of batches
       description: >
         Fetches a list of statuses for a batch or batches. The
-        batch(es) you want to check on are specified using the
+        batch(es) you want to check can be specified using the
         `id` filter parameter. Note that this route does not
         return a full resource, and the response body will
         _not_ include the `head` or `paging` properties.
@@ -129,7 +128,7 @@ paths:
           required: true
       responses:
         200:
-          description: Successfully retrieved the list of statuses
+          description: Successfully retrieved statuses
           schema:
             properties:
               data:
@@ -147,7 +146,24 @@ paths:
 
   /state:
     get:
-      summary: Fetches the current state, or state for a particular head block
+      summary: Fetches the data for the current state
+      description: >
+        Fetches a paginated list of leaves for the current state, or relative
+        to a particular head block. Using the `address` filter parameter, will
+        narrow the list to any leaves that have an address beginning with the
+        characters specified.
+      parameters:
+        - $ref: "#/parameters/head"
+        - name: address
+          in: query
+          type: string
+          description: A partial address to filter leaves by
+        - $ref: "#/parameters/count"
+        - $ref: "#/parameters/min_position"
+        - $ref: "#/parameters/max_position"
+        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/fields"
+        - $ref: "#/parameters/omit"
       responses:
         200:
           description: Successfully retrieved state data
@@ -174,21 +190,14 @@ paths:
     parameters:
       - $ref: "#/parameters/address"
     get:
-      summary: Lists data from the blockchain
-      description: >
-        Fetches a paginated list of leaves for a given
-        address or address prefix on the merkel tree.
+      summary: Fetches a particular leaf from the current state
       parameters:
         - $ref: "#/parameters/head"
-        - $ref: "#/parameters/count"
-        - $ref: "#/parameters/min_position"
-        - $ref: "#/parameters/max_position"
-        - $ref: "#/parameters/sort"
         - $ref: "#/parameters/fields"
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully fetched the list of leaves
+          description: Successfully fetched leaves
           schema:
             properties:
               data:
@@ -214,8 +223,7 @@ paths:
     get:
       summary: Fetches a list of blocks
       description: >
-        Fetches a paginated list of protobuf formatted blocks
-        from the validator.
+        Fetches a paginated list of blocks from the validator.
       parameters:
         - $ref: "#/parameters/head"
         - $ref: "#/parameters/count"
@@ -226,7 +234,7 @@ paths:
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully fetched the list of blocks
+          description: Successfully retrieved blocks
           schema:
             properties:
               data:
@@ -250,14 +258,13 @@ paths:
     parameters:
       - $ref: "#/parameters/block_id"
     get:
-      summary: Fetches a particlar protobuf formatted block
+      summary: Fetches a particlar block
       parameters:
-        - $ref: "#/parameters/head"
         - $ref: "#/parameters/fields"
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully retrieved the block
+          description: Successfully retrieved block
           schema:
             properties:
               data:
@@ -280,8 +287,7 @@ paths:
     get:
       summary: Fetches a list of transactions
       description: >
-        Fetches a paginated list of protobuf formatted transactions
-        from the validator.
+        Fetches a paginated list of transactions from the validator.
       parameters:
         - $ref: "#/parameters/head"
         - $ref: "#/parameters/count"
@@ -292,7 +298,7 @@ paths:
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully fetched the list of transactions
+          description: Successfully retrieved transactions
           schema:
             properties:
               data:
@@ -316,14 +322,13 @@ paths:
     parameters:
       - $ref: "#/parameters/transaction_id"
     get:
-      summary: Fetches a particular protobuf transaction
+      summary: Fetches a particular transaction
       parameters:
-        - $ref: "#/parameters/head"
         - $ref: "#/parameters/fields"
         - $ref: "#/parameters/omit"
       responses:
         200:
-          description: Successfully retrieved the transaction
+          description: Successfully retrieved transaction
           schema:
             properties:
               data:

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -48,13 +48,10 @@ def start_rest_api(host, port, stream_url):
 
     app = web.Application(middlewares=[logging_middleware])
     # Add routes to the web app
-    app.router.add_get('/', handler.hello)
+    app.router.add_post('/batches', handler.batches_post)
 
-    app.router.add_post('/batches', handler.batches)
-
-    app.router.add_get('/state', handler.state_current)
-    app.router.add_get('/state/{merkle_root}', handler.state_list)
-    app.router.add_get('/state/{merkle_root}/{address}', handler.state_get)
+    app.router.add_get('/state', handler.state_list)
+    app.router.add_get('/state/{address}', handler.state_get)
 
     app.router.add_get('/blocks', handler.block_list)
     app.router.add_get('/blocks/{block_id}', handler.block_get)

--- a/sdk/examples/sawtooth_xo/xo_client.py
+++ b/sdk/examples/sawtooth_xo/xo_client.py
@@ -54,14 +54,13 @@ class XoClient:
         return self._send_xo_txn(name, "take", space)
 
     def list(self):
-        merkle_root = self._get_merkle_root()
         xo_prefix = self._get_prefix()
 
-        result = self._send_request("state/{}?prefix={}".format(
-            merkle_root, xo_prefix))
+        result = self._send_request("state?address={}".format(xo_prefix))
 
         try:
-            encoded_entries = yaml.load(result)["entries"]
+            encoded_entries = yaml.load(result)["data"]
+
             return [
                 base64.b64decode(entry["data"]) for entry in encoded_entries
             ]
@@ -70,23 +69,15 @@ class XoClient:
             return None
 
     def show(self, name):
-        merkle_root = self._get_merkle_root()
         address = self._get_address(name)
 
-        result = self._send_request("state/{}/{}".format(merkle_root, address))
+        result = self._send_request("state/{}".format(address))
 
         try:
-            return base64.b64decode(yaml.load(result)["value"])
+            return base64.b64decode(yaml.load(result)["data"])
 
         except urllib.error.HTTPError:
             return None
-
-    def _get_merkle_root(self):
-        result = self._send_request("state")
-        try:
-            return yaml.load(result)['merkleRoot']
-        except BaseException:
-            raise XoException("Could not retrieve merkle root.")
 
     def _get_prefix(self):
         return _sha512('xo'.encode('utf-8'))[0:6]

--- a/validator/sawtooth_validator/journal/block_store_adapter.py
+++ b/validator/sawtooth_validator/journal/block_store_adapter.py
@@ -72,6 +72,8 @@ class BlockStoreAdapter(MutableMapping):
         """
         Return the head block of the current chain.
         """
+        if "chain_head_id" not in self._block_store:
+            return None
         return self.__getitem__(self._block_store["chain_head_id"])
 
     @property


### PR DESCRIPTION
* Add `head` parameter to all endpoints
  - Specificies a block id, which will be treated as the chain head
  - Update response envelope to include `head` and `link`
* Update state routes to bring in line with spec
  - No more fetching or specifying merkle root
  - `head` can be used to specify a particular tree instead
  - Without `head`, routes default to most recent tree
* Update Rest Api error handling as needed to implement changes
* Refactor ClientHandlers to handle genesis changes, and make
    future refactors easier
* Update xo and inkey smoke tests to use new `/state`

Signed-off-by: Zac Delventhal <delventhalz@gmail.com>