### PR TITLE
Fix failing smoke tests

### DIFF
--- a/integration/sawtooth_integration/docker/intkey-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-smoke.yaml
@@ -23,8 +23,9 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: "bash -c \"\
-        ./bin/tp_config -v validator:40000 \""
+    depends_on:
+      - validator
+    entrypoint: ./bin/tp_config -vv validator:40000
     stop_signal: SIGKILL
 
   tp_intkey:
@@ -33,9 +34,9 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: "bash -c \"\
-        sleep 1 && \
-        ./bin/tp_intkey_python -v validator:40000\""
+    depends_on:
+      - validator
+    entrypoint: ./bin/tp_intkey_python -vv validator:40000
     stop_signal: SIGKILL
 
   validator:
@@ -44,13 +45,10 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    depends_on:
-      - tp_intkey
-      - tp_config
     # start the validator with an empty genesis batch
     entrypoint: "bash -c \"\
         ./bin/sawtooth-0.8 admin genesis && \
-        ./bin/validator -v\""
+        ./bin/validator -vv\""
     stop_signal: SIGKILL
 
   rest_api:
@@ -63,9 +61,7 @@ services:
     depends_on:
       - validator
     # Starting rest_api at the same time as tp_intkey breaks
-    entrypoint: "bash -c \"\
-      sleep 4 && \
-      ./bin/rest_api --stream-url validator:40000\""
+    entrypoint: ./bin/rest_api --stream-url validator:40000
     stop_signal: SIGKILL
 
   integration_test:
@@ -81,7 +77,7 @@ services:
       - rest_api
     # Wait for rest_api and genesis
     entrypoint: "bash -c \"\
-      sleep 8 && \
+      sleep 30 && \
       nose2-3 -v test_intkey_smoke.TestIntkeySmoke\""
     stop_signal: SIGKILL
     environment:

--- a/integration/sawtooth_integration/docker/xo-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-smoke.yaml
@@ -23,8 +23,9 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: "bash -c \"\
-        ./bin/tp_config -v validator:40000 \""
+    depends_on:
+      - validator
+    entrypoint: ./bin/tp_config -vv validator:40000
     stop_signal: SIGKILL
 
   tp_xo:
@@ -33,7 +34,9 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: ./bin/tp_xo_python validator:40000
+    depends_on:
+      - validator
+    entrypoint: ./bin/tp_xo_python -vv validator:40000
     stop_signal: SIGKILL
 
   validator:
@@ -44,7 +47,7 @@ services:
       - 40000
     entrypoint: "bash -c \"\
         ./bin/sawtooth-0.8 admin genesis && \
-        ./bin/validator -v\""
+        ./bin/validator -vv\""
     stop_signal: SIGKILL
 
   rest_api:
@@ -54,10 +57,9 @@ services:
     expose:
       - 40000
       - 8080
-    # Starting rest_api at the same time as tp_xo breaks
-    entrypoint: "bash -c \"\
-      sleep 1 && \
-      ./bin/rest_api --stream-url validator:40000\""
+    depends_on:
+     - validator
+    entrypoint: ./bin/rest_api --stream-url validator:40000
     stop_signal: SIGKILL
 
   integration_test:
@@ -74,7 +76,7 @@ services:
       - rest_api
     # Wait for rest_api
     entrypoint: "bash -c \"\
-      sleep 2 && \
+      sleep 30 && \
       nose2-3 -v test_xo_smoke.TestXoSmoke\""
     stop_signal: SIGKILL
     environment:

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -167,7 +167,7 @@ class RouteHandler(object):
         Sends a protobuf message to the validator
         Handles a possible timeout if validator is unresponsive
         """
-        timeout = 5
+        timeout = 300
         timeout_msg = 'Could not reach validator, validator timed out'
 
         if isinstance(content, BaseMessage):

--- a/sdk/python/sawtooth_sdk/client/stream.py
+++ b/sdk/python/sawtooth_sdk/client/stream.py
@@ -16,7 +16,6 @@
 import asyncio
 import hashlib
 import logging
-import os
 import random
 import string
 from threading import Thread
@@ -148,8 +147,7 @@ class _SendReceiveThread(Thread):
         asyncio.set_event_loop(self._event_loop)
         self._context = zmq.asyncio.Context()
         self._sock = self._context.socket(zmq.DEALER)
-        self._sock.identity = "{}-{}".format(self.__class__.__name__,
-                                             os.getpid()).encode('ascii')
+        self._sock.identity = _generate_id()[0:16].encode('ascii')
         self._sock.connect('tcp://' + self._url)
         self._send_queue = asyncio.Queue(loop=self._event_loop)
         self._recv_queue = asyncio.Queue(loop=self._event_loop)


### PR DESCRIPTION
The depends_on portion of the transaction processor service
definition is necessary because they reference a service
with a particular container that the docker dns gives
an address.

The sleeps on integration_test service is necessary until we have a way to get the rest_api status of if the validator is ready. ~~The other sleeps are necessary for unknown reasons that hopefully will be solved in my work this sprint, but if not we should figure out why they are necessary.~~ The socket id was not being set correctly in the python sdk. It was classname-pid which was not guaranteed to be unique in docker.

Signed-off-by: Boyd Johnson <boydx.johnson@intel.com>