### PR TITLE
Initial connectivity handling fixes

### DIFF
--- a/core/sawtooth/manage/daemon.py
+++ b/core/sawtooth/manage/daemon.py
@@ -35,14 +35,6 @@ class DaemonNodeController(NodeController):
         self._host_name = host_name
         self._verbose = verbose
         self._base_config = get_validator_configuration([], {})
-        # Additional configuration for the genesis validator
-        self._genesis_cfg = {
-            "InitialConnectivity": 0,
-        }
-        # Additional configuration for the non-genesis validators
-        self._non_genesis_cfg = {
-            "InitialConnectivity": 1,
-        }
 
         if state_dir is None:
             state_dir = \
@@ -77,13 +69,11 @@ class DaemonNodeController(NodeController):
         if not os.path.exists(config_dir):
             os.makedirs(config_dir)
         config_file = '{}_bootstrap.json'.format(node_name)
-        cfg = self._non_genesis_cfg
         if node_args.genesis:
-            cfg = self._genesis_cfg
+            cmd += ['--initial-connectivity', '0']
+        else:
+            cmd += ['--initial-connectivity', '1']
 
-        with open(os.path.join(config_dir, config_file), 'w') as f:
-            f.write(json.dumps(cfg, indent=4))
-        cmd += ['--config', config_file]
         return cmd
 
     def is_running(self, node_name):

--- a/core/sawtooth/manage/subproc.py
+++ b/core/sawtooth/manage/subproc.py
@@ -30,14 +30,6 @@ class SubprocessNodeController(NodeController):
         self._host_name = host_name
         self._verbose = verbose
         self._base_config = get_validator_configuration([], {})
-        # Additional configuration for the genesis validator
-        self._genesis_cfg = {
-            "InitialConnectivity": 0,
-        }
-        # Additional configuration for the non-genesis validators
-        self._non_genesis_cfg = {
-            "InitialConnectivity": 1,
-        }
         self._nodes = {}
 
     def _construct_start_command(self, node_args):
@@ -59,13 +51,10 @@ class SubprocessNodeController(NodeController):
             config_dir = os.path.join(node_args.currency_home, 'etc')
         if not os.path.exists(config_dir):
             os.makedirs(config_dir)
-        config_file = '{}_bootstrap.json'.format(node_name)
-        cfg = self._non_genesis_cfg
         if node_args.genesis:
-            cfg = self._genesis_cfg
-        with open(os.path.join(config_dir, config_file), 'w') as f:
-            f.write(json.dumps(cfg, indent=4))
-        cmd += ['--config', config_file]
+            cmd += ['--initial-connectivity', '0']
+        else:
+            cmd += ['--initial-connectivity', '1']
         return cmd
 
     def is_running(self, node_name):

--- a/validator/txnserver/validator_cli.py
+++ b/validator/txnserver/validator_cli.py
@@ -239,6 +239,9 @@ def parse_command_line(args):
                         help='Specify transaction families to load. Multiple'
                              ' -F options can be specified.',
                         action='append')
+    parser.add_argument('--initial-connectivity',
+                        help='minimum number of peers',
+                        type=int)
 
     result = parser.parse_args(args)
 
@@ -300,7 +303,8 @@ def get_configuration(args, os_name=os.name, config_files_required=None):
             ('daemon', 'Daemonize'),
             ('check_elevated', 'CheckElevated'),
             ('listen', 'Listen'),
-            ('family', 'TransactionFamilies')
+            ('family', 'TransactionFamilies'),
+            ('initial_connectivity', 'InitialConnectivity')
         ], options)
 
     return get_validator_configuration(options.config, options_config, os_name,


### PR DESCRIPTION
Prior to these changes, it was not possible to use a the default config file with the cluster command since it specified a config argument pointing at a config it wrote to disk.  Tested with sawtooth cluster and launcher.