### PR TITLE
Add State Views and Config View specialization

### DIFF
--- a/bin/protogen
+++ b/bin/protogen
@@ -60,16 +60,17 @@ validator_pkg=sawtooth_validator/protobuf
 rest_api_dir=$top_dir/rest_api
 rest_api_pkg=sawtooth_rest_api/protobuf
 
+config_dir=$top_dir/core_transactions/config
+config_pkg=sawtooth_config/protobuf
+
 run_protoc $sdk_dir $sdk_pkg
 run_protoc $cli_dir $cli_pkg
 run_protoc $validator_dir $validator_pkg
 run_protoc $rest_api_dir $rest_api_pkg
+run_protoc $config_dir $config_pkg
 
 # Config txn family protos, included in the cli, as well
-config_dir=$top_dir/core_transactions/config
 protos_dir=$config_dir/protos
-
-config_pkg=sawtooth_config/protobuf
 run_protoc $config_dir $config_pkg
 
 config_pkg=sawtooth_cli/config_protobuf

--- a/core_transactions/config/protos/config.proto
+++ b/core_transactions/config/protos/config.proto
@@ -69,18 +69,6 @@ message ConfigVote {
     Vote vote = 2;
 }
 
-// Setting Container for the resulting state
-message Setting {
-    // Contains a setting entry (or entries, in the case of collisions).
-    message Entry {
-        string key = 1;
-        string value = 2;
-    }
-
-    // List of setting entries - more than one implies a state key collision
-    repeated Entry entries = 1;
-}
-
 // Contains the vote counts for a given proposal.
 message ConfigCandidate {
     // An individual vote record

--- a/core_transactions/config/sawtooth_config/processor/handler.py
+++ b/core_transactions/config/sawtooth_config/processor/handler.py
@@ -28,7 +28,7 @@ from sawtooth_config.protobuf.config_pb2 import ConfigProposal
 from sawtooth_config.protobuf.config_pb2 import ConfigVote
 from sawtooth_config.protobuf.config_pb2 import ConfigCandidate
 from sawtooth_config.protobuf.config_pb2 import ConfigCandidates
-from sawtooth_config.protobuf.config_pb2 import Setting
+from sawtooth_config.protobuf.setting_pb2 import Setting
 
 LOGGER = logging.getLogger(__name__)
 

--- a/core_transactions/config/tests/sawtooth_config_test/config_message_factory.py
+++ b/core_transactions/config/tests/sawtooth_config_test/config_message_factory.py
@@ -17,7 +17,7 @@ from sawtooth_processor_test.message_factory import MessageFactory
 from sawtooth_config.protobuf.config_pb2 import ConfigPayload
 from sawtooth_config.protobuf.config_pb2 import ConfigProposal
 from sawtooth_config.protobuf.config_pb2 import ConfigVote
-from sawtooth_config.protobuf.config_pb2 import Setting
+from sawtooth_config.protobuf.setting_pb2 import Setting
 
 
 class ConfigMessageFactory(object):

--- a/docs/source/transaction_family_specifications/config_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/config_transaction_family.rst
@@ -84,7 +84,7 @@ Definition of Setting Entries
 The following protocol buffers definition defines setting entries:
 
 .. code-block:: protobuf
-	:caption: File: sawtooth-core/core_transactions/config/protos/config.proto
+	:caption: File: sawtooth-core/protos/setting.proto
 
 	// Setting Container for the resulting state
 	message Setting {
@@ -106,6 +106,7 @@ following protocol buffers definition. The value returned by this  setting is
 a base64 encoded *ConfigCandidates* message:
 
 .. code-block:: protobuf
+	:caption: File: sawtooth-core/core_transactions/config/protos/config.proto
 
 	// Contains the vote counts for a given proposal.
 	message ConfigCandidate {

--- a/protos/setting.proto
+++ b/protos/setting.proto
@@ -1,0 +1,31 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+
+
+// Setting Container for on-chain configuration key/value pairs
+message Setting {
+    // Contains a setting entry (or entries, in the case of collisions).
+    message Entry {
+        string key = 1;
+        string value = 2;
+    }
+
+    // List of setting entries - more than one implies a state key collision
+    repeated Entry entries = 1;
+}

--- a/validator/sawtooth_validator/state/config_view.py
+++ b/validator/sawtooth_validator/state/config_view.py
@@ -1,0 +1,115 @@
+# copyright 2017 intel corporation
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+# ------------------------------------------------------------------------------
+
+import hashlib
+
+from sawtooth_validator.protobuf.setting_pb2 import Setting
+
+
+class ConfigView(object):
+    """
+    A ConfigView is a snapshot view of on-chain configuration settings.
+    """
+
+    def __init__(self, state_view):
+        """Creates a ConfigView, given a StateView as its snapshot.
+
+        Args:
+            state_view (:obj:`StateView`): a state view
+        """
+        self._state_view = state_view
+
+    def get_setting(self, key, default_value=None, value_type=str):
+        """Get the setting stored at the given key.
+
+        Args:
+            key (str): the setting key
+            default_value (str, optional): The default value, if none is
+                found. Defaults to None.
+            type (function, optional): The type of a setting value.
+                Defaults to `str`.
+
+        Returns:
+            str: The value of the setting if found, default_value
+            otherwise.
+        """
+        try:
+            state_entry = self._state_view.get(
+                ConfigView._setting_address(key))
+        except KeyError:
+            return default_value
+
+        if state_entry is not None:
+            setting = Setting()
+            setting.ParseFromString(state_entry.data)
+            for setting_entry in setting.entries:
+                if setting_entry.key == key:
+                    return value_type(setting_entry.value)
+
+        return default_value
+
+    def get_setting_list(self,
+                         key,
+                         default_value=None,
+                         delimiter=',',
+                         value_type=str):
+        """Get the setting stored at the given key and split it to a list.
+
+        Args:
+            key (str): the setting key
+            default_value (list, optional): The default value, if none is
+                found. Defaults to None.
+            delimiter (list of str, optional): The delimiter to break on.
+                Defaults to ','.
+            type (function, optional): The type of a setting value in the list.
+                Defaults to `str`.
+
+        Returns:
+            list of str: The values of the setting if found, default_value
+            otherwise.
+
+            If a value is found, it is split using the given delimiter.
+        """
+        value = self.get_setting(key)
+        if value is not None:
+            return [value_type(v) for v in value.split(delimiter)]
+        else:
+            return default_value
+
+    @staticmethod
+    def _setting_address(key):
+        return '000000' + hashlib.sha256(key.encode()).hexdigest()
+
+
+class ConfigViewFactory(object):
+    """Creates ConfigView instances.
+    """
+
+    def __init__(self, state_view_factory):
+        """Creates this view factory with a given state view factory.
+
+        Args:
+            state_view_factory (:obj:`StateViewFactory`): the state view
+                factory
+        """
+        self._state_view_factory = state_view_factory
+
+    def create_config_view(self, state_root_hash):
+        """
+        Returns:
+            ConfigView: the configuration view at the given state root.
+        """
+        return ConfigView(
+            self._state_view_factory.create_view(state_root_hash))

--- a/validator/sawtooth_validator/state/state_view.py
+++ b/validator/sawtooth_validator/state/state_view.py
@@ -1,0 +1,93 @@
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.protobuf.state_context_pb2 import Entry
+
+
+class StateViewFactory(object):
+    """The StateViewFactory produces StateViews for a particular merkle root.
+
+    This factory produces read-only views of a merkle tree. For a given
+    database, these views are considered immutable.
+    """
+
+    def __init__(self, database):
+        """Initilizes the factory with a given database.
+
+        Args:
+            database (:obj:`Database`): the database containing the merkle
+                tree.
+        """
+        self._database = database
+
+    def create_view(self, state_root_hash):
+        """Creates a StateView for the given state root hash.
+
+        Returns:
+            StateView: state view locked to the given root hash.
+        """
+        return StateView(MerkleDatabase(self._database, state_root_hash))
+
+
+class StateView(object):
+    """The StateView is a snapshot of state stored in a merkle tree.
+
+    The StateView is a read-only view of a merkle tree that stores state
+    entries.  It is locked to a specific merkle root.
+    """
+
+    def __init__(self, tree):
+        """Creates a StateView with a given merkle tree.
+
+        Args:
+            tree (:obj:`MerkleDatabase`): the merkle tree for this view
+        """
+        self._tree = tree
+
+    def get(self, address):
+        """
+        Returns:
+            :obj:`Entry`: the state entry at the given address
+        """
+        return StateView._entry(self._tree.get(address))
+
+    def addresses(self):
+        """
+        Returns:
+            list of str: the list of addresses available in this view
+        """
+        return self._tree.addresses()
+
+    def leaves(self, prefix):
+        """
+        Args:
+            prefix (str): an address prefix under which to look for leaves
+
+        Returns:
+            list of `Entry`: the state entries at the leaves
+        """
+        return {addr: StateView._entry(leaf)
+                for addr, leaf in self._tree.leaves(prefix).items()}
+
+    @staticmethod
+    def _entry(data):
+        if data is not None:
+            entry = Entry()
+            entry.ParseFromString(data)
+            return entry
+        else:
+            return None

--- a/validator/tests/unit3/test_config_view/__init__.py
+++ b/validator/tests/unit3/test_config_view/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = []

--- a/validator/tests/unit3/test_config_view/tests.py
+++ b/validator/tests/unit3/test_config_view/tests.py
@@ -1,0 +1,124 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import hashlib
+import unittest
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.protobuf.setting_pb2 import Setting
+from sawtooth_validator.protobuf.state_context_pb2 import Entry
+
+from sawtooth_validator.state.config_view import ConfigViewFactory
+from sawtooth_validator.state.state_view import StateViewFactory
+
+from sawtooth_validator.state.merkle import MerkleDatabase
+
+
+class TestConfigView(unittest.TestCase):
+    def __init__(self, test_name):
+        super().__init__(test_name)
+        self._config_view_factory = None
+        self._current_root_hash = None
+
+    def setUp(self):
+        database = DictDatabase()
+        state_view_factory = StateViewFactory(database)
+        self._config_view_factory = ConfigViewFactory(state_view_factory)
+
+        merkle_db = MerkleDatabase(database)
+        self._current_root_hash = merkle_db.update({
+            TestConfigView._address('my.setting'):
+                TestConfigView._setting_entry('my.setting', '10'),
+            TestConfigView._address('my.setting.list'):
+                TestConfigView._setting_entry('my.setting.list', '10,11,12'),
+            TestConfigView._address('my.other.list'):
+                TestConfigView._setting_entry('my.other.list', '13;14;15')
+        }, virtual=False)
+
+    def test_get_setting(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+
+        self.assertEqual('10', config_view.get_setting('my.setting'))
+
+    def test_get_setting_with_type_coercion(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+        self.assertEqual(10, config_view.get_setting('my.setting',
+                                                     value_type=int))
+
+    def test_get_setting_not_found(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+
+        self.assertIsNone(config_view.get_setting('non-existant.setting'))
+
+    def test_get_setting_not_found_with_default(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+
+        self.assertEqual('default',
+                         config_view.get_setting('non-existant.setting',
+                                                 default_value='default'))
+
+    def test_get_setting_list(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+
+        # Verify we can still get the "raw" setting
+        self.assertEqual('10,11,12',
+                         config_view.get_setting('my.setting.list'))
+        # And now the split setting
+        self.assertEqual(
+            ['10', '11', '12'],
+            config_view.get_setting_list('my.setting.list'))
+
+    def test_get_setting_list_not_found(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+        self.assertIsNone(
+            config_view.get_setting_list('non-existant.setting.list'))
+
+    def test_get_setting_list_not_found_with_default(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+        self.assertEqual(
+            [],
+            config_view.get_setting_list('non-existant.list',
+                                         default_value=[]))
+
+    def test_get_setting_list_alternate_delimiter(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+        self.assertEqual(
+            ['13', '14', '15'],
+            config_view.get_setting_list('my.other.list', delimiter=';'))
+
+    def test_get_setting_list_with_type_coercion(self):
+        config_view = self._config_view_factory.create_config_view(
+            self._current_root_hash)
+        self.assertEqual(
+            [10, 11, 12],
+            config_view.get_setting_list('my.setting.list', value_type=int))
+
+    @staticmethod
+    def _address(key):
+        return '000000' + hashlib.sha256(key.encode()).hexdigest()
+
+    @staticmethod
+    def _setting_entry(key, value):
+        setting = Setting(entries=[Setting.Entry(key=key, value=value)])
+        return Entry(address=TestConfigView._address(key),
+                     data=setting.SerializeToString()).SerializeToString()

--- a/validator/tests/unit3/test_state_view/__init__.py
+++ b/validator/tests/unit3/test_state_view/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = []

--- a/validator/tests/unit3/test_state_view/tests.py
+++ b/validator/tests/unit3/test_state_view/tests.py
@@ -1,0 +1,56 @@
+# copyright 2017 intel corporation
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.protobuf.state_context_pb2 import Entry
+from sawtooth_validator.state.merkle import MerkleDatabase
+
+from sawtooth_validator.state.state_view import StateViewFactory
+
+
+class StateViewTest(unittest.TestCase):
+    def setUp(self):
+        self._database = DictDatabase()
+
+    def test_state_view(self):
+        merkle_db = MerkleDatabase(self._database)
+
+        state_view_factory = StateViewFactory(self._database)
+
+        initial_state_view = state_view_factory.create_view(
+            merkle_db.get_merkle_root())
+
+        # test that the intial state view returns empty values
+        self.assertEqual([], initial_state_view.addresses())
+        self.assertEqual({}, initial_state_view.leaves(''))
+        with self.assertRaises(KeyError):
+            initial_state_view.get('abcd')
+
+        add_entry = Entry(address='abcd', data='hello'.encode())
+        next_root = merkle_db.update({'abcd': add_entry.SerializeToString()},
+                                     virtual=False)
+
+        next_state_view = state_view_factory.create_view(next_root)
+
+        # Prove that the initial state view is not effected by the change
+        self.assertEqual([], initial_state_view.addresses())
+        self.assertEqual(['abcd'], next_state_view.addresses())
+
+        # Test the entry is transf formed
+        expected_entry = Entry(address='abcd', data='hello'.encode())
+        self.assertEqual(expected_entry, next_state_view.get('abcd'))
+        self.assertEqual({'abcd': expected_entry}, next_state_view.leaves(''))


### PR DESCRIPTION
**Add StateView and its Factory**

StateViewFactory provides read-only views into state stored in a merkle tree database. These views can provide a window into the state which can be used throughout a block of processing without concern of the state being changed underneath the process.

**Add ConfigView and its Factory**

ConfigView is a specialized StateView which translates keys into state addresses and transforms state entries into their respective values.  This can be used by validator components to read on-chain settings at viewed from the lens of a specific point in the chain.