### PR TITLE
Add discard builds property to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,11 @@
 // limitations under the License.
 // ------------------------------------------------------------------------------
 
+// Discard old builds after 31 days
+properties([[$class: 'BuildDiscarderProperty', strategy:
+        [$class: 'LogRotator', artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '', daysToKeepStr: '31', numToKeepStr: '']]]);
+
 node ('master') {
     // Create a unique workspace so Jenkins doesn't reuse an existing one
     ws("workspace/${env.BUILD_TAG}_0-8") {


### PR DESCRIPTION
This will discard builds older than 31 days from Jenkins.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>