### PR TITLE
Implement CurveZMQ security for the network

### DIFF
--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -14,6 +14,14 @@
 # ------------------------------------------------------------------------------
 
 
+class LocalConfigurationError(Exception):
+    """
+    General error thrown when a local configuration issue should prevent
+    the validator from starting.
+    """
+    pass
+
+
 class GenesisError(Exception):
     """
     General Error thrown when an error occurs as a result of an incomplete

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -19,6 +19,7 @@ import argparse
 from sawtooth_validator.server.core import Validator
 from sawtooth_validator.server.log import init_console_logging
 from sawtooth_validator.exceptions import GenesisError
+from sawtooth_validator.exceptions import LocalConfigurationError
 
 
 def parse_args(args):
@@ -59,6 +60,8 @@ def main(args=sys.argv[1:]):
         validator.start()
     except KeyboardInterrupt:
         print("Interrupted!", file=sys.stderr)
+    except LocalConfigurationError as local_config_err:
+        print(local_config_err, file=sys.stderr)
     except GenesisError as genesis_err:
         print(genesis_err, file=sys.stderr)
     finally:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -96,7 +96,9 @@ class Validator(object):
             client_handlers.StateListRequestHandler(lmdb),
             thread_pool)
 
-        self._service = Interconnect(component_endpoint, self._dispatcher)
+        self._service = Interconnect(component_endpoint,
+                                     self._dispatcher,
+                                     secured=False)
         executor = TransactionExecutor(self._service, context_manager)
 
         self._dispatcher.add_handler(
@@ -111,11 +113,22 @@ class Validator(object):
 
         self._network_dispatcher = Dispatcher()
 
+        # Server public and private keys are hardcoded here due to
+        # the decision to avoid having separate identities for each
+        # validator's server socket. This is appropriate for a public
+        # network. For a permissioned network with requirements for
+        # server endpoint authentication at the network level, this can
+        # be augmented with a local lookup service for side-band provided
+        # endpoint, public_key pairs and a local configuration option
+        # for 'server' side private keys.
         self._network = Interconnect(
             network_endpoint,
             dispatcher=self._network_dispatcher,
             identity=identity,
-            peer_connections=peer_list)
+            peer_connections=peer_list,
+            secured=True,
+            server_public_key=b'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)',
+            server_private_key=b'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*')
 
         self._gossip = Gossip(self._network)
 


### PR DESCRIPTION
This implements an authentication handshake and transport encryption using ZMQ's CurveZMQ support (ec based on edwards). The support is implemented in the shared Interconnect object, but is only enabled for the network (validator to validator) instance. In the future, we can also enable this for the intercomponent instance, but that will require changes to 'clients'.