### PR TITLE
Change Data Dir from USER_HOME

### DIFF
--- a/cli/sawtooth_cli/admin.py
+++ b/cli/sawtooth_cli/admin.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+import os
+import sys
+
 from sawtooth_cli.exceptions import CliException
 
 from sawtooth_cli.admin_command.genesis import add_genesis_parser
@@ -19,8 +22,19 @@ from sawtooth_cli.admin_command.genesis import do_genesis
 
 
 def do_admin(args):
+    if 'SAWTOOTH_HOME' in os.environ:
+        data_dir = os.path.join(os.environ['SAWTOOTH_HOME'], 'data')
+    else:
+        data_dir = '/var/lib/sawtooth'
+
+    try:
+        os.makedirs(data_dir, exist_ok=True)
+    except OSError as e:
+        print('Unable to create {}: {}'.format(data_dir, e), file=sys.stderr)
+        return
+
     if args.admin_cmd == 'genesis':
-        do_genesis(args)
+        do_genesis(args, data_dir)
     else:
         raise CliException("invalid command: {}".format(args.command))
 

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -38,7 +38,7 @@ def add_genesis_parser(subparsers, parent_parser):
         help='input files of batches to add to the resulting GenesisData')
 
 
-def do_genesis(args):
+def do_genesis(args, data_dir):
     """Given the command args, take an series of input files containing
     GenesisData, combine all the batches into one GenesisData, and output the
     result into a new file.
@@ -59,7 +59,6 @@ def do_genesis(args):
     if args.output:
         genesis_file = args.output
     else:
-        data_dir = os.path.expanduser('~')
         genesis_file = os.path.join(data_dir, 'genesis.batch')
 
     print('Generating {}'.format(genesis_file))

--- a/tools/guest-files/local-env.sh
+++ b/tools/guest-files/local-env.sh
@@ -13,3 +13,5 @@ export PYTHONPATH
 
 PATH=$PATH:/project/sawtooth-core/bin
 export PATH
+
+export SAWTOOTH_HOME=/home/ubuntu/sawtooth

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -15,6 +15,7 @@
 
 import sys
 import argparse
+import os
 
 from sawtooth_validator.server.core import Validator
 from sawtooth_validator.server.log import init_console_logging
@@ -52,9 +53,21 @@ def main(args=sys.argv[1:]):
 
     init_console_logging(verbose_level=verbose_level)
 
+    if 'SAWTOOTH_HOME' in os.environ:
+        data_dir = os.path.join(os.environ['SAWTOOTH_HOME'], 'data')
+    else:
+        data_dir = '/var/lib/sawtooth'
+
+    try:
+        os.makedirs(data_dir, exist_ok=True)
+    except OSError as e:
+        print('Unable to create {}: {}'.format(data_dir, e), file=sys.stderr)
+        return
+
     validator = Validator(opts.network_endpoint,
                           opts.component_endpoint,
-                          opts.peers)
+                          opts.peers,
+                          data_dir)
 
     try:
         validator.start()

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -50,8 +50,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Validator(object):
-    def __init__(self, network_endpoint, component_endpoint, peer_list):
-        data_dir = os.path.expanduser('~')
+    def __init__(self, network_endpoint, component_endpoint, peer_list,
+                 data_dir):
+        """Constructs a validator instance.
+
+        Args:
+            network_endpoint (str): the network endpoint
+            component_endpoint (str): the component endpoint
+            peer_list (list of str): a list of peer addresses
+            data_dir (str): path to the data directory
+        """
         db_filename = os.path.join(data_dir,
                                    'merkle-{}.lmdb'.format(
                                        network_endpoint[-2:]))


### PR DESCRIPTION
The data directory changes from `<USER_HOME>` to either `<SAWTOOTH_HOME>/data`, if the `SAWTOOTH_HOME` environment variable is set, or `/var/lib/sawtooth` as the default.

This is made available to `admin genesis` and available for use in all future admin commands.

Additionally:
- `Validator` takes `data_dir` as an argument, and it provided the above by the cli
- Updates unit tests and adds a test for defaulting to the data dir