### PR TITLE
Sequence independent validator-transaction processor shutdown, restart

### DIFF
--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -18,7 +18,8 @@ option java_multiple_files = true;
 option java_package = "sawtooth.sdk.protobuf";
 
 
-// The registration request from the transaction processor to the validator/executor
+// The registration request from the transaction processor to the
+// validator/executor
 message TpRegisterRequest {
 
     // A settled upon name for the capabilities of the transaction processor.
@@ -40,8 +41,27 @@ message TpRegisterRequest {
     repeated string namespaces = 4;
 }
 
-// A response sent from the validator to the transaction processor acknowledging the registration
+// A response sent from the validator to the transaction processor
+// acknowledging the registration
 message TpRegisterResponse {
+    enum Status {
+        OK = 0;
+        ERROR = 1;
+    }
+
+    Status status = 1;
+}
+
+// The unregistration request from the transaction processor to the
+// validator/executor. The correct handlers are determined from the
+// zeromq identity of the tp, on the validator side.
+message TpUnregisterRequest {
+
+}
+
+// A response sent from the validator to the transaction processor
+// acknowledging the unregistration
+message TpUnregisterResponse {
     enum Status {
         OK = 0;
         ERROR = 1;

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -31,61 +31,70 @@ message Message {
         DEFAULT = 0;
         // Registration request from the transaction processor to the validator
         TP_REGISTER_REQUEST = 1;
-        // Registration response from the validator to the transaction processor
+        // Registration response from the validator to the
+        // transaction processor
         TP_REGISTER_RESPONSE = 2;
-        // Process Request from the validator/executor to the transaction processor
-        TP_PROCESS_REQUEST = 3;
+        // Tell the validator that the transaction processor
+        // won't take any more transactions
+        TP_UNREGISTER_REQUEST = 3;
+        // Response from the validator to the tp that it won't
+        // send any more transactions
+        TP_UNREGISTER_RESPONSE = 4;
+        // Process Request from the validator/executor to the
+        // transaction processor
+        TP_PROCESS_REQUEST = 5;
         // Process response from the transaction processor to the validator/executor
-        TP_PROCESS_RESPONSE = 4;
+        TP_PROCESS_RESPONSE = 6;
         // State get request from the transaction processor to validator/context_manager
-        TP_STATE_GET_REQUEST = 5;
+        TP_STATE_GET_REQUEST = 7;
         // State get response from the validator/context_manager to the transaction processor
-        TP_STATE_GET_RESPONSE = 6;
+        TP_STATE_GET_RESPONSE = 8;
         // State set request from the transaction processor to the validator/context_manager
-        TP_STATE_SET_REQUEST = 7;
+        TP_STATE_SET_REQUEST = 9;
         // State set response from the validator/context_manager to the transaction processor
-        TP_STATE_SET_RESPONSE = 8;
+        TP_STATE_SET_RESPONSE = 10;
         // State delete request from the transaction processor to the validator/context_manager
-        TP_STATE_DEL_REQUEST = 9;
+        TP_STATE_DEL_REQUEST = 11;
         // State delete response from the validator/context_manager to the transaction processor
-        TP_STATE_DEL_RESPONSE = 10;
+        TP_STATE_DEL_RESPONSE = 12;
         // Submission of a batchlist from the web api or another client to the validator
-        CLIENT_BATCH_SUBMIT_REQUEST = 11;
+        CLIENT_BATCH_SUBMIT_REQUEST = 100;
         // Response from the validator to the web api/client that the submission was accepted
-        CLIENT_BATCH_SUBMIT_RESPONSE = 12;
+        CLIENT_BATCH_SUBMIT_RESPONSE = 101;
         // A request to list blocks from the web api/client to the validator
-        CLIENT_BLOCK_LIST_REQUEST = 13;
-        CLIENT_BLOCK_LIST_RESPONSE = 14;
-        CLIENT_BLOCK_GET_REQUEST = 15;
-        CLIENT_BLOCK_GET_RESPONSE = 16;
-        CLIENT_BATCH_LIST_REQUEST = 17;
-        CLIENT_BATCH_LIST_RESPONSE = 18;
-        CLIENT_BATCH_GET_REQUEST = 19;
-        CLIENT_BATCH_GET_RESPONSE = 20;
-        CLIENT_TRANSACTION_LIST_REQUEST = 21;
-        CLIENT_TRANSACTION_LIST_RESPONSE = 22;
-        CLIENT_TRANSACTION_GET_RESPONSE = 23;
+        CLIENT_BLOCK_LIST_REQUEST = 102;
+        CLIENT_BLOCK_LIST_RESPONSE = 103;
+        CLIENT_BLOCK_GET_REQUEST = 104;
+        CLIENT_BLOCK_GET_RESPONSE = 105;
+        CLIENT_BATCH_LIST_REQUEST = 106;
+        CLIENT_BATCH_LIST_RESPONSE = 107;
+        CLIENT_BATCH_GET_REQUEST = 108;
+        CLIENT_BATCH_GET_RESPONSE = 109;
+        CLIENT_TRANSACTION_LIST_REQUEST = 110;
+        CLIENT_TRANSACTION_LIST_RESPONSE = 111;
+        CLIENT_TRANSACTION_GET_REQUEST = 112;
+        CLIENT_TRANSACTION_GET_RESPONSE = 113;
         // Client state request of the current state hash to be retrieved from the journal
-        CLIENT_STATE_CURRENT_REQUEST = 24;
+        CLIENT_STATE_CURRENT_REQUEST = 114;
         // Response with the current state hash
-        CLIENT_STATE_CURRENT_RESPONSE = 25;
+        CLIENT_STATE_CURRENT_RESPONSE = 115;
         // A request of all the addresses under a particular prefix, for a state hash.
-        CLIENT_STATE_LIST_REQUEST = 26;
+        CLIENT_STATE_LIST_REQUEST = 116;
         // The response of the addresses
-        CLIENT_STATE_LIST_RESPONSE = 27;
+        CLIENT_STATE_LIST_RESPONSE = 117;
         // Get the address:data entry at a particular address
-        CLIENT_STATE_GET_REQUEST = 28;
+        CLIENT_STATE_GET_REQUEST = 118;
         // The response with the entry
-        CLIENT_STATE_GET_RESPONSE = 29;
+        CLIENT_STATE_GET_RESPONSE = 119;
         // Further messages from the stats client through the web api
 
 
         // Temp message types until a discusion can be had about gossip msg
-        GOSSIP_MESSAGE = 30;
-        GOSSIP_REGISTER = 31;
-        GOSSIP_UNREGISTER = 32;
-        GOSSIP_ACK = 33;
-        GOSSIP_PING = 34;
+        GOSSIP_MESSAGE = 200;
+        GOSSIP_REGISTER = 201;
+        GOSSIP_UNREGISTER = 202;
+        GOSSIP_ACK = 203;
+        GOSSIP_PING = 204;
 
     }
     // The type of message, used to determine how to 'route' the message

--- a/sdk/python/sawtooth_processor_test/message_types.py
+++ b/sdk/python/sawtooth_processor_test/message_types.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2016, 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterRequest
+from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterResponse
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessRequest
 
@@ -23,8 +24,10 @@ from sawtooth_sdk.protobuf.state_context_pb2 import TpStateSetResponse
 from sawtooth_sdk.protobuf.state_context_pb2 import TpStateSetRequest
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
+
 _TYPE_TO_PROTO = {
     Message.TP_REGISTER_REQUEST: TpRegisterRequest,
+    Message.TP_REGISTER_RESPONSE: TpRegisterResponse,
     Message.TP_PROCESS_RESPONSE: TpProcessResponse,
     Message.TP_PROCESS_REQUEST: TpProcessRequest,
 

--- a/sdk/python/sawtooth_processor_test/tester.py
+++ b/sdk/python/sawtooth_processor_test/tester.py
@@ -20,6 +20,7 @@ import zmq
 import zmq.asyncio
 
 from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterRequest
+from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterResponse
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
 from sawtooth_processor_test.message_types import to_protobuf_class
@@ -123,7 +124,9 @@ class TransactionProcessorTester(object):
                 request.family, request.version,
                 request.encoding, request.namespaces
             ))
-
+            response = TpRegisterResponse(
+                status=TpRegisterResponse.OK)
+            self.send(response, message.correlation_id)
             return True
 
     def send(self, message_content, correlation_id=None):

--- a/sdk/python/sawtooth_sdk/client/exceptions.py
+++ b/sdk/python/sawtooth_sdk/client/exceptions.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+# ValidatorConnectionError is used internal to the sdk, and
+# any other use can cause undesirable or unexpected behavior.
+class ValidatorConnectionError(Exception):
+    def __init__(self):
+        super().__init__("the connection to the validator was lost")

--- a/sdk/python/sawtooth_sdk/client/future.py
+++ b/sdk/python/sawtooth_sdk/client/future.py
@@ -16,11 +16,29 @@
 from threading import Condition
 from threading import RLock
 
+from sawtooth_sdk.client.exceptions import ValidatorConnectionError
+
 
 class FutureResult(object):
     def __init__(self, message_type, content):
         self.message_type = message_type
         self.content = content
+
+
+class FutureError(object):
+    """Used when resolving a future, to
+    set the FutureResult to an error result.
+    Specifically this raises ValidatorConnectionError
+    when accessing attributes, but can be made more general.
+    """
+
+    @property
+    def content(self):
+        raise ValidatorConnectionError()
+
+    @property
+    def message_type(self):
+        raise ValidatorConnectionError()
 
 
 class Future(object):
@@ -80,3 +98,7 @@ class FutureCollection(object):
                 raise FutureCollectionKeyError(
                     "no such correlation id: {}".format(correlation_id))
             del self._futures[correlation_id]
+
+    def future_values(self):
+        with self._lock:
+            return self._futures.values()

--- a/sdk/python/sawtooth_sdk/client/stream.py
+++ b/sdk/python/sawtooth_sdk/client/stream.py
@@ -18,6 +18,7 @@ import hashlib
 import logging
 import random
 import string
+from threading import Event
 from threading import Thread
 from threading import Condition
 
@@ -26,13 +27,20 @@ import zmq.asyncio
 
 import sawtooth_sdk.protobuf.validator_pb2 as validator_pb2
 
+from sawtooth_sdk.client.exceptions import ValidatorConnectionError
 from sawtooth_sdk.client.future import Future
 from sawtooth_sdk.client.future import FutureCollection
 from sawtooth_sdk.client.future import FutureCollectionKeyError
 from sawtooth_sdk.client.future import FutureResult
-
+from sawtooth_sdk.client.future import FutureError
 
 LOGGER = logging.getLogger(__file__)
+
+# Used to send a message to core.TransactionProcessor to reregister with
+# the validator and wait for TP_PROCESS_REQUEST. All other items on the
+# queue will be validator_pb2.Message objects, so -1 will be an exceptional
+# event.
+RECONNECT_EVENT = -1
 
 
 def _generate_id():
@@ -46,17 +54,27 @@ class _SendReceiveThread(Thread):
     Internal thread to Stream class that runs the asyncio event loop.
     """
 
-    def __init__(self, url, futures):
+    def __init__(self, url, futures, ready_event):
+        """constructor for background thread
+
+        :param url (str): the address to connect to the validator on
+        :param futures (FutureCollection): The Futures associated with
+                messages sent through Stream.send
+        :param ready_event (threading.Event): used to notify waiting/asking
+               classes that the background thread of Stream is ready after
+               a disconnect event.
+        """
         super(_SendReceiveThread, self).__init__()
         self._futures = futures
         self._url = url
 
         self._event_loop = None
         self._sock = None
+        self._monitor_sock = None
         self._recv_queue = None
         self._send_queue = None
         self._context = None
-
+        self._ready_event = ready_event
         self._condition = Condition()
 
     @asyncio.coroutine
@@ -65,9 +83,9 @@ class _SendReceiveThread(Thread):
         internal coroutine that receives messages and puts
         them on the recv_queue
         """
-        with self._condition:
-            self._condition.wait_for(lambda: self._sock is not None)
         while True:
+            if not self._ready_event.is_set():
+                break
             msg_bytes = yield from self._sock.recv()
             message = validator_pb2.Message()
             message.ParseFromString(msg_bytes)
@@ -79,6 +97,8 @@ class _SendReceiveThread(Thread):
                 self._futures.remove(message.correlation_id)
             except FutureCollectionKeyError:
                 # if we are getting an initial message, not a response
+                if not self._ready_event.is_set():
+                    break
                 self._recv_queue.put_nowait(message)
 
     @asyncio.coroutine
@@ -86,27 +106,24 @@ class _SendReceiveThread(Thread):
         """
         internal coroutine that sends messages from the send_queue
         """
-        with self._condition:
-            self._condition.wait_for(lambda: self._send_queue is not None
-                                     and self._sock is not None)
         while True:
+            if not self._ready_event.is_set():
+                break
             msg = yield from self._send_queue.get()
             yield from self._sock.send_multipart([msg.SerializeToString()])
 
     @asyncio.coroutine
     def _put_message(self, message):
         """
-        puts a message on the send_queue. Not to be accessed directly.
+        Puts a message on the send_queue. Not to be accessed directly.
         :param message: protobuf generated validator_pb2.Message
         """
-        with self._condition:
-            self._condition.wait_for(lambda: self._send_queue is not None)
         self._send_queue.put_nowait(message)
 
     @asyncio.coroutine
     def _get_message(self):
         """
-        get a message from the recv_queue. Not to be accessed directly.
+        Gets a message from the recv_queue. Not to be accessed directly.
         """
         with self._condition:
             self._condition.wait_for(lambda: self._recv_queue is not None)
@@ -114,59 +131,124 @@ class _SendReceiveThread(Thread):
 
         return msg
 
+    @asyncio.coroutine
+    def _monitor_disconnects(self):
+        """Monitors the client socket for disconnects
+        """
+        yield from self._monitor_sock.recv()
+        LOGGER.debug("monitor socket received disconnect event")
+        self._ready_event.clear()
+        for future in self._futures.future_values():
+            future.set_result(FutureError())
+        for task in asyncio.Task.all_tasks(self._event_loop):
+            task.cancel()
+        self._send_queue = None
+        self._recv_queue = None
+        self._sock.close()
+        self._sock = None
+        self._event_loop.call_soon(self._event_loop.stop)
+
     def put_message(self, message):
         """
         :param message: protobuf generated validator_pb2.Message
         """
+        if not self._ready_event.is_set():
+            return
         with self._condition:
-            self._condition.wait_for(lambda: self._event_loop is not None)
+            self._condition.wait_for(lambda: self._event_loop is not None
+                                     and self._send_queue is not None)
         asyncio.run_coroutine_threadsafe(self._put_message(message),
                                          self._event_loop)
 
     def get_message(self):
         """
-        :return message: protobuf generated validator_pb2.Message
+        :return message: concurrent.futures.Future
         """
         with self._condition:
             self._condition.wait_for(lambda: self._event_loop is not None)
         return asyncio.run_coroutine_threadsafe(self._get_message(),
-                                                self._event_loop).result()
+                                                self._event_loop)
 
-    def _exit_tasks(self):
-        for task in asyncio.Task.all_tasks(self._event_loop):
-            task.cancel()
+    def _tasks_yet_to_be_done(self):
+        """Gathers all the tasks (pending coroutines and futures)
+        and provides a future that is done when all tasks are done.
+        :return: concurrent.futures.Future
+        """
+        return asyncio.gather(*asyncio.Task.all_tasks(self._event_loop))
 
     def shutdown(self):
-        self._exit_tasks()
+        """Schedules a callback to be run when all of the tasks
+         have completed.
+        """
+        future = self._tasks_yet_to_be_done()
+        future.add_done_callback(self._done_callback)
+
+    def _done_callback(self, future):
+        """Stops the event loop, closes the socket, and destroys the context
+
+        :param future: concurrent.futures.Future not used
+        """
         self._event_loop.call_soon_threadsafe(self._event_loop.stop)
         self._sock.close()
         self._context.destroy()
 
     def run(self):
-        self._event_loop = zmq.asyncio.ZMQEventLoop()
-        asyncio.set_event_loop(self._event_loop)
-        self._context = zmq.asyncio.Context()
-        self._sock = self._context.socket(zmq.DEALER)
-        self._sock.identity = _generate_id()[0:16].encode('ascii')
-        self._sock.connect('tcp://' + self._url)
-        self._send_queue = asyncio.Queue(loop=self._event_loop)
-        self._recv_queue = asyncio.Queue(loop=self._event_loop)
-        with self._condition:
-            self._condition.notify_all()
-        asyncio.ensure_future(self._send_message(), loop=self._event_loop)
-        asyncio.ensure_future(self._receive_message(), loop=self._event_loop)
-        self._event_loop.run_forever()
+        first_time = True
+        while True:
+            if self._event_loop is None:
+                self._event_loop = zmq.asyncio.ZMQEventLoop()
+                asyncio.set_event_loop(self._event_loop)
+            if self._context is None:
+                self._context = zmq.asyncio.Context()
+            self._sock = self._context.socket(zmq.DEALER)
+            self._sock.identity = _generate_id()[0:16].encode('ascii')
+            self._sock.set(zmq.LINGER, 0)
+            self._sock.connect('tcp://' + self._url)
+            self._monitor_sock = self._sock.get_monitor_socket(
+                zmq.EVENT_DISCONNECTED)
+            self._send_queue = asyncio.Queue(loop=self._event_loop)
+            self._recv_queue = asyncio.Queue(loop=self._event_loop)
+            if first_time is False:
+                self._recv_queue.put_nowait(RECONNECT_EVENT)
+            with self._condition:
+                self._condition.notify_all()
+            asyncio.ensure_future(self._send_message(),
+                                  loop=self._event_loop)
+            asyncio.ensure_future(self._receive_message(),
+                                  loop=self._event_loop)
+            asyncio.ensure_future(self._monitor_disconnects(),
+                                  loop=self._event_loop)
+
+            self._ready_event.set()
+            self._event_loop.run_forever()
+            if first_time is True:
+                first_time = False
 
 
 class Stream(object):
     def __init__(self, url):
         self._url = url
         self._futures = FutureCollection()
-        self._send_recieve_thread = _SendReceiveThread(url, self._futures)
+        self._event = Event()
+        self._event.set()
+        self._send_recieve_thread = _SendReceiveThread(
+            url,
+            futures=self._futures,
+            ready_event=self._event)
         self._send_recieve_thread.daemon = True
         self._send_recieve_thread.start()
 
     def send(self, message_type, content):
+        """Send a message to the validator
+
+        :param: message_type(validator_pb2.Message.MessageType)
+        :param: content(bytes)
+        :return: (future.Future)
+        :raises: (ValidatorConnectionError)
+        """
+
+        if not self._event.is_set():
+            raise ValidatorConnectionError()
         message = validator_pb2.Message(
             message_type=message_type,
             correlation_id=_generate_id(),
@@ -183,7 +265,10 @@ class Stream(object):
         :param message_type: validator_pb2.Message.MessageType enum value
         :param correlation_id: a random str internal to the validator
         :param content: protobuf bytes
+        :raises (ValidatorConnectionError):
         """
+        if not self._event.is_set():
+            raise ValidatorConnectionError()
         message = validator_pb2.Message(
             message_type=message_type,
             correlation_id=correlation_id,
@@ -192,10 +277,24 @@ class Stream(object):
 
     def receive(self):
         """
-        Used for receiving messages that are not responses
-
+        Receive messages that are not responses
+        :return: concurrent.futures.Future
         """
         return self._send_recieve_thread.get_message()
+
+    def wait_for_ready(self):
+        """Blocks until the background thread has recovered
+        from a disconnect with the validator.
+        """
+        self._event.wait()
+
+    def is_ready(self):
+        """Whether the background thread has recovered from
+        a disconnect with the validator
+
+        :return: (bool) whether the background thread is ready
+        """
+        return self._event.is_set()
 
     def close(self):
         self._send_recieve_thread.shutdown()

--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -54,7 +54,7 @@ class TransactionProcessor(object):
                     futures.append(future)
 
         for future in futures:
-            LOGGER.debug("future result: %s", repr(future.result))
+            LOGGER.debug("future result: %s", repr(future.result()))
 
         while True:
             if self._stop:

--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -13,8 +13,15 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+from concurrent.futures import CancelledError
+import concurrent.futures
+import itertools
 import logging
 
+
+from sawtooth_sdk.client.exceptions import ValidatorConnectionError
+from sawtooth_sdk.client.future import FutureTimeoutError
+from sawtooth_sdk.client.stream import RECONNECT_EVENT
 from sawtooth_sdk.client.stream import Stream
 
 from sawtooth_sdk.processor.state import State
@@ -22,8 +29,12 @@ from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
 
 from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterRequest
+from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterResponse
+from sawtooth_sdk.protobuf.processor_pb2 import TpUnregisterRequest
+from sawtooth_sdk.protobuf.processor_pb2 import TpUnregisterResponse
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse
+from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
 
@@ -33,65 +44,188 @@ LOGGER = logging.getLogger(__name__)
 class TransactionProcessor(object):
     def __init__(self, url):
         self._stream = Stream(url)
+        self._url = url
         self._handlers = []
-        self._stop = False
 
     def add_handler(self, handler):
+        """Add a transaction family handler
+        :param handler:
+        """
         self._handlers.append(handler)
 
-    def start(self):
-        futures = []
-        for handler in self._handlers:
-            for version in handler.family_versions:
-                for encoding in handler.encodings:
-                    future = self._stream.send(
-                        message_type=Message.TP_REGISTER_REQUEST,
-                        content=TpRegisterRequest(
-                            family=handler.family_name,
-                            version=version,
-                            encoding=encoding,
-                            namespaces=handler.namespaces).SerializeToString())
-                    futures.append(future)
+    def _find_handler(self, header):
+        """Find a handler for a particular (family_name,
+        family_versions, payload_encoding)
+        :param header transaction_pb2.TransactionHeader:
+        :return: handler
+        """
+        return list(filter(lambda h: header.family_name == h.family_name and
+                           header.family_version in h.family_versions and
+                           header.payload_encoding in h.encodings,
+                           self._handlers))[0]
 
-        for future in futures:
-            LOGGER.debug("future result: %s", repr(future.result()))
+    def _register_requests(self):
+        """Returns all of the TpRegisterRequests for handlers
 
-        while True:
-            if self._stop:
-                break
-            msg = self._stream.receive()
-            LOGGER.debug(
-                'received message of type: %s',
-                Message.MessageType.Name(msg.message_type))
+        :return (list): list of TpRegisterRequests
+        """
+        return itertools.chain.from_iterable(  # flattens the nested list
+            [
+                [TpRegisterRequest(
+                    family=n,
+                    version=v,
+                    encoding=e,
+                    namespaces=h.namespaces)
+                 for n, v, e in itertools.product(
+                    [h.family_name],
+                     h.family_versions,
+                     h.encodings)] for h in self._handlers])
 
-            request = TpProcessRequest()
-            request.ParseFromString(msg.content)
-            state = State(self._stream, request.context_id)
+    def _unregister_request(self):
+        """Returns a single TP_UnregisterRequest that requests
+        that the validator stop sending transactions for previously
+        registered handlers.
 
+        :return (processor_pb2.TpUnregisterRequest):
+        """
+        return TpUnregisterRequest()
+
+    def _process(self, msg):
+        request = TpProcessRequest()
+        request.ParseFromString(msg.content)
+        state = State(self._stream, request.context_id)
+        header = TransactionHeader()
+        header.ParseFromString(request.header)
+        try:
+            if not self._stream.is_ready():
+                raise ValidatorConnectionError()
+            self._find_handler(header).apply(request, state)
+            self._stream.send_back(
+                message_type=Message.TP_PROCESS_RESPONSE,
+                correlation_id=msg.correlation_id,
+                content=TpProcessResponse(
+                    status=TpProcessResponse.OK
+                ).SerializeToString())
+        except InvalidTransaction as it:
+            LOGGER.warning("Invalid Transaction %s", it)
             try:
-                self._handlers[0].apply(request, state)
-                self._stream.send_back(
-                    message_type=Message.TP_PROCESS_RESPONSE,
-                    correlation_id=msg.correlation_id,
-                    content=TpProcessResponse(
-                        status=TpProcessResponse.OK
-                    ).SerializeToString())
-            except InvalidTransaction as it:
-                LOGGER.warning("Invalid Transaction %s", it)
                 self._stream.send_back(
                     message_type=Message.TP_PROCESS_RESPONSE,
                     correlation_id=msg.correlation_id,
                     content=TpProcessResponse(
                         status=TpProcessResponse.INVALID_TRANSACTION
                     ).SerializeToString())
-            except InternalError as ie:
-                LOGGER.warning("State Error! %s", ie)
+            except ValidatorConnectionError as vce:
+                # TP_PROCESS_REQUEST has made it through the
+                # handler.apply and an INVALID_TRANSACTION would have been
+                # sent back but the validator has disconnected and so it
+                # doesn't care about the response.
+                LOGGER.warning("during invalid transaction response: %s", vce)
+        except InternalError as ie:
+            LOGGER.warning("internal error: %s", ie)
+            try:
                 self._stream.send_back(
                     message_type=Message.TP_PROCESS_RESPONSE,
                     correlation_id=msg.correlation_id,
                     content=TpProcessResponse(
                         status=TpProcessResponse.INTERNAL_ERROR
                     ).SerializeToString())
+            except ValidatorConnectionError as vce:
+                # Same as the prior except block, but an internal error has
+                # happened, but because of the disconnect the validator
+                # probably doesn't care about the response.
+                LOGGER.warning("during internal error response: %s", vce)
+        except ValidatorConnectionError as vce:
+            # Somewhere within handler.apply a future resolved with an
+            # error status that the validator has disconnected. There is
+            # nothing left to do but reconnect.
+            LOGGER.warning("during handler.apply a future was resolved "
+                           "with error status: %s", vce)
+
+    def _process_future(self, future, timeout=None, sigint=False):
+        try:
+            msg = future.result(timeout)
+        except CancelledError:
+            # This error is raised when Task.cancel is called on
+            # disconnect from the validator in stream.py, for
+            # this future.
+            return
+        if msg is RECONNECT_EVENT:
+            if sigint is False:
+                LOGGER.info("reregistering with validator")
+                self._stream.wait_for_ready()
+                self._register()
+        else:
+            LOGGER.debug(
+                'received message of type: %s',
+                Message.MessageType.Name(msg.message_type))
+            self._process(msg)
+
+    def _register(self):
+        futures = []
+        for message in self._register_requests():
+            self._stream.wait_for_ready()
+            future = self._stream.send(
+                message_type=Message.TP_REGISTER_REQUEST,
+                content=message.SerializeToString())
+            futures.append(future)
+
+        for future in futures:
+            resp = TpRegisterResponse()
+            try:
+                resp.ParseFromString(future.result().content)
+                LOGGER.info("register attempt: %s",
+                            TpRegisterResponse.Status.Name(resp.status))
+            except ValidatorConnectionError as vce:
+                LOGGER.info("during waiting for response on registration: %s",
+                            vce)
+
+    def _unregister(self):
+        message = self._unregister_request()
+        self._stream.wait_for_ready()
+        future = self._stream.send(
+            message_type=Message.TP_UNREGISTER_REQUEST,
+            content=message.SerializeToString())
+        response = TpUnregisterResponse()
+        try:
+            response.ParseFromString(future.result(1).content)
+            LOGGER.info("unregister attempt: %s",
+                        TpUnregisterResponse.Status.Name(response.status))
+        except ValidatorConnectionError as vce:
+            LOGGER.info("during waiting for response on unregistration: %s",
+                        vce)
+
+    def start(self):
+        fut = None
+        try:
+            self._register()
+            while True:
+                # During long running processing this
+                # is where the transaction processor will
+                # spend most of its time
+                fut = self._stream.receive()
+                self._process_future(fut)
+        except KeyboardInterrupt:
+            try:
+                # tell the validator to not send any more messages
+                self._unregister()
+                while True:
+                    if fut is not None:
+                        # process futures as long as the tp has them,
+                        # if the TP_PROCESS_REQUEST doesn't come from
+                        # zeromq->asyncio in 1 second raise a
+                        # concurrent.futures.TimeOutError and be done.
+                        self._process_future(fut, 1, sigint=True)
+                        fut = self._stream.receive()
+            except concurrent.futures.TimeoutError:
+                # Where the tp will usually exit after
+                # a KeyboardInterrupt. Caused by the 1 second
+                # timeout in _process_future.
+                pass
+            except FutureTimeoutError:
+                # If the validator is not able to respond to the
+                # unregister request, exit.
+                pass
 
     def stop(self):
-        self._stop = True
+        self._stream.close()

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -92,7 +92,7 @@ class TransactionExecutorThread(threading.Thread):
 
             if processor_type not in self._processors:
                 raise Exception("internal error, no processor available")
-            processor = self._processors[processor_type]
+            processor = self._processors.get_next_of_type(processor_type)
             identity = processor.identity
 
             future = self._service.send(

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -34,8 +34,7 @@ from sawtooth_validator.journal.completer import Completer
 from sawtooth_validator.networking.dispatch import Dispatcher
 from sawtooth_validator.journal.block_sender import BroadcastBlockSender
 from sawtooth_validator.execution.executor import TransactionExecutor
-from sawtooth_validator.execution.processor_handlers import \
-    ProcessorRegisterHandler
+from sawtooth_validator.execution import processor_handlers
 from sawtooth_validator.state import client_handlers
 from sawtooth_validator.gossip import signature_verifier
 from sawtooth_validator.networking.interconnect import Interconnect
@@ -101,8 +100,14 @@ class Validator(object):
 
         self._dispatcher.add_handler(
             validator_pb2.Message.TP_REGISTER_REQUEST,
-            ProcessorRegisterHandler(executor.processors),
+            processor_handlers.ProcessorRegisterHandler(executor.processors),
             thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.TP_UNREGISTER_REQUEST,
+            processor_handlers.ProcessorUnRegisterHandler(executor.processors),
+            thread_pool
+        )
 
         identity = hashlib.sha512(
             time.time().hex().encode()).hexdigest()[:23]


### PR DESCRIPTION
After this, python transaction processors can stop (if allowed to do so gracefully (1 keyboardinterrupt)) even during load. The tps can also recover after validator shutdown, even during load. The validator still needs at least 2 keyboard interrupts to stop it.

The protos are updated, so if seeking to test it, run protogen.