### PR TITLE
Expand ClientRequestHandler unit test doctrings

### DIFF
--- a/validator/tests/unit3/test_client_request_handlers/__init__.py
+++ b/validator/tests/unit3/test_client_request_handlers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/validator/tests/unit3/test_client_request_handlers/mocks.py
+++ b/validator/tests/unit3/test_client_request_handlers/mocks.py
@@ -23,7 +23,9 @@ from sawtooth_validator.state.merkle import MerkleDatabase
 class MockBlockStore(BlockStoreAdapter):
     """
     Creates a block store with a preseeded chain of blocks.
-    With defaults, creates blocks with ids ranging from '0' to '2'.
+    With defaults, creates three blocks with ids ranging from '0' to '2'.
+    Using optional root parameter for add_block, it is possible to save
+    meaningful state_root_hashes to a block.
     """
     def __init__(self, size=3):
         super().__init__({})
@@ -63,7 +65,7 @@ def make_db_and_store(size=3, start='a'):
         * database - dict database with evolving state
         * store - blocks with with root hashes corresponding to that state
         * roots - list of root hashes used in order
-    With defaults the state at the three roots looks like this:
+    With defaults, the values at the three roots look like this:
         * 0 - {'a': b'1'}
         * 1 - {'a': b'2', 'b': b'4'}
         * 2 - {'a': b'3', 'b': b'5', 'c': b'7'}

--- a/validator/tests/unit3/test_client_request_handlers/tests.py
+++ b/validator/tests/unit3/test_client_request_handlers/tests.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,20 +22,19 @@ from test_client_request_handlers.mocks import make_db_and_store
 
 
 class _ClientHandlerTestCase(unittest.TestCase):
+    """Parent for Client Request Handler tests that simplifies making requests.
+    Run initialize as part of setUp, and then call make_request in each test.
     """
-    Parent class for Client Request Handler tests that handles making requests.
-    Run _initialize as part of setUp, and then call _make_request in each test.
-    """
-    def _initialize(self, handler, request_proto, response_proto,
+    def initialize(self, handler, request_proto, response_proto,
                     store=None, roots=None):
         self._identity = '1234567'
         self._handler = handler
-        self._status = response_proto
         self._request_proto = request_proto
         self._store = store
-        self._roots = roots
+        self.status = response_proto
+        self.roots = roots
 
-    def _make_request(self, **kwargs):
+    def make_request(self, **kwargs):
         return self._handle(self._serialize(**kwargs))
 
     def _serialize(self, **kwargs):
@@ -46,11 +45,23 @@ class _ClientHandlerTestCase(unittest.TestCase):
         result = self._handler.handle(self._identity, request)
         return result.message_out
 
-    def _make_bad_request(self, **kwargs):
+    def make_bad_request(self, **kwargs):
+        """Truncates the protobuf request, which will break it as long as
+        the protobuf is not empty.
+        """
         return self._handle(self._serialize(**kwargs)[0:-1])
 
-    def _break_genesis(self):
+    def break_genesis(self):
+        """Breaks the chain head causing certain "latest" requests to fail.
+        Simulates what block store would look like if genesis had not been run.
+        """
         self._store.store.pop('chain_head_id')
+
+    def assertAllInstances(self, items, cls):
+        """Checks that all items in a collection are instances of a class
+        """
+        for item in items:
+            self.assertIsInstance(item, cls)
 
 
 class TestStateCurrentRequests(_ClientHandlerTestCase):
@@ -58,25 +69,32 @@ class TestStateCurrentRequests(_ClientHandlerTestCase):
         def mock_current_root():
             return '123'
 
-        self._initialize(
+        self.initialize(
             handlers.StateCurrentRequest(mock_current_root),
             client_pb2.ClientStateCurrentRequest,
             client_pb2.ClientStateCurrentResponse)
 
     def test_state_current_request(self):
         """Verifies requests for the current merkle root work properly.
-        Compares response to a mock merkle root of '123'.
+        Should respond with a the hard-coded mock merkle_root of '123'.
         """
-        response = self._make_request()
+        response = self.make_request()
 
-        self.assertEqual(self._status.OK, response.status)
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('123', response.merkle_root)
 
 
 class TestStateListRequests(_ClientHandlerTestCase):
+    def _find_value(self, leaves, address):
+        """The ordering of leaves is fairly arbitrary, so some tests
+        need to filter for the matching address.
+        """
+        matches = filter(lambda leaf: leaf.address == address, leaves)
+        return list(matches)[0].data
+
     def setUp(self):
         db, store, roots = make_db_and_store()
-        self._initialize(
+        self.initialize(
             handlers.StateListRequest(db, store),
             client_pb2.ClientStateListRequest,
             client_pb2.ClientStateListResponse,
@@ -85,127 +103,197 @@ class TestStateListRequests(_ClientHandlerTestCase):
 
     def test_state_list_request(self):
         """Verifies requests for data lists without parameters work properly.
-        Checks status, head_id, and length and type of leaves list.
-        """
-        response = self._make_request()
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the latest state in the default mock db:
+            state: {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        the tests expect to find:
+            - a status of OK
+            - a head_id of '2' (the latest)
+            - a list of leaves with 3 items
+            - that the list contains instances of Leaf
+            - that there is a leaf with an address of 'a' and data of b'3'
+        """
+        response = self.make_request()
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('2', response.head_id)
         self.assertEqual(3, len(response.leaves))
-        self.assertIsInstance(response.leaves[0], client_pb2.Leaf)
+        self.assertAllInstances(response.leaves, client_pb2.Leaf)
+        self.assertEqual(b'3', self._find_value(response.leaves, 'a'))
 
     def test_state_list_bad_request(self):
         """Verifies requests for lists of data break with bad protobufs.
-        Checks response status and that data is missing.
-        """
-        response = self._make_bad_request(head_id='1')
 
-        self.assertEqual(self._status.INTERNAL_ERROR, response.status)
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that leaves and head_id are missing
+        """
+        response = self.make_bad_request(head_id='1')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.leaves)
         self.assertFalse(response.head_id)
 
     def test_state_list_no_genesis(self):
         """Verifies requests for lists of data break properly with no genesis.
-        Checks status and that response data is missing.
-        """
-        self._break_genesis()
-        response = self._make_request()
 
-        self.assertEqual(self._status.NOT_READY, response.status)
+        Expects to find:
+            - a status of NOT_READY
+            - that leaves and head_id are missing
+        """
+        self.break_genesis()
+        response = self.make_request()
+
+        self.assertEqual(self.status.NOT_READY, response.status)
         self.assertFalse(response.leaves)
         self.assertFalse(response.head_id)
 
     def test_state_list_with_root(self):
         """Verifies requests for data lists work properly with a merkle root.
-        Checks status, and length, type and content of leaves list.
-        """
-        response = self._make_request(merkle_root=self._roots[0])
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the first state in the default mock db:
+            {'a': b'1'}
+
+        Expects to find:
+            - a status of OK
+            - that head_id is missing (queried by root)
+            - a list of leaves with 1 item
+            - that the list contains instances of Leaf
+            - that Leaf has an address of 'a' and data of b'1'
+        """
+        response = self.make_request(merkle_root=self.roots[0])
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertFalse(response.head_id)
         self.assertEqual(1, len(response.leaves))
 
-        self.assertIsInstance(response.leaves[0], client_pb2.Leaf)
+        self.assertAllInstances(response.leaves, client_pb2.Leaf)
         self.assertEqual('a', response.leaves[0].address)
         self.assertEqual(b'1', response.leaves[0].data)
 
     def test_state_list_with_bad_root(self):
         """Verifies requests for lists of data break properly with a bad root.
-        Checks status and that response data is missing.
-        """
-        response = self._make_request(merkle_root='bad')
 
-        self.assertEqual(self._status.NO_ROOT, response.status)
+        Expects to find:
+            - a status of NO_ROOT
+            - that leaves and head_id are missing
+        """
+        response = self.make_request(merkle_root='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
+        self.assertFalse(response.head_id)
         self.assertFalse(response.leaves)
 
     def test_state_list_with_head(self):
         """Verifies requests for lists of data work properly with a head_id.
-        Checks status, head_id, and length, type and content of leaves list.
-        """
-        response = self._make_request(head_id='1')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '1'
+            - a list of leaves with 2 items
+            - that the list contains instances of Leaf
+            - that there is a leaf with an address of 'a' and data of b'1'
+        """
+        response = self.make_request(head_id='1')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('1', response.head_id)
         self.assertEqual(2, len(response.leaves))
 
-        self.assertIsInstance(response.leaves[0], client_pb2.Leaf)
-        a = list(filter(lambda l: l.address == 'a', response.leaves))[0]
-        self.assertEqual(b'2', a.data)
+        self.assertAllInstances(response.leaves, client_pb2.Leaf)
+        self.assertEqual(b'2', self._find_value(response.leaves, 'a'))
 
     def test_state_list_with_bad_head(self):
         """Verifies requests for lists of data break with a bad head_id.
-        Checks status and that response data is missing.
-        """
-        response = self._make_request(head_id='bad')
 
-        self.assertEqual(self._status.NO_ROOT, response.status)
+        Expects to find:
+            - a status of NO_ROOT
+            - that leaves and head_id are missing
+        """
+        response = self.make_request(head_id='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.leaves)
 
     def test_state_list_with_address(self):
         """Verifies requests for data lists filtered by address work properly.
-        Checks status, head_id, and length, type and content of leaves list.
-        """
-        response = self._make_request(address='c')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '2' (the latest)
+            - a list of leaves with 1 item
+            - that the list contains instances of Leaf
+            - that Leaf matches the address of 'c' and has data of b'7'
+        """
+        response = self.make_request(address='c')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('2', response.head_id)
         self.assertEqual(1, len(response.leaves))
 
-        self.assertIsInstance(response.leaves[0], client_pb2.Leaf)
+        self.assertAllInstances(response.leaves, client_pb2.Leaf)
         self.assertEqual('c', response.leaves[0].address)
         self.assertEqual(b'7', response.leaves[0].data)
 
     def test_state_list_with_bad_address(self):
         """Verifies requests for data filtered by a bad address break properly.
-        Checks status and that response data is missing.
-        """
-        response = self._make_request(address='bad')
 
-        self.assertEqual(self._status.NO_RESOURCE, response.status)
+        Expects to find:
+            - a status of NO_RESOURCE
+            - a head_id of '2' (the latest chain head id)
+            - that leaves is missing
+        """
+        response = self.make_request(address='bad')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual('2', response.head_id)
         self.assertFalse(response.leaves)
 
     def test_state_list_with_head_and_address(self):
         """Verifies requests for data work with a head and address filter.
-        Checks status, head_id, and length, type and content of leaves list.
-        """
-        response = self._make_request(head_id='1', address='b')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '1'
+            - a list of leaves with 1 item
+            - that the list contains instances of Leaf
+            - that Leaf matches the address of 'b', and has data of b'4'
+        """
+        response = self.make_request(head_id='1', address='b')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('1', response.head_id)
         self.assertEqual(1, len(response.leaves))
 
-        self.assertIsInstance(response.leaves[0], client_pb2.Leaf)
+        self.assertAllInstances(response.leaves, client_pb2.Leaf)
         self.assertEqual('b', response.leaves[0].address)
         self.assertEqual(b'4', response.leaves[0].data)
 
     def test_state_list_with_early_state(self):
         """Verifies requests for data break when the state predates an address.
-        Checks status, head_id, and that response data is missing.
-        """
-        response = self._make_request(address='c', head_id='1')
 
-        self.assertEqual(self._status.NO_RESOURCE, response.status)
+        Attempts to query the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - a head_id of '1'
+            - that leaves is missing
+        """
+        response = self.make_request(address='c', head_id='1')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual('1', response.head_id)
         self.assertFalse(response.leaves)
 
@@ -213,7 +301,7 @@ class TestStateListRequests(_ClientHandlerTestCase):
 class TestStateGetRequests(_ClientHandlerTestCase):
     def setUp(self):
         db, store, roots = make_db_and_store()
-        self._initialize(
+        self.initialize(
             handlers.StateGetRequest(db, store),
             client_pb2.ClientStateGetRequest,
             client_pb2.ClientStateGetResponse,
@@ -222,90 +310,134 @@ class TestStateGetRequests(_ClientHandlerTestCase):
 
     def test_state_get_request(self):
         """Verifies requests for specific data by address work properly.
-        Checks status, head_id, and value returned.
-        """
-        response = self._make_request(address='b')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '2' (the latest)
+            - a value of b'5'
+        """
+        response = self.make_request(address='b')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('2', response.head_id)
         self.assertEqual(b'5', response.value)
 
     def test_state_get_bad_request(self):
         """Verifies requests for specfic data break with bad protobufs.
-        Checks status, and that head_id and response data are missing.
-        """
-        response = self._make_bad_request(address='b')
 
-        self.assertEqual(self._status.INTERNAL_ERROR, response.status)
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that value and head_id are missing
+        """
+        response = self.make_bad_request(address='b')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.value)
 
     def test_state_get_no_genesis(self):
         """Verifies requests for specfic data with break properly no genesis.
-        Checks status, and that head_id and response data are missing.
-        """
-        self._break_genesis()
-        response = self._make_request(address='b')
 
-        self.assertEqual(self._status.NOT_READY, response.status)
+        Expects to find:
+            - a status of NOT_READY
+            - that value and head_id are missing
+        """
+        self.break_genesis()
+        response = self.make_request(address='b')
+
+        self.assertEqual(self.status.NOT_READY, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.value)
 
     def test_state_get_with_bad_address(self):
         """Verifies requests for specific data break properly by a bad address.
-        Checks status, and that head_id and response data are missing.
-        """
-        response = self._make_request(address='bad')
 
-        self.assertEqual(self._status.NO_RESOURCE, response.status)
+        Expects to find:
+            - a status of NO_RESOURCE
+            - that value and head_id are missing
+        """
+        response = self.make_request(address='bad')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.value)
 
     def test_state_get_with_root(self):
         """Verifies requests for specific data work with a merkle root.
-        Checks status, head_id, and value returned.
-        """
-        response = self._make_request(address='b', merkle_root=self._roots[1])
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of OK
+            - that head_id is missing (queried by root)
+            - a value of b'4'
+        """
+        response = self.make_request(address='b', merkle_root=self.roots[1])
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertFalse(response.head_id)
         self.assertEqual(b'4', response.value)
 
     def test_state_get_with_bad_root(self):
         """Verifies requests for specific data break properly with a bad root.
-        Checks status, and that response data is missing.
-        """
-        response = self._make_request(address='b', merkle_root='bad')
 
-        self.assertEqual(self._status.NO_ROOT, response.status)
+        Expects to find:
+            - a status of NO_ROOT
+            - that value and head_id are missing
+        """
+        response = self.make_request(address='b', merkle_root='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
+        self.assertFalse(response.value)
         self.assertFalse(response.value)
 
     def test_state_get_with_head(self):
         """Verifies requests for specific data work properly with a head id.
-        Checks status, head_id, and value returned.
-        """
-        response = self._make_request(address='a', head_id='0')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the first state in the default mock db:
+            {'a': b'1'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '0'
+            - a value of b'1'
+        """
+        response = self.make_request(address='a', head_id='0')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('0', response.head_id)
         self.assertEqual(b'1', response.value)
 
     def test_state_get_with_bad_head(self):
         """Verifies requests for specific data break properly with a bad head.
-        Checks status, and that response data is missing.
-        """
-        response = self._make_request(address='a', head_id='bad')
 
-        self.assertEqual(self._status.NO_ROOT, response.status)
+        Expects to find:
+            - a status of NO_ROOT
+            - that value and head_id are missing
+        """
+        response = self.make_request(address='a', head_id='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.value)
 
     def test_state_get_with_early_state(self):
         """Verifies requests for a datum break when state predates the address.
-        Checks status, and that head_id response data are missing.
-        """
-        response = self._make_request(address='c', head_id='1')
 
-        self.assertEqual(self._status.NO_RESOURCE, response.status)
+        Attempts to query the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - that value and head_id are missing
+        """
+        response = self.make_request(address='c', head_id='1')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.value)
 
@@ -313,7 +445,7 @@ class TestStateGetRequests(_ClientHandlerTestCase):
 class TestBlockListRequests(_ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
-        self._initialize(
+        self.initialize(
             handlers.BlockListRequest(store),
             client_pb2.ClientBlockListRequest,
             client_pb2.ClientBlockListResponse,
@@ -321,54 +453,86 @@ class TestBlockListRequests(_ClientHandlerTestCase):
 
     def test_block_list_request(self):
         """Verifies requests for block lists without parameters work properly.
-        Checks status, head_id, and length and type of blocks list.
-        """
-        response = self._make_request()
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the default mock block store with three blocks:
+            {header: {block_num: 2 ...}, header_signature: '2' ...},
+            {header: {block_num: 1 ...}, header_signature: '1' ...},
+            {header: {block_num: 0 ...}, header_signature: '0' ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '2' (the latest)
+            - a list of blocks with 3 items
+            - the items are instances of Block
+            - The first item has a header_signature of '2'
+        """
+        response = self.make_request()
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('2', response.head_id)
         self.assertEqual(3, len(response.blocks))
-        self.assertIsInstance(response.blocks[0], Block)
+        self.assertAllInstances(response.blocks, Block)
+        self.assertEqual('2', response.blocks[0].header_signature)
 
     def test_block_list_bad_request(self):
         """Verifies requests for lists of blocks break with bad protobufs.
-        Checks status, and that head_id blocks list are missing.
-        """
-        response = self._make_bad_request(head_id='1')
 
-        self.assertEqual(self._status.INTERNAL_ERROR, response.status)
+        Expects to find:
+            - a status of INBTERNAL_ERROR
+            - that blocks and head_id are missing
+        """
+        response = self.make_bad_request(head_id='1')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.blocks)
 
     def test_block_list_bad_request(self):
         """Verifies requests for lists of blocks break with no genesis.
-        Checks status, and that head_id blocks list are missing.
-        """
-        self._break_genesis()
-        response = self._make_bad_request()
 
-        self.assertEqual(self._status.NOT_READY, response.status)
+        Expects to find:
+            - a status of NOT_READY
+            - that blocks and head_id are missing
+        """
+        self.break_genesis()
+        response = self.make_bad_request()
+
+        self.assertEqual(self.status.NOT_READY, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.blocks)
 
     def test_block_list_with_head(self):
         """Verifies requests for lists of blocks work properly with a head id.
-        Checks status, head_id, and length and type of blocks list.
-        """
-        response = self._make_request(head_id='1')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the default mock block store with '1' as the head:
+            {header: {block_num: 1 ...}, header_signature: '1' ...},
+            {header: {block_num: 0 ...}, header_signature: '0' ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of '1'
+            - a list of blocks with 2 items
+            - the items are instances of Block
+            - The first item has a header_signature of '1'
+        """
+        response = self.make_request(head_id='1')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertEqual('1', response.head_id)
         self.assertEqual(2, len(response.blocks))
-        self.assertIsInstance(response.blocks[0], Block)
+        self.assertAllInstances(response.blocks, Block)
+        self.assertEqual('1', response.blocks[0].header_signature)
 
     def test_block_list_with_bad_head(self):
         """Verifies requests for lists of blocks break with a bad head.
-        Checks status, and that head_id blocks list are missing.
-        """
-        response = self._make_request(head_id='bad')
 
-        self.assertEqual(self._status.NO_ROOT, response.status)
+        Expects to find:
+            - a status of NO_ROOT
+            - that blocks and head_id are missing
+        """
+        response = self.make_request(head_id='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
         self.assertFalse(response.blocks)
 
@@ -376,35 +540,46 @@ class TestBlockListRequests(_ClientHandlerTestCase):
 class TestBlockGetRequests(_ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
-        self._initialize(
+        self.initialize(
             handlers.BlockGetRequest(store),
             client_pb2.ClientBlockGetRequest,
             client_pb2.ClientBlockGetResponse)
 
     def test_block_get_request(self):
         """Verifies requests for a specific block by id work properly.
-        Checks status, and type and id of block.
-        """
-        response = self._make_request(block_id='1')
 
-        self.assertEqual(self._status.OK, response.status)
+        Queries the default three block mock store for an id of '1'.
+        Expects to find:
+            - a status of OK
+            - the block property which is an instances of Block
+            - The block has a header_signature of '1'
+        """
+        response = self.make_request(block_id='1')
+
+        self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.block, Block)
         self.assertEqual('1', response.block.header_signature)
 
     def test_block_get_bad_request(self):
         """Verifies requests for a specific block break with a bad protobuf.
-        Checks status, and that the block is missing.
-        """
-        response = self._make_bad_request(block_id='1')
 
-        self.assertEqual(self._status.INTERNAL_ERROR, response.status)
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that the Block returned, when serialized, is empty
+        """
+        response = self.make_bad_request(block_id='1')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.block.SerializeToString())
 
     def test_block_get_with_bad_id(self):
         """Verifies requests for a specific block break with a bad id.
-        Checks status, and that the block is missing.
-        """
-        response = self._make_request(block_id='bad')
 
-        self.assertEqual(self._status.NO_RESOURCE, response.status)
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that the Block returned, when serialized, is empty
+        """
+        response = self.make_request(block_id='bad')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())


### PR DESCRIPTION
Make test doctrings much more comprehensive, also add a handful of
additional asserts to make tests somewhat more robust.

Signed-off-by: Zac Delventhal <delventhalz@gmail.com>