### PR TITLE
Generate Validator Signing Key and Use for Genesis Block

### DIFF
--- a/cli/sawtooth_cli/admin.py
+++ b/cli/sawtooth_cli/admin.py
@@ -40,7 +40,7 @@ def do_admin(args):
 
 
 def add_admin_parser(subparsers, parent_parser):
-    parser = subparsers.add_parser('admin')
+    parser = subparsers.add_parser('admin', parents=[parent_parser])
     admin_sub = parser.add_subparsers(title='admin_commands', dest='admin_cmd')
 
     add_genesis_parser(admin_sub, parser)

--- a/cli/sawtooth_cli/admin.py
+++ b/cli/sawtooth_cli/admin.py
@@ -12,35 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-import os
-import sys
 
 from sawtooth_cli.exceptions import CliException
 
 from sawtooth_cli.admin_command.genesis import add_genesis_parser
 from sawtooth_cli.admin_command.genesis import do_genesis
+from sawtooth_cli.admin_command.keygen import add_keygen_parser
+from sawtooth_cli.admin_command.keygen import do_keygen
+from sawtooth_cli.admin_command.utils import ensure_directory
 
 
 def do_admin(args):
-    if 'SAWTOOTH_HOME' in os.environ:
-        data_dir = os.path.join(os.environ['SAWTOOTH_HOME'], 'data')
-    else:
-        data_dir = '/var/lib/sawtooth'
-
-    try:
-        os.makedirs(data_dir, exist_ok=True)
-    except OSError as e:
-        print('Unable to create {}: {}'.format(data_dir, e), file=sys.stderr)
-        return
+    data_dir = ensure_directory('data', '/var/lib/sawtooth')
 
     if args.admin_cmd == 'genesis':
         do_genesis(args, data_dir)
+    elif args.admin_cmd == 'keygen':
+        do_keygen(args)
     else:
-        raise CliException("invalid command: {}".format(args.command))
+        raise CliException("invalid command: {}".format(args.admin_cmd))
 
 
 def add_admin_parser(subparsers, parent_parser):
     parser = subparsers.add_parser('admin', parents=[parent_parser])
     admin_sub = parser.add_subparsers(title='admin_commands', dest='admin_cmd')
 
-    add_genesis_parser(admin_sub, parser)
+    add_genesis_parser(admin_sub, parent_parser)
+    add_keygen_parser(admin_sub, parent_parser)

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -24,7 +24,7 @@ from sawtooth_cli.protobuf.transaction_pb2 import TransactionHeader
 def add_genesis_parser(subparsers, parent_parser):
     """Creates the arg parsers needed for the genesis command.
     """
-    parser = subparsers.add_parser('genesis')
+    parser = subparsers.add_parser('genesis', parents=[parent_parser])
 
     parser.add_argument(
         '-o', '--output',

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -1,0 +1,103 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+
+from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.admin_command.utils import ensure_directory
+from sawtooth_signing import pbct as signing
+
+
+def add_keygen_parser(subparsers, parent_parser):
+    """Adds subparser command and flags for 'keygen' command.
+
+    Args:
+        subparsers (:obj:`ArguementParser`): The subcommand parsers.
+        parent_parser (:obj:`ArguementParser`): The parent of the subcomman
+            parsers.
+    """
+    parser = subparsers.add_parser('keygen', parents=[parent_parser])
+
+    parser.add_argument(
+        'key_name',
+        help='name of the key to create',
+        nargs='?')
+
+    parser.add_argument(
+        '--force',
+        help="overwrite files if they exist",
+        action='store_true')
+
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        help="print no output",
+        action='store_true')
+
+
+def do_keygen(args):
+    """Executes the key generation operation, given the parsed arguments.
+
+    Args:
+        args (:obj:`Namespace`): The parsed args.
+    """
+    if args.key_name is not None:
+        key_name = args.key_name
+    else:
+        key_name = 'validator'
+
+    key_dir = ensure_directory('etc/keys', '/etc/sawtooth/keys')
+
+    wif_filename = os.path.join(key_dir, key_name + '.wif')
+    addr_filename = os.path.join(key_dir, key_name + '.addr')
+
+    if not args.force:
+        file_exists = False
+        for filename in [wif_filename, addr_filename]:
+            if os.path.exists(filename):
+                file_exists = True
+                print('file exists: {}'.format(filename), file=sys.stderr)
+        if file_exists:
+            raise CliException(
+                'files exist, rerun with --force to overwrite existing files')
+
+    privkey = signing.generate_privkey()
+    encoded = signing.encode_privkey(privkey)
+    pubkey = signing.generate_pubkey(privkey)
+    addr = signing.generate_identifier(pubkey)
+
+    try:
+        wif_exists = os.path.exists(wif_filename)
+        with open(wif_filename, 'w') as wif_fd:
+            if not args.quiet:
+                if wif_exists:
+                    print('overwriting file: {}'.format(wif_filename))
+                else:
+                    print('writing file: {}'.format(wif_filename))
+            wif_fd.write(encoded)
+            wif_fd.write('\n')
+
+        addr_exists = os.path.exists(addr_filename)
+        with open(addr_filename, 'w') as addr_fd:
+            if not args.quiet:
+                if addr_exists:
+                    print('overwriting file: {}'.format(addr_filename))
+                else:
+                    print('writing file: {}'.format(addr_filename))
+            addr_fd.write(addr)
+            addr_fd.write('\n')
+    except IOError as ioe:
+        raise CliException('IOError: {}'.format(str(ioe)))

--- a/cli/sawtooth_cli/admin_command/utils.py
+++ b/cli/sawtooth_cli/admin_command/utils.py
@@ -1,0 +1,56 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+
+
+def ensure_directory(sawtooth_home_path, posix_fallback_path):
+    """Ensures the one of the given sets of directories exists.
+
+    The dirctory in sawtooth_home_path is ensured to exist, if `SAWTOOTH_HOME`
+    exists. If the host operating system is windows, `SAWTOOTH_HOME` is
+    defaulted to `C:\\Program Files (x86)\\Intel\\sawtooth-validator`,
+    Otherwise, the given posix fallback path is ensured to exist.
+
+    Args:
+        sawtooth_home_dirs (str): Subdirectory of `SAWTOOTH_HOME`.
+        posix_fallback_dir (str): Fallback directory path if `SAWTOOTH_HOME` is
+            unset on posix host system.
+
+    Returns:
+        str: The path determined to exist.
+    """
+    if 'SAWTOOTH_HOME' in os.environ:
+        sawtooth_home_dirs = sawtooth_home_path.split('/')
+        sawtooth_dir = os.path.join(os.environ['SAWTOOTH_HOME'],
+                                    *sawtooth_home_dirs)
+    elif os.name == 'nt':
+        default_win_home = \
+            'C:\\Program Files (x86)\\Intel\\sawtooth-validator\\'
+        sawtooth_home_dirs = sawtooth_home_path.split('/')
+        sawtooth_dir = os.path.join(default_win_home, *sawtooth_home_dirs)
+    else:
+        sawtooth_dir = posix_fallback_path
+
+    if not os.path.exists(sawtooth_dir):
+        try:
+            os.makedirs(sawtooth_dir, exist_ok=True)
+        except OSError as e:
+            print('Unable to create {}: {}'.format(sawtooth_dir, e),
+                  file=sys.stderr)
+            sys.exit(1)
+
+    return sawtooth_dir

--- a/cli/tests/test_genesis.py
+++ b/cli/tests/test_genesis.py
@@ -42,11 +42,14 @@ class TestGenesisDependencyValidation(unittest.TestCase):
         self._temp_dir = tempfile.mkdtemp()
         self._temp_data_dir = tempfile.mkdtemp()
 
-        self._parser = argparse.ArgumentParser()
+        parent_parser = argparse.ArgumentParser(prog='test_genesis',
+                                                add_help=False)
+
+        self._parser = argparse.ArgumentParser(add_help=False)
         subparsers = self._parser.add_subparsers(title='subcommands',
                                                  dest='command')
 
-        genesis.add_genesis_parser(subparsers, self._parser)
+        genesis.add_genesis_parser(subparsers, parent_parser)
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir)

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -47,27 +47,59 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
+def ensure_directory(sawtooth_home_path, posix_fallback_path):
+    """Ensures the one of the given sets of directories exists.
+
+    The dirctory in sawtooth_home_path is ensured to exist, if `SAWTOOTH_HOME`
+    exists. If the host operating system is windows, `SAWTOOTH_HOME` is
+    defaulted to `C:\\Program Files (x86)\\Intel\\sawtooth-validator`,
+    Otherwise, the given posix fallback path is ensured to exist.
+
+    Args:
+        sawtooth_home_dirs (str): Subdirectory of `SAWTOOTH_HOME`.
+        posix_fallback_dir (str): Fallback directory path if `SAWTOOTH_HOME` is
+            unset on posix host system.
+
+    Returns:
+        str: The path determined to exist.
+    """
+    if 'SAWTOOTH_HOME' in os.environ:
+        sawtooth_home_dirs = sawtooth_home_path.split('/')
+        sawtooth_dir = os.path.join(os.environ['SAWTOOTH_HOME'],
+                                    *sawtooth_home_dirs)
+    elif os.name == 'nt':
+        default_win_home = \
+            'C:\\Program Files (x86)\\Intel\\sawtooth-validator\\'
+        sawtooth_home_dirs = sawtooth_home_path.split('/')
+        sawtooth_dir = os.path.join(default_win_home, *sawtooth_home_dirs)
+    else:
+        sawtooth_dir = posix_fallback_path
+
+    if not os.path.exists(sawtooth_dir):
+        try:
+            os.makedirs(sawtooth_dir, exist_ok=True)
+        except OSError as e:
+            print('Unable to create {}: {}'.format(sawtooth_dir, e),
+                  file=sys.stderr)
+            sys.exit(1)
+
+    return sawtooth_dir
+
+
 def main(args=sys.argv[1:]):
     opts = parse_args(args)
     verbose_level = opts.verbose
 
     init_console_logging(verbose_level=verbose_level)
 
-    if 'SAWTOOTH_HOME' in os.environ:
-        data_dir = os.path.join(os.environ['SAWTOOTH_HOME'], 'data')
-    else:
-        data_dir = '/var/lib/sawtooth'
-
-    try:
-        os.makedirs(data_dir, exist_ok=True)
-    except OSError as e:
-        print('Unable to create {}: {}'.format(data_dir, e), file=sys.stderr)
-        return
+    data_dir = ensure_directory('data', '/var/lib/sawtooth')
+    key_dir = ensure_directory('etc/keys', '/etc/sawtooth/keys')
 
     validator = Validator(opts.network_endpoint,
                           opts.component_endpoint,
                           opts.peers,
-                          data_dir)
+                          data_dir,
+                          key_dir)
 
     try:
         validator.start()

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -197,6 +197,7 @@ class Validator(object):
             transaction_executor=executor,
             completer=completer,
             block_store=block_store,
+            identity_key=identity_signing_key,
             data_dir=data_dir
         )
 

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -20,6 +20,8 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from sawtooth_signing import pbct as signing
+
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
 from sawtooth_validator.journal.genesis import GenesisController
 from sawtooth_validator.journal.genesis import InvalidGenesisStateError
@@ -29,9 +31,12 @@ class TestGenesisController(unittest.TestCase):
     def __init__(self, test_name):
         super().__init__(test_name)
         self._temp_dir = None
+        self._identity_key = None
 
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
+        self._identity_key = signing.encode_privkey(
+            signing.generate_privkey(), 'hex')
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir)
@@ -44,6 +49,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             {},  # Empty block store
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -59,6 +65,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -74,6 +81,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -94,6 +102,7 @@ class TestGenesisController(unittest.TestCase):
             Mock(name='txn_executor'),
             Mock('completer'),
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -118,6 +127,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -142,6 +152,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 
@@ -176,6 +187,7 @@ class TestGenesisController(unittest.TestCase):
             txn_executor,
             completer,
             block_store,
+            self._identity_key,
             data_dir=self._temp_dir
         )
 


### PR DESCRIPTION
This adds the `admin keygen` subcommand, which produces a key file in the validator's `keys` directory.

The validator loads the key and passes it to the `GenesisController`, for use when signing the genesis block.

This key will most likely, be used by journal, as well, to sign blocks, after #98 is merged.