### PR TITLE
Bug fix for transaction processors maxing cpu on validator disconnect

### DIFF
--- a/core_transactions/config/tests/sawtooth_config_test/tp-config.yaml
+++ b/core_transactions/config/tests/sawtooth_config_test/tp-config.yaml
@@ -23,7 +23,7 @@ services:
       - ../../../..:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: ./bin/tp_config validator:40000
+    entrypoint: ./bin/tp_config tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:

--- a/docker/sawtooth-tp_config
+++ b/docker/sawtooth-tp_config
@@ -21,4 +21,4 @@ ARG PROJECT_DIR="/project/sawtooth-core"
 
 WORKDIR $PROJECT_DIR
 
-ENTRYPOINT ./bin/tp_config validator:40000
+ENTRYPOINT ./bin/tp_config tcp://validator:40000

--- a/docker/sawtooth-tp_intkey_python
+++ b/docker/sawtooth-tp_intkey_python
@@ -21,4 +21,4 @@ ARG PROJECT_DIR="/project/sawtooth-core"
 
 WORKDIR $PROJECT_DIR
 
-ENTRYPOINT ./bin/tp_intkey_python validator:40000
+ENTRYPOINT ./bin/tp_intkey_python tcp://validator:40000

--- a/docker/sawtooth-tp_xo_python
+++ b/docker/sawtooth-tp_xo_python
@@ -21,4 +21,4 @@ ARG PROJECT_DIR="/project/sawtooth-core"
 
 WORKDIR $PROJECT_DIR
 
-ENTRYPOINT ./bin/tp_xo_python validator
+ENTRYPOINT ./bin/tp_xo_python tcp://validator:40000

--- a/integration/sawtooth_integration/docker/intkey-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-smoke.yaml
@@ -25,7 +25,7 @@ services:
       - 40000
     depends_on:
       - validator
-    entrypoint: ./bin/tp_config -vv validator:40000
+    entrypoint: ./bin/tp_config -vv tcp://validator:40000
     stop_signal: SIGKILL
 
   tp_intkey:
@@ -36,7 +36,7 @@ services:
       - 40000
     depends_on:
       - validator
-    entrypoint: ./bin/tp_intkey_python -vv validator:40000
+    entrypoint: ./bin/tp_intkey_python -vv tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:
@@ -60,8 +60,7 @@ services:
       - 8080
     depends_on:
       - validator
-    # Starting rest_api at the same time as tp_intkey breaks
-    entrypoint: ./bin/rest_api --stream-url validator:40000
+    entrypoint: ./bin/rest_api --stream-url tcp://validator:40000
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/tp-intkey-python.yaml
+++ b/integration/sawtooth_integration/docker/tp-intkey-python.yaml
@@ -23,7 +23,7 @@ services:
       - ../../..:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: ./bin/tp_intkey_python validator:40000
+    entrypoint: ./bin/tp_intkey_python tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:

--- a/integration/sawtooth_integration/docker/tp-xo-python.yaml
+++ b/integration/sawtooth_integration/docker/tp-xo-python.yaml
@@ -23,7 +23,7 @@ services:
       - ../../../:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: ./bin/tp_xo_python validator:40000
+    entrypoint: ./bin/tp_xo_python tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:

--- a/integration/sawtooth_integration/docker/xo-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-smoke.yaml
@@ -25,7 +25,7 @@ services:
       - 40000
     depends_on:
       - validator
-    entrypoint: ./bin/tp_config -vv validator:40000
+    entrypoint: ./bin/tp_config -vv tcp://validator:40000
     stop_signal: SIGKILL
 
   tp_xo:
@@ -36,7 +36,7 @@ services:
       - 40000
     depends_on:
       - validator
-    entrypoint: ./bin/tp_xo_python -vv validator:40000
+    entrypoint: ./bin/tp_xo_python -vv tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:
@@ -59,7 +59,7 @@ services:
       - 8080
     depends_on:
      - validator
-    entrypoint: ./bin/rest_api --stream-url validator:40000
+    entrypoint: ./bin/rest_api --stream-url tcp://validator:40000
     stop_signal: SIGKILL
 
   integration_test:

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -143,7 +143,7 @@ class DockerNodeController(NodeController):
                 'links': ['validator'],
                 'volumes': ['/project:/project'],
                 'container_name': '-'.join([self._prefix, proc, node_num]),
-                'entrypoint': 'bin/{} {}:40000'.format(proc, node_name)
+                'entrypoint': 'bin/{} tcp://{}:40000'.format(proc, node_name)
             }
 
         # add the host:container port mapping for validator

--- a/poet/sawtooth_poet/tests/validator_registry_test/tp_validator_registry.yaml
+++ b/poet/sawtooth_poet/tests/validator_registry_test/tp_validator_registry.yaml
@@ -23,7 +23,7 @@ services:
       - ../../../..:/project/sawtooth-core
     expose:
       - 40000
-    entrypoint: ./bin/tp_validator_registry validator:40000
+    entrypoint: ./bin/tp_validator_registry tcp://validator:40000
     stop_signal: SIGKILL
 
   validator:

--- a/poet/sawtooth_poet/validator_registry/processor/main.py
+++ b/poet/sawtooth_poet/validator_registry/processor/main.py
@@ -65,7 +65,7 @@ def parse_args(args):
 
     parser.add_argument('endpoint',
                         nargs='?',
-                        default='localhost:40000',
+                        default='tcp://localhost:40000',
                         help='Endpoint for the validator connection')
     parser.add_argument('-v', '--verbose',
                         action='count',

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -28,7 +28,7 @@ def parse_args(args):
                         default="0.0.0.0")
     parser.add_argument('--stream-url',
                         help='The url to connect to a running Validator',
-                        default="localhost:40000")
+                        default="tcp://localhost:40000")
 
     return parser.parse_args(args)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
@@ -80,4 +80,4 @@ def add_load_parser(subparsers, parent_parser):
         '-U', '--url',
         type=str,
         help='connection URL for validator',
-        default='localhost:40000')
+        default='tcp://localhost:40000')

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
@@ -65,7 +65,7 @@ def parse_args(args):
 
     parser.add_argument('endpoint',
                         nargs='?',
-                        default='localhost:40000',
+                        default='tcp://localhost:40000',
                         help='Endpoint for the validator connection')
     parser.add_argument('-v', '--verbose',
                         action='count',

--- a/sdk/examples/sawtooth_xo/processor/main.py
+++ b/sdk/examples/sawtooth_xo/processor/main.py
@@ -66,7 +66,7 @@ def parse_args(args):
 
     parser.add_argument('endpoint',
                         nargs='?',
-                        default='localhost:40000',
+                        default='tcp://localhost:40000',
                         help='Endpoint for the validator connection')
     parser.add_argument('-v', '--verbose',
                         action='count',


### PR DESCRIPTION
The fix was disabling the monitor socket right after it receives a disconnect event and disconnecting but not closing the external socket on validator disconnect. After this, the validator can stop and restart with no ill effects on the transaction processor.

Also, the hard-coded "tcp://" is removed from the Stream python class as we might want to support other transport protocols. Then main modules used in bins are updated to specify tcp, as well as docker files and the docker manage library.