### PR TITLE
Add unit tests for Rest Api

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -113,6 +113,7 @@ test_core() {
 
 test_rest_api() {
     echo "[---Running REST API tests---]"
+    run_docker_test ./rest_api/tests/unit_rest_api.yaml -s unit-tests -p $ISOLATION_ID
 }
 
 test_sdk() {

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -28,7 +28,10 @@ def parse_args(args):
                         default="0.0.0.0")
     parser.add_argument('--stream-url',
                         help='The url to connect to a running Validator',
-                        default="tcp://localhost:40000")
+                        default='tcp://localhost:40000')
+    parser.add_argument('--timeout',
+                        help='Seconds to wait for a validator response',
+                        default=300)
 
     return parser.parse_args(args)
 
@@ -43,8 +46,8 @@ async def logging_middleware(app, handler):
     return logging_handler
 
 
-def start_rest_api(host, port, stream_url):
-    handler = RouteHandler(stream_url)
+def start_rest_api(host, port, stream_url, timeout):
+    handler = RouteHandler(stream_url, timeout)
 
     app = web.Application(middlewares=[logging_middleware])
     # Add routes to the web app
@@ -62,7 +65,11 @@ def start_rest_api(host, port, stream_url):
 def main():
     try:
         opts = parse_args(sys.argv[1:])
-        start_rest_api(opts.host, int(opts.port), opts.stream_url)
+        start_rest_api(
+            opts.host,
+            int(opts.port),
+            opts.stream_url,
+            int(opts.timeout))
         # pylint: disable=broad-except
     except Exception as e:
         print("Error: {}".format(e), file=sys.stderr)

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -15,7 +15,6 @@
 import asyncio
 import json
 import base64
-from urllib.parse import unquote
 from aiohttp import web
 from aiohttp.helpers import parse_mimetype
 # pylint: disable=no-name-in-module,import-error
@@ -118,12 +117,7 @@ class RouteHandler(object):
         Fetch a list of blocks from the validator
         """
         error_traps = [error_handlers.MissingBlock()]
-
-        # aiohttp parses both "+" and "%2B" as " ", so we grab the last segment
-        # of the URL and parse it manually, rather than use `match_info`
-        block_id = unquote(request.url.raw_name)
-
-        print('BLOCK ID', block_id)
+        block_id = request.match_info.get('block_id', '')
 
         response = self._query_validator(
             Message.CLIENT_BLOCK_GET_REQUEST,

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -35,8 +35,9 @@ from sawtooth_rest_api.protobuf.transaction_pb2 import TransactionHeader
 
 
 class RouteHandler(object):
-    def __init__(self, stream_url):
+    def __init__(self, stream_url, timeout=300):
         self._stream = Stream(stream_url)
+        self._timeout = timeout
 
     @asyncio.coroutine
     def batches_post(self, request):
@@ -141,15 +142,13 @@ class RouteHandler(object):
         Sends a protobuf message to the validator
         Handles a possible timeout if validator is unresponsive
         """
-        timeout = 300
-
         if isinstance(content, BaseMessage):
             content = content.SerializeToString()
 
         future = self._stream.send(message_type=message_type, content=content)
 
         try:
-            response = future.result(timeout=timeout)
+            response = future.result(timeout=self._timeout)
         except FutureTimeoutError:
             raise errors.ValidatorUnavailable()
 

--- a/rest_api/tests/unit/mock_stream.py
+++ b/rest_api/tests/unit/mock_stream.py
@@ -1,0 +1,256 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+from sawtooth_rest_api.protobuf import client_pb2 as client
+from sawtooth_rest_api.protobuf.block_pb2 import Block
+from sawtooth_rest_api.protobuf.block_pb2 import BlockHeader
+from sawtooth_rest_api.protobuf.batch_pb2 import Batch
+from sawtooth_rest_api.protobuf.batch_pb2 import BatchHeader
+from sawtooth_rest_api.protobuf.transaction_pb2 import Transaction
+from sawtooth_rest_api.protobuf.transaction_pb2 import TransactionHeader
+
+
+class _MockFuture(object):
+    class Response(object):
+        def __init__(self, content):
+            self.content = content
+
+    def __init__(self, response_content):
+        self._response = self.Response(response_content)
+
+    def result(self, timeout):
+        return self._response
+
+
+class MockStream(object):
+    """Replace a route handler's stream with an instance of this class to
+    intercept attempts to send requests, and send back custom responses.
+    """
+    def __init__(self):
+        self._handlers = {}
+        self._add_handler(Message.CLIENT_BLOCK_LIST_REQUEST, _BlockListHandler)
+        self._add_handler(Message.CLIENT_BLOCK_GET_REQUEST, _BlockGetHandler)
+
+    def send(self, message_type, content):
+        if not self._handlers[message_type]:
+            raise NotImplementedError(
+                'No handler for type {}'.format(message_type))
+        response = self._handlers[message_type].handle(content)
+        return _MockFuture(response.SerializeToString())
+
+    def _add_handler(self, message_type, handler_class):
+        self._handlers[message_type] = handler_class()
+
+
+class _MockBlockStore(object):
+    """A wrapper for a mock block store.
+    Access data with the get_blocks and get_block methods.
+
+    By default, it creates a store that looks like this:
+        chain_head_id: '2',
+        '2': {
+            header: {previous_block_id: '1', ...},
+            header_signature: '2',
+            batches: [{
+                header: {signer_pubkey: 'pubkey', ...},
+                header_signature: '2',
+                transactions: [{
+                    header: {nonce: '2', ...},
+                    header_signature: '2',
+                    payload: b'payload'
+                }]
+            }]
+        },
+        '1': {header: {...}, header_signature: '1', batches: [{...}]},
+        '0': {header: {...}, header_signature: '0', batches: [{...}]}
+    """
+    def __init__(self, size=3):
+        self._store = {}
+        self._chain_head_id = 'zzzzz'
+        for i in range(size):
+            self.add_block(str(i))
+
+    def add_block(self, block_id, root='merkle_root'):
+        txn_header = TransactionHeader(
+            batcher_pubkey='pubkey',
+            family_name='family',
+            family_version='0.0',
+            nonce=block_id,
+            signer_pubkey='pubkey')
+
+        txn = Transaction(
+            header=txn_header.SerializeToString(),
+            header_signature=block_id,
+            payload=b'payload')
+
+        batch_header = BatchHeader(
+            signer_pubkey='pubkey',
+            transaction_ids=[txn.header_signature])
+
+        batch = Batch(
+            header=batch_header.SerializeToString(),
+            header_signature=block_id,
+            transactions=[txn])
+
+        blk_header = BlockHeader(
+            block_num=len(self._store),
+            previous_block_id=self._chain_head_id,
+            signer_pubkey='pubkey',
+            batch_ids=[batch.header_signature],
+            consensus=b'consensus',
+            state_root_hash=root)
+
+        block = Block(
+            header=blk_header.SerializeToString(),
+            header_signature=block_id,
+            batches=[batch])
+
+        self._store[block_id] = block
+        self._chain_head_id = block_id
+
+    def get_blocks(self, head_id=None):
+        blocks = []
+        current_id = head_id or self._chain_head_id
+        while current_id in self._store:
+            blocks.append(self._store[current_id])
+            header = BlockHeader()
+            header.ParseFromString(blocks[-1].header)
+            current_id = header.previous_block_id
+        return blocks
+
+    def get_block(self, block_id):
+        return self._store.get(block_id, None)
+
+
+class _MockState(object):
+    """A wrapper for simplified state data.
+
+    By default, it creates a dict of state contexts that look like this:
+        '0': {'a': b'1'},
+        '1': {'a': b'2', 'b': b'4'},
+        '2': {'a': b'3', 'b': b'5', 'c': b'7'}
+    """
+    def __init__(self, size=3, start='a'):
+        self._state = {}
+        start_ord = ord(start)
+
+        for i in range(size):
+            if self._state:
+                self._state[str(i)] = self._state[str(i - 1)].copy()
+            else:
+                self._state[str(i)] = {}
+
+            data = self._state[str(i)]
+            data[chr(start_ord + i)] = str(i * size).encode()
+            for k, v in data.items():
+                data[k] = str(int(v) + 1).encode()
+
+    def get_leaves(self, address=None, head=None):
+        """Fetches state data as a list of leaves, as well as
+        determining the head id as needed
+        """
+        if not head:
+            head = str(len(self._state) - 1)
+        if not address:
+            address = ''
+
+        try:
+            state = self._state[head]
+        except KeyError:
+            return head, None
+
+        return head, [client.Leaf(address=k, data=v)
+            for k, v in state.items()
+            if k.startswith(address)]
+
+    def get_leaf(self, address, head=None):
+        """Fetches state data for a particular address, as well as
+        determining the head id as needed
+        """
+        if not head:
+            head = str(len(self._state) - 1)
+
+        try:
+            state = self._state[head]
+        except KeyError:
+            return head, None
+
+        try:
+            value = state[address]
+        except KeyError:
+            return head, ''
+
+        return head, value
+
+
+class _MockHandler(object):
+    """Parent class for any mock validator handlers. Children should call
+    super().__init__ as part of their own __init__.
+    """
+    def __init__(self, request_proto, response_proto, response_type):
+        self._request_proto = request_proto
+        self._response_proto = response_proto
+        self.response_type = response_type
+
+    def handle(self):
+        raise NotImplementedError('Handler needs handle method')
+
+    def _parse_request(self, content):
+        request = self._request_proto()
+        request.ParseFromString(content)
+        return request
+
+
+class _BlockListHandler(_MockHandler):
+    def __init__(self):
+        super().__init__(
+            client.ClientBlockListRequest,
+            client.ClientBlockListResponse,
+            Message.CLIENT_BLOCK_LIST_RESPONSE)
+
+    def handle(self, content):
+        request = self._parse_request(content)
+        store = _MockBlockStore()
+
+        blocks = store.get_blocks(request.head_id)
+        if not blocks:
+            return self._response_proto(status=self._response_proto.NO_ROOT)
+
+        return self._response_proto(
+            status=self._response_proto.OK,
+            head_id=blocks[0].header_signature,
+            blocks=blocks)
+
+
+class _BlockGetHandler(_MockHandler):
+    def __init__(self):
+        super().__init__(
+            client.ClientBlockGetRequest,
+            client.ClientBlockGetResponse,
+            Message.CLIENT_BLOCK_GET_RESPONSE)
+
+    def handle(self, content):
+        request = self._parse_request(content)
+        store = _MockBlockStore()
+
+        block = store.get_block(request.block_id)
+        if not block:
+            return self._response_proto(
+                status=self._response_proto.NO_RESOURCE)
+
+        return self._response_proto(
+            status=self._response_proto.OK,
+            block=block)

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -1,0 +1,244 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from base64 import b64decode
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from sawtooth_rest_api.routes import RouteHandler
+from tests.unit.mock_stream import MockStream
+
+class ApiTest(AioHTTPTestCase):
+
+    async def get_application(self, loop):
+        # Create handler and replace stream with mock
+        handlers = RouteHandler('tcp://0.0.0.0:40404', 5)
+        handlers._stream = MockStream()
+
+        # Add handlers
+        app = web.Application(loop=loop)
+        app.router.add_get('/state', handlers.state_list)
+        app.router.add_get('/state/{address}', handlers.state_get)
+        app.router.add_get('/blocks', handlers.block_list)
+        app.router.add_get('/blocks/{block_id}', handlers.block_get)
+        return app
+
+    async def get_and_assert_status(self, endpoint, status):
+        request = await self.client.request('GET', endpoint)
+        self.assertEqual(status, request.status)
+        return request
+
+    async def get_json_assert_200(self, endpoint):
+        request = await self.get_and_assert_status(endpoint, 200)
+        return await request.json()
+
+    async def assert_404(self, endpoint):
+        await self.get_and_assert_status(endpoint, 404)
+
+    def assert_all_instances(self, items, cls):
+        """Asserts that all items in a collection are instances of a class
+        """
+        for item in items:
+            self.assertIsInstance(item, cls)
+
+    def assert_has_valid_head(self, response, expected):
+        """Asserts a response has a head string with an expected value
+        """
+        self.assertIn('head', response)
+        head = response['head']
+        self.assertIsInstance(head, str)
+        self.assertEqual(head, expected)
+
+    def assert_has_valid_link(self, response, expected_ending):
+        """Asserts a response has a link url string with an expected ending
+        """
+        self.assertIn('link', response)
+        link = response['link']
+        self.assertIsInstance(link, str)
+        self.assertTrue(link.startswith('http'))
+        self.assertTrue(link.endswith(expected_ending))
+
+    def assert_has_valid_data_list(self, response, expected_length):
+        """Asserts a response has a data list of dicts of an expected length,
+        """
+        self.assertIn('data', response)
+        data = response['data']
+        self.assertIsInstance(data, list)
+        self.assert_all_instances(data, dict)
+        self.assertEqual(expected_length, len(data))
+
+    def assert_block_well_formed(self, block, expected_id):
+        """Tests a block dict is fully expanded and matches the expected id.
+        Assumes the block contains one batch and txn which share the id.
+        """
+
+        # Check block and its header
+        self.assertIsInstance(block, dict)
+        self.assertEqual(expected_id, block['header_signature'])
+        self.assertIsInstance(block['header'], dict)
+        self.assertEqual(b'consensus', b64decode(block['header']['consensus']))
+
+        # Check batch and its header
+        batches = block['batches']
+        self.assertIsInstance(batches, list)
+        self.assertEqual(1, len(batches))
+        self.assert_all_instances(batches, dict)
+
+        self.assertEqual(expected_id, batches[0]['header_signature'])
+        self.assertIsInstance(batches[0]['header'], dict)
+        self.assertEqual('pubkey', batches[0]['header']['signer_pubkey'])
+
+        # Check transaction and its header
+        txns = batches[0]['transactions']
+        self.assertIsInstance(txns, list)
+        self.assertEqual(1, len(txns))
+        self.assert_all_instances(txns, dict)
+
+        self.assertEqual(expected_id, txns[0]['header_signature'])
+        self.assertEqual(b'payload', b64decode(txns[0]['payload']))
+        self.assertIsInstance(txns[0]['header'], dict)
+        self.assertEqual(expected_id, txns[0]['header']['nonce'])
+
+    @unittest_run_loop
+    async def test_block_list(self):
+        """Verifies a GET /blocks without parameters works properly.
+
+        Fetches all blocks from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2'
+            - a link property that ends in '/blocks?head=2'
+            - a data property that:
+                * contains a list of 3 block dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/blocks')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/blocks?head=2')
+        self.assert_has_valid_data_list(response, 3)
+
+        first_block = response['data'][0]
+        self.assertEqual(response['head'], first_block['header_signature'])
+        self.assert_block_well_formed(first_block, '2')
+
+    @unittest_run_loop
+    async def test_block_list_with_head(self):
+        """Verifies a GET /blocks with a head parameter works properly.
+
+        Fetches blocks from '1' and older from the store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/blocks?head=1'
+            - a data property that:
+                * contains a list of 2 block dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/blocks?head=1')
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/blocks?head=1')
+        self.assert_has_valid_data_list(response, 2)
+
+        first_block = response['data'][0]
+        self.assertEqual(response['head'], first_block['header_signature'])
+        self.assert_block_well_formed(first_block, '1')
+
+    @unittest_run_loop
+    async def test_block_list_with_bad_head(self):
+        """Verifies a GET /blocks with a bad head breaks properly.
+
+        Expects to find:
+            - a response status of 404
+        """
+        await self.assert_404('/blocks?head=bad')
+
+    @unittest_run_loop
+    async def test_block_get(self):
+        """Verifies a GET /blocks/{block_id} works properly.
+
+        Fetches block '1' from the default mock store:
+            {
+                header: {previous_block_id: '0', ...},
+                header_signature: '1',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '1',
+                    transactions: [{
+                        header: {nonce: '1', ...},
+                        header_signature: '1',
+                        payload: b'payload'
+                    }]
+                }]
+            }
+
+        Expects to find:
+            - a response status of 200
+            - no head property
+            - a link property that ends in '/blocks/1'
+            - a data property that:
+                * contains a single block dict with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/blocks/1')
+
+        self.assertNotIn('head', response)
+        self.assert_has_valid_link(response, '/blocks/1')
+        self.assertIn('data', response)
+        self.assert_block_well_formed(response['data'], '1')
+
+    @unittest_run_loop
+    async def test_block_get_with_bad_id(self):
+        """Verifies a GET /blocks with a bad head breaks properly.
+
+        Expects to find:
+            - a response status of 404
+        """
+        await self.assert_404('/blocks/bad')

--- a/rest_api/tests/unit_rest_api.yaml
+++ b/rest_api/tests/unit_rest_api.yaml
@@ -13,18 +13,16 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM sawtooth-base
+version: "2.1"
 
-RUN apt-get update && apt-get install -y -q \
-    inetutils-ping \
-    python3-nose2
+services:
 
-RUN pip3 install \
-    PyYAML \
-    aiohttp
-
-VOLUME /project/sawtooth-core
-
-WORKDIR /project/sawtooth-core
-
-ENV PATH="/project/sawtooth-core/bin:$PATH"
+  unit-tests:
+    image: sawtooth-test:$ISOLATION_ID
+    volumes:
+      - ../../:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/rest_api/tests/unit
+    entrypoint: nose2-3 -v
+    environment:
+        PYTHONPATH: "/project/sawtooth-core/rest_api:\
+            /project/sawtooth-core/sdk/python"


### PR DESCRIPTION
Add the infrastructure for unit testing the Rest Api within `run_tests`, including a simplified mock validator that responds to ZMQ requests with mock data.

Add tests for both `/blocks`, and `/state`, the routes that are currently up to spec.

Also add small fixups to the rest api, adding a timeout option, and taking advantage of aiohttp's recently fixed `match_info` property (no more weird hacks to get a `+`!).