### PR TITLE
Rest api restart

### DIFF
--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -23,6 +23,7 @@ from aiohttp.helpers import parse_mimetype
 from google.protobuf.json_format import MessageToJson, MessageToDict
 from google.protobuf.message import Message as BaseMessage
 
+from sawtooth_sdk.client.exceptions import ValidatorConnectionError
 from sawtooth_sdk.client.future import FutureTimeoutError
 from sawtooth_sdk.client.stream import Stream
 from sawtooth_sdk.protobuf.validator_pb2 import Message
@@ -159,7 +160,12 @@ class RouteHandler(object):
         except FutureTimeoutError:
             raise errors.ValidatorUnavailable()
 
-        return response.content
+        try:
+            return response.content
+            # the error is caused by resolving a FutureError
+            # on validator disconnect.
+        except ValidatorConnectionError:
+            raise errors.ValidatorUnavailable()
 
     @staticmethod
     def _try_response_parse(proto, response, traps=None):

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 import time
 
+from sawtooth_sdk.client.exceptions import ValidatorConnectionError
 from sawtooth_sdk.client.stream import Stream
 
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
@@ -54,7 +55,10 @@ def do_load(args):
 
     for future in futures:
         result = future.result()
-        assert result.message_type == Message.CLIENT_BATCH_SUBMIT_RESPONSE
+        try:
+            assert result.message_type == Message.CLIENT_BATCH_SUBMIT_RESPONSE
+        except ValidatorConnectionError as vce:
+            LOGGER.warning("the future resolved to %s", vce)
 
     stop = time.time()
     print("batches: {} batch/sec: {}".format(


### PR DESCRIPTION
Previously it was possible to restart the rest api without restarting the validator. Then it was possible to restart the validator without restarting the rest api, but not while the rest api was waiting for a response from the validator. This PR makes it possible to restart the validator while the rest api is waiting for a response. It will return a 503 Service Unavailable. 

This PR also fixes similar behavior in the intkey load cli, where if the validator stopped before returning responses to all messages an uncaught error would happen. This PR catches that error and logs a message.