### PR TITLE
Determine and use Consensus Module using On-chain Settings 

### DIFF
--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -44,3 +44,9 @@ class NotAvailableException(Exception):
     tried again later.
     """
     pass
+
+
+class UnknownConsensusModuleError(Exception):
+    """Error thrown when there is an invalid consensus module configuration.
+    """
+    pass

--- a/validator/sawtooth_validator/journal/consensus/consensus_factory.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus_factory.py
@@ -1,0 +1,47 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import importlib
+
+from sawtooth_validator.exceptions import UnknownConsensusModuleError
+
+
+class ConsensusFactory(object):
+    """ConsensusFactory returns consensus modules by short name.
+    """
+
+    @staticmethod
+    def get_consensus_module(module_name):
+        """Returns a consensus module by name.
+
+        Args:
+            module_name (str): The name of the module to load.
+
+        Returns:
+            module: The consensus module.
+
+        Raises:
+            UnknownConsensusModuleError: Raised if the given module_name does
+                not correspond to a consensus implementation.
+        """
+        if module_name == 'devmode':
+            return importlib.import_module(
+                'sawtooth_validator.journal.consensus.dev_mode.'
+                'dev_mode_consensus')
+        elif module_name == 'poet1':
+            return importlib.import_module(
+                'sawtooth_validator.journal.consensus.poet1.poet_consensus')
+        else:
+            raise UnknownConsensusModuleError(
+                'Consensus module "{}" does not exist.'.format(module_name))

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -40,7 +40,7 @@ class BlockPublisher(BlockPublisherInterface):
         self._num_batches = 1
         self._count = 0
 
-    def initialize_block(self, block_header):
+    def initialize_block(self, block):
         """Do initialization necessary for the consensus to claim a block,
         this may include initiating voting activates, starting proof of work
         hash generation, or create a PoET wait timer.
@@ -51,7 +51,7 @@ class BlockPublisher(BlockPublisherInterface):
         Returns:
             none
         """
-        block_header.consensus = b"Devmode"
+        block.block_header.consensus = b"Devmode"
 
     def check_publish_block(self, block):
         """Check if a candidate block is ready to be claimed.
@@ -69,7 +69,7 @@ class BlockPublisher(BlockPublisherInterface):
         self._count += 1
         return False
 
-    def finalize_block(self, block_header):
+    def finalize_block(self, block):
         """Finalize a block to be claimed. Provide any signatures and
         data updates that need to be applied to the block before it is
         signed and broadcast to the network.
@@ -94,8 +94,8 @@ class TimedBlockPublisher(BlockPublisherInterface):
         self._wait_time = wait_time
         self._last_block_time = time.time()
 
-    def initialize_block(self, block_header):
-        block_header.consensus = b"TimedDevmode"
+    def initialize_block(self, block):
+        block.block_header.consensus = b"TimedDevmode"
 
     def check_publish_block(self, block):
         if time.time() - self._last_block_time > self._wait_time:
@@ -103,7 +103,7 @@ class TimedBlockPublisher(BlockPublisherInterface):
             return True
         return False
 
-    def finalize_block(self, block_header):
+    def finalize_block(self, block):
         pass
 
 

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -97,7 +97,6 @@ class Journal(object):
             self._exit = True
 
     def __init__(self,
-                 consensus_module,
                  block_store,
                  state_view_factory,
                  block_sender,
@@ -109,8 +108,6 @@ class Journal(object):
         Creates a Journal instance.
 
         Args:
-            consensus_module (module): The consensus module for block
-                processing.
             block_store (:obj:): The block store.
             state_view_factory (:obj:`StateViewFactory`): StateViewFactory for
                 read-only state views.
@@ -123,7 +120,6 @@ class Journal(object):
             block_cache (:obj:`BlockCache`, optional): A BlockCache to use in
                 place of an internally created instance. Defaults to None.
         """
-        self._consensus_module = consensus_module
         self._block_store = BlockStoreAdapter(block_store)
         self._block_cache = block_cache
         if self._block_cache is None:
@@ -145,7 +141,6 @@ class Journal(object):
 
     def _init_subprocesses(self):
         self._block_publisher = BlockPublisher(
-            consensus_module=self._consensus_module,
             transaction_executor=self._transaction_executor,
             block_cache=self._block_cache,
             state_view_factory=self._state_view_factory,
@@ -157,7 +152,6 @@ class Journal(object):
         self._publisher_thread = self._PublisherThread(self._block_publisher,
                                                        self._batch_queue)
         self._chain_controller = ChainController(
-            consensus_module=self._consensus_module,
             block_sender=self._block_sender,
             block_cache=self._block_cache,
             state_view_factory=self._state_view_factory,

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -23,6 +23,8 @@ from sawtooth_validator.execution.scheduler_exceptions import SchedulerError
 from sawtooth_validator.journal.block_builder import BlockBuilder
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.consensus.consensus_factory import \
+    ConsensusFactory
 
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 
@@ -37,7 +39,6 @@ class BlockPublisher(object):
     Consensus deems it appropriate.
     """
     def __init__(self,
-                 consensus_module,
                  transaction_executor,
                  block_cache,
                  state_view_factory,
@@ -64,7 +65,6 @@ class BlockPublisher(object):
         """
         self._lock = RLock()
         self._candidate_block = None  # the next block in potentia
-        self._consensus_module = consensus_module  # the consensus module.
         self._consensus = None
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory
@@ -94,7 +94,9 @@ class BlockPublisher(object):
         prev_state = self._get_previous_block_root_state_hash(chain_head)
         state_view = self._state_view_factory. \
             create_view(prev_state)
-        self._consensus = self._consensus_module.\
+        consensus_module = ConsensusFactory.get_configured_consensus_module(
+            state_view)
+        self._consensus = consensus_module.\
             BlockPublisher(block_cache=self._block_cache,
                            state_view=state_view)
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -24,7 +24,6 @@ from sawtooth_signing import pbct as signing
 
 from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
-from sawtooth_validator.journal.consensus.dev_mode import dev_mode_consensus
 from sawtooth_validator.journal.genesis import GenesisController
 from sawtooth_validator.journal.journal import Journal
 from sawtooth_validator.protobuf import validator_pb2
@@ -186,7 +185,6 @@ class Validator(object):
 
         # Create and configure journal
         self._journal = Journal(
-            consensus_module=dev_mode_consensus,
             block_store=block_store,
             state_view_factory=state_view_factory,
             block_sender=block_sender,

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -38,6 +38,7 @@ from sawtooth_validator.journal.block_sender import BroadcastBlockSender
 from sawtooth_validator.execution.executor import TransactionExecutor
 from sawtooth_validator.execution import processor_handlers
 from sawtooth_validator.state import client_handlers
+from sawtooth_validator.state.state_view import StateViewFactory
 from sawtooth_validator.gossip import signature_verifier
 from sawtooth_validator.networking.interconnect import Interconnect
 from sawtooth_validator.gossip.gossip import Gossip
@@ -46,7 +47,6 @@ from sawtooth_validator.gossip.gossip_handlers import GossipMessageHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PingHandler
-from sawtooth_validator.state.state_view import StateViewFactory
 
 LOGGER = logging.getLogger(__name__)
 
@@ -74,6 +74,7 @@ class Validator(object):
 
         merkle_db = LMDBNoLockDatabase(db_filename, 'n')
         context_manager = ContextManager(merkle_db)
+        state_view_factory = StateViewFactory(merkle_db)
 
         block_db_filename = os.path.join(data_dir, 'block.lmdb')
         LOGGER.debug('block store file is %s', block_db_filename)
@@ -187,7 +188,7 @@ class Validator(object):
         self._journal = Journal(
             consensus_module=dev_mode_consensus,
             block_store=block_store,
-            state_view_factory=StateViewFactory(merkle_db),
+            state_view_factory=state_view_factory,
             block_sender=block_sender,
             transaction_executor=executor,
             squash_handler=context_manager.get_squash_handler(),
@@ -198,6 +199,7 @@ class Validator(object):
             transaction_executor=executor,
             completer=completer,
             block_store=block_store,
+            state_view_factory=state_view_factory,
             identity_key=identity_signing_key,
             data_dir=data_dir
         )

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -22,9 +22,12 @@ from unittest.mock import patch
 
 from sawtooth_signing import pbct as signing
 
+from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
 from sawtooth_validator.journal.genesis import GenesisController
 from sawtooth_validator.journal.genesis import InvalidGenesisStateError
+from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.state.state_view import StateViewFactory
 
 
 class TestGenesisController(unittest.TestCase):
@@ -49,6 +52,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             {},  # Empty block store
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -65,6 +69,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -81,6 +86,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -102,6 +108,7 @@ class TestGenesisController(unittest.TestCase):
             Mock(name='txn_executor'),
             Mock('completer'),
             block_store,
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -127,6 +134,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -152,6 +160,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
+            StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir
         )
@@ -174,9 +183,12 @@ class TestGenesisController(unittest.TestCase):
         genesis_file = self._with_empty_batch_file()
         block_store = {}
 
+        state_database = DictDatabase()
+        merkle_db = MerkleDatabase(state_database)
+
         ctx_mgr = Mock(name='ContextManager')
         ctx_mgr.get_squash_handler.return_value = Mock()
-        ctx_mgr.get_first_root.return_value = '000000000'
+        ctx_mgr.get_first_root.return_value = merkle_db.get_merkle_root()
 
         txn_executor = Mock(name='txn_executor')
         completer = Mock('completer')
@@ -187,6 +199,7 @@ class TestGenesisController(unittest.TestCase):
             txn_executor,
             completer,
             block_store,
+            StateViewFactory(state_database),
             self._identity_key,
             data_dir=self._temp_dir
         )

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -34,7 +34,7 @@ class BlockPublisher(BlockPublisherInterface):
         self._block_cache = block_cache
         self._state_view = state_view
 
-    def initialize_block(self, block_header):
+    def initialize_block(self, block):
         """Do initialization necessary for the consensus to claim a block,
         this may include initiating voting activates, starting proof of work
         hash generation, or create a PoET wait timer.
@@ -45,7 +45,7 @@ class BlockPublisher(BlockPublisherInterface):
         Returns:
             none
         """
-        block_header.consensus = b"test_mode"
+        block.block_header.consensus = b"test_mode"
 
     def check_publish_block(self, block):
         """Check if a candidate block is ready to be claimed.
@@ -59,7 +59,7 @@ class BlockPublisher(BlockPublisherInterface):
         """
         return True
 
-    def finalize_block(self, block_header):
+    def finalize_block(self, block):
         """Finalize a block to be claimed. Provide any signatures and
         data updates that need to be applied to the block before it is
         signed and broadcast to the network.
@@ -71,8 +71,8 @@ class BlockPublisher(BlockPublisherInterface):
             None
         """
         hasher = hashlib.sha256()
-        hasher.update(block_header.consensus)
-        block_header.consensus = hasher.hexdigest().encode()
+        hasher.update(block.block_header.consensus)
+        block.block_header.consensus = hasher.hexdigest().encode()
 
 
 class BlockVerifier(BlockVerifierInterface):
@@ -87,6 +87,7 @@ class BlockVerifier(BlockVerifierInterface):
 
     def compute_block_weight(self, block_state):
         return block_state.block_num
+
 
 class ForkResolver(ForkResolverInterface):
     # Provides the fork resolution interface for the BlockValidator to use

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -86,7 +86,6 @@ class TestBlockPublisher(unittest.TestCase):
 
         LOGGER.info(self.blocks)
         publisher = BlockPublisher(
-            consensus_module=mock_consensus,
             transaction_executor=MockTransactionExecutor(),
             block_cache=self.blocks.block_cache,
             state_view_factory=self.state_view_factory,
@@ -337,7 +336,6 @@ class TestChainController(unittest.TestCase):
             pass
 
         self.chain_ctrl = ChainController(
-            consensus_module=mock_consensus,
             block_cache=self.blocks.block_cache,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
@@ -435,7 +433,6 @@ class TestJournal(unittest.TestCase):
         journal = None
         try:
             journal = Journal(
-                consensus_module=mock_consensus,
                 block_store=btm.block_store.store,
                 block_cache=btm.block_cache,
                 state_view_factory=StateViewFactory(DictDatabase()),


### PR DESCRIPTION
During genesis block construction, the consensus module can be loaded based on the settings supplied by the sawtooth_config transaction family.  The module is then used to correctly initialize and finalize the block before committing it to the block store.

The consensus module is also before it is used during Journal's processing of blocks.