### PR TITLE
Add block and batch request messages

### DIFF
--- a/protos/network.proto
+++ b/protos/network.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Intel Corporation
+// Copyright 2016, 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,4 +45,31 @@ message NetworkAcknowledgement {
     }
 
     Status status = 1;
+}
+
+message GossipBlockRequest {
+    // The id of the block that is being requested
+    string block_id = 1;
+
+    // The identity of the validator that is requesting the block
+    bytes node_id = 2;
+
+}
+
+message GossipBatchByBatchIdRequest {
+    // The id of the batch that is being requested
+    string id = 1;
+
+    // The identity of the validator that is requesting the batch
+    bytes node_id = 2;
+
+}
+
+message GossipBatchByTransactionIdRequest {
+    // The id's of the transaction that are in the batches requested
+    repeated string ids = 1;
+
+    // The identity of the validator that is requesting the batches
+    bytes node_id = 2;
+
 }

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -1,4 +1,4 @@
-// Copyright 2016 Intel Corporation
+// Copyright 2016, 2017 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,6 +95,9 @@ message Message {
         GOSSIP_UNREGISTER = 202;
         GOSSIP_ACK = 203;
         GOSSIP_PING = 204;
+        GOSSIP_BLOCK_REQUEST = 205;
+        GOSSIP_BATCH_BY_BATCH_ID_REQUEST = 206;
+        GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST = 207;
 
     }
     // The type of message, used to determine how to 'route' the message

--- a/validator/sawtooth_validator/journal/chain_id_manager.py
+++ b/validator/sawtooth_validator/journal/chain_id_manager.py
@@ -1,0 +1,53 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import os
+import logging
+from pathlib import Path
+from sawtooth_validator.exceptions import LocalConfigurationError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ChainIdManager(object):
+    """
+    The ChainIdManager is in charge of of keeping track of the block-chain-id
+    stored in the data_dir.
+    """
+    def __init__(self, data_dir):
+        self._data_dir = data_dir
+
+    def save_block_chain_id(self, block_chain_id):
+        LOGGER.debug('writing block chain id')
+        block_chain_id_file = os.path.join(self._data_dir, 'block-chain-id')
+        try:
+            with open(block_chain_id_file, 'w') as f:
+                f.write(block_chain_id)
+        except IOError:
+            raise LocalConfigurationError(
+                "Unable to write to {}".format(block_chain_id_file))
+
+    def get_block_chain_id(self):
+        block_chain_id_file = os.path.join(self._data_dir, 'block-chain-id')
+        if not Path(block_chain_id_file).is_file():
+            return None
+
+        try:
+            with open(block_chain_id_file, 'r') as f:
+                block_chain_id = f.read()
+                return block_chain_id if block_chain_id else None
+
+        except IOError:
+            raise LocalConfigurationError(
+                'The block-chain-id file exists, but is unreadable')

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -103,6 +103,7 @@ class Journal(object):
                  transaction_executor,
                  squash_handler,
                  identity_signing_key,
+                 chain_id_manager,
                  block_cache=None):
         """
         Creates a Journal instance.
@@ -117,6 +118,8 @@ class Journal(object):
             squash_handler (function): Squash handler function for merging
                 contexts.
             identity_signing_key (str): Private key for signing blocks
+            chain_id_manager (:obj:`ChainIdManager`) The ChainIdManager
+                instance.
             block_cache (:obj:`BlockCache`, optional): A BlockCache to use in
                 place of an internally created instance. Defaults to None.
         """
@@ -138,6 +141,7 @@ class Journal(object):
         self._chain_controller = None
         self._block_queue = queue.Queue()
         self._chain_thread = None
+        self._chain_id_manager = chain_id_manager
 
     def _init_subprocesses(self):
         self._block_publisher = BlockPublisher(
@@ -158,7 +162,8 @@ class Journal(object):
             executor=ThreadPoolExecutor(1),
             transaction_executor=self._transaction_executor,
             on_chain_updated=self._block_publisher.on_chain_updated,
-            squash_handler=self._squash_handler
+            squash_handler=self._squash_handler,
+            chain_id_manager=self._chain_id_manager
         )
         self._chain_thread = self._ChainThread(self._chain_controller,
                                                self._block_queue,

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -1,0 +1,143 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.protobuf import network_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Responder(object):
+    def __init__(self, completer):
+        self.completer = completer
+
+    def check_for_block(self, block_id):
+        # Ask Completer
+        block = self.completer.get_block(block_id)
+        return block
+
+    def check_for_batch(self, batch_id):
+        batch = self.completer.get_batch(batch_id)
+        return batch
+
+    def check_for_batch_by_transaction(self, transaction_id):
+        batch = self.completer.get_batch(transaction_id)
+        return batch
+
+
+class BlockResponderHandler(Handler):
+    def __init__(self, responder, gossip):
+        self._responder = responder
+        self._gossip = gossip
+
+    def handle(self, identity, message_content):
+        gossip_message = network_pb2.GossipBlockRequest()
+        gossip_message.ParseFromString(message_content)
+        block_id = gossip_message.block_id
+        block = self._responder.check_for_block(block_id)
+        if block is None:
+            # No block found, broadcast orignal message to other peers
+            self._gossip.broadcast(gossip_message,
+                                   validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
+        else:
+            # Found block, Currently we create a new gossip message, in the
+            # the future a direct message to the node that requested the block
+            # will be used.
+            LOGGER.debug("Responding to block requests: %s",
+                         block.get_block().header_signature)
+            self._gossip.broadcast_block(block.get_block())
+
+        return HandlerResult(
+            status=HandlerStatus.PASS)
+
+
+class BatchByBatchIdResponderHandler(Handler):
+    def __init__(self, responder, gossip):
+        self._responder = responder
+        self._gossip = gossip
+
+    def handle(self, identity, message_content):
+        gossip_message = network_pb2.GossipBatchByBatchIdRequest()
+        gossip_message.ParseFromString(message_content)
+        batch = None
+        batch = self._responder.check_for_batch(gossip_message.id)
+
+        if batch is None:
+            self._gossip.broadcast(
+                gossip_message,
+                validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
+
+        else:
+            LOGGER.debug("Responding to batch requests %s",
+                         batch.header_signature)
+            self._gossip.broadcast_batch(batch)
+
+        return HandlerResult(
+            status=HandlerStatus.PASS)
+
+
+class BatchByTransactionIdResponderHandler(Handler):
+    def __init__(self, responder, gossip):
+        self._responder = responder
+        self._gossip = gossip
+
+    def handle(self, identity, message_content):
+        gossip_message = network_pb2.GossipBatchByTransactionIdRequest()
+        gossip_message.ParseFromString(message_content)
+        batch = None
+        batches = []
+        unfound_txn_ids = []
+        for txn_id in gossip_message.ids:
+            batch = self._responder.check_for_batch_by_transaction(
+                txn_id)
+
+            # The txn_id was not found.
+            if batch is None:
+                unfound_txn_ids.append(txn_id)
+
+            # Check to see if a previous txn was in the same batch.
+            elif batch not in batches:
+                batches.append(batch)
+
+            batch = None
+
+        if batches == []:
+            self._gossip.broadcast(
+                gossip_message,
+                validator_pb2.Message.
+                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST)
+
+        elif unfound_txn_ids != []:
+            new_request = network_pb2.GossipBatchByTransactionIdRequest()
+            new_request.ids.extend(unfound_txn_ids)
+            new_request.node_id = gossip_message.node_id
+            self._gossip.broadcast(
+                new_request,
+                validator_pb2.Message.
+                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST)
+
+        if batches != []:
+            for batch in batches:
+                LOGGER.debug("Responding to batch requests %s",
+                             batch.header_signature)
+                self._gossip.broadcast_batch(batch)
+
+        return HandlerResult(
+            status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2016, 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,11 @@ from sawtooth_validator.journal.completer import CompleterGossipHandler
 from sawtooth_validator.journal.completer import \
     CompleterBatchListBroadcastHandler
 from sawtooth_validator.journal.completer import Completer
+from sawtooth_validator.journal.responder import Responder
+from sawtooth_validator.journal.responder import BlockResponderHandler
+from sawtooth_validator.journal.responder import BatchByBatchIdResponderHandler
+from sawtooth_validator.journal.responder import \
+    BatchByTransactionIdResponderHandler
 from sawtooth_validator.networking.dispatch import Dispatcher
 from sawtooth_validator.journal.block_sender import BroadcastBlockSender
 from sawtooth_validator.execution.executor import TransactionExecutor
@@ -85,36 +90,13 @@ class Validator(object):
         # setup network
         self._dispatcher = Dispatcher()
 
-        completer = Completer(block_store)
-
         thread_pool = ThreadPoolExecutor(max_workers=10)
         process_pool = ProcessPoolExecutor(max_workers=3)
-
-        self._dispatcher.add_handler(
-            validator_pb2.Message.TP_STATE_GET_REQUEST,
-            tp_state_handlers.TpStateGetHandler(context_manager),
-            thread_pool)
-
-        self._dispatcher.add_handler(
-            validator_pb2.Message.TP_STATE_SET_REQUEST,
-            tp_state_handlers.TpStateSetHandler(context_manager),
-            thread_pool)
 
         self._service = Interconnect(component_endpoint,
                                      self._dispatcher,
                                      secured=False)
         executor = TransactionExecutor(self._service, context_manager)
-
-        self._dispatcher.add_handler(
-            validator_pb2.Message.TP_REGISTER_REQUEST,
-            processor_handlers.ProcessorRegisterHandler(executor.processors),
-            thread_pool)
-
-        self._dispatcher.add_handler(
-            validator_pb2.Message.TP_UNREGISTER_REQUEST,
-            processor_handlers.ProcessorUnRegisterHandler(executor.processors),
-            thread_pool
-        )
 
         identity = hashlib.sha512(
             time.time().hex().encode()).hexdigest()[:23]
@@ -146,7 +128,54 @@ class Validator(object):
 
         self._gossip = Gossip(self._network)
 
+        completer = Completer(block_store, self._gossip)
+
         block_sender = BroadcastBlockSender(completer, self._gossip)
+
+        # Create and configure journal
+        self._journal = Journal(
+            block_store=block_store,
+            state_view_factory=StateViewFactory(merkle_db),
+            block_sender=block_sender,
+            transaction_executor=executor,
+            squash_handler=context_manager.get_squash_handler(),
+            identity_signing_key=identity_signing_key))
+
+        self._genesis_controller = GenesisController(
+            context_manager=context_manager,
+            transaction_executor=executor,
+            completer=completer,
+            block_store=block_store,
+            state_view_factory=state_view_factory,
+            identity_key=identity_signing_key,
+            data_dir=data_dir
+        )
+
+        responder = Responder(completer)
+
+        completer.set_on_batch_received(self._journal.on_batch_received)
+        completer.set_on_block_received(self._journal.on_block_received)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.TP_STATE_GET_REQUEST,
+            tp_state_handlers.TpStateGetHandler(context_manager),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.TP_STATE_SET_REQUEST,
+            tp_state_handlers.TpStateSetHandler(context_manager),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.TP_REGISTER_REQUEST,
+            processor_handlers.ProcessorRegisterHandler(executor.processors),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.TP_UNREGISTER_REQUEST,
+            processor_handlers.ProcessorUnRegisterHandler(executor.processors),
+            thread_pool
+        )
 
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_PING,
@@ -167,47 +196,44 @@ class Validator(object):
             validator_pb2.Message.GOSSIP_MESSAGE,
             GossipMessageHandler(),
             network_thread_pool)
+
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_MESSAGE,
             signature_verifier.GossipMessageSignatureVerifier(),
             process_pool)
+
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_MESSAGE,
             GossipBroadcastHandler(
                 gossip=self._gossip),
             network_thread_pool)
+
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_MESSAGE,
             CompleterGossipHandler(
                 completer),
             network_thread_pool)
 
-        # Create and configure journal
-        self._journal = Journal(
-            block_store=block_store,
-            state_view_factory=state_view_factory,
-            block_sender=block_sender,
-            transaction_executor=executor,
-            squash_handler=context_manager.get_squash_handler(),
-            identity_signing_key=identity_signing_key)
+        self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_BLOCK_REQUEST,
+            BlockResponderHandler(responder, self._gossip),
+            network_thread_pool)
 
-        self._genesis_controller = GenesisController(
-            context_manager=context_manager,
-            transaction_executor=executor,
-            completer=completer,
-            block_store=block_store,
-            state_view_factory=state_view_factory,
-            identity_key=identity_signing_key,
-            data_dir=data_dir
-        )
+        self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST,
+            BatchByBatchIdResponderHandler(responder, self._gossip),
+            network_thread_pool)
 
-        completer.set_on_batch_received(self._journal.on_batch_received)
-        completer.set_on_block_received(self._journal.on_block_received)
+        self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST,
+            BatchByTransactionIdResponderHandler(responder, self._gossip),
+            network_thread_pool)
 
         self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
             signature_verifier.BatchListSignatureVerifier(),
             process_pool)
+
         self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
             CompleterBatchListBroadcastHandler(

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -40,6 +40,7 @@ from sawtooth_validator.journal.responder import \
     BatchByTransactionIdResponderHandler
 from sawtooth_validator.networking.dispatch import Dispatcher
 from sawtooth_validator.journal.block_sender import BroadcastBlockSender
+from sawtooth_validator.journal.chain_id_manager import ChainIdManager
 from sawtooth_validator.execution.executor import TransactionExecutor
 from sawtooth_validator.execution import processor_handlers
 from sawtooth_validator.state import client_handlers
@@ -131,7 +132,7 @@ class Validator(object):
         completer = Completer(block_store, self._gossip)
 
         block_sender = BroadcastBlockSender(completer, self._gossip)
-
+        chain_id_manager = ChainIdManager(data_dir)
         # Create and configure journal
         self._journal = Journal(
             block_store=block_store,
@@ -139,7 +140,9 @@ class Validator(object):
             block_sender=block_sender,
             transaction_executor=executor,
             squash_handler=context_manager.get_squash_handler(),
-            identity_signing_key=identity_signing_key))
+            identity_signing_key=identity_signing_key,
+            chain_id_manager=chain_id_manager
+        )
 
         self._genesis_controller = GenesisController(
             context_manager=context_manager,
@@ -148,7 +151,8 @@ class Validator(object):
             block_store=block_store,
             state_view_factory=state_view_factory,
             identity_key=identity_signing_key,
-            data_dir=data_dir
+            data_dir=data_dir,
+            chain_id_manager=chain_id_manager
         )
 
         responder = Responder(completer)

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -24,6 +24,7 @@ from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
 from sawtooth_validator.journal.block_store import BlockStore
+from sawtooth_validator.journal.chain_id_manager import ChainIdManager
 from sawtooth_validator.journal.genesis import GenesisController
 from sawtooth_validator.journal.genesis import InvalidGenesisStateError
 from sawtooth_validator.state.merkle import MerkleDatabase
@@ -58,7 +59,8 @@ class TestGenesisController(unittest.TestCase):
             self.make_block_store(),  # Empty block store
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         self.assertEqual(True, genesis_ctrl.requires_genesis())
@@ -75,7 +77,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
@@ -92,7 +95,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
@@ -114,7 +118,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
@@ -144,7 +149,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         with self.assertRaises(InvalidGenesisStateError):
@@ -170,7 +176,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(DictDatabase()),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         with self.assertRaises(InvalidGenesisStateError):
@@ -209,7 +216,8 @@ class TestGenesisController(unittest.TestCase):
             block_store,
             StateViewFactory(state_database),
             self._identity_key,
-            data_dir=self._temp_dir
+            data_dir=self._temp_dir,
+            chain_id_manager=ChainIdManager(self._temp_dir)
         )
 
         on_done_fn = Mock(return_value='')

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -342,7 +342,8 @@ class TestChainController(unittest.TestCase):
             executor=self.executor,
             transaction_executor=MockTransactionExecutor(),
             on_chain_updated=chain_updated,
-            squash_handler=None)
+            squash_handler=None,
+            chain_id_manager=None)
 
     def test_simple_case(self):
         # TEST Run the simple case
@@ -439,7 +440,8 @@ class TestJournal(unittest.TestCase):
                 block_sender=self.block_sender,
                 transaction_executor=self.txn_executor,
                 squash_handler=None,
-                identity_signing_key=btm.identity_signing_key
+                identity_signing_key=btm.identity_signing_key,
+                chain_id_manager=None
             )
 
             self.gossip.on_batch_received = journal.on_batch_received


### PR DESCRIPTION
The best way to test that this works (since we do not have network tests yet) is the following. You will see one validator create the genesis block. When you start loading transaction the non-genesis validator will not process any blocks and will send out a GossipBlockRequest message. Once it recives the genesis block, you will see it start processing batches. Currently, for this to work the validators need to be peered in both directions and they will continue to send batches back and forth forever. 

In terminal:
sawtooth admin genesis
validator -vv --peers tcp://0.0.0.0:8801

In new terminal:
validator --network-endpoint tcp://0.0.0.0:8801 --component-endpoint tcp://0.0.0.0:40001 --peers tcp://0.0.0.0:8800 -vv

In new terminal:
tp_intkey_python tcp://localhost:40000 -vv

In new terminal:
tp_intkey_python tcp://localhost:40001 -vv

Finally: 
intkey populate
intkey load