### PR TITLE
Pass Identity Key to Journal

### DIFF
--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -104,9 +104,25 @@ class Journal(object):
                  transaction_executor,
                  squash_handler,
                  identity_signing_key,
-                 block_cache=None  # not require, allows tests to inject a
-                 # prepopulated block cache.
-                 ):
+                 block_cache=None):
+        """
+        Creates a Journal instance.
+
+        Args:
+            consensus_module (module): The consensus module for block
+                processing.
+            block_store (:obj:): The block store.
+            state_view_factory (:obj:`StateViewFactory`): StateViewFactory for
+                read-only state views.
+            block_sender (:obj:`BlockSender`): The BlockSender instance.
+            transaction_executor (:obj:`TransactionExecutor`): A
+                TransactionExecutor instance.
+            squash_handler (function): Squash handler function for merging
+                contexts.
+            identity_signing_key (str): Private key for signing blocks
+            block_cache (:obj:`BlockCache`, optional): A BlockCache to use in
+                place of an internally created instance. Defaults to None.
+        """
         self._consensus_module = consensus_module
         self._block_store = BlockStoreAdapter(block_store)
         self._block_cache = block_cache

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -103,6 +103,7 @@ class Journal(object):
                  block_sender,
                  transaction_executor,
                  squash_handler,
+                 identity_signing_key,
                  block_cache=None  # not require, allows tests to inject a
                  # prepopulated block cache.
                  ):
@@ -115,6 +116,7 @@ class Journal(object):
 
         self._transaction_executor = transaction_executor
         self._squash_handler = squash_handler
+        self._identity_signing_key = identity_signing_key
         self._block_sender = block_sender
 
         self._block_publisher = None
@@ -133,7 +135,8 @@ class Journal(object):
             state_view_factory=self._state_view_factory,
             block_sender=self._block_sender,
             squash_handler=self._squash_handler,
-            chain_head=self._block_store.chain_head
+            chain_head=self._block_store.chain_head,
+            identity_signing_key=self._identity_signing_key
         )
         self._publisher_thread = self._PublisherThread(self._block_publisher,
                                                        self._batch_queue)

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -45,6 +45,23 @@ class BlockPublisher(object):
                  squash_handler,
                  chain_head,
                  identity_signing_key):
+        """
+        Creates a Journal instance.
+
+        Args:
+            consensus_module (module): The consensus module for block
+                processing.
+            transaction_executor (:obj:`TransactionExecutor`): A
+                TransactionExecutor instance.
+            block_cache (:obj:`BlockCache`): A BlockCache instance.
+            state_view_factory (:obj:`StateViewFactory`): StateViewFactory for
+                read-only state views.
+            block_sender (:obj:`BlockSender`): The BlockSender instance.
+            squash_handler (function): Squash handler function for merging
+                contexts.
+            chain_head (:obj:`BlockWrapper`): The inital chain head.
+            identity_signing_key (str): Private key for signing blocks
+        """
         self._lock = RLock()
         self._candidate_block = None  # the next block in potentia
         self._consensus_module = consensus_module  # the consensus module.

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -190,7 +190,8 @@ class Validator(object):
             state_view_factory=StateViewFactory(merkle_db),
             block_sender=block_sender,
             transaction_executor=executor,
-            squash_handler=context_manager.get_squash_handler())
+            squash_handler=context_manager.get_squash_handler(),
+            identity_signing_key=identity_signing_key)
 
         self._genesis_controller = GenesisController(
             context_manager=context_manager,

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -48,7 +48,6 @@ from test_journal import mock_consensus
 LOGGER = logging.getLogger(__name__)
 
 
-
 class TestBlockCache(unittest.TestCase):
     def test_load_from_block_store(self):
         """ Test that misses will load from the block store.
@@ -75,6 +74,7 @@ class TestBlockCache(unittest.TestCase):
 
         self.assertTrue("test" in bc)
         self.assertTrue(bc["test"] == "value")
+
 
 class TestBlockPublisher(unittest.TestCase):
     def setUp(self):
@@ -120,7 +120,6 @@ class TestBlockValidator(unittest.TestCase):
     def setUp(self):
         self.btm = BlockTreeManager()
         self.state_view_factory = MockStateViewFactory()
-
 
     def create_block_validator(self, new_block, on_block_validated):
         return BlockValidator(
@@ -484,7 +483,6 @@ class TestTimedCache(unittest.TestCase):
         del bc["test"]
         self.assertFalse("test" in bc)
 
-
     def test_evict_expired(self):
         """ Test that values will be evicted from the
         cache as they time out.
@@ -521,4 +519,3 @@ class TestTimedCache(unittest.TestCase):
         self.assertEqual(len(bc), 2)
         self.assertTrue("test" in bc)
         self.assertTrue("test2" in bc)
-

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -16,6 +16,8 @@
 import logging
 import unittest
 
+from sawtooth_signing import pbct as signing
+
 from sawtooth_validator.database.dict_database import DictDatabase
 
 from sawtooth_validator.journal.block_cache import BlockCache
@@ -90,7 +92,8 @@ class TestBlockPublisher(unittest.TestCase):
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             squash_handler=None,
-            chain_head=self.blocks.chain_head)
+            chain_head=self.blocks.chain_head,
+            identity_signing_key=self.blocks.identity_signing_key)
 
         # initial load of existing state
         publisher.on_chain_updated(self.blocks.chain_head, [], [])
@@ -439,7 +442,8 @@ class TestJournal(unittest.TestCase):
                 state_view_factory=StateViewFactory(DictDatabase()),
                 block_sender=self.block_sender,
                 transaction_executor=self.txn_executor,
-                squash_handler=None
+                squash_handler=None,
+                identity_signing_key=btm.identity_signing_key
             )
 
             self.gossip.on_batch_received = journal.on_batch_received


### PR DESCRIPTION
Journal and its subcomponents use this key, in place of the temporary key, to
sign blocks, similar to the GenesisController.

Additionally:
- Add doc string to Journal and BlockPublisher constructors
- whitespace cleanup