### PR TITLE
Bringing in Fixes to PoET1 code before major re-implementation occurs

### DIFF
--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/enclave_wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/enclave_wait_certificate.py
@@ -40,7 +40,7 @@ class EnclaveWaitCertificate(object):
             history of certs
         validator_address (str): The address of the validator that created the
             wait certificate.
-        block_digest (str): The digest of the block for which this wait
+        block_hash (str): The hash of the block for which this wait
             certificate was generated
         signature (str): Signature of the certificate using PoET private key
             generated during creation of signup info
@@ -50,7 +50,7 @@ class EnclaveWaitCertificate(object):
     def wait_certificate_with_wait_timer(cls,
                                          wait_timer,
                                          nonce,
-                                         block_digest):
+                                         block_hash):
         """
         Creates a wait certificate object using an already-created wait
         timer.
@@ -59,7 +59,7 @@ class EnclaveWaitCertificate(object):
             wait_timer (EnclaveWaitTimer): The wait timer we are creating
                 wait certificate for
             nonce (str): A random nonce created for this certificate
-            block_digest (str): The digest for the block that this wait
+            block_hash (str): The hash for the block that this wait
                 certificate is being created for
 
         Returns:
@@ -73,7 +73,7 @@ class EnclaveWaitCertificate(object):
                 request_time=wait_timer.request_time,
                 validator_address=wait_timer.validator_address,
                 nonce=nonce,
-                block_digest=block_digest)
+                block_hash=block_hash)
 
     @classmethod
     def wait_certificate_from_serialized(cls,
@@ -103,8 +103,8 @@ class EnclaveWaitCertificate(object):
                 validator_address=str(
                     deserialized_certificate.get('validator_address')),
                 nonce=str(deserialized_certificate.get('nonce')),
-                block_digest=str(deserialized_certificate.get(
-                    'block_digest')),
+                block_hash=str(deserialized_certificate.get(
+                    'block_hash')),
                 signature=signature,
                 serialized_certificate=serialized_certificate)
 
@@ -128,7 +128,7 @@ class EnclaveWaitCertificate(object):
                  request_time,
                  validator_address,
                  nonce,
-                 block_digest,
+                 block_hash,
                  signature=None,
                  serialized_certificate=None):
         self.duration = float(duration)
@@ -137,7 +137,7 @@ class EnclaveWaitCertificate(object):
         self.request_time = float(request_time)
         self.validator_address = str(validator_address)
         self.nonce = str(nonce)
-        self.block_digest = str(block_digest)
+        self.block_hash = str(block_hash)
         self.signature = signature
         self._serialized = serialized_certificate
 
@@ -165,7 +165,7 @@ class EnclaveWaitCertificate(object):
                 'request_time': self.request_time,
                 'validator_address': self.validator_address,
                 'nonce': self.nonce,
-                'block_digest': self.block_digest
+                'block_hash': self.block_hash
             }
 
             self._serialized = dict2json(certificate_dict)

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/enclave_wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/enclave_wait_certificate.py
@@ -110,7 +110,6 @@ class EnclaveWaitCertificate(object):
 
         return certificate
 
-    @property
     def identifier(self):
         my_id = NULL_BLOCK_IDENTIFIER
         if self.signature is not None:

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/poet_enclave_simulator.py
@@ -383,7 +383,7 @@ class _PoetEnclaveSimulator(object):
     @classmethod
     def create_wait_certificate(cls,
                                 wait_timer,
-                                block_digest):
+                                block_hash):
         with cls._lock:
             # If we don't have a PoET private key, then the enclave has not
             # been properly initialized (either by calling create_signup_info
@@ -466,7 +466,7 @@ class _PoetEnclaveSimulator(object):
                 EnclaveWaitCertificate.wait_certificate_with_wait_timer(
                     wait_timer=cls._active_wait_timer,
                     nonce=nonce,
-                    block_digest=block_digest)
+                    block_hash=block_hash)
             wait_certificate.signature = \
                 signing.sign(
                     wait_certificate.serialize(),
@@ -551,11 +551,11 @@ def deserialize_wait_timer(serialized_timer, signature):
             signature=signature)
 
 
-def create_wait_certificate(wait_timer, block_digest):
+def create_wait_certificate(wait_timer, block_hash):
     return \
         _PoetEnclaveSimulator.create_wait_certificate(
             wait_timer=wait_timer,
-            block_digest=block_digest)
+            block_hash=block_hash)
 
 
 def deserialize_wait_certificate(serialized_certificate, signature):

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_transaction_block.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_transaction_block.py
@@ -239,7 +239,7 @@ class PoetTransactionBlock(transaction_block.TransactionBlock):
                 self.wait_certificate.check_valid(
                     certificates=journal.consensus.build_certificate_list(
                         journal.block_store, self),
-                    poet_public_key=poet_public_key)
+                    poet_public_key=str(poet_public_key))
             except (ValueError, TypeError) as err:
                 LOGGER.error('Wait certificate is not valid: %s', err)
                 return False

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_transaction_block.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_transaction_block.py
@@ -269,12 +269,12 @@ class PoetTransactionBlock(transaction_block.TransactionBlock):
             hasher = hashlib.sha256()
             for tid in self.TransactionIDs:
                 hasher.update(tid.encode())
-            block_digest = hasher.hexdigest()
+            block_hash = hasher.hexdigest()
 
             self.wait_certificate = \
                 WaitCertificate.create_wait_certificate(
                     wait_timer=self.wait_timer,
-                    block_digest=block_digest)
+                    block_hash=block_hash)
             if self.wait_certificate:
                 self.wait_timer = None
 

--- a/validator/sawtooth_validator/journal/consensus/poet1/signup_info.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/signup_info.py
@@ -80,8 +80,7 @@ class SignupInfo(object):
                 info object.
         """
         enclave_signup_info = \
-            cls.poet_enclave.deserialize_signup_info(
-                serialized_signup_info=serialized)
+            cls.poet_enclave.deserialize_signup_info(serialized)
 
         return cls(enclave_signup_info)
 
@@ -115,8 +114,8 @@ class SignupInfo(object):
         """
         return \
             cls.poet_enclave.unseal_signup_data(
-                validator_address=validator_address,
-                sealed_signup_data=sealed_signup_data)
+                validator_address,
+                sealed_signup_data)
 
     def __init__(self, enclave_signup_info):
         self.poet_public_key = enclave_signup_info.poet_public_key
@@ -155,9 +154,9 @@ class SignupInfo(object):
             SignupInfo object
         """
         self.poet_enclave.verify_signup_info(
-            signup_info=self.enclave_signup_info,
-            originator_public_key_hash=originator_public_key_hash,
-            most_recent_wait_certificate_id=most_recent_wait_certificate_id)
+            self.enclave_signup_info,
+            originator_public_key_hash,
+            most_recent_wait_certificate_id)
 
     def serialize(self):
         # Simply return the serialized version of the enclave signup info

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
@@ -75,10 +75,16 @@ class WaitCertificate(object):
                 wait certificate.
         """
 
-        enclave_certificate = \
-            cls.poet_enclave.create_wait_certificate(
-                wait_timer=wait_timer,
-                block_hash=block_hash)
+        enclave_certificate = None
+        try:
+            enclave_certificate = \
+                cls.poet_enclave.create_wait_certificate(
+                    wait_timer.enclave_wait_timer,
+                    block_hash)
+        except AttributeError as ex:
+            LOGGER.error(
+                'Exception caught trying to create wait certificate: %s',
+                ex)
 
         if not enclave_certificate:
             raise \

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
@@ -113,8 +113,8 @@ class WaitCertificate(object):
         """
         enclave_certificate = \
             cls.poet_enclave.deserialize_wait_certificate(
-                serialized_certificate=serialized,
-                signature=signature)
+                serialized,
+                signature)
 
         if not enclave_certificate:
             raise \
@@ -209,8 +209,8 @@ class WaitCertificate(object):
 
         try:
             self.poet_enclave.verify_wait_certificate(
-                certificate=enclave_certificate,
-                poet_public_key=poet_public_key)
+                enclave_certificate,
+                poet_public_key)
         except Timeout:
             raise NotAvailableException
         except requests.ConnectionError:

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
@@ -149,7 +149,7 @@ class WaitCertificate(object):
         self.validator_address = enclave_certificate.validator_address
         self.block_hash = enclave_certificate.block_hash
         self.signature = enclave_certificate.signature
-        self.identifier = enclave_certificate.identifier
+        self.identifier = enclave_certificate.identifier()
 
         # we cannot hold the certificate because it cannot be pickled for
         # storage in the transaction block array

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_certificate.py
@@ -50,8 +50,8 @@ class WaitCertificate(object):
         duration (float): The duration of the wait timer.
         validator_address (str): The address of the validator that created
             the wait certificate.
-        block_digest (str): The block digest of the block for which this
-            wait certificate was created.
+        block_hash (str): The hash of the block for which this wait
+            certificate was created.
         signature (str): The signature of the certificate.
         identifier (str): The identifier of this certificate.
     """
@@ -60,15 +60,15 @@ class WaitCertificate(object):
     @classmethod
     def create_wait_certificate(cls,
                                 wait_timer,
-                                block_digest):
+                                block_hash):
         """Creates a wait certificate in the enclave and then constructs
         a WaitCertificate object from it.
 
         Args:
             wait_timer (WaitTimer): The wait timer for which the wait
                 certificate is being requested.
-            block_digest (str): The block digest of the block for which
-                this certificate is being created.
+            block_hash (str): The hash of the block for which this
+                certificate is being created.
 
         Returns:
             journal.consensus.poet1.wait_certificate.WaitCertificate: A new
@@ -78,7 +78,7 @@ class WaitCertificate(object):
         enclave_certificate = \
             cls.poet_enclave.create_wait_certificate(
                 wait_timer=wait_timer,
-                block_digest=block_digest)
+                block_hash=block_hash)
 
         if not enclave_certificate:
             raise \
@@ -141,7 +141,7 @@ class WaitCertificate(object):
         self.request_time = enclave_certificate.request_time
         self.duration = enclave_certificate.duration
         self.validator_address = enclave_certificate.validator_address
-        self.block_digest = enclave_certificate.block_digest
+        self.block_hash = enclave_certificate.block_hash
         self.signature = enclave_certificate.signature
         self.identifier = enclave_certificate.identifier
 

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_timer.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_timer.py
@@ -156,6 +156,15 @@ class WaitTimer(object):
     def population_estimate(self):
         return self.local_mean / WaitTimer.target_wait_time
 
+    @property
+    def enclave_wait_timer(self):
+        """Converts the serialized timer into an eclave timer object.
+
+        Returns:
+            poet_enclave.WaitTimer: The deserialized enclave timer object.
+        """
+        return self._enclave_wait_timer
+
     def __init__(self, enclave_timer):
         self.previous_certificate_id =\
             str(enclave_timer.previous_certificate_id)

--- a/validator/sawtooth_validator/journal/consensus/poet1/wait_timer.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/wait_timer.py
@@ -115,10 +115,10 @@ class WaitTimer(object):
         # WaitTimer object
         enclave_timer = \
             cls.poet_enclave.create_wait_timer(
-                validator_address=validator_address,
-                previous_certificate_id=previous_certificate_id,
-                local_mean=local_mean,
-                minimum_wait_time=cls.minimum_wait_time)
+                validator_address,
+                previous_certificate_id,
+                local_mean,
+                cls.minimum_wait_time)
         timer = cls(enclave_timer)
 
         LOGGER.info('wait timer created; %s', timer)

--- a/validator/tests/unit3/test_poet1/test_enclave_wait_certificate.py
+++ b/validator/tests/unit3/test_poet1/test_enclave_wait_certificate.py
@@ -39,7 +39,7 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             EnclaveWaitCertificate.wait_certificate_with_wait_timer(
                 wait_timer=wait_timer,
                 nonce='Eeny, meeny, miny, moe.',
-                block_digest='Indigestion. Pepto Bismol.')
+                block_hash='Indigestion. Pepto Bismol.')
 
         self.assertAlmostEqual(
             wait_timer.request_time,
@@ -58,7 +58,7 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             wait_certificate.validator_address)
         self.assertEqual(wait_certificate.nonce, 'Eeny, meeny, miny, moe.')
         self.assertEqual(
-            wait_certificate.block_digest,
+            wait_certificate.block_hash,
             'Indigestion. Pepto Bismol.')
         self.assertIsNone(wait_certificate.signature)
 
@@ -76,7 +76,7 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
                 request_time=wait_certificate.request_time,
                 validator_address='1600 Pennsylvania Avenue NW',
                 nonce='Eeny, meeny, miny, moe.',
-                block_digest=wait_certificate.block_digest)
+                block_hash=wait_certificate.block_hash)
 
         self.assertAlmostEqual(
             wait_certificate.duration,
@@ -95,8 +95,8 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             other_wait_certificate.validator_address)
         self.assertEqual(wait_certificate.nonce, other_wait_certificate.nonce)
         self.assertEqual(
-            wait_certificate.block_digest,
-            other_wait_certificate.block_digest)
+            wait_certificate.block_hash,
+            other_wait_certificate.block_hash)
         self.assertIsNone(other_wait_certificate.signature)
 
     def test_serialize_wait_certificate(self):
@@ -111,7 +111,7 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             EnclaveWaitCertificate.wait_certificate_with_wait_timer(
                 wait_timer=wait_timer,
                 nonce='Eeny, meeny, miny, moe.',
-                block_digest='Indigestion. Pepto Bismol.')
+                block_hash='Indigestion. Pepto Bismol.')
 
         self.assertIsNotNone(wait_certificate.serialize())
 
@@ -127,7 +127,7 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             EnclaveWaitCertificate.wait_certificate_with_wait_timer(
                 wait_timer=wait_timer,
                 nonce='Eeny, meeny, miny, moe.',
-                block_digest='Indigestion. Pepto Bismol.')
+                block_hash='Indigestion. Pepto Bismol.')
 
         serialized = wait_certificate.serialize()
         signing_key = self._create_random_key()
@@ -158,8 +158,8 @@ class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
             wait_certificate.nonce,
             copy_wait_certificate.nonce)
         self.assertEqual(
-            wait_certificate.block_digest,
-            copy_wait_certificate.block_digest)
+            wait_certificate.block_hash,
+            copy_wait_certificate.block_hash)
         self.assertEqual(
             wait_certificate.signature,
             copy_wait_certificate.signature)

--- a/validator/tests/unit3/test_poet1/test_wait_certificate.py
+++ b/validator/tests/unit3/test_poet1/test_wait_certificate.py
@@ -58,7 +58,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=None,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
     def test_create_wait_certificate_before_create_wait_timer(self):
         # Need to create signup information
@@ -72,7 +72,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=None,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
     @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_before_wait_timer_expires(self):
@@ -91,7 +91,7 @@ class TestWaitCertificate(unittest.TestCase):
         wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         wt = \
             WaitTimer.create_wait_timer(
@@ -100,7 +100,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
     @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_after_wait_timer_timed_out(self):
@@ -119,7 +119,7 @@ class TestWaitCertificate(unittest.TestCase):
         wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         wt = \
             WaitTimer.create_wait_timer(
@@ -132,7 +132,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
     @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_with_wrong_wait_timer(self):
@@ -158,11 +158,11 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=invalid_wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         WaitCertificate.create_wait_certificate(
             wait_timer=valid_wt,
-            block_digest="Reader's Digest")
+            block_hash="Reader's Digest")
 
     @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_with_reused_wait_timer(self):
@@ -181,7 +181,7 @@ class TestWaitCertificate(unittest.TestCase):
         wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         consumed_wt = wt
 
@@ -190,7 +190,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=consumed_wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
         wt = \
             WaitTimer.create_wait_timer(
                 validator_address='1660 Pennsylvania Avenue NW',
@@ -198,7 +198,7 @@ class TestWaitCertificate(unittest.TestCase):
         with self.assertRaises(ValueError):
             WaitCertificate.create_wait_certificate(
                 wait_timer=consumed_wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         # Verify that once the new timer expires, we can create a wait
         # certificate with it
@@ -207,7 +207,7 @@ class TestWaitCertificate(unittest.TestCase):
 
         WaitCertificate.create_wait_certificate(
             wait_timer=wt,
-            block_digest="Reader's Digest")
+            block_hash="Reader's Digest")
 
     @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate(self):
@@ -230,7 +230,7 @@ class TestWaitCertificate(unittest.TestCase):
         wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         self.assertIsNotNone(wc)
 
@@ -241,7 +241,7 @@ class TestWaitCertificate(unittest.TestCase):
         self.assertAlmostEqual(wc.request_time, wt.request_time)
         self.assertAlmostEqual(wc.duration, wt.duration)
         self.assertEqual(wc.validator_address, wt.validator_address)
-        self.assertEqual(wc.block_digest, "Reader's Digest")
+        self.assertEqual(wc.block_hash, "Reader's Digest")
         self.assertIsNotNone(wc.signature)
         self.assertIsNotNone(wc.identifier)
 
@@ -261,7 +261,7 @@ class TestWaitCertificate(unittest.TestCase):
         another_wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Pepto Bismol")
+                block_hash="Pepto Bismol")
 
         another_wc.check_valid([wc], signup_info.poet_public_key)
 
@@ -285,7 +285,7 @@ class TestWaitCertificate(unittest.TestCase):
         wc = \
             WaitCertificate.create_wait_certificate(
                 wait_timer=wt,
-                block_digest="Reader's Digest")
+                block_hash="Reader's Digest")
 
         dumped = wc.dump()
 
@@ -306,7 +306,7 @@ class TestWaitCertificate(unittest.TestCase):
         self.assertAlmostEqual(wc.request_time, wc_copy.request_time)
         self.assertAlmostEqual(wc.duration, wc_copy.duration)
         self.assertEqual(wc.validator_address, wc_copy.validator_address)
-        self.assertEqual(wc.block_digest, wc_copy.block_digest)
+        self.assertEqual(wc.block_hash, wc_copy.block_hash)
         self.assertEqual(wc.signature, wc_copy.signature)
         self.assertEqual(wc.identifier, wc_copy.identifier)
 


### PR DESCRIPTION
Changes include:
* Rename wait certificate block_digest to block_hash to make everything consistent with PoET enclave
* Remove keyword arguments when calling into PoET enclave as apparently SWIGged C++ code does not like it
* Correctly provide enclave wait timer to PoET enclave when trying to create a wait certificate