### PR TITLE
Switch from pbct/bitcoin signing to secp256k_signer

### DIFF
--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -18,7 +18,7 @@ import sys
 
 from sawtooth_cli.exceptions import CliException
 from sawtooth_cli.admin_command.utils import ensure_directory
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 def add_keygen_parser(subparsers, parent_parser):

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -25,7 +25,7 @@ from sawtooth_cli.protobuf.batch_pb2 import BatchHeader
 from sawtooth_cli.protobuf.batch_pb2 import Batch
 from sawtooth_cli.protobuf.batch_pb2 import BatchList
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 def add_config_parser(subparsers, parent_parser):

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 from sawtooth_cli.exceptions import CliException
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 def add_keygen_parser(subparsers, parent_parser):

--- a/core/sawtooth/client.py
+++ b/core/sawtooth/client.py
@@ -30,7 +30,7 @@ import cbor
 from sawtooth.exceptions import ClientException
 from sawtooth.exceptions import InvalidTransactionError
 from sawtooth.exceptions import MessageException
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 LOGGER = logging.getLogger(__name__)

--- a/core/sawtooth/simulator_workload.py
+++ b/core/sawtooth/simulator_workload.py
@@ -16,7 +16,7 @@
 # pylint: disable=no-self-use
 
 from tempfile import NamedTemporaryFile
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 class SawtoothWorkload(object):

--- a/core_transactions/config/tests/sawtooth_config_test/tp-config.yaml
+++ b/core_transactions/config/tests/sawtooth_config_test/tp-config.yaml
@@ -39,4 +39,5 @@ services:
         PYTHONPATH: "/project/sawtooth-core/core_transactions/config:\
             /project/sawtooth-core/core_transactions/config/tests:\
             /project/sawtooth-core/sdk/python:\
-            /project/sawtooth-core/integration"
+            /project/sawtooth-core/integration:\
+            /project/sawtooth-core/signing"

--- a/extensions/arcade/sawtooth_battleship/battleship_cli.py
+++ b/extensions/arcade/sawtooth_battleship/battleship_cli.py
@@ -28,7 +28,7 @@ import sys
 
 from colorlog import ColoredFormatter
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth.exceptions import ClientException
 from sawtooth.exceptions import InvalidTransactionError
 

--- a/integration/sawtooth_integration/docker/intkey-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-smoke.yaml
@@ -81,4 +81,5 @@ services:
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
-        /project/sawtooth-core/integration"
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/docker/tp-intkey-python.yaml
+++ b/integration/sawtooth_integration/docker/tp-intkey-python.yaml
@@ -37,4 +37,5 @@ services:
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
-        /project/sawtooth-core/integration"
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/docker/tp-xo-python.yaml
+++ b/integration/sawtooth_integration/docker/tp-xo-python.yaml
@@ -37,4 +37,5 @@ services:
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
-        /project/sawtooth-core/integration"
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/docker/xo-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-smoke.yaml
@@ -81,4 +81,5 @@ services:
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
-        /project/sawtooth-core/integration"
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/poet/sawtooth_poet/tests/validator_registry_test/tests.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/tests.py
@@ -17,7 +17,7 @@ import unittest
 import json
 import base64
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from validator_registry_test.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory
 from sawtooth_poet.protobuf.validator_registry_pb2 import \

--- a/poet/sawtooth_poet/tests/validator_registry_test/validator_reg_message_factory.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/validator_reg_message_factory.py
@@ -16,7 +16,7 @@ import base64
 import json
 import hashlib
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_processor_test.message_factory import MessageFactory
 from sawtooth_poet.protobuf.validator_registry_pb2 import \

--- a/poet/sawtooth_poet/validator_registry/processor/handler.py
+++ b/poet/sawtooth_poet/validator_registry/processor/handler.py
@@ -18,7 +18,7 @@ import hashlib
 import base64
 import json
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_sdk.processor.state import StateEntry
 from sawtooth_sdk.client.future import FutureTimeoutError

--- a/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
+++ b/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
@@ -15,13 +15,14 @@
 # ------------------------------------------------------------------------------
 
 import hashlib
-import pybitcointools
 import os
 import random
 import sys
 import time
 import cProfile
 import argparse
+
+from sawtooth_signing import secp256k1_signer as signing
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 from sawtooth_sdk.protobuf import jvm_sc_pb2
@@ -83,9 +84,7 @@ def create_jvm_sc_transaction(verb, private_key, public_key,
         batcher=public_key)
     header_bytes = header.SerializeToString()
 
-    signature = pybitcointools.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     transaction = transaction_pb2.Transaction(
         header=header_bytes,
@@ -104,9 +103,7 @@ def create_batch(transactions, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = pybitcointools.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     batch = batch_pb2.Batch(
         header=header_bytes,
@@ -133,9 +130,8 @@ def generate_word_list(count):
 
 
 def do_generate(args):
-    private_key = pybitcointools.random_key()
-    public_key = pybitcointools.encode_pubkey(
-        pybitcointools.privkey_to_pubkey(private_key), "hex")
+    private_key = signing.generate_privkey()
+    public_key = signing.generate_pubkey(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -23,7 +23,7 @@ import random
 import string
 import time
 import cbor
-import bitcoin
+from sawtooth_signing import secp256k1_signer as signing
 
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
@@ -102,9 +102,7 @@ def create_intkey_transaction(verb, name, value, deps,
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     transaction = transaction_pb2.Transaction(
         header=header_bytes,
@@ -123,9 +121,7 @@ def create_batch(transactions, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     batch = batch_pb2.Batch(
         header=header_bytes,
@@ -148,9 +144,8 @@ def generate_word_list(count):
 
 
 def do_populate(args, batches, words):
-    private_key = bitcoin.random_key()
-    public_key = bitcoin.encode_pubkey(
-        bitcoin.privkey_to_pubkey(private_key), "hex")
+    private_key = signing.generate_privkey()
+    public_key = signing.generate_pubkey(private_key)
 
     total_txn_count = 0
     txns = []
@@ -178,9 +173,8 @@ def do_populate(args, batches, words):
 
 
 def do_generate(args, batches, words):
-    private_key = bitcoin.random_key()
-    public_key = bitcoin.encode_pubkey(
-        bitcoin.privkey_to_pubkey(private_key), "hex")
+    private_key = signing.generate_privkey()
+    public_key = signing.generate_pubkey(private_key)
 
     start = time.time()
     total_txn_count = 0

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
@@ -24,8 +24,8 @@ import string
 import time
 
 import cbor
-import bitcoin
 
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_sdk.protobuf import transaction_pb2
 from sawtooth_sdk.protobuf import batch_pb2
 
@@ -84,9 +84,7 @@ def create_intkey_transaction(verb, name, value, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     transaction = transaction_pb2.Transaction(
         header=header_bytes,
@@ -105,9 +103,7 @@ def create_batch(transactions, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     batch = batch_pb2.Batch(
         header=header_bytes,
@@ -130,9 +126,8 @@ def generate_word_list(count):
 
 
 def do_generate(args):
-    private_key = bitcoin.random_key()
-    public_key = bitcoin.encode_pubkey(
-        bitcoin.privkey_to_pubkey(private_key), "hex")
+    private_key = signing.generate_privkey()
+    public_key = signing.generate_pubkey(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
@@ -24,8 +24,8 @@ import string
 import time
 
 import cbor
-import bitcoin
 
+from sawtooth_signing import secp256k1_signer as signing
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
 
@@ -84,9 +84,7 @@ def create_intkey_transaction(verb, name, value, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     transaction = transaction_pb2.Transaction(
         header=header_bytes,
@@ -105,9 +103,7 @@ def create_batch(transactions, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     batch = batch_pb2.Batch(
         header=header_bytes,
@@ -130,9 +126,8 @@ def generate_word_list(count):
 
 
 def do_populate(args):
-    private_key = bitcoin.random_key()
-    public_key = bitcoin.encode_pubkey(
-        bitcoin.privkey_to_pubkey(private_key), "hex")
+    private_key = signing.generate_privkey()
+    public_key = signing.generate_pubkey(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/sawtooth_xo/xo_cli.py
@@ -26,7 +26,7 @@ import shutil
 
 from colorlog import ColoredFormatter
 
-import sawtooth_signing.pbct as signing
+import sawtooth_signing.secp256k1_signer as signing
 
 from sawtooth_xo.xo_client import XoClient
 from sawtooth_xo.xo_exceptions import XoException

--- a/sdk/examples/sawtooth_xo/xo_client.py
+++ b/sdk/examples/sawtooth_xo/xo_client.py
@@ -18,7 +18,7 @@ import base64
 import urllib.request
 import yaml
 
-import sawtooth_signing.pbct as signing
+import sawtooth_signing.secp256k1_signer as signing
 
 from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.transaction_pb2 import Transaction

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -14,7 +14,8 @@
 # ------------------------------------------------------------------------------
 
 import hashlib
-import bitcoin
+
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse
@@ -35,17 +36,15 @@ from sawtooth_sdk.protobuf.state_context_pb2 import Entry
 
 
 def _private():
-    return bitcoin.random_key()
+    return signing.generate_privkey()
 
 
 def _private_to_public(private):
-    return bitcoin.encode_pubkey(
-        bitcoin.privkey_to_pubkey(private), "hex"
-    )
+    return signing.generate_pubkey(private)
 
 
 def _sign(content, private):
-    return bitcoin.ecdsa_sign(content, private)
+    return signing.sign(content, private)
 
 
 class MessageFactory(object):

--- a/signing/sawtooth_signing/secp256k1_signer.py
+++ b/signing/sawtooth_signing/secp256k1_signer.py
@@ -36,12 +36,73 @@ def generate_privkey():
     return _encode_privkey(secp256k1.PrivateKey(ctx=__CTX__))
 
 
+def encode_privkey(privkey, encoding_format='wif'):
+    """Encodes a provided wif encoded privkey in the requested
+    encoding format.
+
+    Args:
+        privkey (str): A wif-encoded private key string
+        encoding_format (str): One of the pybitcointools supported
+            encoding formats
+
+    Returns:
+        str: An encoded private key in the requested format
+    """
+    return _encode_privkey(_decode_privkey(privkey, 'wif'),
+                           encoding_format)
+
+
 def _encode_privkey(privkey, encoding_format='wif'):
     try:  # check python3
         priv = int.from_bytes(privkey.private_key, byteorder='big')
     except AttributeError:
         priv = binascii.hexlify(privkey.private_key)
-    return pybitcointools.encode_privkey(priv, encoding_format)
+
+    encoded = pybitcointools.encode_privkey(priv, encoding_format)
+
+    return encoded
+
+
+def _decode_privkey_to_bytes(encoded_privkey, encoding_format='wif'):
+    """
+    Args:
+        encoded_privkey: an encoded private key string
+        encoding_format: string indicating format such as 'wif'
+
+    Returns:
+        priv (bytes): bytes representation of the private key
+    """
+    if encoding_format == 'wif':
+        # int to hex string
+        priv = pybitcointools.encode_privkey(encoded_privkey, 'hex')
+        # hex string to bytes
+        try:  # check python 3
+            priv = priv.to_bytes(32, byteorder='big')
+        except AttributeError:
+            priv = binascii.unhexlify(priv)
+    elif encoding_format == 'hex':
+        try:
+            priv = encoded_privkey.to_bytes(32, byteorder='big')
+        except AttributeError:
+            priv = binascii.unhexlify(encoded_privkey)
+    else:
+        raise TypeError("unsupported private key format")
+
+    return priv
+
+
+def decode_privkey(encoded_privkey, encoding_format='wif'):
+    """Decodes a provided encoded privkey to a secp256k1 bytes representation
+
+    Args:
+        encoded_privkey (str): An encoded private key string
+        encoding_format (str): The encoded format of the provided
+            private key. Must be either 'wif' or 'hex'.
+
+    Returns:
+        bytes: A private key in native bytes format
+    """
+    return _decode_privkey_to_bytes(encoded_privkey, encoding_format)
 
 
 def _decode_privkey(encoded_privkey, encoding_format='wif'):
@@ -53,19 +114,7 @@ def _decode_privkey(encoded_privkey, encoding_format='wif'):
     Returns:
         private key object useable with this module
     """
-    if encoding_format == 'wif':
-        # base58 to int
-        priv = pybitcointools.decode_privkey(encoded_privkey, encoding_format)
-        # int to hex string
-        priv = pybitcointools.encode_privkey(priv, 'hex')
-        # hex string to bytes
-        try:  # check python 3
-            priv = priv.to_bytes(32, byteorder='big')
-        except AttributeError:
-            priv = binascii.unhexlify(priv)
-    else:
-        raise TypeError("unsupported private key format")
-
+    priv = _decode_privkey_to_bytes(encoded_privkey, encoding_format)
     return secp256k1.PrivateKey(priv, ctx=__CTX__)
 
 
@@ -79,6 +128,21 @@ def generate_pubkey(privkey):
     return _encode_pubkey(_decode_privkey(privkey).pubkey, 'hex')
 
 
+def encode_pubkey(pubkey, encoding_format='hex'):
+    """Encodes a provided encoded pubkey to a supported encoding_format
+
+    Args:
+        pubkey (str): An encoded public key string
+        encoding_format (str): The encoded format of the provided
+            private key. Must be 'hex'.
+
+    Returns:
+        str: A public key in the requested format
+    """
+    return _encode_pubkey(_decode_pubkey(pubkey, encoding_format),
+                          encoding_format)
+
+
 def _encode_pubkey(pubkey, encoding_format='hex'):
     with warnings.catch_warnings() as enc:  # squelch secp256k1 warning
         warnings.simplefilter('ignore')
@@ -88,6 +152,25 @@ def _encode_pubkey(pubkey, encoding_format='hex'):
     elif encoding_format != 'bytes':
         raise ValueError("Unrecognized pubkey encoding format")
     return enc
+
+
+def decode_pubkey(serialized_pubkey, encoding_format='hex'):
+    """Decodes a provided public key into the requested format
+
+    Args:
+        serialized_pubkey (str): The encoded public key
+        encoding_format (str): The format of the provided encoded
+            public key. Must be 'hex'.
+
+    Returns:
+        bytes: The native bytes representation of the public key
+    """
+    if encoding_format == 'hex':
+        serialized_pubkey = binascii.unhexlify(serialized_pubkey)
+    else:
+        raise ValueError("Unrecognized pubkey encoding format")
+
+    return serialized_pubkey
 
 
 def _decode_pubkey(serialized_pubkey, encoding_format='hex'):

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader, BatchList

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -15,7 +15,7 @@
 import logging
 from threading import RLock
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_consensus.py
@@ -20,7 +20,7 @@ import hashlib
 import random
 import math
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.consensus.poet1 import poet_transaction_block
 

--- a/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/validator/sawtooth_validator/journal/consensus/poet1/poet_enclave_simulator/poet_enclave_simulator.py
@@ -22,7 +22,7 @@ import hashlib
 import base64
 import time
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -17,7 +17,7 @@ import logging
 import os
 from pathlib import Path
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.protobuf import genesis_pb2
 from sawtooth_validator.protobuf import block_pb2
 from sawtooth_validator.journal.block_builder import BlockBuilder

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -16,7 +16,7 @@ import copy
 import logging
 from threading import RLock
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.execution.scheduler_exceptions import SchedulerError
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -20,7 +20,7 @@ import logging
 import os
 import time
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -20,8 +20,7 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from sawtooth_signing import pbct as signing
-
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
 from sawtooth_validator.journal.genesis import GenesisController

--- a/validator/tests/unit3/test_journal/block_tree_manager.py
+++ b/validator/tests/unit3/test_journal/block_tree_manager.py
@@ -18,7 +18,7 @@ import pprint
 import random
 import string
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.journal.block_builder import BlockBuilder
 from sawtooth_validator.journal.block_cache import BlockCache

--- a/validator/tests/unit3/test_message_validation/tests.py
+++ b/validator/tests/unit3/test_message_validation/tests.py
@@ -20,7 +20,7 @@ import queue
 import string
 
 from threading import Condition
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader, \
     Transaction
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader, Batch

--- a/validator/tests/unit3/test_poet1/test_enclave_wait_certificate.py
+++ b/validator/tests/unit3/test_poet1/test_enclave_wait_certificate.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.journal.consensus.poet1.poet_enclave_simulator.\
     enclave_wait_timer import EnclaveWaitTimer
 from sawtooth_validator.journal.consensus.poet1.poet_enclave_simulator.\

--- a/validator/tests/unit3/test_poet1/test_enclave_wait_timer.py
+++ b/validator/tests/unit3/test_poet1/test_enclave_wait_timer.py
@@ -16,7 +16,7 @@
 import unittest
 import time
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_validator.journal.consensus.poet1.poet_enclave_simulator.\
     enclave_wait_timer import EnclaveWaitTimer
 

--- a/validator/tests/unit3/test_poet1/utils.py
+++ b/validator/tests/unit3/test_poet1/utils.py
@@ -16,7 +16,7 @@ import hashlib
 import random
 import string
 
-from sawtooth_signing import pbct as signing
+from sawtooth_signing import secp256k1_signer as signing
 
 
 class AttrDict(dict):

--- a/validator/tests/unit3/test_scheduler/tests.py
+++ b/validator/tests/unit3/test_scheduler/tests.py
@@ -16,8 +16,8 @@
 import unittest
 import logging
 import hashlib
-import bitcoin
 
+from sawtooth_signing import secp256k1_signer as signing
 import sawtooth_validator.protobuf.batch_pb2 as batch_pb2
 import sawtooth_validator.protobuf.transaction_pb2 as transaction_pb2
 
@@ -47,9 +47,7 @@ def create_transaction(name, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     transaction = transaction_pb2.Transaction(
         header=header_bytes,
@@ -68,9 +66,7 @@ def create_batch(transactions, private_key, public_key):
 
     header_bytes = header.SerializeToString()
 
-    signature = bitcoin.ecdsa_sign(
-        header_bytes,
-        private_key)
+    signature = signing.sign(header_bytes, private_key)
 
     batch = batch_pb2.Batch(
         header=header_bytes,
@@ -93,9 +89,9 @@ class TestSerialScheduler(unittest.TestCase):
         This test also finalizes the scheduler and verifies that StopIteration
         is thrown by the iterator.
         """
-        private_key = bitcoin.random_key()
-        public_key = bitcoin.encode_pubkey(
-            bitcoin.privkey_to_pubkey(private_key), "hex")
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+
         context_manager = ContextManager(dict_database.DictDatabase())
         squash_handler = context_manager.get_squash_handler()
         first_state_root = context_manager.get_first_root()
@@ -154,9 +150,8 @@ class TestSerialScheduler(unittest.TestCase):
         since the first Transaction was marked as applied in the previous
         step.
         """
-        private_key = bitcoin.random_key()
-        public_key = bitcoin.encode_pubkey(
-            bitcoin.privkey_to_pubkey(private_key), "hex")
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
 
         context_manager = ContextManager(dict_database.DictDatabase())
         squash_handler = context_manager.get_squash_handler()
@@ -208,9 +203,8 @@ class TestSerialScheduler(unittest.TestCase):
                through the squash function.
             4. Verify that correct batch statuses are set
         """
-        private_key = bitcoin.random_key()
-        public_key = bitcoin.encode_pubkey(
-            bitcoin.privkey_to_pubkey(private_key), "hex")
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
 
         context_manager = ContextManager(dict_database.DictDatabase())
         squash_handler = context_manager.get_squash_handler()


### PR DESCRIPTION
This moves signing from pbct and bitcoin to the sawtooth_signing.secp256k_signer for both server components and clients.

If you have existing keys in /etc/sawtooth, you may need to regenerate them with sawtooth admin keygen.

