### PR TITLE
Fix BlockStore: get_block_by_batch_id, __iter__, __len__

### DIFF
--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -56,10 +56,12 @@ class BlockStore(MutableMapping):
         return x in self._block_store
 
     def __iter__(self):
-        return iter(self._block_store)
+        # Required by abstract base class, but implementing is non-trivial
+        raise NotImplementedError('BlockStore is not iterable')
 
     def __len__(self):
-        return len(self._block_store)
+        # Required by abstract base class, but implementing is non-trivial
+        raise NotImplementedError('BlockStore has no meaningful length')
 
     def __str__(self):
         out = []
@@ -158,7 +160,7 @@ class BlockStore(MutableMapping):
         return txn_id in self._block_store
 
     def get_block_by_batch_id(self, batch_id):
-        return batch_id in self._block_store
+        return self.__getitem__(self._block_store[batch_id])
 
     def has_batch(self, batch_id):
         return batch_id in self._block_store


### PR DESCRIPTION
Fix get_block_by_batch_id to properly return a block.

Previously, iterating over a BlockStore instance would throw an
error, and calling `len` on one would return the total number of
indexed keys (including `"chain_head_id"`), which is not especially
meaningful. Fix these to now more correctly throw `NotImplementedError`s.

Signed-off-by: Zac Delventhal <delventhalz@gmail.com>