### PR TITLE
Minor doc fix for bond family guide

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -26,6 +26,9 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("txn_family_tutorial") }}">{% trans %}Transaction Family Tutorial{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}create a new Sawtooth Lake transaction family{% endtrans %}</span></p>
 
+  <p class="biglink"><a class="biglink" href="{{ pathto("bond_family_guide") }}">{% trans %}Bond Family Guide{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}use and administrate the bond transaction family{% endtrans %}</span></p>
+
   <p class="biglink"><a class="biglink" href="{{ pathto("sawtooth_developers_guide") }}">{% trans %}Distributed Ledger Developer's Guide{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}extend or contribute code and documentation{% endtrans %}</span></p>
 


### PR DESCRIPTION
Added bond family guide to the indexcontent.html file.
Causes bond family guide to appear in main frame upon
loading docs.

Signed-off-by: Todd Ojala <todd@bitwse.io>