### PR TITLE
Manage gossip identities and broadcast to ROUTER connected peers

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -30,12 +30,15 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PeerRegisterHandler(Handler):
+    def __init__(self, gossip):
+        self._gossip = gossip
 
     def handle(self, identity, message_content):
         request = PeerRegisterRequest()
         request.ParseFromString(message_content)
         LOGGER.debug("got peer register message "
                      "from %s. sending ack", identity)
+        self._gossip.register_identity(identity)
         ack = NetworkAcknowledgement()
         ack.status = ack.OK
 
@@ -46,13 +49,15 @@ class PeerRegisterHandler(Handler):
 
 
 class PeerUnregisterHandler(Handler):
+    def __init__(self, gossip):
+        self._gossip = gossip
 
     def handle(self, identity, message_content):
         request = PeerUnregisterRequest()
         request.ParseFromString(message_content)
         LOGGER.debug("got peer unregister message "
                      "from %s. sending ack", identity)
-
+        self._gossip.unregister_identity(identity)
         ack = NetworkAcknowledgement()
         ack.status = ack.OK
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -194,12 +194,12 @@ class Validator(object):
 
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_REGISTER,
-            PeerRegisterHandler(),
+            PeerRegisterHandler(gossip=self._gossip),
             network_thread_pool)
 
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_UNREGISTER,
-            PeerUnregisterHandler(),
+            PeerUnregisterHandler(gossip=self._gossip),
             network_thread_pool)
 
         self._network_dispatcher.add_handler(


### PR DESCRIPTION
This adds an identity registration mechanism to gossip and broadcasts out to connected identities on the router socket.