### PR TITLE
Add requests for batch status to REST and ZMQ APIs

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -41,6 +41,40 @@ message ClientBatchSubmitResponse {
     Status status = 1;
 }
 
+// A request for the status of one or more batches, specified by id.
+message ClientBatchStatusRequest {
+    repeated string batch_ids = 1;
+}
+
+// This is a response to a request for the status of specific batches. The
+// batches_statuses field is a hashmap where the keys correspond to the ids
+// of the batches queried, and the values are their status.
+// Statuses:
+//   * OK - everything with the request worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - the response contains no data, likely because
+//     no ids were specified in the request
+// BatchesStatuses:
+//   * COMMITTED - the batch was accepted and has been committed to the chain
+//   * INVALID - the batch failed validation, it should be resubmitted
+//   * UNKNOWN - no status for the batch could be found (possibly invalid)
+//   * PENDING - the batch is still being processed
+message ClientBatchStatusResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NO_RESOURCE = 4;
+    }
+    enum BatchStatus {
+        COMMITTED = 0;
+        INVALID = 1;
+        UNKNOWN = 2;
+        PENDING = 3;
+    }
+    Status status = 1;
+    map<string, BatchStatus> batch_statuses = 2;
+}
+
 message ClientStateCurrentRequest {
 }
 

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -86,6 +86,10 @@ message Message {
         CLIENT_STATE_GET_REQUEST = 118;
         // The response with the entry
         CLIENT_STATE_GET_RESPONSE = 119;
+        // A request for the status of a batch or batches
+        CLIENT_BATCH_STATUS_REQUEST = 120;
+        // A response with the batch statuses
+        CLIENT_BATCH_STATUS_RESPONSE = 121;
         // Further messages from the stats client through the web api
 
 

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -61,6 +61,14 @@ class MissingHead(_ErrorTrap):
         super().__init__(trigger, error, message)
 
 
+class MissingStatus(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBatchStatusResponse.NO_RESOURCE,
+            error=web.HTTPNotFound,
+            message='No statuses were found for the specified ids')
+
+
 class MissingLeaf(_ErrorTrap):
     def __init__(self):
         super().__init__(

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -22,6 +22,12 @@ class WrongBodyType(web.HTTPBadRequest):
         super().__init__(reason=message)
 
 
+class MissingStatusId(web.HTTPBadRequest):
+    def __init__(self):
+        message = 'At least one batch id must be specified to check status'
+        super().__init__(reason=message)
+
+
 class ValidatorUnavailable(web.HTTPServiceUnavailable):
     def __init__(self):
         message = 'Could not reach validator, validator timed out'

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -113,13 +113,15 @@ paths:
 
   /batch_status:
     get:
-      summary: Fetches a list of the committed statuses for a set of batches
+      summary: Fetches the committed statuses for a set of batches
       description: >
-        Fetches a list of statuses for a batch or batches. The
-        batch(es) you want to check can be specified using the
-        `id` filter parameter. Note that this route does not
-        return a full resource, and the response body will
-        _not_ include the `head` or `paging` properties.
+        Fetches an object with a status for each batch requested. The keys of
+        the data object will be the ids of the batch(es), while the values will
+        be a string status with the values `'COMMITTED'`, `'INVALID'`,
+        `'PENDING'`, or `'UNKNOWN'`.
+        The batch(es) you want to check can be specified using the `id` filter
+        parameter. Note that as this route does not return a full resource, and
+        the response body will _not_ include the `head` or `paging` properties.
       parameters:
         - name: id
           in: query
@@ -132,9 +134,7 @@ paths:
           schema:
             properties:
               data:
-                type: array
-                items:
-                  $ref: "#/definitions/BatchStatus"
+                $ref: "#/definitions/BatchStatuses"
               link:
                 $ref: "#/definitions/Link"
         400:
@@ -563,6 +563,17 @@ definitions:
         items:
           $ref: "#/definitions/Error"
 
+  BatchStatuses:
+    properties:
+      "{batch_id}":
+        type: string
+        example: PENDING
+        enum:
+          - COMMITTED
+          - INVALID
+          - PENDING
+          - UNKNOWN
+
   Leaf:
     properties:
       address:
@@ -649,15 +660,6 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/Batch"
-  BatchStatus:
-    properties:
-      status:
-        type: string
-        example: PENDING
-        enum:
-          - PENDING
-          - REJECTED
-          - COMMITTED
 
   BlockHeader:
     properties:

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -52,6 +52,7 @@ def start_rest_api(host, port, stream_url, timeout):
     app = web.Application(middlewares=[logging_middleware])
     # Add routes to the web app
     app.router.add_post('/batches', handler.batches_post)
+    app.router.add_get('/batch_status', handler.status_list)
 
     app.router.add_get('/state', handler.state_list)
     app.router.add_get('/state/{address}', handler.state_get)

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -58,6 +58,25 @@ class RouteHandler(object):
         return RouteHandler._try_client_response(request.headers, response)
 
     @asyncio.coroutine
+    def status_list(self, request):
+        error_traps = [error_handlers.MissingStatus()]
+
+        try:
+            batch_ids = request.url.query['id'].split(',')
+        except KeyError:
+            return errors.MissingStatusId()
+
+        response = self._query_validator(
+            Message.CLIENT_BATCH_STATUS_REQUEST,
+            client.ClientBatchStatusResponse,
+            client.ClientBatchStatusRequest(batch_ids=batch_ids),
+            error_traps)
+
+        return RouteHandler._wrap_response(
+            data=response.get('batch_statuses'),
+            metadata=RouteHandler._get_metadata(request, response))
+
+    @asyncio.coroutine
     def state_list(self, request):
         """
         Fetch a list of data leaves from the validator's state merkle-tree

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -251,6 +251,13 @@ class Validator(object):
             thread_pool)
 
         self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_BATCH_STATUS_REQUEST,
+            client_handlers.BatchStatusRequest(
+                self._journal.get_block_store(),
+                completer.batch_cache),
+            thread_pool)
+
+        self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_STATE_LIST_REQUEST,
             client_handlers.StateListRequest(
                 merkle_db,

--- a/validator/tests/unit3/test_client_request_handlers/mocks.py
+++ b/validator/tests/unit3/test_client_request_handlers/mocks.py
@@ -15,24 +15,63 @@
 
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+from sawtooth_validator.protobuf.batch_pb2 import Batch
+from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
+from sawtooth_validator.protobuf.transaction_pb2 import Transaction
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_store import BlockStore
+from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.state.merkle import MerkleDatabase
+
+def _increment_key(key, offset=1):
+    if type(key) == int:
+        return key + offset
+    try:
+        return str(int(key) + offset)
+    except ValueError:
+        return chr(ord(key) + offset)
+
+def _make_mock_transaction(self, txn_id='txn_id', payload='payload'):
+        header = TransactionHeader(
+            batcher_pubkey='pubkey',
+            family_name='family',
+            family_version='0.0',
+            nonce=txn_id,
+            signer_pubkey='pubkey')
+
+        return Transaction(
+            header=header.SerializeToString(),
+            header_signature=txn_id,
+            payload=payload.encode())
+
+def _make_mock_batch(self, batch_id='batch_id'):
+        txn = _make_mock_transaction(batch_id)
+
+        header = BatchHeader(
+            signer_pubkey='pubkey',
+            transaction_ids=[txn.header_signature])
+
+        return Batch(
+            header=header.SerializeToString(),
+            header_signature=batch_id,
+            transactions=[txn])
 
 
 class MockBlockStore(BlockStore):
     """
     Creates a block store with a preseeded chain of blocks.
-    With defaults, creates three blocks with ids ranging from '0' to '2'.
+    With defaults, creates three blocks with ids ranging from '0' to '2',
+    and a single batch, and single transaction each, with matching ids.
     Using optional root parameter for add_block, it is possible to save
     meaningful state_root_hashes to a block.
     """
-    def __init__(self, size=3):
+    def __init__(self, size=3, start='0'):
         super().__init__(DictDatabase())
 
         for i in range(size):
-            self.add_block(str(i))
+            self.add_block(_increment_key(start, i))
 
     def add_block(self, block_id, root='merkle_root'):
         head = self.chain_head
@@ -47,23 +86,36 @@ class MockBlockStore(BlockStore):
             block_num=num,
             previous_block_id=previous_id,
             signer_pubkey='pubkey',
-            batch_ids=[],
+            batch_ids=[block_id],
             consensus=b'consensus',
             state_root_hash=root)
 
         block = Block(
             header=header.SerializeToString(),
             header_signature=block_id,
-            batches=[])
+            batches=[_make_mock_batch(block_id)])
 
         self.update_chain([BlockWrapper(block)], [])
+
+
+class MockBatchCache(TimedCache):
+    """
+    Creates a batch cache (TimedCache), containing a preseeded set of batches.
+    By default includes two batches with ids '2', and '3'.
+    """
+    def __init__(self, size=2, start='2'):
+        super().__init__()
+
+        for i in range(size):
+            batch_id = _increment_key(start, i)
+            self[batch_id] = _make_mock_batch(batch_id)
 
 
 def make_db_and_store(size=3, start='a'):
     """
     Creates and returns three related objects for testing:
         * database - dict database with evolving state
-        * store - blocks with with root hashes corresponding to that state
+        * store - blocks with root hashes corresponding to that state
         * roots - list of root hashes used in order
     With defaults, the values at the three roots look like this:
         * 0 - {'a': b'1'}
@@ -75,13 +127,12 @@ def make_db_and_store(size=3, start='a'):
     roots = []
 
     merkle = MerkleDatabase(database)
-    start_ord = ord(start)
     data = {}
 
     for i in range(size):
         for k, v in data.items():
             data[k] = str(int(v) + 1).encode()
-        data[chr(start_ord + i)] = str(i * size + 1).encode()
+        data[_increment_key(start, i)] = str(i * size + 1).encode()
 
         root = merkle.update(data, virtual=False)
         roots.append(root)
@@ -89,3 +140,16 @@ def make_db_and_store(size=3, start='a'):
 
     return database, store, roots
 
+def make_store_and_cache(size=3):
+    """
+    Creates and returns two related objects for testing:
+        * store - a mock block store, with a default start
+        * cache - a batch cache with two batches, one in the store, and one not
+    With defaults, the three block/batch ids in the store will be:
+        * '0', '1', 2'
+    And the two batch ids in the cache will be:
+        * '2', '3'
+    """
+    store = MockBlockStore(size=size)
+    cache = MockBatchCache(start=str(size-1))
+    return store, cache


### PR DESCRIPTION
Makes it possible to query for the status of a batch by id from either API. Batches can have one of three statuses:
      • `COMMITTED` - batch was found in block chain
      • `PENDING` - batch found in batch cache, but not in chain
      • `REJECTED` - batch not found

Also includes unit tests for the new requests to both APIs