### PR TITLE
Cluster stop

### DIFF
--- a/cli/sawtooth_cli/cluster.py
+++ b/cli/sawtooth_cli/cluster.py
@@ -367,18 +367,18 @@ def do_cluster_stop(args):
 
     vnm.update()
 
-    # Wait up to 16 seconds for our targeted nodes to gracefully shut down
+    # Wait for targeted nodes to gracefully shut down, then kill
+    timeout = 30
+
     def find_still_up(targeted_nodes):
         return set(vnm.get_node_names()).intersection(set(targeted_nodes))
 
-    timeout = 16
     mark = time.time()
     while len(find_still_up(node_names)) > 0:
         if time.time() - mark > timeout:
             break
         time.sleep(1)
 
-    # Force kill any targeted nodes that are still up
     for node_name in find_still_up(node_names):
         print("Node name still up: killling {}".format(node_name))
         node_controller.kill(node_name)

--- a/cli/sawtooth_cli/cluster.py
+++ b/cli/sawtooth_cli/cluster.py
@@ -292,7 +292,6 @@ def do_cluster_start(args):
         if node_args.genesis is True:
             node_controller.create_genesis_block(node_args)
 
-        print("Starting: {}".format(node_name))
         node_command_generator.start(node_args)
 
         state["Nodes"][node_name] = {
@@ -344,7 +343,6 @@ def do_cluster_stop(args):
         if state_nodes[node_name]['Status'] == 'Stopped':
             raise CliException('{} already stopped'.format(node_name))
 
-        print("Stopping: {}".format(node_name))
         node_command_generator.stop(node_name)
 
         # Update status of Nodes

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -19,8 +19,9 @@ import subprocess
 import tempfile
 import yaml
 
-
 from sawtooth_manage.node import NodeController
+from sawtooth_manage.exceptions import ManagementError
+
 
 LOGGER = logging.getLogger(__name__)
 
@@ -163,14 +164,14 @@ class DockerNodeController(NodeController):
         except subprocess.CalledProcessError as e:
             processors = state['Processors']
             # check if the docker image is built
-            unbuilt = self._get_unbuilt_images(processors)
+            unbuilt = _get_unbuilt_images(processors)
             if unbuilt:
                 raise ManagementError(
                     'Docker images not built: {}. Try running '
                     '"docker_build_all"'.format(
                         ', '.join(unbuilt)))
 
-            invalid = self._check_invalid_processors(processors)
+            invalid = _check_invalid_processors(processors)
             if invalid:
                 raise ManagementError(
                     'No such processor: {}'.format(', '.join(invalid)))
@@ -187,36 +188,6 @@ class DockerNodeController(NodeController):
             if len(line) < 1:
                 continue
             LOGGER.debug("command output: %s", str(line))
-
-    def _get_unbuilt_images(self, processors):
-        processors += ['sawtooth-validator']
-        built_ins = self._built_in_processor_types()
-        built_images = self._get_built_images()
-
-        unbuilt = [image for image in processors
-                   if image not in built_images and image in built_ins]
-
-        return unbuilt
-
-    def _check_invalid_processors(self, processors):
-        built_ins = self._built_in_processor_types()
-        built_images = self._get_built_images()
-
-        invalid = [image for image in processors
-                   if image not in built_images and image not in built_ins]
-
-        return invalid
-
-    def _get_built_images(self):
-        docker_img_cmd = ['docker', 'images', '--format', '{{.Repository}}']
-        return subprocess.check_output(docker_img_cmd).decode()\
-            .split('\n')
-
-    def _built_in_processor_types(self):
-        image_data_dir = os.path.join(os.path.dirname(__file__),
-                                      os.path.pardir,
-                                      'cli', 'data')
-        return os.listdir(image_data_dir)
 
     def stop(self, node_name):
         state_file_path = os.path.join(self._state_dir, 'state.yaml')
@@ -325,3 +296,40 @@ class DockerNodeController(NodeController):
                 return entry.status.startswith("Up")
         return False
 
+
+# docker image checking -- these need to be kept up to date
+
+def _get_unbuilt_images(processors):
+    sawtooth_processors = [
+        'sawtooth-' + processor
+        for processor in processors + ['validator']
+    ]
+    built_ins = _built_in_processor_types()
+    built_images = _get_built_images()
+
+    unbuilt = [image for image in sawtooth_processors
+               if image not in built_images and image in built_ins]
+
+    return unbuilt
+
+def _check_invalid_processors(processors):
+    sawtooth_processors = [
+        'sawtooth-' + processor
+        for processor in processors + ['validator']
+    ]
+    built_ins = _built_in_processor_types()
+    built_images = _get_built_images()
+
+    invalid = [image for image in sawtooth_processors
+               if image not in built_images and image not in built_ins]
+
+    return invalid
+
+def _get_built_images():
+    docker_img_cmd = ['docker', 'images', '--format', '{{.Repository}}']
+    return subprocess.check_output(docker_img_cmd).decode().split('\n')
+
+def _built_in_processor_types():
+    image_data_dir = os.path.join(
+        os.path.dirname(__file__), '..', '..', 'docker')
+    return os.listdir(image_data_dir)

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -154,6 +154,9 @@ class DockerNodeController(NodeController):
         yaml.dump(compose_dict,
                   open(os.path.join(compose_dir, 'docker-compose.yaml'),
                        mode='w'))
+
+        print("Starting: {}".format(node_name))
+
         try:
             os.chdir(compose_dir)
             output = subprocess.check_output(args)

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -227,8 +227,13 @@ class DockerNodeController(NodeController):
         containers = ['-'.join([self._prefix, proc, node_num])
                       for proc in processes]
 
+        print("Stopping: {}".format(node_name))
+
+        # Seconds docker waits for stop before killing
+        docker_wait = 1
+
         for c_name in containers:
-            args = ['docker', 'stop', c_name]
+            args = ['docker', 'stop', '-t', str(docker_wait), c_name]
             LOGGER.debug('stopping %s: %s', c_name, ' '.join(args))
 
             try:
@@ -276,7 +281,6 @@ class DockerNodeController(NodeController):
         args = [
             'docker',
             'ps',
-            '-a',
             '--no-trunc',
             '--format',
             '{{.Names}},{{.ID}},{{.Status}},'

--- a/manage/sawtooth_manage/subproc.py
+++ b/manage/sawtooth_manage/subproc.py
@@ -66,6 +66,8 @@ class SubprocessNodeController(NodeController):
             regex = re.compile('.*')
             self._rm_wildcard(data_dir, regex)
 
+        print("Starting: {}".format(node_name))
+
         for cmd in commands:
             # get_executable_script returns (path, executable)
             _, executable = get_executable_script(cmd)
@@ -99,6 +101,7 @@ class SubprocessNodeController(NodeController):
 
     def _send_signal_to_node(self, signal_type, node_name):
         state = self._load_state()
+        print("Stopping: {}".format(node_name))
         for pid in state['Nodes'][node_name]['pid']:
             os.kill(pid, int(signal_type))
 


### PR DESCRIPTION
Aside from being slow, `sawtooth cluster stop` prints its `Stopping: validator-***` messages all at once, without regard for when the validators actually stop. `start` does the same thing. Those messages have been moved to track the actual starting and stopping of validators.