### PR TITLE
JS SDK: Handle disconnects and SIGTERM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,11 @@
 /sdk/python/build/
 /sdk/python/sawtooth_sdk/protobuf/
 /sdk/python/**/__pycache__/
+/sdk/javascript/node_modules
+/sdk/javascript/protobuf/protobuf_bundle.json
 /sdk/examples/sawtooth_xo/**/__pycache__/
 /sdk/examples/intkey_python/**/__pycache__/
+/sdk/examples/intkey_javascript/node_modules/
 
 /signing/build/
 /signing/sawtooth_signing.egg-info/

--- a/sdk/javascript/client/deferred.js
+++ b/sdk/javascript/client/deferred.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Intel Corporation
+ * Copyright 2017 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,44 +17,21 @@
 
 'use strict'
 
-//
-// TODO: Timeouts
+function Deferred () {
+  if (Promise.defer) {
+    return Promise.defer()
+  } else {
+    this.resolve = null
+    this.reject = null
 
-const _handleResult = (self, f) => (v) => {
-  self._isDone = true
-  self._value = v
-  return f(v)
-}
-
-class Future {
-  constructor () {
-    let self = this
-    this._promise = new Promise((resolve, reject) => {
-      self._resolver = resolve
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve
+      this.reject = reject
     })
-  }
 
-  get (f) {
-    if (this._isDone) {
-      return f(this._value)
-    } else {
-      return this._promise.then(_handleResult(this, f))
-    }
-  }
-
-  set (value) {
-    if (!this._isDone) {
-      this._resolver(value)
-    }
-  }
-
-  then (f) {
-    return this._promise.then(_handleResult(this, f))
-  }
-
-  catch (f) {
-    return this._promise.catch(f)
+    Object.freeze(this)
   }
 }
 
-module.exports = Future
+module.exports = Deferred
+

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -20,6 +20,9 @@
     "standard": "^8.6.0"
   },
   "standard": {
-    "globals": ["describe", "it"]
+    "globals": [
+      "describe",
+      "it"
+    ]
   }
 }

--- a/sdk/javascript/processor/exceptions.js
+++ b/sdk/javascript/processor/exceptions.js
@@ -31,4 +31,15 @@ class InternalError extends Error {
   }
 }
 
-module.exports = {InvalidTransaction, InternalError}
+class ValidatorConnectionError extends Error {
+  constructor (message = '') {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+module.exports = {
+  InvalidTransaction,
+  InternalError,
+  ValidatorConnectionError
+}

--- a/sdk/javascript/protobuf/index.js
+++ b/sdk/javascript/protobuf/index.js
@@ -27,6 +27,9 @@ TpRegisterResponse.Status = TpRegisterResponse.nested.Status.values
 const TpProcessResponse = root.lookup('TpProcessResponse')
 TpProcessResponse.Status = TpProcessResponse.nested.Status.values
 
+const TpUnregisterResponse = root.lookup('TpUnregisterResponse')
+TpUnregisterResponse.Status = TpUnregisterResponse.nested.Status.values
+
 const Message = root.lookup('Message')
 Message.MessageType = Message.nested.MessageType.values
 
@@ -41,6 +44,11 @@ module.exports = {
     root.lookup('TpRegisterRequest'),
 
   TpRegisterResponse,
+
+  TpUnregisterRequest:
+    root.lookup('TpUnregisterRequest'),
+
+  TpUnregisterResponse,
 
   TpProcessRequest:
     root.lookup('TpProcessRequest'),

--- a/sdk/javascript/spec/client/deferred_test.js
+++ b/sdk/javascript/spec/client/deferred_test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+'use strict'
+
+const assert = require('assert')
+
+const Deferred = require('../../client/deferred')
+
+describe('Deferred', () => {
+  describe('resolve', () => {
+    it('should immediately return the value of a resolved deferred', () => {
+      let deferred = new Deferred()
+
+      deferred.resolve('my result')
+
+      return deferred.promise.then((result) => {
+        assert.equal('my result', result)
+      })
+    })
+
+    it('should not return until resolved.', () => {
+      let deferred = new Deferred()
+
+      let promise = deferred.promise.then((result) => {
+        assert.equal('my result', result)
+      })
+
+      deferred.resolve('my result')
+
+      return promise
+    })
+  })
+
+  describe('reject', () => {
+    it('should return a undefined error when none is set', (done) => {
+      let deferred = new Deferred()
+
+      deferred.promise.catch((e) => {
+        assert.equal(undefined, e)
+        done()
+      })
+      .then(() => {
+        assert.ok(false, 'Did not catch')
+      })
+
+      deferred.reject()
+    })
+
+    it('should return the error when one is set', (done) => {
+      let deferred = new Deferred()
+
+      deferred.promise.catch((e) => {
+        assert.equal('my error msg', e.message)
+        done()
+      })
+      .then(() => {
+        assert.ok(false, 'Did not catch')
+      })
+
+      deferred.reject(new Error('my error msg'))
+    })
+  })
+})

--- a/tools/package_groups/ubuntu-16.04-deps
+++ b/tools/package_groups/ubuntu-16.04-deps
@@ -1,7 +1,7 @@
 libcrypto++-dev
 libjson0
 libjson0-dev
-libzmq-dev
+libzmq3-dev
 python3-pip
 python3-nose2
 python3-cbor


### PR DESCRIPTION
The Javascript client can handle disconnects from the server, and reconnects, as well as handles SIGTERM by sending the Unregister event before shutting down.

Additionally, updates the Debian package for ZMQ from `libzmq-dev` to `libzmq3-dev`.  This is needed  as the former is version 2.x, which is missing the monitor feature, and the later is (currently) 4.x, which has it. The monitor feature is required for handling validator disconnects.