### PR TITLE
Clean up consensus interface documentation, update consensus.BlockPub…

### DIFF
--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -38,6 +38,14 @@ class InvalidGenesisStateError(GenesisError):
     pass
 
 
+class InvalidGenesisConsensusError(GenesisError):
+    """
+    Error thrown when the consensus algorithm refuses or fails to initialize
+    or finalize the genesis block.
+    """
+    pass
+
+
 class NotAvailableException(Exception):
     """
     Indicates a required service is not available and the action should be

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -42,11 +42,10 @@ class BlockStore(MutableMapping):
         stored_block = self._block_store[key]
         if stored_block is not None:
             block = Block()
-            block.ParseFromString(stored_block['block'])
+            block.ParseFromString(stored_block)
             return BlockWrapper(
                 status=BlockStatus.Valid,
-                block=block,
-                weight=stored_block['weight'])
+                block=block)
         raise KeyError("Key {} not found.".format(key))
 
     def __delitem__(self, key):
@@ -113,13 +112,6 @@ class BlockStore(MutableMapping):
         return self._block_store
 
     @staticmethod
-    def wrap_block(blkw):
-        return {
-            "block": blkw.block.SerializeToString(),
-            "weight": blkw.weight
-        }
-
-    @staticmethod
     def _build_add_block_ops(blkw):
         """Build the batch operations to add a block to the BlockStore.
 
@@ -129,7 +121,7 @@ class BlockStore(MutableMapping):
         """
         out = []
         blk_id = blkw.identifier
-        out.append((blk_id, BlockStore.wrap_block(blkw)))
+        out.append((blk_id, blkw.block.SerializeToString()))
         for batch in blkw.batches:
             out.append((batch.header_signature, blk_id))
             for txn in batch.transactions:

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -194,8 +194,6 @@ class BlockValidator(object):
                 if valid:
                     valid = consensus.verify_block(blkw)
 
-                # Update the block store
-                blkw.weight = consensus.compute_block_weight(blkw)
                 blkw.status = BlockStatus.Valid if \
                     valid else BlockStatus.Invalid
                 return valid
@@ -346,7 +344,7 @@ class BlockValidator(object):
                 return
 
             # 4) Evaluate the 2 chains to see if the new chain should be
-            # commited
+            # committed
             commit_new_chain = self._test_commit_new_chain()
 
             # 5) Consensus to compute batch sets (only if we are switching).

--- a/validator/sawtooth_validator/journal/consensus/consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus.py
@@ -41,41 +41,48 @@ class BlockPublisherInterface(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def initialize_block(self, block):
+    def initialize_block(self, block_header):
         """Do initialization necessary for the consensus to claim a block,
         this may include initiating voting activities, starting proof of work
-        hash generation, or create a PoET wait timer.
+        hash generation, or create a PoET wait timer. The block
+        is represented by a block_header since the full block will not be
+        built until the block is finalized.
 
         Args:
-            block (Block): the block to initialize.
+            block_header (BlockHeader): the BlockHeader to initialize.
         Returns:
-            consensus: the serialized consensus data for the block header, this
-            can be temporary state data or None.
+            Boolean: True if the candidate block should be built. False if
+            no candidate should be built.
         """
         pass
 
     @abstractmethod
-    def check_publish_block(self, block):
-        """Check if a candidate block is ready to be claimed.
+    def check_publish_block(self, block_header):
+        """Check if a candidate block is ready to be claimed. The block
+        is represented by a block_header since the full block will not be
+        built until the block is finalized.
 
         Args:
-            block (Block): the block to be checked if it should be claimed
+            block_header (BlockHeader): the block_header to be checked if it
+            should be claimed
         Returns:
-            Boolean: True if the candidate block should be claimed.
+            Boolean: True if the candidate block should be claimed. False if
+            the block is not ready to be claimed.
         """
         pass
 
     @abstractmethod
-    def finalize_block(self, block):
-        """Finalize a block to be claimed. Provide any signatures and
-        data updates that need to be applied to the block before it is
-        signed and broadcast to the network.
+    def finalize_block(self, block_header):
+        """Finalize a block to be claimed. Update the
+        Block.block_header.consensus field with any data this consensus's
+        BlockVerifier needs to establish the validity of the block.
 
         Args:
-            block (Block): The candidate block that needs to be finalized
-             by the consensus
+            block_header (BlockHeader): The candidate block that needs to be
+            finalized.
         Returns:
-            consensus: The consensus data to store on the block.
+            Boolean: True if the candidate block good and should be generated.
+            False if the block should be abandoned.
         """
         pass
 
@@ -107,16 +114,7 @@ class BlockVerifierInterface(metaclass=ABCMeta):
         Args:
             block (Block): The block to validate.
         Returns:
-            None
-        """
-        pass
-
-    def compute_block_weight(self, block):
-        """
-        Args:
-            block (Block): The block to compute weight of.
-        Returns:
-            An opaque weight object.
+            Boolean: True if the Block is valid, False if the block is invalid.
         """
         pass
 
@@ -147,9 +145,10 @@ class ForkResolverInterface(metaclass=ABCMeta):
          only valid blocks.
 
         Args:
-            cur_fork_head (Block): The current head of the block chain.
-            new_fork_head (Block): The head of the fork that is being
-                evaluated.
+            cur_fork_head (BlockWrapper): The current head of the block
+            chain.
+            new_fork_head (BlockWrapper): The head of the fork that is being
+            evaluated.
         Returns:
             bool: True if the new chain should replace the current chain.
             False if the new chain should be discarded.

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -136,10 +136,7 @@ class TestGenesisController(unittest.TestCase):
 
         block_store = self.make_block_store({
             'chain_head_id': 'some_other_id',
-            'some_other_id': {
-                'weight': 0,
-                'block': b''
-            }
+            'some_other_id': b''
         })
 
         genesis_ctrl = GenesisController(

--- a/validator/tests/unit3/test_journal/block_tree_manager.py
+++ b/validator/tests/unit3/test_journal/block_tree_manager.py
@@ -178,12 +178,6 @@ class BlockTreeManager(object):
             self.block_cache[block.identifier] = block
 
         if add_to_store:
-            if block.weight is None:
-                state_view = self.state_view_factory.create_view(None)
-                tmv = mock_consensus.\
-                    BlockVerifier(block_cache=self.block_cache,
-                                  state_view=state_view)
-                block.weight = tmv.compute_block_weight(block)
             self.block_store[block.identifier] = block
 
         return block

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-import hashlib
-
 from sawtooth_validator.journal.consensus.consensus\
     import BlockPublisherInterface
 from sawtooth_validator.journal.consensus.consensus\
@@ -23,75 +21,56 @@ from sawtooth_validator.journal.consensus.consensus\
 
 
 class BlockPublisher(BlockPublisherInterface):
-    """Consensus objects provide the following services to the Journal:
-    1) Build candidate blocks ( this temporary until the block types are
-    combined into a single block type)
-    2) Check if it is time to claim the current candidate blocks.
-    3) Provide the data a signatures required for a block to be validated by
-    other consensus algorithms
+    """ MockConsensus BlockPublisher
     """
     def __init__(self, block_cache, state_view):
         self._block_cache = block_cache
         self._state_view = state_view
 
-    def initialize_block(self, block):
-        """Do initialization necessary for the consensus to claim a block,
-        this may include initiating voting activates, starting proof of work
-        hash generation, or create a PoET wait timer.
-
-        Args:
-            journal (Journal): the current journal object
-            block (TransactionBlock): the block to initialize.
-        Returns:
-            none
+    def initialize_block(self, block_header):
         """
-        block.block_header.consensus = b"test_mode"
-
-    def check_publish_block(self, block):
-        """Check if a candidate block is ready to be claimed.
-
         Args:
-            journal (Journal): the current journal object
-            block: the block to be checked if it should be claimed
-            now: the current time
+            block_header (BlockHeader): the block_header to initialize.
         Returns:
-            Boolean: True if the candidate block should be claimed.
+            Boolean: True if the block should become a candidate
+        """
+        return True;
+
+    def check_publish_block(self, block_header):
+        """Initialize the candidate block_header.
+        Args:
+            block_header (block_header): the block_header to check.
+        Returns:
+            Boolean: True if the candidate block_header should be built.
         """
         return True
 
-    def finalize_block(self, block):
-        """Finalize a block to be claimed. Provide any signatures and
-        data updates that need to be applied to the block before it is
-        signed and broadcast to the network.
+    def finalize_block(self, block_header):
+        """Finalize a block_header to be claimed.
 
         Args:
-            journal (Journal): the current journal object
-            block: The candidate block that
+            block_header: The candidate block_header to be finalized.
         Returns:
-            None
+            Boolean: True if the candidate block should be claimed.
         """
-        hasher = hashlib.sha256()
-        hasher.update(block.block_header.consensus)
-        block.block_header.consensus = hasher.hexdigest().encode()
+        block_header.consensus = b"test_mode"
+        return True
 
 
 class BlockVerifier(BlockVerifierInterface):
+    """MockConsensus BlockVerifier implementation
+    """
     def __init__(self, block_cache, state_view):
         self._block_cache = block_cache
         self._state_view = state_view
 
-    def verify_block(self, block_state):
-        hasher = hashlib.sha256()
-        hasher.update(b"test_mode")
-        return block_state.consensus == hasher.hexdigest().encode()
-
-    def compute_block_weight(self, block_state):
-        return block_state.block_num
+    def verify_block(self, block_wrapper):
+        return block_wrapper.consensus == b"test_mode"
 
 
 class ForkResolver(ForkResolverInterface):
-    # Provides the fork resolution interface for the BlockValidator to use
-    # when deciding between 2 forks.
+    """MockConsensus ForkResolver implementation
+    """
     def __init__(self, block_cache):
         self._block_cache = block_cache
 
@@ -99,8 +78,9 @@ class ForkResolver(ForkResolverInterface):
         """
 
         Args:
-            cur_fork_head: The current head of the block chain.
-            new_fork_head: The head of the fork that is being evaluated.
+            cur_fork_head (BlockWrapper): The current head of the block chain.
+            new_fork_head (BlockWrapper): The head of the fork that is being
+            evaluated.
         Returns:
             bool: True if the new chain should replace the current chain.
             False if the new chain should be discarded.


### PR DESCRIPTION
…lisher to take block_headers(since blocks don't exist yet). Remove weight calculation from the consensus interface( to be replaced shortly by access to consensus state store). Update BlockPublisher and GenesisController to honor consensus returns on initialize_block and finalize_block.

Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>