### PR TITLE
Update POST /batches to match spec

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -28,15 +28,21 @@ message Leaf {
     bytes data = 2;
 }
 
-// Corresponds to messagetype CLIENT_BATCH_SUBMIT_REQUEST
+// Submits a list of Batches to be added to the blockchain.
 message ClientBatchSubmitRequest {
     repeated Batch batches = 1;
 }
 
+// This is a response to a submission of one or more Batches.
+// Statuses:
+//   * OK - everything with the request worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
 message ClientBatchSubmitResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
+        INVALID_BATCH = 2;
     }
     Status status = 1;
 }

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -61,6 +61,14 @@ class MissingHead(_ErrorTrap):
         super().__init__(trigger, error, message)
 
 
+class InvalidBatch(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBatchSubmitResponse.INVALID_BATCH,
+            error=web.HTTPBadRequest,
+            message='A submitted batch had an invalid signature')
+
+
 class MissingStatus(_ErrorTrap):
     def __init__(self):
         super().__init__(

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -43,8 +43,6 @@ paths:
                 $ref: "#/definitions/Link"
         400:
           $ref: "#/responses/400BadRequest"
-        422:
-          $ref: "#/responses/422UnprocessableEntity"
         500:
           $ref: "#/responses/500ServerError"
         503:

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -47,6 +47,7 @@ class RouteHandler(object):
         """
         if request.headers['Content-Type'] != 'application/octet-stream':
             return errors.WrongBodyType()
+        error_traps = [error_handlers.InvalidBatch()]
 
         payload = yield from request.read()
 
@@ -54,7 +55,8 @@ class RouteHandler(object):
         self._query_validator(
             Message.CLIENT_BATCH_SUBMIT_REQUEST,
             client.ClientBatchSubmitResponse,
-            payload)
+            payload,
+            error_traps)
 
         # Build link to query submitted batch status
         batch_list = BatchList()

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -35,98 +35,6 @@ class ApiTest(AioHTTPTestCase):
         app.router.add_get('/blocks/{block_id}', handlers.block_get)
         return app
 
-    async def get_and_assert_status(self, endpoint, status):
-        request = await self.client.request('GET', endpoint)
-        self.assertEqual(status, request.status)
-        return request
-
-    async def get_json_assert_200(self, endpoint):
-        request = await self.get_and_assert_status(endpoint, 200)
-        return await request.json()
-
-    async def assert_404(self, endpoint):
-        await self.get_and_assert_status(endpoint, 404)
-
-    def assert_all_instances(self, items, cls):
-        """Asserts that all items in a collection are instances of a class
-        """
-        for item in items:
-            self.assertIsInstance(item, cls)
-
-    def assert_has_valid_head(self, response, expected):
-        """Asserts a response has a head string with an expected value
-        """
-        self.assertIn('head', response)
-        head = response['head']
-        self.assertIsInstance(head, str)
-        self.assertEqual(head, expected)
-
-    def assert_has_valid_link(self, response, expected_ending):
-        """Asserts a response has a link url string with an expected ending
-        """
-        self.assertIn('link', response)
-        link = response['link']
-        self.assertIsInstance(link, str)
-        self.assertTrue(link.startswith('http'))
-        self.assertTrue(link.endswith(expected_ending))
-
-    def assert_has_valid_data_list(self, response, expected_length):
-        """Asserts a response has a data list of dicts of an expected length.
-        """
-        self.assertIn('data', response)
-        data = response['data']
-        self.assertIsInstance(data, list)
-        self.assert_all_instances(data, dict)
-        self.assertEqual(expected_length, len(data))
-
-    def assert_has_valid_data_dict(self, response, expected_value):
-        """Asserts a response has a data dict with an expected value.
-        """
-        self.assertIn('data', response)
-        data = response['data']
-        self.assertIsInstance(data, dict)
-        self.assertEqual(expected_value, data)
-
-    def assert_leaves_contain(self, leaves, address, value):
-        """Asserts that there is one leaf that matches an address,
-        and that its data when b64decoded matches an expected value.
-        """
-        matches = [l for l in leaves if l['address'] == address]
-        self.assertEqual(1, len(matches))
-        self.assertEqual(value, b64decode(matches[0]['data']))
-
-    def assert_block_well_formed(self, block, expected_id):
-        """Tests a block dict is fully expanded and matches the expected id.
-        Assumes the block contains one batch and txn which share the id.
-        """
-
-        # Check block and its header
-        self.assertIsInstance(block, dict)
-        self.assertEqual(expected_id, block['header_signature'])
-        self.assertIsInstance(block['header'], dict)
-        self.assertEqual(b'consensus', b64decode(block['header']['consensus']))
-
-        # Check batch and its header
-        batches = block['batches']
-        self.assertIsInstance(batches, list)
-        self.assertEqual(1, len(batches))
-        self.assert_all_instances(batches, dict)
-
-        self.assertEqual(expected_id, batches[0]['header_signature'])
-        self.assertIsInstance(batches[0]['header'], dict)
-        self.assertEqual('pubkey', batches[0]['header']['signer_pubkey'])
-
-        # Check transaction and its header
-        txns = batches[0]['transactions']
-        self.assertIsInstance(txns, list)
-        self.assertEqual(1, len(txns))
-        self.assert_all_instances(txns, dict)
-
-        self.assertEqual(expected_id, txns[0]['header_signature'])
-        self.assertEqual(b'payload', b64decode(txns[0]['payload']))
-        self.assertIsInstance(txns[0]['header'], dict)
-        self.assertEqual(expected_id, txns[0]['header']['nonce'])
-
     @unittest_run_loop
     async def test_batch_status_with_one_id(self):
         """Verifies a GET /batch_status with one id works properly.
@@ -548,3 +456,95 @@ class ApiTest(AioHTTPTestCase):
             - a response status of 404
         """
         await self.assert_404('/blocks/bad')
+
+    async def get_and_assert_status(self, endpoint, status):
+        request = await self.client.request('GET', endpoint)
+        self.assertEqual(status, request.status)
+        return request
+
+    async def get_json_assert_200(self, endpoint):
+        request = await self.get_and_assert_status(endpoint, 200)
+        return await request.json()
+
+    async def assert_404(self, endpoint):
+        await self.get_and_assert_status(endpoint, 404)
+
+    def assert_all_instances(self, items, cls):
+        """Asserts that all items in a collection are instances of a class
+        """
+        for item in items:
+            self.assertIsInstance(item, cls)
+
+    def assert_has_valid_head(self, response, expected):
+        """Asserts a response has a head string with an expected value
+        """
+        self.assertIn('head', response)
+        head = response['head']
+        self.assertIsInstance(head, str)
+        self.assertEqual(head, expected)
+
+    def assert_has_valid_link(self, response, expected_ending):
+        """Asserts a response has a link url string with an expected ending
+        """
+        self.assertIn('link', response)
+        link = response['link']
+        self.assertIsInstance(link, str)
+        self.assertTrue(link.startswith('http'))
+        self.assertTrue(link.endswith(expected_ending))
+
+    def assert_has_valid_data_list(self, response, expected_length):
+        """Asserts a response has a data list of dicts of an expected length.
+        """
+        self.assertIn('data', response)
+        data = response['data']
+        self.assertIsInstance(data, list)
+        self.assert_all_instances(data, dict)
+        self.assertEqual(expected_length, len(data))
+
+    def assert_has_valid_data_dict(self, response, expected_value):
+        """Asserts a response has a data dict with an expected value.
+        """
+        self.assertIn('data', response)
+        data = response['data']
+        self.assertIsInstance(data, dict)
+        self.assertEqual(expected_value, data)
+
+    def assert_leaves_contain(self, leaves, address, value):
+        """Asserts that there is one leaf that matches an address,
+        and that its data when b64decoded matches an expected value.
+        """
+        matches = [l for l in leaves if l['address'] == address]
+        self.assertEqual(1, len(matches))
+        self.assertEqual(value, b64decode(matches[0]['data']))
+
+    def assert_block_well_formed(self, block, expected_id):
+        """Tests a block dict is fully expanded and matches the expected id.
+        Assumes the block contains one batch and txn which share the id.
+        """
+
+        # Check block and its header
+        self.assertIsInstance(block, dict)
+        self.assertEqual(expected_id, block['header_signature'])
+        self.assertIsInstance(block['header'], dict)
+        self.assertEqual(b'consensus', b64decode(block['header']['consensus']))
+
+        # Check batch and its header
+        batches = block['batches']
+        self.assertIsInstance(batches, list)
+        self.assertEqual(1, len(batches))
+        self.assert_all_instances(batches, dict)
+
+        self.assertEqual(expected_id, batches[0]['header_signature'])
+        self.assertIsInstance(batches[0]['header'], dict)
+        self.assertEqual('pubkey', batches[0]['header']['signer_pubkey'])
+
+        # Check transaction and its header
+        txns = batches[0]['transactions']
+        self.assertIsInstance(txns, list)
+        self.assertEqual(1, len(txns))
+        self.assert_all_instances(txns, dict)
+
+        self.assertEqual(expected_id, txns[0]['header_signature'])
+        self.assertEqual(b'payload', b64decode(txns[0]['payload']))
+        self.assertIsInstance(txns[0]['header'], dict)
+        self.assertEqual(expected_id, txns[0]['header']['nonce'])


### PR DESCRIPTION
Update the `POST /batches` REST API endpoint to match the OpenAPI spec.

Includes:
- Add `link` to response envelope with appropriate `/batch_status` url
- Send back `400` when invalid batches are submitted
- Unit tests for `POST /batches`