### PR TITLE
Add ValidatorRegistryView for registry info

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -146,6 +146,7 @@ test_poet(){
     echo "[---Running poet---]"
     run_docker_test ./poet/sawtooth_poet/tests/validator_registry_test/tp_validator_registry.yaml \
     -s validator -p $ISOLATION_ID
+    run_docker_test ./poet/tests/unit_poet.yaml -s poet -p $ISOLATION_ID
 }
 
 main

--- a/poet/sawtooth_poet/validator_registry/state/__init__.py
+++ b/poet/sawtooth_poet/validator_registry/state/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/poet/sawtooth_poet/validator_registry/state/validator_registry_view.py
+++ b/poet/sawtooth_poet/validator_registry/state/validator_registry_view.py
@@ -1,0 +1,101 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import hashlib
+
+from sawtooth_poet.protobuf.validator_registry_pb2 import ValidatorInfo
+
+
+_NAMESPACE = hashlib.sha256('validator_registry'.encode()).hexdigest()[0:6]
+
+
+class ValidatorRegistryView(object):
+    """
+    A ValidatorRegistryView provides access to the on-chain validator info.
+
+    The ValidatorRegistryView provides access to the validator registry's
+    information about validators stored within a particular state view. This
+    access is read-only.
+    """
+
+    def __init__(self, state_view):
+        """
+        Constructs a view, on top of the given read-only state view.
+
+        Args:
+            state_view (:obj:`StateView`): The read-only state view for the
+                current snapshot of chain state.
+        """
+        self._state_view = state_view
+
+    def get_validators(self):
+        """Gets a dict of validator infos for all validators known to the
+        registry. The dict is a mapping of validator id to ValidatorInfo.
+
+        Returns:
+            dict:(str, `ValidatorInfo`): A dict of validator id to
+                `ValidatorInfo` objects.
+        """
+        validator_map_addr = ValidatorRegistryView._to_address('validator_map')
+        leaves = self._state_view.leaves(_NAMESPACE)
+        infos = [ValidatorRegistryView._parse_validator_info(state_data)
+                 for address, state_data in leaves.items()
+                 if address != validator_map_addr]
+        return {info.id: info for info in infos}
+
+    def has_validator_info(self, validator_id):
+        """Checks to see if it has the validator info for a given validator ID.
+
+        Args:
+            validator_id (str): The ID of the validator in question.
+
+        Returns:
+            bool: True if the registry has info on the given ID, False if
+                otherwise.
+        """
+        try:
+            self._state_view.get(
+                ValidatorRegistryView._to_address(validator_id))
+            return True
+        except KeyError:
+            return False
+
+    def get_validator_info(self, validator_id):
+        """Get the validator info for a given validator ID.
+
+        Args:
+            validator_id (str): The ID of the validator in question.
+
+        Returns:
+            :obj:`ValidatorInfo`: The validator info.
+
+        Raises:
+            KeyError: If no validator info exists for the given ID.
+        """
+        state_data = self._state_view.get(
+            ValidatorRegistryView._to_address(validator_id))
+
+        return ValidatorRegistryView._parse_validator_info(state_data)
+
+    @staticmethod
+    def _to_address(addressable_key):
+        return _NAMESPACE + hashlib.sha256(
+            addressable_key.encode()).hexdigest()
+
+    @staticmethod
+    def _parse_validator_info(state_data):
+        validator_info = ValidatorInfo()
+        validator_info.ParseFromString(state_data)
+
+        return validator_info

--- a/poet/tests/unit3/test_validator_registry_view/__init__.py
+++ b/poet/tests/unit3/test_validator_registry_view/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/poet/tests/unit3/test_validator_registry_view/mocks.py
+++ b/poet/tests/unit3/test_validator_registry_view/mocks.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+class MockStateView(object):
+    """Simulates a StateView by wrapping a dictionary of address/bytes pairs.
+    """
+
+    def __init__(self, state_dict):
+        """Constructs a MockStateView with a dict of address/bytes pairs.
+
+        Args:
+            state_dict (dict): Dict of address/byte pairs
+        """
+        self._state = state_dict
+
+    def get(self, address):
+        """See sawtooth_validator.state.state_view.StateView.get"""
+        return self._state[address]
+
+    def addresses(self):
+        """See sawtooth_validator.state.state_view.StateView.addresses"""
+        return self._state.keys()
+
+    def leaves(self, prefix):
+        """See sawtooth_validator.state.state_view.StateView.leaves"""
+        return {address: data
+                for address, data in self._state.items()
+                if address.startswith(prefix)}

--- a/poet/tests/unit3/test_validator_registry_view/tests.py
+++ b/poet/tests/unit3/test_validator_registry_view/tests.py
@@ -1,0 +1,128 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import unittest
+
+from sawtooth_poet.protobuf.validator_registry_pb2 import ValidatorInfo
+from sawtooth_poet.protobuf.validator_registry_pb2 import SignUpInfo
+
+from sawtooth_poet.validator_registry.state.validator_registry_view import \
+    ValidatorRegistryView
+
+from test_validator_registry_view.mocks import MockStateView
+from test_validator_registry_view.utils import to_address
+
+
+class TestValidatorRegistryView(unittest.TestCase):
+
+    def test_get_validator_info(self):
+        """Given a state view that contains a state entry for a given validator
+        info, verify that the validator registry returns a ValidatorInfo when
+        get_validator_info is called with the validator's id."""
+
+        state_view = MockStateView({
+            to_address('my_id'): ValidatorInfo(
+                registered='sure',
+                name='my_validator',
+                id='my_id',
+                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                                       proof_data='beleive me',
+                                       anti_sybil_id='no sybil'),
+                block_num=123
+            ).SerializeToString()
+        })
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        info = validator_registry_view.get_validator_info('my_id')
+        self.assertEqual('my_id', info.id)
+        self.assertEqual('my_validator', info.name)
+        self.assertEqual('sure', info.registered)
+        self.assertEqual(123, info.block_num)
+        self.assertEqual('my_pubkey', info.signup_info.poet_public_key)
+        self.assertEqual('beleive me', info.signup_info.proof_data)
+        self.assertEqual('no sybil', info.signup_info.anti_sybil_id)
+
+    def test_get_validator_info_not_exists(self):
+        """Given a state view that does not contain a state view for a given
+        validator info, verify that it throws a key error on `get`.
+        """
+        state_view = MockStateView({})
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        with self.assertRaises(KeyError):
+            validator_registry_view.get_validator_info('my_id')
+
+    def test_has_validator_info(self):
+        """Given a state view that contains a state entry for a given validator
+        info, verify that the validator registry returns a true when
+        has_validator_info is called with the validator's id."""
+
+        state_view = MockStateView({
+            to_address('my_id'): ValidatorInfo(
+                registered='sure',
+                name='my_validator',
+                id='my_id',
+                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                                       proof_data='beleive me',
+                                       anti_sybil_id='no sybil'),
+                block_num=123
+            ).SerializeToString()
+        })
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        self.assertTrue(validator_registry_view.has_validator_info('my_id'))
+
+    def test_has_validator_info_not_exists(self):
+        """Given a state view that does not contain a state view for a given
+        validator info, verify that has_validator_info returns False with an
+        unkown id.
+        """
+        state_view = MockStateView({})
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        self.assertFalse(validator_registry_view.has_validator_info('my_id'))
+
+    def test_get_validators(self):
+        """Given a state view with multiple validators, and the 'validator_map'
+        entry, verify that get_validators returns the list of just
+        ValidatorInfo instances.
+        """
+        state_view = MockStateView({
+            to_address('validator_map'): b'this should be ignored',
+            to_address('my_id'): ValidatorInfo(
+                registered='sure',
+                name='my_validator',
+                id='my_id',
+                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                                       proof_data='beleive me',
+                                       anti_sybil_id='no sybil'),
+                block_num=123
+            ).SerializeToString(),
+            to_address('another_id'): ValidatorInfo(
+                registered='yep',
+                name='your_validator',
+                id='another_id',
+                signup_info=SignUpInfo(poet_public_key='your_pubkey',
+                                       proof_data='you betcha',
+                                       anti_sybil_id='poor sybil'),
+                block_num=100
+            ).SerializeToString()
+        })
+
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        infos = validator_registry_view.get_validators()
+        self.assertEqual(2, len(infos))
+        self.assertEqual('my_validator', infos['my_id'].name)
+        self.assertEqual('your_validator', infos['another_id'].name)

--- a/poet/tests/unit3/test_validator_registry_view/utils.py
+++ b/poet/tests/unit3/test_validator_registry_view/utils.py
@@ -1,0 +1,24 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import hashlib
+
+
+VALIDATOR_REGISTRY_NAMESPACE = \
+    hashlib.sha256('validator_registry'.encode()).hexdigest()[0:6]
+
+
+def to_address(addressable_key):
+    return VALIDATOR_REGISTRY_NAMESPACE + hashlib.sha256(
+        addressable_key.encode()).hexdigest()

--- a/poet/tests/unit_poet.yaml
+++ b/poet/tests/unit_poet.yaml
@@ -1,0 +1,29 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  poet:
+    image: sawtooth-test:$ISOLATION_ID
+    volumes:
+      - ../../:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/poet
+    entrypoint: nose2-3 -s tests/unit3 -v 
+    environment:
+        PYTHONPATH: "\
+          /project/sawtooth-core/poet:\
+          "


### PR DESCRIPTION
The ValidatorRegistryView provides access to the validator registry's
on-chain information about validators stored within a particular state view.
This access is read-only.

Additionally, added unit tests for poet code, which get run by CI