### PR TITLE
Fix PoET simulator based upon canonical key representation in signing module

### DIFF
--- a/poet/sawtooth_poet/validator_registry/processor/handler.py
+++ b/poet/sawtooth_poet/validator_registry/processor/handler.py
@@ -121,11 +121,9 @@ class ValidatorRegistryTransactionHandler(object):
         '5Jz5Kaiy3kCiHE537uXcQnJuiNJshf2bZZn43CrALMGoCd3zRuo'
 
     def __init__(self):
-        self._report_private_key = \
-            signing.encode_privkey(
-                signing.decode_privkey(self.__REPORT_PRIVATE_KEY_WIF, 'wif'),
-                'hex')
-
+        # Since signing works with WIF-encoded private keys, we don't have to
+        # decode the encoded key string.
+        self._report_private_key = self.__REPORT_PRIVATE_KEY_WIF
         self._report_public_key = signing.generate_pubkey(
             self._report_private_key)
 

--- a/validator/tests/unit3/test_poet/test_wait_certificate.py
+++ b/validator/tests/unit3/test_poet/test_wait_certificate.py
@@ -74,7 +74,6 @@ class TestWaitCertificate(unittest.TestCase):
                 wait_timer=None,
                 block_hash="Reader's Digest")
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_before_wait_timer_expires(self):
         # Need to create signup information
         SignupInfo.create_signup_info(
@@ -102,7 +101,6 @@ class TestWaitCertificate(unittest.TestCase):
                 wait_timer=wt,
                 block_hash="Reader's Digest")
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_after_wait_timer_timed_out(self):
         # Need to create signup information
         SignupInfo.create_signup_info(
@@ -134,7 +132,6 @@ class TestWaitCertificate(unittest.TestCase):
                 wait_timer=wt,
                 block_hash="Reader's Digest")
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_with_wrong_wait_timer(self):
         # Need to create signup information
         SignupInfo.create_signup_info(
@@ -164,7 +161,6 @@ class TestWaitCertificate(unittest.TestCase):
             wait_timer=valid_wt,
             block_hash="Reader's Digest")
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate_with_reused_wait_timer(self):
         # Need to create signup information
         SignupInfo.create_signup_info(
@@ -209,7 +205,6 @@ class TestWaitCertificate(unittest.TestCase):
             wait_timer=wt,
             block_hash="Reader's Digest")
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_certificate(self):
         # Need to create signup information and wait timer first
         signup_info = \
@@ -265,7 +260,6 @@ class TestWaitCertificate(unittest.TestCase):
 
         another_wc.check_valid([wc], signup_info.poet_public_key)
 
-    @unittest.skip("Disabled until poet integration")
     def test_wait_certificate_serialization(self):
         # Need to create signup information and wait timer first
         signup_info = \

--- a/validator/tests/unit3/test_poet/test_wait_timer.py
+++ b/validator/tests/unit3/test_poet/test_wait_timer.py
@@ -86,7 +86,6 @@ class TestWaitTimer(unittest.TestCase):
                 validator_address='1060 W Addison Street',
                 certificates=tuple())
 
-    @unittest.skip("Disabled until poet integration")
     def test_create_wait_timer(self):
         # Need to create signup information first
         signup_info = \


### PR DESCRIPTION
Changes include:
* Updated PoET simulator to no longer encode/decode private/public keys as the signing module uses string representing WIF/hex encodings for keys, respectively.
* Updated validator registry transaction processor accordingly to match PoET simulator.
* Re-enabled some unit tests for wait timer and certificate as they are not dependent upon final integration of new PoET consensus into the new architecture.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>