### PR TITLE
Send correct charset name for UTF-8

### DIFF
--- a/extensions/bond/ui/client/src/main/sawtooth/http.cljs
+++ b/extensions/bond/ui/client/src/main/sawtooth/http.cljs
@@ -38,8 +38,8 @@
               (str (encode-uri-query (name k)) "=" (encode-uri-query v)))))
 
 (def ^:private content-types
-  {:json "application/json; charset=UTF8"
-   :form "application/x-www-form-urlencoded; charset=UTF8"})
+  {:json "application/json; charset=UTF-8"
+   :form "application/x-www-form-urlencoded; charset=UTF-8"})
 
 (def ^:private data-formatters
   {:json #(->> % (clj->js) (.stringify js/JSON))

--- a/extensions/mktplace/navigator/client/src/main/sawtooth/http.cljs
+++ b/extensions/mktplace/navigator/client/src/main/sawtooth/http.cljs
@@ -37,8 +37,8 @@
               (str (encode-uri-query (name k)) "=" (encode-uri-query v)))))
 
 (def ^:private content-types
-  {:json "application/json; charset=UTF8"
-   :form "application/x-www-form-urlencoded; charset=UTF8"})
+  {:json "application/json; charset=UTF-8"
+   :form "application/x-www-form-urlencoded; charset=UTF-8"})
 
 (def ^:private data-formatters
   {:json #(->> % (clj->js) (.stringify js/JSON))


### PR DESCRIPTION
Not sending the correct charset name for UTF-8 causes an error (which only seems to occur on some pathways through express)
