### PR TITLE
On rebroadcast of a gossip message, do not resend to node who you received it from

### DIFF
--- a/validator/sawtooth_validator/execution/processor_handlers.py
+++ b/validator/sawtooth_validator/execution/processor_handlers.py
@@ -30,7 +30,7 @@ class ProcessorRegisterHandler(Handler):
     def __init__(self, processor_collection):
         self._collection = processor_collection
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = processor_pb2.TpRegisterRequest()
         request.ParseFromString(message_content)
 
@@ -67,7 +67,7 @@ class ProcessorUnRegisterHandler(Handler):
     def __init__(self, processor_collection):
         self._collection = processor_collection
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = processor_pb2.TpUnregisterRequest()
         request.ParseFromString(message_content)
 

--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -28,7 +28,7 @@ class TpStateGetHandler(Handler):
     def __init__(self, context_manager):
         self._context_manager = context_manager
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         get_request = state_context_pb2.TpStateGetRequest()
         get_request.ParseFromString(message_content)
         return_values = self._context_manager.get(
@@ -55,7 +55,7 @@ class TpStateSetHandler(Handler):
         """
         self._context_manager = context_manager
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         set_request = state_context_pb2.TpStateSetRequest()
         set_request.ParseFromString(message_content)
         set_values_list = [{e.address: e.data} for e in set_request.entries]

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -33,7 +33,7 @@ class PeerRegisterHandler(Handler):
     def __init__(self, gossip):
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = PeerRegisterRequest()
         request.ParseFromString(message_content)
         LOGGER.debug("got peer register message "
@@ -52,7 +52,7 @@ class PeerUnregisterHandler(Handler):
     def __init__(self, gossip):
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = PeerUnregisterRequest()
         request.ParseFromString(message_content)
         LOGGER.debug("got peer unregister message "
@@ -68,7 +68,7 @@ class PeerUnregisterHandler(Handler):
 
 
 class GossipMessageHandler(Handler):
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
 
         ack = NetworkAcknowledgement()
         ack.status = ack.OK
@@ -107,7 +107,7 @@ class GossipBroadcastHandler(Handler):
 
 class PingHandler(Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = PingRequest()
         request.ParseFromString(message_content)
 

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -86,17 +86,18 @@ class GossipBroadcastHandler(Handler):
     def __init__(self, gossip):
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
+        exclude = [(connection, identity)]
         gossip_message = GossipMessage()
         gossip_message.ParseFromString(message_content)
         if gossip_message.content_type == "BATCH":
             batch = Batch()
             batch.ParseFromString(gossip_message.content)
-            self._gossip.broadcast_batch(batch)
+            self._gossip.broadcast_batch(batch, exclude)
         elif gossip_message.content_type == "BLOCK":
             block = Block()
             block.ParseFromString(gossip_message.content)
-            self._gossip.broadcast_block(block)
+            self._gossip.broadcast_block(block, exclude)
         else:
             LOGGER.info("received %s, not BATCH or BLOCK",
                         gossip_message.content_type)

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -111,7 +111,7 @@ def validate_transaction(txn):
 
 class GossipMessageSignatureVerifier(Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
 
         gossip_message = GossipMessage()
         gossip_message.ParseFromString(message_content)
@@ -142,7 +142,7 @@ class GossipMessageSignatureVerifier(Handler):
 
 class BatchListSignatureVerifier(Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         try:
             batch_list = BatchList()
             batch_list.ParseFromString(message_content)

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -311,7 +311,7 @@ class CompleterBatchListBroadcastHandler(Handler):
         self._completer = completer
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         batch_list = BatchList()
         batch_list.ParseFromString(message_content)
         for batch in batch_list.batches:
@@ -330,7 +330,7 @@ class CompleterGossipHandler(Handler):
     def __init__(self, completer):
         self._completer = completer
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         gossip_message = network_pb2.GossipMessage()
         gossip_message.ParseFromString(message_content)
         if gossip_message.content_type == "BLOCK":

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -47,7 +47,7 @@ class BlockResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         gossip_message = network_pb2.GossipBlockRequest()
         gossip_message.ParseFromString(message_content)
         block_id = gossip_message.block_id
@@ -73,7 +73,7 @@ class BatchByBatchIdResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         gossip_message = network_pb2.GossipBatchByBatchIdRequest()
         gossip_message.ParseFromString(message_content)
         batch = None
@@ -98,7 +98,7 @@ class BatchByTransactionIdResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         gossip_message = network_pb2.GossipBatchByTransactionIdRequest()
         gossip_message.ParseFromString(message_content)
         batch = None

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -75,6 +75,14 @@ class _SendReceive(object):
         self._socket = None
         self._condition = Condition()
 
+    @property
+    def connection(self):
+        return self._connection
+
+    @property
+    def identity(self):
+        return self._identity
+
     @asyncio.coroutine
     def _receive_message(self):
         """
@@ -308,6 +316,10 @@ class Connection(object):
             server_private_key=server_private_key)
 
         self._thread = None
+
+    @property
+    def local_id(self):
+        return self._send_receive_thread.connection
 
     def send(self, message_type, data):
         """

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -36,7 +36,7 @@ class BatchStatusRequest(Handler):
         self._block_store = block_store
         self._batch_cache = batch_cache
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBatchStatusRequest,
@@ -68,7 +68,7 @@ class StateCurrentRequest(Handler):
     def __init__(self, current_root_func):
         self._current_root_func = current_root_func
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateCurrentRequest,
@@ -88,7 +88,7 @@ class StateListRequest(Handler):
         self._tree = MerkleDatabase(database)
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateListRequest,
@@ -124,7 +124,7 @@ class StateGetRequest(Handler):
         self._tree = MerkleDatabase(database)
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateGetRequest,
@@ -162,7 +162,7 @@ class BlockListRequest(Handler):
     def __init__(self, block_store):
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBlockListRequest,
@@ -195,7 +195,7 @@ class BlockGetRequest(Handler):
     def __init__(self, block_store):
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBlockGetRequest,

--- a/validator/tests/unit3/test_client_request_handlers/tests.py
+++ b/validator/tests/unit3/test_client_request_handlers/tests.py
@@ -30,6 +30,7 @@ class _ClientHandlerTestCase(unittest.TestCase):
     def initialize(self, handler, request_proto, response_proto,
                     store=None, roots=None):
         self._identity = '1234567'
+        self._connection = "Connection"
         self._handler = handler
         self._request_proto = request_proto
         self._store = store
@@ -44,7 +45,8 @@ class _ClientHandlerTestCase(unittest.TestCase):
         return request.SerializeToString()
 
     def _handle(self, request):
-        result = self._handler.handle(self._identity, request)
+        result = self._handler.handle(
+            self._identity, self._connection, request)
         return result.message_out
 
     def make_bad_request(self, **kwargs):

--- a/validator/tests/unit3/test_dispatcher/mock.py
+++ b/validator/tests/unit3/test_dispatcher/mock.py
@@ -25,7 +25,7 @@ class MockHandler1(dispatch.Handler):
     def __init__(self):
         self._time_to_sleep = 2.0
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         if self._time_to_sleep > 0:
             time.sleep(self._time_to_sleep)
             self._time_to_sleep -= 0.1
@@ -35,7 +35,7 @@ class MockHandler1(dispatch.Handler):
 
 class MockHandler2(dispatch.Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, identity, connection, message_content):
         request = validator_pb2.Message()
         request.ParseFromString(message_content)
         return dispatch.HandlerResult(


### PR DESCRIPTION
This stops the state were validators will continuously send gossip messages back and forth forever.