### PR TITLE
Implement heartbeat ping on inbound connections

### DIFF
--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -92,17 +92,16 @@ message Message {
         CLIENT_BATCH_STATUS_RESPONSE = 121;
         // Further messages from the stats client through the web api
 
-
         // Temp message types until a discusion can be had about gossip msg
         GOSSIP_MESSAGE = 200;
         GOSSIP_REGISTER = 201;
         GOSSIP_UNREGISTER = 202;
-        GOSSIP_ACK = 203;
-        GOSSIP_PING = 204;
         GOSSIP_BLOCK_REQUEST = 205;
         GOSSIP_BATCH_BY_BATCH_ID_REQUEST = 206;
         GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST = 207;
 
+        NETWORK_PING = 300;
+        NETWORK_ACK = 301;
     }
     // The type of message, used to determine how to 'route' the message
     // to the appropriate handler as well as how to deserialize the

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -23,7 +23,6 @@ from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
 from sawtooth_validator.protobuf.network_pb2 import PeerRegisterRequest
 from sawtooth_validator.protobuf.network_pb2 import PeerUnregisterRequest
-from sawtooth_validator.protobuf.network_pb2 import PingRequest
 from sawtooth_validator.protobuf.network_pb2 import NetworkAcknowledgement
 
 LOGGER = logging.getLogger(__name__)
@@ -45,7 +44,7 @@ class PeerRegisterHandler(Handler):
         return HandlerResult(
             HandlerStatus.RETURN,
             message_out=ack,
-            message_type=validator_pb2.Message.GOSSIP_ACK)
+            message_type=validator_pb2.Message.NETWORK_ACK)
 
 
 class PeerUnregisterHandler(Handler):
@@ -64,7 +63,7 @@ class PeerUnregisterHandler(Handler):
         return HandlerResult(
             HandlerStatus.RETURN,
             message_out=ack,
-            message_type=validator_pb2.Message.GOSSIP_ACK)
+            message_type=validator_pb2.Message.NETWORK_ACK)
 
 
 class GossipMessageHandler(Handler):
@@ -78,7 +77,7 @@ class GossipMessageHandler(Handler):
         return HandlerResult(
             HandlerStatus.RETURN_AND_PASS,
             message_out=ack,
-            message_type=validator_pb2.Message.GOSSIP_ACK)
+            message_type=validator_pb2.Message.NETWORK_ACK)
 
 
 class GossipBroadcastHandler(Handler):
@@ -103,22 +102,3 @@ class GossipBroadcastHandler(Handler):
         return HandlerResult(
             status=HandlerStatus.PASS
         )
-
-
-class PingHandler(Handler):
-
-    def handle(self, identity, message_content):
-        request = PingRequest()
-        request.ParseFromString(message_content)
-
-        LOGGER.debug("got ping message "
-                     "from %s. sending ack",
-                     identity)
-
-        ack = NetworkAcknowledgement()
-        ack.status = ack.OK
-
-        return HandlerResult(
-            HandlerStatus.RETURN,
-            message_out=ack,
-            message_type=validator_pb2.Message.GOSSIP_ACK)

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import logging
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.protobuf.network_pb2 import PingRequest
+from sawtooth_validator.protobuf.network_pb2 import NetworkAcknowledgement
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PingHandler(Handler):
+
+    def handle(self, identity, message_content):
+        request = PingRequest()
+        request.ParseFromString(message_content)
+
+        ack = NetworkAcknowledgement()
+        ack.status = ack.OK
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=validator_pb2.Message.NETWORK_ACK)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -54,7 +54,7 @@ from sawtooth_validator.gossip.gossip_handlers import GossipBroadcastHandler
 from sawtooth_validator.gossip.gossip_handlers import GossipMessageHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
-from sawtooth_validator.gossip.gossip_handlers import PingHandler
+from sawtooth_validator.networking.handlers import PingHandler
 
 
 LOGGER = logging.getLogger(__name__)
@@ -100,7 +100,8 @@ class Validator(object):
 
         self._service = Interconnect(component_endpoint,
                                      self._dispatcher,
-                                     secured=False)
+                                     secured=False,
+                                     heartbeat=False)
         executor = TransactionExecutor(service=self._service,
                                        context_manager=context_manager,
                                        config_view_factory=ConfigViewFactory(
@@ -132,7 +133,8 @@ class Validator(object):
             peer_connections=peer_list,
             secured=True,
             server_public_key=b'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)',
-            server_private_key=b'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*')
+            server_private_key=b'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*',
+            heartbeat=True)
 
         self._gossip = Gossip(self._network)
 
@@ -191,11 +193,13 @@ class Validator(object):
             thread_pool
         )
 
+        # Set up base network handlers
         self._network_dispatcher.add_handler(
-            validator_pb2.Message.GOSSIP_PING,
+            validator_pb2.Message.NETWORK_PING,
             PingHandler(),
             network_thread_pool)
 
+        # Set up gossip handlers
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_REGISTER,
             PeerRegisterHandler(gossip=self._gossip),


### PR DESCRIPTION
This moves GOSSIP_PING and GOSSIP_ACK to lower level NETWORK
message types, moves the PingHandler from the gossip package to
the networking package, and implements heartbeat pings over
connections on the ZMQ ROUTER socket.

Signed-off-by: James Mitchell <mitchell@bitwise.io>