### PR TITLE
Add wait-for-commit to batch status requests and batch submits

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -48,8 +48,13 @@ message ClientBatchSubmitResponse {
 }
 
 // A request for the status of one or more batches, specified by id.
+// If `wait_for_commit` is set to true, the validator will wait to respond
+// until all batches are committed, or until the specified `timeout
+// in seconds has elapsed. Defaults to 300.
 message ClientBatchStatusRequest {
     repeated string batch_ids = 1;
+    bool wait_for_commit = 2;
+    int32 timeout = 3;
 }
 
 // This is a response to a request for the status of specific batches. The

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -29,27 +29,46 @@ message Leaf {
 }
 
 // Submits a list of Batches to be added to the blockchain.
+// If `wait_for_commit` is set to true, the validator will wait to respond
+// until all batches are committed, or until the specified `timeout
+// in seconds has elapsed. Defaults to 300.
 message ClientBatchSubmitRequest {
     repeated Batch batches = 1;
+    bool wait_for_commit = 2;
+    int32 timeout = 3;
 }
 
 // This is a response to a submission of one or more Batches.
+// If `wait_for_commit` was set in the request, this response will include a
+// `batch_statuses` hashmap, with the status of each batch submitted.
 // Statuses:
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
+// BatchesStatuses:
+//   * COMMITTED - the batch was accepted and has been committed to the chain
+//   * INVALID - the batch failed validation, it should be resubmitted
+//   * UNKNOWN - no status for the batch could be found (possibly invalid)
+//   * PENDING - the batch is still being processed
 message ClientBatchSubmitResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         INVALID_BATCH = 2;
     }
+    enum BatchStatus {
+        COMMITTED = 0;
+        INVALID = 1;
+        UNKNOWN = 2;
+        PENDING = 3;
+    }
     Status status = 1;
+    map<string, BatchStatus> batch_statuses = 2;
 }
 
 // A request for the status of one or more batches, specified by id.
 // If `wait_for_commit` is set to true, the validator will wait to respond
-// until all batches are committed, or until the specified `timeout
+// until all batches are committed, or until the specified `timeout`
 // in seconds has elapsed. Defaults to 300.
 message ClientBatchStatusRequest {
     repeated string batch_ids = 1;

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -22,6 +22,12 @@ class WrongBodyType(web.HTTPBadRequest):
         super().__init__(reason=message)
 
 
+class EmptyProtobuf(web.HTTPBadRequest):
+    def __init__(self):
+        message = 'Your submission contained no batches'
+        super().__init__(reason=message)
+
+
 class BadProtobuf(web.HTTPBadRequest):
     def __init__(self):
         message = 'There was a problem decoding your Protobuf binary'

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -22,6 +22,12 @@ class WrongBodyType(web.HTTPBadRequest):
         super().__init__(reason=message)
 
 
+class BadProtobuf(web.HTTPBadRequest):
+    def __init__(self):
+        message = 'There was a problem decoding your Protobuf binary'
+        super().__init__(reason=message)
+
+
 class MissingStatusId(web.HTTPBadRequest):
     def __init__(self):
         message = 'At least one batch id must be specified to check status'

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -112,20 +112,31 @@ paths:
   /batch_status:
     get:
       summary: Fetches the committed statuses for a set of batches
-      description: >
+      description: |
         Fetches an object with a status for each batch requested. The keys of
         the data object will be the ids of the batch(es), while the values will
         be a string status with the values `'COMMITTED'`, `'INVALID'`,
         `'PENDING'`, or `'UNKNOWN'`.
+
         The batch(es) you want to check can be specified using the `id` filter
-        parameter. Note that as this route does not return a full resource, and
-        the response body will _not_ include the `head` or `paging` properties.
+        parameter. If a `wait` time is specified in the url, the API will wait
+        to respond until all batches are committed, or the time in seconds has
+        elapsed. If the value of `wait` is not set (i.e. `?wait&id=...`), or
+        it is set to any non-integer value other than `false`, the wait time
+        will be just shy of the api's specified timeout (usually 300).
+
+        Note that as this route does not return a full resource, and the
+        response body will _not_ include the `head` or `paging` properties.
       parameters:
         - name: id
           in: query
           description: A comma seperated list of batch ids
           type: string
           required: true
+        - name: wait
+          in: query
+          description: A time in seconds to wait for commit
+          type: integer
       responses:
         200:
           description: Successfully retrieved statuses

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -446,10 +446,6 @@ responses:
     description: Address, prefix, or root did not match any resource
     schema:
       $ref: "#/definitions/ErrorList"
-  422UnprocessableEntity:
-    description: Submitted Batch was improperly signed
-    schema:
-      $ref: "#/definitions/ErrorList"
   500ServerError:
     description: Something went wrong with the server
     schema:

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -13,30 +13,57 @@ paths:
   /batches:
     post:
       summary: Sends a BatchList to the validator
-      description: >
-        Accepts a protobuf formatted `BatchList` as an octet-stream
-        binary file and submits it to the validator to be
-        committed. Note that since the submitted batches are not yet on the
-        blockchain, there will be no `data` object returned with
-        the response, just a `link` to check the committed status.
+      description: |
+        Accepts a protobuf formatted `BatchList` as an octet-stream binary
+        file and submits it to the validator to be committed.
+
+        If the `wait` parameter is set in the url, the API will try to wait to
+        respond until all batches have been committed to the blockchain,
+        returning a `201` response with a `link` to the committed batches.
+
+        If `wait` is set to a positive integer, the API will timeout and return
+        after that time in seconds has elapsed. If set to any non-integer value
+        other than `false` (including simply `?wait`), *the API may still
+        timeout*, but will use its own settings (usually 300s). After timing
+        out, a `200` is returned with a `data` object that include the statuses
+        of each batch (`COMMITTED`, `INVALID`, `PENDING`, or `UNKNOWN`), and a
+        `link` to a `/batch_status` endpoint for further polling.
+
+        If `wait` is not set, or is set to `false`, the API will return
+        immediately with a status of `202`. There will be no `data` object,
+        only a `link` to a `/batch_status` endpoint to be polled to check
+        the status of submitted batches.
       consumes:
         - application/octet-stream
       parameters:
-        -
-          name: BatchList
+        - name: BatchList
           in: body
           description: A binary encoded protobuf BatchList
           schema:
             $ref: "#/definitions/BatchList"
           required: true
-        -
-          name: callback
+        - name: callback
           in: query
           type: string
           description: Callback url
+        - $ref: "#/parameters/wait"
       responses:
+        200:
+          description: Batches submitted, but not all committed
+          schema:
+            properties:
+              data:
+                $ref: "#/definitions/BatchStatuses"
+              link:
+                $ref: "#/definitions/Link"
+        201:
+          description: Successfully committed all Batches in BatchList
+          schema:
+            properties:
+              link:
+                $ref: "#/definitions/Link"
         202:
-          description: Successfully submitted BatchList
+          description: Successfully submitted BatchList for validation
           schema:
             properties:
               link:
@@ -133,10 +160,7 @@ paths:
           description: A comma seperated list of batch ids
           type: string
           required: true
-        - name: wait
-          in: query
-          description: A time in seconds to wait for commit
-          type: integer
+        - $ref: "#/parameters/wait"
       responses:
         200:
           description: Successfully retrieved statuses
@@ -497,6 +521,11 @@ parameters:
     type: string
     default: latest
     description: Index or id of head block
+  wait:
+    name: wait
+    in: query
+    type: integer
+    description: A time in seconds to wait for commit
   fields:
     name: fields
     in: query

--- a/rest_api/tests/unit/mock_stream.py
+++ b/rest_api/tests/unit/mock_stream.py
@@ -251,6 +251,10 @@ class _StatusHandler(_MockHandler):
 
         request = self._parse_request(content)
 
+        # simulate having waited for a pending batch to be committed
+        if request.wait_for_commit == True and request.timeout > 0:
+            mock['pending'] = self._response_proto.COMMITTED
+
         statuses = {
             b_id: mock[b_id] if b_id in mock else self._response_proto.UNKNOWN
             for b_id in request.batch_ids}

--- a/rest_api/tests/unit/mock_stream.py
+++ b/rest_api/tests/unit/mock_stream.py
@@ -234,6 +234,20 @@ class _SubmitHandler(_MockHandler):
                 return self._response_proto(
                     status=self._response_proto.INVALID_BATCH)
 
+        # simulate having waited for a batches to be committed
+        if request.wait_for_commit == True and request.timeout > 0:
+            statuses = {}
+            for batch in request.batches:
+                key = batch.header_signature
+                if key == 'pending':
+                    statuses[key] = self._response_proto.PENDING
+                else:
+                    statuses[key] = self._response_proto.COMMITTED
+
+            return self._response_proto(
+                status=self._response_proto.OK,
+                batch_statuses=statuses)
+
         return self._response_proto(status=self._response_proto.OK)
 
 

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -95,6 +95,16 @@ class ApiTest(AioHTTPTestCase):
         self.assert_has_valid_link(response, '/batch_status?id=a,b,c')
 
     @unittest_run_loop
+    async def test_post_no_batches(self):
+        """Verifies a POST /batches with no batches breaks properly.
+
+        Expects to find:
+            - a response status of 400
+        """
+        request = await self.post_batch_ids()
+        self.assertEqual(400, request.status)
+
+    @unittest_run_loop
     async def test_post_batch_with_wait(self):
         """Verifies a POST /batches can wait for commit properly.
 

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -43,12 +43,14 @@ class ApiTest(AioHTTPTestCase):
 
         Expects to find:
             - a response status of 202
+            - no data property
             - a link property that ends in '/batches?id=a'
         """
         request = await self.post_batch_ids('a')
         self.assertEqual(202, request.status)
 
         response = await request.json()
+        self.assertNotIn('data', response)
         self.assert_has_valid_link(response, '/batch_status?id=a')
 
     @unittest_run_loop
@@ -82,14 +84,48 @@ class ApiTest(AioHTTPTestCase):
 
         Expects to find:
             - a response status of 202
-            - a link property that ends in '/batches?id=a,b,c'
+            - no data property
+            - a link property that ends in '/batch_status?id=a,b,c'
         """
         request = await self.post_batch_ids('a', 'b', 'c')
         self.assertEqual(202, request.status)
 
         response = await request.json()
+        self.assertNotIn('data', response)
         self.assert_has_valid_link(response, '/batch_status?id=a,b,c')
 
+    @unittest_run_loop
+    async def test_post_batch_with_wait(self):
+        """Verifies a POST /batches can wait for commit properly.
+
+        Expects to find:
+            - a response status of 201
+            - no data property
+        """
+        request = await self.post_batch_ids('a', wait=True)
+        self.assertEqual(201, request.status)
+
+        response = await request.json()
+        self.assertNotIn('data', response)
+
+    @unittest_run_loop
+    async def test_post_batch_with_timeout(self):
+        """Verifies a POST /batches works when timed out while waiting.
+
+        *Note: the mock submit handler marks ids of 'pending' as PENDING
+
+        Expects to find:
+            - a response status of 200
+            - a link property that ends in '/batch_status?id=pending'
+            - a data property that is a dict with the key/value pair:
+                * 'pending': 'PENDING'
+        """
+        request = await self.post_batch_ids('pending', wait=True)
+        self.assertEqual(200, request.status)
+
+        response = await request.json()
+        self.assert_has_valid_link(response, '/batch_status?id=pending')
+        self.assert_has_valid_data_dict(response, {'pending': 'PENDING'})
 
     @unittest_run_loop
     async def test_batch_status_with_one_id(self):
@@ -103,7 +139,7 @@ class ApiTest(AioHTTPTestCase):
         Expects to find:
             - a response status of 200
             - a link property that ends in '/batch_status?id=pending'
-            - a data property that is a dict with the key/value pair
+            - a data property that is a dict with the key/value pair:
                 * 'pending': 'PENDING'
         """
         response = await self.get_json_assert_200('/batch_status?id=pending')
@@ -123,7 +159,7 @@ class ApiTest(AioHTTPTestCase):
         Expects to find:
             - a response status of 200
             - a link property that ends in '/batch_status?id=pending&wait'
-            - a data property that is a dict with the key/value pair
+            - a data property that is a dict with the key/value pair:
                 * 'pending': 'COMMITTED'
         """
         response = await self.get_json_assert_200('/batch_status?id=pending&wait')
@@ -143,7 +179,7 @@ class ApiTest(AioHTTPTestCase):
         Expects to find:
             - a response status of 200
             - link property ending in '/batch_status?id=committed,unknown,bad'
-            - a data property that is a dict with the key/value pair
+            - a data property that is a dict with the key/value pairs:
                 * 'committed': 'COMMITTED'
                 * 'unknown': 'UNKNOWN'
                 * 'bad': 'UNKNOWN'
@@ -533,14 +569,14 @@ class ApiTest(AioHTTPTestCase):
         """
         await self.assert_404('/blocks/bad')
 
-    async def post_batch_ids(self, *batch_ids):
+    async def post_batch_ids(self, *batch_ids, wait=False):
         batches = [batch_pb2.Batch(
             header_signature=batch_id,
             header=b'header') for batch_id in batch_ids]
         batch_list = batch_pb2.BatchList(batches=batches)
 
         return await self.client.post(
-            '/batches',
+            '/batches' + ('?wait' if wait else ''),
             data=batch_list.SerializeToString(),
             headers={'content-type': 'application/octet-stream'})
 

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -112,6 +112,26 @@ class ApiTest(AioHTTPTestCase):
         self.assert_has_valid_data_dict(response, {'pending': 'PENDING'})
 
     @unittest_run_loop
+    async def test_batch_status_with_wait(self):
+        """Verifies a GET /batch_status with a wait set works properly.
+
+        Fetches from preseeded id/status pairs that look like this with a wait:
+            'committed': COMMITTED
+            'pending': COMMITTED
+             *: UNKNOWN
+
+        Expects to find:
+            - a response status of 200
+            - a link property that ends in '/batch_status?id=pending&wait'
+            - a data property that is a dict with the key/value pair
+                * 'pending': 'COMMITTED'
+        """
+        response = await self.get_json_assert_200('/batch_status?id=pending&wait')
+
+        self.assert_has_valid_link(response, '/batch_status?id=pending&wait')
+        self.assert_has_valid_data_dict(response, {'pending': 'COMMITTED'})
+
+    @unittest_run_loop
     async def test_batch_status_with_many_ids(self):
         """Verifies a GET /batch_status with many ids works properly.
 

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -22,12 +22,10 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf.batch_pb2 import Batch
-from sawtooth_validator.protobuf.batch_pb2 import BatchList
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
-from sawtooth_validator.protobuf import client_pb2
+from sawtooth_validator.protobuf.client_pb2 import ClientBatchSubmitRequest
 from sawtooth_validator.protobuf import network_pb2
-from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
@@ -312,17 +310,12 @@ class CompleterBatchListBroadcastHandler(Handler):
         self._gossip = gossip
 
     def handle(self, identity, message_content):
-        batch_list = BatchList()
-        batch_list.ParseFromString(message_content)
-        for batch in batch_list.batches:
+        request = ClientBatchSubmitRequest()
+        request.ParseFromString(message_content)
+        for batch in request.batches:
             self._completer.add_batch(batch)
             self._gossip.broadcast_batch(batch)
-        message = client_pb2.ClientBatchSubmitResponse(
-            status=client_pb2.ClientBatchSubmitResponse.OK)
-        return HandlerResult(
-            status=HandlerStatus.RETURN,
-            message_out=message,
-            message_type=validator_pb2.Message.CLIENT_BATCH_SUBMIT_RESPONSE)
+        return HandlerResult(status=HandlerStatus.PASS)
 
 
 class CompleterGossipHandler(Handler):

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -259,6 +259,13 @@ class Validator(object):
             thread_pool)
 
         self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
+            client_handlers.BatchSubmitFinisher(
+                self._journal.get_block_store(),
+                completer.batch_cache),
+            thread_pool)
+
+        self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_STATUS_REQUEST,
             client_handlers.BatchStatusRequest(
                 self._journal.get_block_store(),

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -45,6 +45,11 @@ class BatchStatusRequest(Handler):
         if helper.has_response():
             return helper.result
 
+        if helper.request.wait_for_commit:
+            self._block_store.wait_for_batch_commits(
+                batch_ids=helper.request.batch_ids,
+                timeout=helper.request.timeout)
+
         statuses = {}
 
         for batch_id in helper.request.batch_ids:

--- a/validator/tests/unit3/test_client_request_handlers/mocks.py
+++ b/validator/tests/unit3/test_client_request_handlers/mocks.py
@@ -46,7 +46,7 @@ def _make_mock_transaction(self, txn_id='txn_id', payload='payload'):
             header_signature=txn_id,
             payload=payload.encode())
 
-def _make_mock_batch(self, batch_id='batch_id'):
+def make_mock_batch(self, batch_id='batch_id'):
         txn = _make_mock_transaction(batch_id)
 
         header = BatchHeader(
@@ -93,7 +93,7 @@ class MockBlockStore(BlockStore):
         block = Block(
             header=header.SerializeToString(),
             header_signature=block_id,
-            batches=[_make_mock_batch(block_id)])
+            batches=[make_mock_batch(block_id)])
 
         self.update_chain([BlockWrapper(block)], [])
 
@@ -108,7 +108,7 @@ class MockBatchCache(TimedCache):
 
         for i in range(size):
             batch_id = _increment_key(start, i)
-            self[batch_id] = _make_mock_batch(batch_id)
+            self[batch_id] = make_mock_batch(batch_id)
 
 
 def make_db_and_store(size=3, start='a'):


### PR DESCRIPTION
Add the capability to specify that requests for batch status, or submissions of new batches, should wait to return until all the batches have been committed to the blockchain, or a timeout has expired.

This covers both the REST and ZMQ APIs, and adds unit tests for all new capabilities.