### PR TITLE
Rearrange Setting Subcommands and add `settings list`

### DIFF
--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -52,7 +52,8 @@ class TestConfigBatchlist(unittest.TestCase):
         shutil.rmtree(self._temp_dir)
 
     def _parse_set_command(self, *settings):
-        cmd_args = ['config', 'set', '-k', self._wif_file,
+        cmd_args = ['config', 'proposal', 'create',
+                    '-k', self._wif_file,
                     '-o', os.path.join(self._temp_dir, 'myconfig.batch')]
         cmd_args += settings
 

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -220,7 +220,11 @@ class RouteHandler(object):
         for trap in traps:
             trap.check(parsed.status)
 
-        return MessageToDict(parsed, preserving_proto_field_name=True)
+        return MessageToDict(
+            parsed,
+            including_default_value_fields=True,
+            preserving_proto_field_name=True,
+        )
 
     @staticmethod
     def _wrap_response(data=None, metadata=None, status=200):


### PR DESCRIPTION
The sawtooth config subcommands are rearranged into meaningful subgroups,`proposal` and `settings`.

The `proposal` subcommand group, is made up of the `create` subcommand. This takes the place of the `set` and `propose` commands by combining them into one operation, which either records a file or submits the settings to the validator.

The `settings` subcommand group is made up (currently) of the `list` subcommand. This command displays the list of current on-chain settings, read from a validator's REST api.  The settings may be outputed as key/value text (the default), CSV, JSON or YAML.


Additionally:

- Corrects an issue with the rest api not returning empty fields from protobuf objects. 