### PR TITLE
Graceful validator shutdown

### DIFF
--- a/bin/run_docker_test
+++ b/bin/run_docker_test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from subprocess import run, PIPE, CalledProcessError
+from subprocess import run, PIPE, CalledProcessError, Popen
 import os
 import sys
 import argparse
@@ -46,12 +46,13 @@ def main():
     ]
 
     compose_up = compose + [
-        'up', '--abort-on-container-exit'
+        'up', '-d'
     ]
 
-    compose_down = compose + ['down', '--remove-orphans']
+    docker_wait = ['docker', 'wait',
+                    "{}_{}_1".format(isolation_id, args.test_service)]
 
-    compose_kill = compose + ['kill']
+    compose_down = compose + ['down', '--remove-orphans']
 
     inspect = [
         'docker', 'inspect',
@@ -65,6 +66,9 @@ def main():
             "Test service '{}' does not exist in compose file: '{}'".format(
                 args.test_service, compose_file))
 
+    compose_logs = compose + ['logs', '--follow'] + \
+                   [s for s in compose_dict['services']]
+
     start_time = time.time()
     timeout = args.timeout
 
@@ -76,6 +80,12 @@ def main():
         try:
             print("Running: {}".format(compose_up))
             run(compose_up, check=True, timeout=timeout)
+            handle = Popen(args=compose_logs, stdout=PIPE,
+                           stderr=PIPE,
+                           universal_newlines=True)
+            print("Running: {}".format(docker_wait))
+            run(docker_wait, check=True, timeout=timeout)
+
         except CalledProcessError:
             raise RunDockerTestError(
                 "Failed to start all docker containers. Do `docker ps -a` to "
@@ -113,6 +123,8 @@ def main():
                 "Failed to remove all docker containers. Do `docker ps -a` to "
                 "list residual containers.")
 
+        sys.stdout.write(handle.stdout.read())
+        sys.stdout.write(handle.stderr.read())
         exit(int(success))
 
     except KeyboardInterrupt:

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -222,6 +222,8 @@ test_signing() {
 
 test_validator() {
     run_docker_test ./validator/tests/unit_validator.yaml -s validator
+    run_docker_test shutdown-smoke.yaml -s integration_test
 }
+
 
 main

--- a/docker/sawtooth-build-python
+++ b/docker/sawtooth-build-python
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y -q \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install \
-    aiohttp \
+    aiohttp==1.3.5 \
     cryptography \
     grpcio-tools \
     lmdb \

--- a/docker/sawtooth-rest_api
+++ b/docker/sawtooth-rest_api
@@ -15,7 +15,7 @@
 
 FROM sawtooth-base
 
-RUN pip3 install aiohttp
+RUN pip3 install aiohttp==1.3.5
 
 RUN mkdir -p /project/sawtooth-core
 

--- a/docker/sawtooth-test
+++ b/docker/sawtooth-test
@@ -16,8 +16,20 @@
 FROM sawtooth-base
 
 RUN apt-get update && apt-get install -y -q \
+    apt-transport-https \
+    ca-certificates \
+    add-apt-key
+
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
+    --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+RUN echo "deb https://apt.dockerproject.org/repo ubuntu-xenial main" \
+    > /etc/apt/sources.list.d/docker.list
+
+RUN apt-get update && apt-get install -y -q \
     inetutils-ping \
-    python3-nose2
+    python3-nose2 \
+    docker-engine
 
 RUN pip3 install \
     PyYAML \

--- a/docker/sawtooth-test
+++ b/docker/sawtooth-test
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y -q \
 
 RUN pip3 install \
     PyYAML \
-    aiohttp
+    aiohttp==1.3.5
 
 VOLUME /project/sawtooth-core
 

--- a/integration/sawtooth_integration/docker/intkey-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-smoke.yaml
@@ -71,7 +71,6 @@ services:
     expose:
       - 8080
     working_dir: /project/sawtooth-core/integration/sawtooth_integration/tests
-    entrypoint: python3 -m http.server
     depends_on:
       - validator
       - rest_api

--- a/integration/sawtooth_integration/docker/shutdown-smoke.yaml
+++ b/integration/sawtooth_integration/docker/shutdown-smoke.yaml
@@ -1,0 +1,72 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  genesis:
+    image: sawtooth-validator:$ISOLATION_ID
+    container_name: genesis
+    volumes:
+      - ../../../:/project/sawtooth-core
+      - /var/lib/sawtooth
+      - /etc/sawtooth
+    entrypoint: "bash -c \"
+      bin/sawtooth admin keygen --force &&
+      bin/sawtooth admin genesis\""
+
+  validator-genesis:
+    image: sawtooth-validator:$ISOLATION_ID
+    container_name: validator-genesis
+    volumes:
+      - ../../../:/project/sawtooth-core
+    volumes_from:
+      - genesis
+    entrypoint: bin/validator -v
+
+  keygen:
+    image: sawtooth-validator:$ISOLATION_ID
+    container_name: keygen
+    volumes:
+      - ../../../:/project/sawtooth-core
+      - /etc/sawtooth
+    entrypoint: bin/sawtooth admin keygen --force
+
+  validator-non-genesis:
+    image: sawtooth-validator:$ISOLATION_ID
+    container_name: validator-non-genesis
+    depends_on:
+     - validator-genesis
+    volumes_from:
+     - keygen
+    volumes:
+      - ../../../:/project/sawtooth-core
+    entrypoint: bin/validator -v --peers tcp://validator-genesis:8800
+
+  integration_test:
+    image: sawtooth-test:$ISOLATION_ID
+    volumes:
+      - ../../../:/project/sawtooth-core
+      - /var/run/docker.sock:/var/run/docker.sock
+    working_dir: /project/sawtooth-core/integration/sawtooth_integration/tests
+    depends_on:
+      - validator-non-genesis
+      - validator-genesis
+    entrypoint: "bash -c \"
+      sleep 5 && \
+      nose2-3 -v test_shutdown_smoke.TestShutdownSmoke\""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/integration"

--- a/integration/sawtooth_integration/docker/xo-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-smoke.yaml
@@ -70,7 +70,6 @@ services:
     expose:
       - 8080
     working_dir: /project/sawtooth-core/integration/sawtooth_integration/tests
-    entrypoint: python3 -m http.server
     depends_on:
       - validator
       - rest_api

--- a/integration/sawtooth_integration/tests/test_shutdown_smoke.py
+++ b/integration/sawtooth_integration/tests/test_shutdown_smoke.py
@@ -1,0 +1,111 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+import logging
+import subprocess
+import time
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+
+class TestShutdownSmoke(unittest.TestCase):
+    def test_resting_shutdown(self):
+        """Tests that SIGINT and SIGTERM will cause validators with and without
+        genesis to gracefully exit.
+
+        Notes:
+            1) A genesis validator and a non-genesis validator are started with
+            the non-genesis validator specifying the genesis validator as
+            a peer.
+            2) The SIGINT os signal is sent to both validators.
+            3) The validators' return codes are checked and asserted to be 0.
+            4) Repeat step 1.
+            5) The SIGTERM os signal is sent to both validators.
+            6) The validators' return codes are checked and asserted to be 0.
+        """
+        # 2)
+        containers = ['validator-genesis', 'validator-non-genesis']
+        for c in containers:
+            self._send_docker_signal('SIGINT', c)
+        # 3)
+        sigint_exit_statuses = self._wait_for_containers_exit_status(
+            containers)
+
+        self.assertEqual(len(sigint_exit_statuses), len(containers))
+        for s in sigint_exit_statuses:
+            self.assertEqual(s, 0)
+
+        # 4)
+        for c in containers:
+            self._start_container(c)
+
+        time.sleep(3)
+
+        # 5)
+        for c in containers:
+            self._send_docker_signal('SIGTERM', c)
+
+        # 6)
+        sigterm_exit_statuses = self._wait_for_containers_exit_status(
+            containers)
+        self.assertEqual(len(sigterm_exit_statuses), len(containers))
+        for s in sigterm_exit_statuses:
+            self.assertEqual(s, 0)
+
+    def _send_docker_signal(self, sig, container_name):
+        """
+        Args:
+            sig (str): examples: SIGTERM, SIGINT
+            container_name (str): The name of the docker container
+        """
+        args = ['docker', 'kill', '--signal={}'.format(sig), container_name]
+
+        # Not catching the CalledProcessError so the test errors and stops
+        # if there is a problem calling docker.
+        subprocess.run(
+                args, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, check=True)
+
+    def _wait_for_containers_exit_status(self, containers):
+        """Wait for all of the specified containers to exit
+        and return their exit codes.
+        Args:
+            containers (list of str): The containers to wait to exit.
+
+        Returns:
+            list of int: The list of return codes for the process in each
+                container.
+
+        """
+        wait = ['docker', 'wait'] + containers
+        handle = subprocess.Popen(
+            args=wait,
+            stdout=subprocess.PIPE,
+            universal_newlines=True)
+        try:
+            output, _ = handle.communicate(timeout=35)
+            return [int(e) for e in output.strip().split('\n')]
+        except subprocess.TimeoutExpired:
+            handle.kill()
+            LOGGER.warning("Docker timed out waiting for %s to exit",
+                           containers)
+            return []
+
+    def _start_container(self, container):
+        start = ['docker', 'start', container]
+        subprocess.run(start, timeout=15, check=True)

--- a/tools/plugins/install_aiohttp.sh
+++ b/tools/plugins/install_aiohttp.sh
@@ -3,6 +3,6 @@
 set -e
 
 pip3 install \
-    aiohttp \
+    aiohttp==1.3.5 \
     cchardet \
     aiodns

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -42,6 +42,9 @@ class SquashException(Exception):
     pass
 
 
+_SHUTDOWN_SENTINEL = -1
+
+
 class StateContext(object):
     """A data structure holding address-_ContextFuture pairs and the addresses
     that can be written to and read from.
@@ -181,12 +184,10 @@ class ContextManager(object):
 
         self._context_reader = _ContextReader(database, self._address_queue,
                                               self._inflated_addresses)
-        self._context_reader.setDaemon(True)
         self._context_reader.start()
 
         self._context_writer = _ContextWriter(self._inflated_addresses,
                                               self._contexts)
-        self._context_writer.setDaemon(True)
         self._context_writer.start()
 
     def get_first_root(self):
@@ -399,8 +400,8 @@ class ContextManager(object):
         return _squash
 
     def stop(self):
-        self._context_writer.join(1)
-        self._context_reader.join(1)
+        self._address_queue.put_nowait(_SHUTDOWN_SENTINEL)
+        self._inflated_addresses.put_nowait(_SHUTDOWN_SENTINEL)
 
 
 class _ContextReader(Thread):
@@ -421,6 +422,8 @@ class _ContextReader(Thread):
     def run(self):
         while True:
             context_state_addresslist_tuple = self._addresses.get(block=True)
+            if context_state_addresslist_tuple is _SHUTDOWN_SENTINEL:
+                break
             c_id, state_hash, address_list = context_state_addresslist_tuple
             tree = MerkleDatabase(self._database, state_hash)
             return_values = []
@@ -454,8 +457,11 @@ class _ContextWriter(Thread):
 
     def run(self):
         while True:
-            c_id, inflated_address_list = self._inflated_addresses.get(
+            context_id_list_tuple = self._inflated_addresses.get(
                 block=True)
+            if context_id_list_tuple is _SHUTDOWN_SENTINEL:
+                break
+            c_id, inflated_address_list = context_id_list_tuple
             inflated_value_map = {k: v for k, v in inflated_address_list}
             if c_id in self._contexts:
                 self._contexts[c_id].set_futures(inflated_value_map,

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -106,7 +106,28 @@ class Scheduler(object, metaclass=ABCMeta):
 
         Returns:
             True if all transactions have been marked as applied and that the
-            finalize() as been called.
+            finalize() has been called.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def cancel(self):
+        """Cancels the schedule of transactions. The cancelling of a scheduler
+        is an idempotent operation. The iterator will raise
+        StopIteration, completing iteration on the iterator.
+        Returns:
+            None
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def is_cancelled(self):
+        """Returns whether .cancel() has been called on this scheduler.
+
+
+        Returns:
+            A bool specifing if the scheduler's .cancel() method has been
+            called.
         """
         raise NotImplementedError()
 
@@ -164,10 +185,12 @@ class SchedulerIterator(object):
 
             # Return the next transaction, potentially blocking with wait().
             # Exit by throwing StopIteration when the scheduler is complete
-            # and we have returned all the scheduler's transactions.
+            # and we have returned all the scheduler's transactions or the
+            # scheduler was cancelled.
             while True:
                 if (self._scheduler.complete(block=False)
-                        and self._scheduler.count() == self._next_index):
+                        and self._scheduler.count() == self._next_index or
+                        self._scheduler.is_cancelled()):
                     raise StopIteration()
 
                 txn = self._scheduler.next_transaction()

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -41,6 +41,7 @@ class SerialScheduler(Scheduler):
         self._in_progress_transaction = None
         self._final = False
         self._complete = False
+        self._cancelled = False
         self._squash = squash_handler
         self._condition = Condition()
         # contains all txn.signatures where txn is
@@ -150,3 +151,12 @@ class SerialScheduler(Scheduler):
                 self._condition.wait_for(lambda: self._complete)
                 return True
             return False
+
+    def cancel(self):
+        with self._condition:
+            self._cancelled = True
+            self._condition.notify_all()
+
+    def is_cancelled(self):
+        with self._condition:
+            return self._cancelled

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -144,8 +144,8 @@ def main(args=sys.argv[1:]):
     try:
         validator.start()
     except KeyboardInterrupt:
-        print("Interrupted!", file=sys.stderr)
-        sys.exit(1)
+        LOGGER.info("Initiating graceful "
+                    "shutdown (press Ctrl+C again to force)")
     except LocalConfigurationError as local_config_err:
         LOGGER.error(str(local_config_err))
         sys.exit(1)
@@ -155,3 +155,5 @@ def main(args=sys.argv[1:]):
     except Exception as e:
         LOGGER.exception(e)
         sys.exit(1)
+    finally:
+        validator.stop()

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -104,6 +104,9 @@ class Validator(object):
                                        config_view_factory=ConfigViewFactory(
                                            StateViewFactory(merkle_db)))
 
+        # needed for running callbacks from the TransactionExecutor
+        self._service.setup_future_threadpool(max_workers=10)
+
         zmq_identity = hashlib.sha512(
             time.time().hex().encode()).hexdigest()[:23]
 
@@ -129,6 +132,8 @@ class Validator(object):
             heartbeat=True,
             connection_timeout=30,
             max_incoming_connections=100)
+
+        self._network.setup_future_threadpool(max_workers=10)
 
         self._gossip = Gossip(self._network,
                               initial_peer_endpoints=peer_list)

--- a/validator/tests/unit3/test_context_manager/tests.py
+++ b/validator/tests/unit3/test_context_manager/tests.py
@@ -145,3 +145,6 @@ class TestContextManager(unittest.TestCase):
 
         # used for replicating state hash through direct merkle tree updates
         self.database_results = dict_database.DictDatabase()
+
+    def tearDown(self):
+        self.context_manager.stop()

--- a/validator/tests/unit3/test_journal/mock.py
+++ b/validator/tests/unit3/test_journal/mock.py
@@ -109,6 +109,12 @@ class MockScheduler(Scheduler):
     def count(self):
         raise NotImplementedError()
 
+    def cancel(self):
+        pass
+
+    def is_cancelled(self):
+        return False
+
 
 class MockTransactionExecutor(object):
     def __init__(self):


### PR DESCRIPTION
After this PR a validator will be able to gracefully shutdown with one SIGINT or SIGTERM if given time, from a resting state. This doesn't handle shutdown under load, as that still isn't always graceful.

The run_docker_test script is modified for not stopping until the test container exits, so that other containers can exit which should be orchestrated by the test container.