### PR TITLE
Change publisher so that when building a block it uses the current chain head to create the state view

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -113,9 +113,8 @@ class BlockPublisher(object):
         :return: (BlockBuilder) - The candidate block in a BlockBuilder
         wrapper.
         """
-        prev_state = self._get_previous_block_root_state_hash(chain_head)
-        state_view = self._state_view_factory. \
-            create_view(prev_state)
+        state_view = \
+            self._state_view_factory.create_view(chain_head.state_root_hash)
         consensus_module = ConsensusFactory.get_configured_consensus_module(
             state_view)
 


### PR DESCRIPTION
The publisher should be using the chain head when building a new block instead of the chain head's previous block.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>