### PR TITLE
Add connection collection to Interconnect and stop Rebroadcasting to originally sender

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -183,14 +183,14 @@ class TransactionExecutorThread(threading.Thread):
                 self._waiters_by_type[processor_type].add_to_in_queue(
                     content)
         else:
-            identity = processor.identity
-            self._send_and_process_result(content, identity)
+            connection_id = processor.connection_id
+            self._send_and_process_result(content, connection_id)
 
-    def _send_and_process_result(self, content, identity):
+    def _send_and_process_result(self, content, connection_id):
         future = self._service.send(
             validator_pb2.Message.TP_PROCESS_REQUEST,
             content,
-            identity=identity,
+            connection_id=connection_id,
             has_callback=True)
         future.add_callback(self._future_done_callback)
 
@@ -270,9 +270,9 @@ class _Waiter(object):
         self._processors.wait_to_process(self._processor_type)
         while not self._in_queue.empty():
             content = self._in_queue.get_nowait()
-            identity = self._processors.get_next_of_type(
-                self._processor_type).identity
-            self._send_and_process(content, identity)
+            connection_id = self._processors.get_next_of_type(
+                self._processor_type).connection_id
+            self._send_and_process(content, connection_id)
 
         del self._waiters_by_type[self._processor_type]
 

--- a/validator/sawtooth_validator/execution/processor_handlers.py
+++ b/validator/sawtooth_validator/execution/processor_handlers.py
@@ -30,14 +30,14 @@ class ProcessorRegisterHandler(Handler):
     def __init__(self, processor_collection):
         self._collection = processor_collection
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         request = processor_pb2.TpRegisterRequest()
         request.ParseFromString(message_content)
 
         LOGGER.info(
-            'registered transaction processor: identity=%s, family=%s, '
+            'registered transaction processor: connection_id=%s, family=%s, '
             'version=%s, encoding=%s, namespaces=%s',
-            identity,
+            connection_id,
             request.family,
             request.version,
             request.encoding,
@@ -49,7 +49,7 @@ class ProcessorRegisterHandler(Handler):
             request.encoding)
 
         processor = processor_iterator.Processor(
-            identity,
+            connection_id,
             request.namespaces)
 
         self._collection[processor_type] = processor
@@ -67,14 +67,14 @@ class ProcessorUnRegisterHandler(Handler):
     def __init__(self, processor_collection):
         self._collection = processor_collection
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         request = processor_pb2.TpUnregisterRequest()
         request.ParseFromString(message_content)
 
         LOGGER.info("try to unregister all transaction processor "
-                    "capabilities for identity %s", identity)
+                    "capabilities for connection_id %s", connection_id)
 
-        self._collection.remove(processor_identity=identity)
+        self._collection.remove(processor_identity=connection_id)
 
         ack = processor_pb2.TpUnregisterResponse()
         ack.status = ack.OK

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -78,10 +78,10 @@ class ProcessorIteratorCollection(object):
                 self._processors[key] = proc_iterator
             else:
                 self._processors[key].add_processor(value)
-            if value.identity not in self._identities:
-                self._identities[value.identity] = [key]
+            if value.connection_id not in self._identities:
+                self._identities[value.connection_id] = [key]
             else:
-                self._identities[value.identity].append(key)
+                self._identities[value.connection_id].append(key)
             self._condition.notify_all()
 
     def remove(self, processor_identity):
@@ -118,16 +118,16 @@ class ProcessorIteratorCollection(object):
 
 
 class Processor(object):
-    def __init__(self, identity, namespaces):
-        self.identity = identity
+    def __init__(self, connection_id, namespaces):
+        self.connection_id = connection_id
         self.namespaces = namespaces
 
     def __repr__(self):
-        return "{}: {}".format(self.identity,
+        return "{}: {}".format(self.connection_id,
                                self.namespaces)
 
     def __eq__(self, other):
-        return self.identity == other.identity
+        return self.connection_id == other.connection_id
 
 
 class ProcessorType(object):

--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -28,7 +28,7 @@ class TpStateGetHandler(Handler):
     def __init__(self, context_manager):
         self._context_manager = context_manager
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         get_request = state_context_pb2.TpStateGetRequest()
         get_request.ParseFromString(message_content)
         return_values = self._context_manager.get(
@@ -55,7 +55,7 @@ class TpStateSetHandler(Handler):
         """
         self._context_manager = context_manager
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         set_request = state_context_pb2.TpStateSetRequest()
         set_request.ParseFromString(message_content)
         set_values_list = [{e.address: e.data} for e in set_request.entries]

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -112,8 +112,7 @@ def validate_transaction(txn):
 
 class GossipMessageSignatureVerifier(Handler):
 
-    def handle(self, identity, message_content):
-
+    def handle(self, connection_id, message_content):
         gossip_message = GossipMessage()
         gossip_message.ParseFromString(message_content)
         if gossip_message.content_type == "BLOCK":
@@ -143,7 +142,7 @@ class GossipMessageSignatureVerifier(Handler):
 
 class BatchListSignatureVerifier(Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         response_proto = client_pb2.ClientBatchSubmitResponse
 
         def make_response(out_status):
@@ -151,7 +150,6 @@ class BatchListSignatureVerifier(Handler):
                 status=HandlerStatus.RETURN,
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
-
         try:
             request = client_pb2.ClientBatchSubmitRequest()
             request.ParseFromString(message_content)

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -317,7 +317,7 @@ class CompleterBatchListBroadcastHandler(Handler):
         self._completer = completer
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         request = ClientBatchSubmitRequest()
         request.ParseFromString(message_content)
         for batch in request.batches:
@@ -331,7 +331,7 @@ class CompleterGossipHandler(Handler):
     def __init__(self, completer):
         self._completer = completer
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         gossip_message = network_pb2.GossipMessage()
         gossip_message.ParseFromString(message_content)
         if gossip_message.content_type == "BLOCK":

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -47,7 +47,7 @@ class BlockResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         gossip_message = network_pb2.GossipBlockRequest()
         gossip_message.ParseFromString(message_content)
         block_id = gossip_message.block_id
@@ -73,7 +73,7 @@ class BatchByBatchIdResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         gossip_message = network_pb2.GossipBatchByBatchIdRequest()
         gossip_message.ParseFromString(message_content)
         batch = None
@@ -98,7 +98,7 @@ class BatchByTransactionIdResponderHandler(Handler):
         self._responder = responder
         self._gossip = gossip
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         gossip_message = network_pb2.GossipBatchByTransactionIdRequest()
         gossip_message.ParseFromString(message_content)
         batch = None

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 class PingHandler(Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         request = PingRequest()
         request.ParseFromString(message_content)
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -101,7 +101,7 @@ class Validator(object):
                                        config_view_factory=ConfigViewFactory(
                                            StateViewFactory(merkle_db)))
 
-        identity = hashlib.sha512(
+        zmq_identity = hashlib.sha512(
             time.time().hex().encode()).hexdigest()[:23]
 
         network_thread_pool = ThreadPoolExecutor(max_workers=10)
@@ -119,7 +119,7 @@ class Validator(object):
         self._network = Interconnect(
             network_endpoint,
             dispatcher=self._network_dispatcher,
-            identity=identity,
+            zmq_identity=zmq_identity,
             peer_connections=peer_list,
             secured=True,
             server_public_key=b'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)',

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -67,7 +67,7 @@ class BatchStatusRequest(Handler):
         self._block_store = block_store
         self._batch_cache = batch_cache
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBatchStatusRequest,
@@ -96,7 +96,7 @@ class StateCurrentRequest(Handler):
     def __init__(self, current_root_func):
         self._current_root_func = current_root_func
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateCurrentRequest,
@@ -116,7 +116,7 @@ class StateListRequest(Handler):
         self._tree = MerkleDatabase(database)
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateListRequest,
@@ -152,7 +152,7 @@ class StateGetRequest(Handler):
         self._tree = MerkleDatabase(database)
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientStateGetRequest,
@@ -190,7 +190,7 @@ class BlockListRequest(Handler):
     def __init__(self, block_store):
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBlockListRequest,
@@ -223,7 +223,7 @@ class BlockGetRequest(Handler):
     def __init__(self, block_store):
         self._block_store = block_store
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         helper = _ClientHelper(
             message_content,
             client_pb2.ClientBlockGetRequest,

--- a/validator/tests/unit3/test_dispatcher/mock.py
+++ b/validator/tests/unit3/test_dispatcher/mock.py
@@ -25,7 +25,7 @@ class MockHandler1(dispatch.Handler):
     def __init__(self):
         self._time_to_sleep = 2.0
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         if self._time_to_sleep > 0:
             time.sleep(self._time_to_sleep)
             self._time_to_sleep -= 0.1
@@ -35,7 +35,7 @@ class MockHandler1(dispatch.Handler):
 
 class MockHandler2(dispatch.Handler):
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         request = validator_pb2.Message()
         request.ParseFromString(message_content)
         return dispatch.HandlerResult(

--- a/validator/tests/unit3/test_dispatcher/mock.py
+++ b/validator/tests/unit3/test_dispatcher/mock.py
@@ -48,14 +48,15 @@ class MockHandler2(dispatch.Handler):
 
 class MockSendMessage(object):
 
-    def __init__(self):
+    def __init__(self, connections):
         self.message_ids = []
         self.identities = []
         self._lock = RLock()
+        self.connections = connections
 
-    def send_message(self, identity, msg):
+    def send_message(self, connection_id, msg):
         with self._lock:
             message = validator_pb2.Message()
             message.ParseFromString(msg.content)
-            self.identities.append(identity)
+            self.identities.append(self.connections[connection_id])
             self.message_ids.append(message.correlation_id)


### PR DESCRIPTION
This includes replacing keeping track of both outgoing and incoming connections separately and consolidates them into one dictionary owned by interconnect. This allows gossip handlers to know nothing about the type of connection that it is broadcasting to. 

Also fixes the problem with peered validators rebroadcasting the same messages over and over again. 