### PR TITLE
Add installation of Python cryptography package and its dependencies to vagrant/docker

### DIFF
--- a/docker/sawtooth-base
+++ b/docker/sawtooth-base
@@ -23,10 +23,15 @@ RUN apt-get update && apt-get install -y -q \
     python3-cbor \
     python3-requests \
     python3-yaml \
-    libcrypto++-dev
+    libcrypto++-dev \
+    build-essential \
+    libssl-dev \
+    libffi-dev \
+    python3-dev
 
 RUN pip3 install \
     grpcio-tools \
     bitcoin \
     secp256k1 \
-    lmdb
+    lmdb \
+    cryptography

--- a/tools/conf-defaults.sh
+++ b/tools/conf-defaults.sh
@@ -2,7 +2,7 @@
 
 [[ -z "$SETUP_SAWTOOTH_ENVIRONMENT" ]] && export SETUP_SAWTOOTH_ENVIRONMENT=yes
 [[ -z "$SETUP_SAWTOOTH_PATH" ]] && export SETUP_SAWTOOTH_PATH=no
-[[ -z "$PLUGINS" ]] && export PLUGINS="setup_homedir install_sphinx install_grpc install_bitcoin install_aiohttp install_js_tools install_docker install_secp256k1"
+[[ -z "$PLUGINS" ]] && export PLUGINS="setup_homedir install_sphinx install_grpc install_bitcoin install_aiohttp install_js_tools install_docker install_secp256k1 install_cryptography"
 
 function get_vagrant_user() {
     for user in vagrant ubuntu

--- a/tools/plugins/install_cryptography.sh
+++ b/tools/plugins/install_cryptography.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Make sure that the cryptography package dependencies are installed
+apt-get install build-essential libssl-dev libffi-dev python3-dev
+
+pip3 install \
+   cryptography 


### PR DESCRIPTION
To bring PoET simulator in line with SGX implementation, we need the PyCA package to be present.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>