### PR TITLE
Add capability for clients to request batches

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -1,0 +1,176 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import sys
+import csv
+import json
+import yaml
+
+from sawtooth_cli import tty
+from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli.exceptions import CliException
+
+
+def add_batch_parser(subparsers, parent_parser):
+    """Adds arguments parsers for the batch list and batch show commands
+
+        Args:
+            subparsers: Add parsers to this subparser object
+            parent_parser: The parent argparse.ArgumentParser object
+    """
+    parser = subparsers.add_parser('batch')
+
+    grand_parsers = parser.add_subparsers(title='grandchildcommands',
+                                          dest='subcommand')
+    grand_parsers.required = True
+    epilog = '''details:
+        Lists committed batches from newest to oldest, including their id (i.e.
+    header signature), transaction count, and their signer's public key.
+    '''
+
+    list_parser = grand_parsers.add_parser('list', epilog=epilog)
+    list_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    list_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='default',
+        choices=['csv', 'json', 'yaml', 'default'],
+        help='the format of the output, options: csv, json or yaml')
+
+    epilog = '''details:
+        Shows the data for a single batch, or for a particular property within
+    that batch or its header. Displays data in YAML (default), or JSON formats.
+    '''
+    show_parser = grand_parsers.add_parser('show', epilog=epilog)
+    show_parser.add_argument(
+        'batch_id',
+        type=str,
+        help='the id (i.e. header_signature) of the batch')
+    show_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    show_parser.add_argument(
+        '-k', '--key',
+        type=str,
+        help='specify to show a single property from the batch or header')
+    show_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='yaml',
+        choices=['yaml', 'json'],
+        help='the format of the output, options: yaml (default), or json')
+
+
+def do_batch(args):
+    """Runs the batch list or batch show command, printing output to the console
+
+        Args:
+            args: The parsed arguments sent to the command at runtime
+    """
+
+    rest_client = RestClient(args.url)
+
+    def print_json(data):
+        print(json.dumps(
+            data,
+            indent=2,
+            separators=(',', ': '),
+            sort_keys=True))
+
+    def print_yaml(data):
+        print(yaml.dump(data, default_flow_style=False)[0:-1])
+
+    if args.subcommand == 'list':
+        batches = rest_client.list_batches()
+        keys = ('batch_id', 'txns', 'signer')
+        headers = (k.upper() for k in keys)
+
+        def get_data(batch):
+            return (
+                batch['header_signature'],
+                len(batch.get('transactions', [])),
+                batch['header']['signer_pubkey'])
+
+        if args.format == 'default':
+            # Set column widths based on window and data size
+            window_width = tty.width()
+
+            try:
+                id_width = len(batches[0]['header_signature'])
+                sign_width = len(batches[0]['header']['signer_pubkey'])
+            except IndexError:
+                # if no data was returned, use short default widths
+                id_width = 30
+                sign_width = 15
+
+            if sys.stdout.isatty():
+                adjusted = int(window_width) - id_width - 11
+                adjusted = 6 if adjusted < 6 else adjusted
+            else:
+                adjusted = sign_width
+
+            fmt_string = '{{:{i}.{i}}}  {{:<4}}  {{:{a}.{a}}}'\
+                .format(i=id_width, a=adjusted)
+
+            # Print data in rows and columns
+            print(fmt_string.format(*headers))
+            for batch in batches:
+                print(fmt_string.format(*get_data(batch)) +
+                      ('...' if adjusted < sign_width and sign_width else ''))
+
+        elif args.format == 'csv':
+            try:
+                writer = csv.writer(sys.stdout)
+                writer.writerow(headers)
+                for batch in batches:
+                    writer.writerow(get_data(batch))
+            except csv.Error as e:
+                raise CliException('Error writing CSV: {}'.format(e))
+
+        elif args.format == 'json' or args.format == 'yaml':
+            data = [{k: d for k, d in zip(keys, get_data(b))} for b in batches]
+
+            if args.format == 'yaml':
+                print_yaml(data)
+            elif args.format == 'json':
+                print_json(data)
+            else:
+                raise AssertionError('Missing handler: {}'.format(args.format))
+
+        else:
+            raise AssertionError('Missing handler: {}'.format(args.format))
+
+    if args.subcommand == 'show':
+        batch = rest_client.get_batch(args.batch_id)
+
+        if args.key:
+            if args.key in batch:
+                print(batch[args.key])
+            elif args.key in batch['header']:
+                print(batch['header'][args.key])
+            else:
+                raise CliException(
+                    'key "{}" not found in batch or header'.format(args.key))
+        else:
+            if args.format == 'yaml':
+                print_yaml(batch)
+            elif args.format == 'json':
+                print_json(batch)
+            else:
+                raise AssertionError('Missing handler: {}'.format(args.format))

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -33,6 +33,8 @@ from sawtooth_cli.config import add_config_parser
 from sawtooth_cli.config import do_config
 from sawtooth_cli.block import add_block_parser
 from sawtooth_cli.block import do_block
+from sawtooth_cli.batch import add_batch_parser
+from sawtooth_cli.batch import do_batch
 from sawtooth_cli.state import add_state_parser
 from sawtooth_cli.state import do_state
 from sawtooth_cli.cluster import add_cluster_parser
@@ -95,6 +97,7 @@ def create_parser(prog_name):
     add_admin_parser(subparsers, parent_parser)
     add_config_parser(subparsers, parent_parser)
     add_block_parser(subparsers, parent_parser)
+    add_batch_parser(subparsers, parent_parser)
     add_state_parser(subparsers, parent_parser)
     add_cluster_parser(subparsers, parent_parser)
 
@@ -121,6 +124,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
         do_config(args)
     elif args.command == 'block':
         do_block(args)
+    elif args.command == 'batch':
+        do_batch(args)
     elif args.command == 'state':
         do_state(args)
     elif args.command == 'cluster':

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -32,6 +32,13 @@ class RestClient(object):
         safe_id = urllib.quote(block_id, safe='')
         return self._get('/blocks/' + safe_id)['data']
 
+    def list_batches(self):
+        return self._get('/batches')['data']
+
+    def get_batch(self, batch_id):
+        safe_id = urllib.quote(batch_id, safe='')
+        return self._get('/batches/' + safe_id)['data']
+
     def list_state(self, subtree=None, head=None):
         queries = RestClient._remove_nones(address=subtree, head=head)
         return self._get('/state', queries)

--- a/cli/sawtooth_cli/tty.py
+++ b/cli/sawtooth_cli/tty.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import sys
+import os
+
+
+DEFAULT_HEIGHT = 45
+DEFAULT_WIDTH = 158
+
+
+def size():
+    """Determines the height and width of the console window
+
+        Returns:
+            tuple of int: The height in lines, then width in characters
+    """
+    try:
+        assert os != 'nt' and sys.stdout.isatty()
+        rows, columns = os.popen('stty size', 'r').read().split()
+    except (AssertionError, AttributeError, ValueError):
+        # in case of failure, use dimensions of a full screen 13" laptop
+        rows, columns = DEFAULT_HEIGHT, DEFAULT_WIDTH
+
+    return rows, columns
+
+
+def height():
+    """Determines the height of console window in lines
+
+        Returns:
+            int: The height in lines
+    """
+    console_height, _ = size()
+    return console_height
+
+
+def width():
+    """Determines the width of console window in characters
+
+        Returns:
+            int: The width in characters
+    """
+    _, console_width = size()
+    return console_width

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -206,8 +206,8 @@ message ClientBlockListRequest {
     string head_id = 1;
 }
 
-// A response that lists a chain of blocks with the newest at the end, and the
-// oldest (genesis) block at the beginning.
+// A response that lists a chain of blocks with the newest at the beginning,
+// and the oldest (genesis) block at the end.
 //
 // Statuses:
 //   * OK - everything worked as expected
@@ -247,4 +247,31 @@ message ClientBlockGetResponse {
     }
     Status status = 1;
     Block block = 2;
+}
+
+// A request to return a list of batches from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include the batches from that block, and all batches
+// previous to that block on the chain.
+message ClientBatchListRequest {
+    string head_id = 1;
+}
+
+// A response that lists batches with the newest to oldest.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
+message ClientBatchListResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_ROOT = 3;
+    }
+    Status status = 1;
+    repeated Batch batches = 2;
+    string head_id = 3;
 }

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -238,11 +238,13 @@ message ClientBlockGetRequest {
 //   * OK - everything worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NO_RESOURCE - no block with the specified id exists
+//   * INVALID_ID - id isn't a valid, it may actually be a batch or txn
 message ClientBlockGetResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NO_RESOURCE = 4;
+        INVALID_ID = 5;
     }
     Status status = 1;
     Block block = 2;
@@ -286,11 +288,13 @@ message ClientBatchGetRequest {
 //   * OK - everything worked as expected, batch has been fetched
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NO_RESOURCE - no batch with the specified id exists
+//   * INVALID_ID - id isn't a valid, possibly because it is actually a block
 message ClientBatchGetResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NO_RESOURCE = 4;
+        INVALID_ID = 5;
     }
     Status status = 1;
     Batch batch = 2;

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -242,7 +242,6 @@ message ClientBlockGetResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
-        NOT_READY = 2;
         NO_RESOURCE = 4;
     }
     Status status = 1;
@@ -274,4 +273,25 @@ message ClientBatchListResponse {
     Status status = 1;
     repeated Batch batches = 2;
     string head_id = 3;
+}
+
+// Fetches a specific batch by its id (header_signature) from the blockchain.
+message ClientBatchGetRequest {
+    string batch_id = 1;
+}
+
+// A response that returns the batch specified by a ClientBatchGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, batch has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no batch with the specified id exists
+message ClientBatchGetResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NO_RESOURCE = 4;
+    }
+    Status status = 1;
+    Batch batch = 2;
 }

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -93,6 +93,14 @@ class MissingBlock(_ErrorTrap):
             message='There is no block with that id')
 
 
+class MissingBatch(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBatchGetResponse.NO_RESOURCE,
+            error=web.HTTPNotFound,
+            message='There is no batch with that id')
+
+
 class BadAddress(_ErrorTrap):
     def __init__(self):
         super().__init__(

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -93,12 +93,30 @@ class MissingBlock(_ErrorTrap):
             message='There is no block with that id')
 
 
+class InvalidBlockId(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBlockGetResponse.INVALID_ID,
+            error=web.HTTPBadRequest,
+            message='''The specified id is not a valid block id.
+                Did you mean to send this to /batches?''')
+
+
 class MissingBatch(_ErrorTrap):
     def __init__(self):
         super().__init__(
             trigger=client.ClientBatchGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no batch with that id')
+
+
+class InvalidBatchId(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client.ClientBatchGetResponse.INVALID_ID,
+            error=web.HTTPBadRequest,
+            message='''The specified id is not a valid batch id.
+                Did you mean to send this to /blocks?''')
 
 
 class BadAddress(_ErrorTrap):

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -60,6 +60,8 @@ def start_rest_api(host, port, stream_url, timeout):
     app.router.add_get('/blocks', handler.block_list)
     app.router.add_get('/blocks/{block_id}', handler.block_get)
 
+    app.router.add_get('/batches', handler.batch_list)
+
     web.run_app(app, host=host, port=port)
 
 

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -61,6 +61,7 @@ def start_rest_api(host, port, stream_url, timeout):
     app.router.add_get('/blocks/{block_id}', handler.block_get)
 
     app.router.add_get('/batches', handler.batch_list)
+    app.router.add_get('/batches/{batch_id}', handler.batch_get)
 
     web.run_app(app, host=host, port=port)
 

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -164,7 +164,7 @@ class RouteHandler(object):
     @asyncio.coroutine
     def block_list(self, request):
         """
-        Fetch a list of blocks from the validator
+        Fetch a particular block from the validator
         """
         head = request.url.query.get('head', '')
 
@@ -211,6 +211,24 @@ class RouteHandler(object):
         batches = [RouteHandler._expand_batch(b) for b in response['batches']]
         return RouteHandler._wrap_response(
             data=batches,
+            metadata=RouteHandler._get_metadata(request, response))
+
+    @asyncio.coroutine
+    def batch_get(self, request):
+        """
+        Fetch a particular batch from the validator
+        """
+        error_traps = [error_handlers.MissingBatch()]
+        batch_id = request.match_info.get('batch_id', '')
+
+        response = self._query_validator(
+            Message.CLIENT_BATCH_GET_REQUEST,
+            client.ClientBatchGetResponse,
+            client.ClientBatchGetRequest(batch_id=batch_id),
+            error_traps)
+
+        return RouteHandler._wrap_response(
+            data=RouteHandler._expand_batch(response['batch']),
             metadata=RouteHandler._get_metadata(request, response))
 
     def _query_validator(self, req_type, resp_proto, content, traps=None):

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -183,7 +183,10 @@ class RouteHandler(object):
         """
         Fetch a list of blocks from the validator
         """
-        error_traps = [error_handlers.MissingBlock()]
+        error_traps = [
+            error_handlers.MissingBlock(),
+            error_handlers.InvalidBlockId()]
+
         block_id = request.match_info.get('block_id', '')
 
         response = self._query_validator(
@@ -218,7 +221,10 @@ class RouteHandler(object):
         """
         Fetch a particular batch from the validator
         """
-        error_traps = [error_handlers.MissingBatch()]
+        error_traps = [
+            error_handlers.MissingBatch(),
+            error_handlers.InvalidBatchId()]
+
         batch_id = request.match_info.get('batch_id', '')
 
         response = self._query_validator(

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -196,6 +196,23 @@ class RouteHandler(object):
             data=RouteHandler._expand_block(response['block']),
             metadata=RouteHandler._get_metadata(request, response))
 
+    @asyncio.coroutine
+    def batch_list(self, request):
+        """
+        Fetch a list of batches from the validator
+        """
+        head = request.url.query.get('head', '')
+
+        response = self._query_validator(
+            Message.CLIENT_BATCH_LIST_REQUEST,
+            client.ClientBatchListResponse,
+            client.ClientBatchListRequest(head_id=head))
+
+        batches = [RouteHandler._expand_batch(b) for b in response['batches']]
+        return RouteHandler._wrap_response(
+            data=batches,
+            metadata=RouteHandler._get_metadata(request, response))
+
     def _query_validator(self, req_type, resp_proto, content, traps=None):
         """
         Sends a request to the validator and parses the response

--- a/rest_api/tests/unit/mock_stream.py
+++ b/rest_api/tests/unit/mock_stream.py
@@ -366,6 +366,10 @@ class _BlockGetHandler(_MockHandler):
         request = self._parse_request(content)
         store = _MockBlockStore()
 
+        if request.block_id == 'bad':
+            return self._response_proto(
+                status=self._response_proto.INVALID_ID)
+
         block = store.get_block(request.block_id)
         if not block:
             return self._response_proto(
@@ -408,6 +412,10 @@ class _BatchGetHandler(_MockHandler):
     def handle(self, content):
         request = self._parse_request(content)
         store = _MockBlockStore()
+
+        if request.batch_id == 'bad':
+            return self._response_proto(
+                status=self._response_proto.INVALID_ID)
 
         block = store.get_block(request.batch_id)
 

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -573,12 +573,21 @@ class ApiTest(AioHTTPTestCase):
 
     @unittest_run_loop
     async def test_block_get_with_bad_id(self):
-        """Verifies a GET /blocks/{block_id} with a bad id breaks properly.
+        """Verifies a GET /blocks/{block_id} with invalid id breaks properly.
+
+        Expects to find:
+            - a response status of 400
+        """
+        await self.assert_400('/blocks/bad')
+
+    @unittest_run_loop
+    async def test_block_get_with_missing_id(self):
+        """Verifies a GET /blocks/{block_id} with not found id breaks properly.
 
         Expects to find:
             - a response status of 404
         """
-        await self.assert_404('/blocks/bad')
+        await self.assert_404('/blocks/missing')
 
     @unittest_run_loop
     async def test_batch_list(self):
@@ -692,12 +701,22 @@ class ApiTest(AioHTTPTestCase):
 
     @unittest_run_loop
     async def test_batch_get_with_bad_id(self):
-        """Verifies a GET /batches/{batch_id} with a bad id breaks properly.
+        """Verifies a GET /batches/{batch_id} with invalid id breaks properly.
+
+        Expects to find:
+            - a response status of 400
+        """
+        await self.assert_400('/batches/bad')
+
+    @unittest_run_loop
+    async def test_batch_get_with_missing_id(self):
+        """Verifies a GET /batches/{batch_id} with not found id breaks properly.
 
         Expects to find:
             - a response status of 404
         """
-        await self.assert_404('/batches/bad')
+        await self.assert_404('/batches/missing')
+
 
     async def post_batch_ids(self, *batch_ids, wait=False):
         batches = [batch_pb2.Batch(
@@ -718,6 +737,9 @@ class ApiTest(AioHTTPTestCase):
     async def get_json_assert_200(self, endpoint):
         request = await self.get_and_assert_status(endpoint, 200)
         return await request.json()
+
+    async def assert_400(self, endpoint):
+        await self.get_and_assert_status(endpoint, 400)
 
     async def assert_404(self, endpoint):
         await self.get_and_assert_status(endpoint, 404)

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -35,6 +35,7 @@ class ApiTest(AioHTTPTestCase):
         app.router.add_get('/state/{address}', handlers.state_get)
         app.router.add_get('/blocks', handlers.block_list)
         app.router.add_get('/blocks/{block_id}', handlers.block_get)
+        app.router.add_get('/batches', handlers.batch_list)
         return app
 
     @unittest_run_loop
@@ -504,7 +505,6 @@ class ApiTest(AioHTTPTestCase):
                     }]
                 }]
             },
-            {header: {...}, header_signature: '1', batches: [{...}]},
             {header: {...}, header_signature: '0', batches: [{...}]}
 
         Expects to find:
@@ -578,6 +578,86 @@ class ApiTest(AioHTTPTestCase):
             - a response status of 404
         """
         await self.assert_404('/blocks/bad')
+
+    @unittest_run_loop
+    async def test_batch_list(self):
+        """Verifies a GET /batches without parameters works properly.
+
+        Fetches all batches from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2'
+            - a link property that ends in '/batches?head=2'
+            - a data property that:
+                * is a list of 3 batch dicts with a header and transactions
+                * transactions property has 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/batches')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/batches?head=2')
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_batch_well_formed(response['data'][0], '2')
+
+    @unittest_run_loop
+    async def test_batch_list_with_head(self):
+        """Verifies a GET /batches with a head parameter works properly.
+
+        Fetches batches from '1' and older from the store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/batches?head=1'
+            - a data property that:
+                * is a list of 2 batch dicts with a header and transactions
+                * transactions properties with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/batches?head=1')
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/batches?head=1')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_batch_well_formed(response['data'][0], '1')
+
+    @unittest_run_loop
+    async def test_batch_list_with_bad_head(self):
+        """Verifies a GET /batches with a bad head breaks properly.
+
+        Expects to find:
+            - a response status of 404
+        """
+        await self.assert_404('/batches?head=bad')
 
     async def post_batch_ids(self, *batch_ids, wait=False):
         batches = [batch_pb2.Batch(
@@ -654,30 +734,30 @@ class ApiTest(AioHTTPTestCase):
         """Tests a block dict is fully expanded and matches the expected id.
         Assumes the block contains one batch and txn which share the id.
         """
-
-        # Check block and its header
         self.assertIsInstance(block, dict)
         self.assertEqual(expected_id, block['header_signature'])
         self.assertIsInstance(block['header'], dict)
         self.assertEqual(b'consensus', b64decode(block['header']['consensus']))
 
-        # Check batch and its header
         batches = block['batches']
         self.assertIsInstance(batches, list)
         self.assertEqual(1, len(batches))
         self.assert_all_instances(batches, dict)
+        self.assert_batch_well_formed(batches[0], expected_id)
 
-        self.assertEqual(expected_id, batches[0]['header_signature'])
-        self.assertIsInstance(batches[0]['header'], dict)
-        self.assertEqual('pubkey', batches[0]['header']['signer_pubkey'])
+    def assert_batch_well_formed(self, batch, expected_id):
+        self.assertEqual(expected_id, batch['header_signature'])
+        self.assertIsInstance(batch['header'], dict)
+        self.assertEqual('pubkey', batch['header']['signer_pubkey'])
 
-        # Check transaction and its header
-        txns = batches[0]['transactions']
+        txns = batch['transactions']
         self.assertIsInstance(txns, list)
         self.assertEqual(1, len(txns))
         self.assert_all_instances(txns, dict)
+        self.assert_txn_well_formed(txns[0], expected_id)
 
-        self.assertEqual(expected_id, txns[0]['header_signature'])
-        self.assertEqual(b'payload', b64decode(txns[0]['payload']))
-        self.assertIsInstance(txns[0]['header'], dict)
-        self.assertEqual(expected_id, txns[0]['header']['nonce'])
+    def assert_txn_well_formed(self, txn, expected_id):
+        self.assertEqual(expected_id, txn['header_signature'])
+        self.assertEqual(b'payload', b64decode(txn['payload']))
+        self.assertIsInstance(txn['header'], dict)
+        self.assertEqual(expected_id, txn['header']['nonce'])

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -213,8 +213,7 @@ class BlockStore(MutableMapping):
         The batch with the batch_id.
         """
         if self.has_batch(batch_id):
-            block = self.block_store.get_block_by_batch_id(
-                batch_id)
+            block = self.get_block_by_batch_id(batch_id)
 
             for batch in block.batches:
                 if batch.header_signature == batch_id:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -307,6 +307,11 @@ class Validator(object):
             thread_pool)
 
         self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_BATCH_GET_REQUEST,
+            client_handlers.BatchGetRequest(self._journal.get_block_store()),
+            thread_pool)
+
+        self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_STATE_CURRENT_REQUEST,
             client_handlers.StateCurrentRequest(
                 self._journal.get_current_root), thread_pool)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -292,13 +292,18 @@ class Validator(object):
             thread_pool)
 
         self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_BLOCK_LIST_REQUEST,
+            client_handlers.BlockListRequest(self._journal.get_block_store()),
+            thread_pool)
+
+        self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BLOCK_GET_REQUEST,
             client_handlers.BlockGetRequest(self._journal.get_block_store()),
             thread_pool)
 
         self._dispatcher.add_handler(
-            validator_pb2.Message.CLIENT_BLOCK_LIST_REQUEST,
-            client_handlers.BlockListRequest(self._journal.get_block_store()),
+            validator_pb2.Message.CLIENT_BATCH_LIST_REQUEST,
+            client_handlers.BatchListRequest(self._journal.get_block_store()),
             thread_pool)
 
         self._dispatcher.add_handler(

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -392,6 +392,9 @@ class BlockGetRequest(_ClientRequestHandler):
         except KeyError:
             LOGGER.debug('No block "%s" in store', request.block_id)
             return self._status.NO_RESOURCE
+        except TypeError:
+            LOGGER.debug('"%s" is a batch is, not block', request.block_id)
+            return self._status.INVALID_ID
         return self._wrap_response(block=block)
 
 
@@ -423,4 +426,7 @@ class BatchGetRequest(_ClientRequestHandler):
         except ValueError:
             LOGGER.debug('No batch "%s" in store', request.batch_id)
             return self._status.NO_RESOURCE
+        except KeyError:
+            LOGGER.debug('"%s" is a block id, not batch', request.batch_id)
+            return self._status.INVALID_ID
         return self._wrap_response(batch=batch)

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -407,3 +407,20 @@ class BatchListRequest(_ClientRequestHandler):
         head_id = self._get_head_block(request).header_signature
         batches = self._list_blocks(head_id, lambda b: [a for a in b.batches])
         return self._wrap_response(head_id=head_id, batches=batches)
+
+
+class BatchGetRequest(_ClientRequestHandler):
+    def __init__(self, block_store):
+        super().__init__(
+            client_pb2.ClientBatchGetRequest,
+            client_pb2.ClientBatchGetResponse,
+            validator_pb2.Message.CLIENT_BATCH_GET_RESPONSE,
+            block_store=block_store)
+
+    def _respond(self, request):
+        try:
+            batch = self._block_store.get_batch(request.batch_id)
+        except ValueError:
+            LOGGER.debug('No batch "%s" in store', request.batch_id)
+            return self._status.NO_RESOURCE
+        return self._wrap_response(batch=batch)

--- a/validator/tests/unit3/test_client_request_handlers/tests.py
+++ b/validator/tests/unit3/test_client_request_handlers/tests.py
@@ -800,6 +800,18 @@ class TestBlockGetRequests(_ClientHandlerTestCase):
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())
 
+    def test_block_get_with_batch_id(self):
+        """Verifies requests for a block break properly with a batch id.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the Block returned, when serialized, is empty
+        """
+        response = self.make_request(block_id='b-1')
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertFalse(response.block.SerializeToString())
+
 
 class TestBatchListRequests(_ClientHandlerTestCase):
     def setUp(self):
@@ -941,4 +953,16 @@ class TestBatchGetRequests(_ClientHandlerTestCase):
         response = self.make_request(batch_id='bad')
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.batch.SerializeToString())
+
+    def test_batch_get_with_block_id(self):
+        """Verifies requests for a batch break properly with a block id.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the Batch returned, when serialized, is actually empty
+        """
+        response = self.make_request(batch_id='B-1')
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
         self.assertFalse(response.batch.SerializeToString())


### PR DESCRIPTION
End-to-end solution for batch fetching. Includes:
  - `batch list` and `batch show` commands for the Sawtooth CLI
  - `GET /batches` and `GET /batches/{batch_id}` routes for the REST API
  - `ClientBatchList` and `ClientBatchGet` messages for the ZMQ API
  - Unit tests for REST and ZMQ APIs
  - Major refactor to `client_handlers.py` to be more straightforward, better documented
  - Various minor bug fixes and cleanup