### PR TITLE
Fix POST /batches sometimes using wrong status

### DIFF
--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -73,15 +73,16 @@ class RouteHandler(object):
             error_traps)
 
         # Build response
-        data = response.get('batch_statuses', None)
+        data = response['batch_statuses']
         metadata = {
             'link': '{}://{}/batch_status?id={}'.format(
                 request.scheme,
                 request.host,
                 ','.join(b.header_signature for b in batch_list.batches))}
 
-        if data is None:
+        if not data:
             status = 202
+            data = None
         elif any(s != 'COMMITTED' for _, s in data.items()):
             status = 200
         else:


### PR DESCRIPTION
With `including_default_value_fields` set to `True` in the `MessageToDict` function, `batch_statuses` will always come back with a value, even if not set.

Signed-off-by: Zac Delventhal <delventhalz@gmail.com>