### PR TITLE
Add CLI tool to list Pending Proposals 

### DIFF
--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -148,5 +148,8 @@ def do_state(args):
 
     if args.subcommand == 'show':
         leaf = rest_client.get_leaf(args.address, args.head)
-        print('DATA: "{}"'.format(b64decode(leaf['data'])))
-        print('HEAD: "{}"'.format(leaf['head']))
+        if leaf is not None:
+            print('DATA: "{}"'.format(b64decode(leaf['data'])))
+            print('HEAD: "{}"'.format(leaf['head']))
+        else:
+            raise CliException('No data available at {}'.format(args.address))

--- a/core_transactions/config/sawtooth_config/processor/handler.py
+++ b/core_transactions/config/sawtooth_config/processor/handler.py
@@ -246,7 +246,7 @@ class ConfigurationTransactionHandler(object):
 
         _validate_setting(config_proposal.setting, config_proposal.value)
 
-        if approval_threshold >= 1:
+        if approval_threshold > 1:
             config_candidates = _get_config_candidates(state)
 
             existing_candidate = _first(


### PR DESCRIPTION
Add a `sawtooth config proposals` subcommand to list the currently pending proposals, when a validator is in "Ballot" mode for setting application.

Additionally:

* Allow for differentiation of return values by status.
* Only check approval_threshold > 1