### PR TITLE
NML 2127 - Update PoET simulator and validator registry transaction processor to match IAS

### DIFF
--- a/poet/sawtooth_poet/tests/validator_registry_test/tests.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/tests.py
@@ -17,6 +17,11 @@ import unittest
 import json
 import base64
 
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
 from sawtooth_signing import secp256k1_signer as signing
 from validator_registry_test.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory
@@ -29,6 +34,35 @@ class TestValidatorRegistry(unittest.TestCase):
     Set of tests to run in a test suite with an existing TPTester and
     transaction processor.
     """
+    __REPORT_PRIVATE_KEY_PEM__ = \
+        '-----BEGIN PRIVATE KEY-----\n' \
+        'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsy/NmLwZP6Uj0\n' \
+        'p5mIiefgK8VOK7KJ34g3h0/X6aFOd/Ff4j+e23wtQpkxsjVHWLM5SjElGhfpVDhL\n' \
+        '1WAMsQI9bpCWR4sjV6p7gOJhv34nkA2Grj5eSHCAJRQXCl+pJ9dYIeKaNoaxkdtq\n' \
+        '+Xme//ohtkkv/ZjMTfsjMl0RLXokJ+YhSuTpNSovRaCtZfLB5MihVJuV3Qzb2ROh\n' \
+        'KQxcuyPy9tBtOIrBWJaFiXOLRxAijs+ICyzrqUBbRfoAztkljIBx9KNItHiC4zPv\n' \
+        'o6DxpGSO2yMQSSrs13PkfyGWVZSgenEYOouEz07X+H5B29PPuW5mCl4nkoH3a9gv\n' \
+        'rI6VLEx9AgMBAAECggEAImfFge4RCq4/eX85gcc7pRXyBjuLJAqe+7d0fWAmXxJg\n' \
+        'vB+3XTEEi5p8GDoMg7U0kk6kdGe6pRnAz9CffEduU78FCPcbzCCzcD3cVWwkeUok\n' \
+        'd1GQV4OC6vD3DBNjsrGdHg45KU18CjUphCZCQhdjvXynG+gZmWxZecuYXkg4zqPT\n' \
+        'LwOkcdWBPhJ9CbjtiYOtKDZbhcbdfnb2fkxmvnAoz1OWNfVFXh+x7651FrmL2Pga\n' \
+        'xGz5XoxFYYT6DWW1fL6GNuVrd97wkcYUcjazMgunuUMC+6XFxqK+BoqnxeaxnsSt\n' \
+        'G2r0sdVaCyK1sU41ftbEQsc5oYeQ3v5frGZL+BgrYQKBgQDgZnjqnVI/B+9iarx1\n' \
+        'MjAFyhurcKvFvlBtGKUg9Q62V6wI4VZvPnzA2zEaR1J0cZPB1lCcMsFACpuQF2Mr\n' \
+        '3VDyJbnpSG9q05POBtfLjGQdXKtGb8cfXY2SwjzLH/tvxHm3SP+RxvLICQcLX2/y\n' \
+        'GTJ+mY9C6Hs6jIVLOnMWkRWamQKBgQDFITE3Qs3Y0ZwkKfGQMKuqJLRw29Tyzw0n\n' \
+        'XKaVmO/pEzYcXZMPBrFhGvdmNcJLo2fcsmGZnmit8RP4ChwHUlD11dH1Ffqw9FWc\n' \
+        '387i0chlE5FhQPirSM8sWFVmjt2sxC4qFWJoAD/COQtKHgEaVKVc4sH/yRostL1C\n' \
+        'r+7aWuqzhQKBgQDcuC5LJr8VPGrbtPz1kY3mw+r/cG2krRNSm6Egj6oO9KFEgtCP\n' \
+        'zzjKQU9E985EtsqNKI5VdR7cLRLiYf6r0J6j7zO0IAlnXADP768miUqYDuRw/dUw\n' \
+        'JsbwCZneefDI+Mp325d1/egjla2WJCNqUBp4p/Zf62f6KOmbGzzEf6RuUQKBgG2y\n' \
+        'E8YRiaTOt5m0MXUwcEZk2Hg5DF31c/dkalqy2UYU57aPJ8djzQ8hR2x8G9ulWaWJ\n' \
+        'KiCm8s9gaOFNFt3II785NfWxPmh7/qwmKuUzIdWFNxAsbHQ8NvURTqyccaSzIpFO\n' \
+        'hw0inlhBEBQ1cB2r3r06fgQNb2BTT0Itzrd5gkNVAoGBAJcMgeKdBMukT8dKxb4R\n' \
+        '1PgQtFlR3COu2+B00pDyUpROFhHYLw/KlUv5TKrH1k3+E0KM+winVUIcZHlmFyuy\n' \
+        'Ilquaova1YSFXP5cpD+PKtxRV76Qlqt6o+aPywm81licdOAXotT4JyJhrgz9ISnn\n' \
+        'J13KkHoAZ9qd0rX7s37czb3O\n' \
+        '-----END PRIVATE KEY-----'
 
     def __init__(self, test_name, tester):
         super().__init__(test_name)
@@ -39,10 +73,10 @@ class TestValidatorRegistry(unittest.TestCase):
         self.factory = ValidatorRegistryMessageFactory(
             private=self.private_key, public=self.public_key)
         self._report_private_key = \
-            signing.encode_privkey(
-                signing.decode_privkey(
-                    '5Jz5Kaiy3kCiHE537uXcQnJuiNJshf2bZZn43CrALMGoCd3zRuo',
-                    'wif'), 'hex')
+            serialization.load_pem_private_key(
+                self.__REPORT_PRIVATE_KEY_PEM__.encode(),
+                password=None,
+                backend=backends.default_backend())
 
     def _expect_invalid_transaction(self):
         self.tester.expect(
@@ -262,12 +296,16 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
 
         verification_report["nonce"] = None
+
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -291,12 +329,15 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         pse_status = verification_report['pseManifestStatus']
         verification_report['pseManifestStatus'] = None
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -308,12 +349,15 @@ class TestValidatorRegistry(unittest.TestCase):
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report['pseManifestStatus'] = "bad"
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -326,12 +370,15 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         verification_report['pseManifestStatus'] = pse_status
         verification_report['pseManifestHash'] = None
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -343,12 +390,15 @@ class TestValidatorRegistry(unittest.TestCase):
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report['pseManifestHash'] = "Bad"
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -372,12 +422,15 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         enclave_status = verification_report["isvEnclaveQuoteStatus"]
         verification_report["isvEnclaveQuoteStatus"] = None
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -389,12 +442,15 @@ class TestValidatorRegistry(unittest.TestCase):
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report["isvEnclaveQuoteStatus"] = "Bad"
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -407,12 +463,15 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         verification_report["isvEnclaveQuoteStatus"] = enclave_status
         verification_report['isvEnclaveQuoteBody'] = None
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -429,12 +488,15 @@ class TestValidatorRegistry(unittest.TestCase):
             base64.b64encode(
                 json.dumps(quote).encode()).decode()
 
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)
@@ -451,12 +513,15 @@ class TestValidatorRegistry(unittest.TestCase):
             base64.b64encode(
                 json.dumps(quote).encode()).decode()
 
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            self._report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    self._report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
 
         signup_info.proof_data = json.dumps(proof_data_dict)

--- a/poet/sawtooth_poet/tests/validator_registry_test/tests.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/tests.py
@@ -17,11 +17,6 @@ import unittest
 import json
 import base64
 
-from cryptography.hazmat import backends
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import padding
-
 from sawtooth_signing import secp256k1_signer as signing
 from validator_registry_test.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory
@@ -34,35 +29,6 @@ class TestValidatorRegistry(unittest.TestCase):
     Set of tests to run in a test suite with an existing TPTester and
     transaction processor.
     """
-    __REPORT_PRIVATE_KEY_PEM__ = \
-        '-----BEGIN PRIVATE KEY-----\n' \
-        'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsy/NmLwZP6Uj0\n' \
-        'p5mIiefgK8VOK7KJ34g3h0/X6aFOd/Ff4j+e23wtQpkxsjVHWLM5SjElGhfpVDhL\n' \
-        '1WAMsQI9bpCWR4sjV6p7gOJhv34nkA2Grj5eSHCAJRQXCl+pJ9dYIeKaNoaxkdtq\n' \
-        '+Xme//ohtkkv/ZjMTfsjMl0RLXokJ+YhSuTpNSovRaCtZfLB5MihVJuV3Qzb2ROh\n' \
-        'KQxcuyPy9tBtOIrBWJaFiXOLRxAijs+ICyzrqUBbRfoAztkljIBx9KNItHiC4zPv\n' \
-        'o6DxpGSO2yMQSSrs13PkfyGWVZSgenEYOouEz07X+H5B29PPuW5mCl4nkoH3a9gv\n' \
-        'rI6VLEx9AgMBAAECggEAImfFge4RCq4/eX85gcc7pRXyBjuLJAqe+7d0fWAmXxJg\n' \
-        'vB+3XTEEi5p8GDoMg7U0kk6kdGe6pRnAz9CffEduU78FCPcbzCCzcD3cVWwkeUok\n' \
-        'd1GQV4OC6vD3DBNjsrGdHg45KU18CjUphCZCQhdjvXynG+gZmWxZecuYXkg4zqPT\n' \
-        'LwOkcdWBPhJ9CbjtiYOtKDZbhcbdfnb2fkxmvnAoz1OWNfVFXh+x7651FrmL2Pga\n' \
-        'xGz5XoxFYYT6DWW1fL6GNuVrd97wkcYUcjazMgunuUMC+6XFxqK+BoqnxeaxnsSt\n' \
-        'G2r0sdVaCyK1sU41ftbEQsc5oYeQ3v5frGZL+BgrYQKBgQDgZnjqnVI/B+9iarx1\n' \
-        'MjAFyhurcKvFvlBtGKUg9Q62V6wI4VZvPnzA2zEaR1J0cZPB1lCcMsFACpuQF2Mr\n' \
-        '3VDyJbnpSG9q05POBtfLjGQdXKtGb8cfXY2SwjzLH/tvxHm3SP+RxvLICQcLX2/y\n' \
-        'GTJ+mY9C6Hs6jIVLOnMWkRWamQKBgQDFITE3Qs3Y0ZwkKfGQMKuqJLRw29Tyzw0n\n' \
-        'XKaVmO/pEzYcXZMPBrFhGvdmNcJLo2fcsmGZnmit8RP4ChwHUlD11dH1Ffqw9FWc\n' \
-        '387i0chlE5FhQPirSM8sWFVmjt2sxC4qFWJoAD/COQtKHgEaVKVc4sH/yRostL1C\n' \
-        'r+7aWuqzhQKBgQDcuC5LJr8VPGrbtPz1kY3mw+r/cG2krRNSm6Egj6oO9KFEgtCP\n' \
-        'zzjKQU9E985EtsqNKI5VdR7cLRLiYf6r0J6j7zO0IAlnXADP768miUqYDuRw/dUw\n' \
-        'JsbwCZneefDI+Mp325d1/egjla2WJCNqUBp4p/Zf62f6KOmbGzzEf6RuUQKBgG2y\n' \
-        'E8YRiaTOt5m0MXUwcEZk2Hg5DF31c/dkalqy2UYU57aPJ8djzQ8hR2x8G9ulWaWJ\n' \
-        'KiCm8s9gaOFNFt3II785NfWxPmh7/qwmKuUzIdWFNxAsbHQ8NvURTqyccaSzIpFO\n' \
-        'hw0inlhBEBQ1cB2r3r06fgQNb2BTT0Itzrd5gkNVAoGBAJcMgeKdBMukT8dKxb4R\n' \
-        '1PgQtFlR3COu2+B00pDyUpROFhHYLw/KlUv5TKrH1k3+E0KM+winVUIcZHlmFyuy\n' \
-        'Ilquaova1YSFXP5cpD+PKtxRV76Qlqt6o+aPywm81licdOAXotT4JyJhrgz9ISnn\n' \
-        'J13KkHoAZ9qd0rX7s37czb3O\n' \
-        '-----END PRIVATE KEY-----'
 
     def __init__(self, test_name, tester):
         super().__init__(test_name)
@@ -72,11 +38,6 @@ class TestValidatorRegistry(unittest.TestCase):
             signing.generate_pubkey(self.private_key), "hex")
         self.factory = ValidatorRegistryMessageFactory(
             private=self.private_key, public=self.public_key)
-        self._report_private_key = \
-            serialization.load_pem_private_key(
-                self.__REPORT_PRIVATE_KEY_PEM__.encode(),
-                password=None,
-                backend=backends.default_backend())
 
     def _expect_invalid_transaction(self):
         self.tester.expect(
@@ -97,7 +58,7 @@ class TestValidatorRegistry(unittest.TestCase):
             verb="reg", name="val_1", id=self.factory.public_key,
             signup_info=signup_info, block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
 
@@ -137,7 +98,7 @@ class TestValidatorRegistry(unittest.TestCase):
             verb="reg", name="val_1", id=self.factory.public_key,
             signup_info=signup_info, block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
 
@@ -196,7 +157,7 @@ class TestValidatorRegistry(unittest.TestCase):
             signup_info=signup_info,
             block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
 
@@ -218,7 +179,7 @@ class TestValidatorRegistry(unittest.TestCase):
             signup_info=signup_info,
             block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
 
@@ -241,7 +202,7 @@ class TestValidatorRegistry(unittest.TestCase):
             signup_info=signup_info,
             block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
 
@@ -255,20 +216,20 @@ class TestValidatorRegistry(unittest.TestCase):
             signup_info=signup_info,
             block_num=0)
 
-        # Send validator registry paylaod
+        # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
         self._expect_invalid_transaction()
 
-    def test_invalid_verfication_report(self):
+    def test_invalid_verification_report(self):
         """
-        Test that a transaction whose verication report is invalid returns an
-        invalid transaction.
+        Test that a transaction whose verification report is invalid returns
+        an invalid transaction.
         """
         signup_info = self.factory.create_signup_info(
             self.factory.pubkey_hash, "000")
 
-        # Verifcation Report is None
+        # Verification Report is None
         proof_data = signup_info.proof_data
         signup_info.proof_data = json.dumps({})
         self._test_bad_signup_info(signup_info)
@@ -291,24 +252,44 @@ class TestValidatorRegistry(unittest.TestCase):
         self._test_bad_signup_info(signup_info)
 
         # ------------------------------------------------------
-        # No Nonce
+        # No EPID pseudonym
+        proof_data_dict = json.loads(proof_data)
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
+        del verification_report["epidPseudonym"]
 
-        verification_report["nonce"] = None
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
+        self._test_bad_signup_info(signup_info)
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        # ------------------------------------------------------
+        # Altered EPID pseudonym (does not match anti_sybil_id)
+        proof_data_dict = json.loads(proof_data)
+        verification_report = \
+            json.loads(proof_data_dict["verification_report"])
+        verification_report["epidPseudonym"] = "altered"
+
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
+
+        self._test_bad_signup_info(signup_info)
+
+        # ------------------------------------------------------
+        # No Nonce
+        proof_data_dict = json.loads(proof_data)
+        verification_report = \
+            json.loads(proof_data_dict["verification_report"])
+        del verification_report["nonce"]
+
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -327,20 +308,12 @@ class TestValidatorRegistry(unittest.TestCase):
         # no pseManifestStatus
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
-        pse_status = verification_report['pseManifestStatus']
-        verification_report['pseManifestStatus'] = None
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
+        del verification_report['pseManifestStatus']
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -349,18 +322,11 @@ class TestValidatorRegistry(unittest.TestCase):
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report['pseManifestStatus'] = "bad"
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -368,20 +334,12 @@ class TestValidatorRegistry(unittest.TestCase):
         # No pseManifestHash
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
-        verification_report['pseManifestStatus'] = pse_status
-        verification_report['pseManifestHash'] = None
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
+        del verification_report['pseManifestHash']
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -390,22 +348,41 @@ class TestValidatorRegistry(unittest.TestCase):
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report['pseManifestHash'] = "Bad"
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
+
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
+
+        self._test_bad_signup_info(signup_info)
+
+        # ------------------------------------------------------
+        # Missing evidence payload
+        evidence_payload = proof_data_dict["evidence_payload"]
+        del proof_data_dict["evidence_payload"]
 
         signup_info.proof_data = json.dumps(proof_data_dict)
 
         self._test_bad_signup_info(signup_info)
 
-    def test_invalid_envalve_body(self):
+        # ------------------------------------------------------
+        # Missing PSE manifest
+        del evidence_payload["pse_manifest"]
+        proof_data_dict["evidence_payload"] = evidence_payload
+
+        signup_info.proof_data = json.dumps(proof_data_dict)
+
+        self._test_bad_signup_info(signup_info)
+
+        # ------------------------------------------------------
+        # Bad PSE manifest
+        evidence_payload["pse_manifest"] = "bad"
+
+        signup_info.proof_data = json.dumps(proof_data_dict)
+
+        self._test_bad_signup_info(signup_info)
+
+    def test_invalid_enclave_body(self):
         """
         Test that a transaction whose enclave_body is invalid returns an
         invalid transaction.
@@ -422,38 +399,24 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         enclave_status = verification_report["isvEnclaveQuoteStatus"]
         verification_report["isvEnclaveQuoteStatus"] = None
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
         # ------------------------------------------------------
-        # No isvEnclaveQuoteStatus
+        # Bad isvEnclaveQuoteStatus
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
         verification_report["isvEnclaveQuoteStatus"] = "Bad"
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -463,18 +426,11 @@ class TestValidatorRegistry(unittest.TestCase):
             json.loads(proof_data_dict["verification_report"])
         verification_report["isvEnclaveQuoteStatus"] = enclave_status
         verification_report['isvEnclaveQuoteBody'] = None
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
 
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -488,18 +444,10 @@ class TestValidatorRegistry(unittest.TestCase):
             base64.b64encode(
                 json.dumps(quote).encode()).decode()
 
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
-
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)
 
@@ -507,23 +455,15 @@ class TestValidatorRegistry(unittest.TestCase):
         # Bad isvEnclaveQuoteBody
         verification_report = \
             json.loads(proof_data_dict["verification_report"])
-        quote = {"report_body": "none"}
+        quote = {"report_body": "bad"}
 
         verification_report['isvEnclaveQuoteBody'] = \
             base64.b64encode(
                 json.dumps(quote).encode()).decode()
 
-        verification_report_json = json.dumps(verification_report)
-        signature = \
-            self._report_private_key.sign(
-                verification_report_json.encode(),
-                padding.PKCS1v15(),
-                hashes.SHA256())
-        proof_data_dict = {
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
-
-        signup_info.proof_data = json.dumps(proof_data_dict)
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
 
         self._test_bad_signup_info(signup_info)

--- a/poet/sawtooth_poet/tests/validator_registry_test/ts_validator_registry.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/ts_validator_registry.py
@@ -62,9 +62,9 @@ class TestSuiteValidatorRegistry(unittest.TestCase):
             suite.addTest(TestValidatorRegistry(
                 'test_invalid_poet_pubkey', self.tester))
             suite.addTest(TestValidatorRegistry(
-                'test_invalid_verfication_report', self.tester))
+                'test_invalid_verification_report', self.tester))
             suite.addTest(TestValidatorRegistry(
-                'test_invalid_envalve_body', self.tester))
+                'test_invalid_enclave_body', self.tester))
             suite.addTest(TestValidatorRegistry(
                 'test_invalid_pse_manifest', self.tester))
 

--- a/poet/sawtooth_poet/tests/validator_registry_test/validator_reg_message_factory.py
+++ b/poet/sawtooth_poet/tests/validator_registry_test/validator_reg_message_factory.py
@@ -16,6 +16,11 @@ import base64
 import json
 import hashlib
 
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
 from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_processor_test.message_factory import MessageFactory
@@ -28,6 +33,36 @@ from sawtooth_poet.protobuf.validator_registry_pb2 import \
 
 
 class ValidatorRegistryMessageFactory(object):
+    __REPORT_PRIVATE_KEY_PEM__ = \
+        '-----BEGIN PRIVATE KEY-----\n' \
+        'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsy/NmLwZP6Uj0\n' \
+        'p5mIiefgK8VOK7KJ34g3h0/X6aFOd/Ff4j+e23wtQpkxsjVHWLM5SjElGhfpVDhL\n' \
+        '1WAMsQI9bpCWR4sjV6p7gOJhv34nkA2Grj5eSHCAJRQXCl+pJ9dYIeKaNoaxkdtq\n' \
+        '+Xme//ohtkkv/ZjMTfsjMl0RLXokJ+YhSuTpNSovRaCtZfLB5MihVJuV3Qzb2ROh\n' \
+        'KQxcuyPy9tBtOIrBWJaFiXOLRxAijs+ICyzrqUBbRfoAztkljIBx9KNItHiC4zPv\n' \
+        'o6DxpGSO2yMQSSrs13PkfyGWVZSgenEYOouEz07X+H5B29PPuW5mCl4nkoH3a9gv\n' \
+        'rI6VLEx9AgMBAAECggEAImfFge4RCq4/eX85gcc7pRXyBjuLJAqe+7d0fWAmXxJg\n' \
+        'vB+3XTEEi5p8GDoMg7U0kk6kdGe6pRnAz9CffEduU78FCPcbzCCzcD3cVWwkeUok\n' \
+        'd1GQV4OC6vD3DBNjsrGdHg45KU18CjUphCZCQhdjvXynG+gZmWxZecuYXkg4zqPT\n' \
+        'LwOkcdWBPhJ9CbjtiYOtKDZbhcbdfnb2fkxmvnAoz1OWNfVFXh+x7651FrmL2Pga\n' \
+        'xGz5XoxFYYT6DWW1fL6GNuVrd97wkcYUcjazMgunuUMC+6XFxqK+BoqnxeaxnsSt\n' \
+        'G2r0sdVaCyK1sU41ftbEQsc5oYeQ3v5frGZL+BgrYQKBgQDgZnjqnVI/B+9iarx1\n' \
+        'MjAFyhurcKvFvlBtGKUg9Q62V6wI4VZvPnzA2zEaR1J0cZPB1lCcMsFACpuQF2Mr\n' \
+        '3VDyJbnpSG9q05POBtfLjGQdXKtGb8cfXY2SwjzLH/tvxHm3SP+RxvLICQcLX2/y\n' \
+        'GTJ+mY9C6Hs6jIVLOnMWkRWamQKBgQDFITE3Qs3Y0ZwkKfGQMKuqJLRw29Tyzw0n\n' \
+        'XKaVmO/pEzYcXZMPBrFhGvdmNcJLo2fcsmGZnmit8RP4ChwHUlD11dH1Ffqw9FWc\n' \
+        '387i0chlE5FhQPirSM8sWFVmjt2sxC4qFWJoAD/COQtKHgEaVKVc4sH/yRostL1C\n' \
+        'r+7aWuqzhQKBgQDcuC5LJr8VPGrbtPz1kY3mw+r/cG2krRNSm6Egj6oO9KFEgtCP\n' \
+        'zzjKQU9E985EtsqNKI5VdR7cLRLiYf6r0J6j7zO0IAlnXADP768miUqYDuRw/dUw\n' \
+        'JsbwCZneefDI+Mp325d1/egjla2WJCNqUBp4p/Zf62f6KOmbGzzEf6RuUQKBgG2y\n' \
+        'E8YRiaTOt5m0MXUwcEZk2Hg5DF31c/dkalqy2UYU57aPJ8djzQ8hR2x8G9ulWaWJ\n' \
+        'KiCm8s9gaOFNFt3II785NfWxPmh7/qwmKuUzIdWFNxAsbHQ8NvURTqyccaSzIpFO\n' \
+        'hw0inlhBEBQ1cB2r3r06fgQNb2BTT0Itzrd5gkNVAoGBAJcMgeKdBMukT8dKxb4R\n' \
+        '1PgQtFlR3COu2+B00pDyUpROFhHYLw/KlUv5TKrH1k3+E0KM+winVUIcZHlmFyuy\n' \
+        'Ilquaova1YSFXP5cpD+PKtxRV76Qlqt6o+aPywm81licdOAXotT4JyJhrgz9ISnn\n' \
+        'J13KkHoAZ9qd0rX7s37czb3O\n' \
+        '-----END PRIVATE KEY-----'
+
     def __init__(self, private=None, public=None):
         self._factory = MessageFactory(
             encoding="application/protobuf",
@@ -66,10 +101,10 @@ class ValidatorRegistryMessageFactory(object):
         # _active_wait_timer = None
 
         _report_private_key = \
-            signing.encode_privkey(
-                signing.decode_privkey(
-                    '5Jz5Kaiy3kCiHE537uXcQnJuiNJshf2bZZn43CrALMGoCd3zRuo',
-                    'wif'), 'hex')
+            serialization.load_pem_private_key(
+                self.__REPORT_PRIVATE_KEY_PEM__.encode(),
+                password=None,
+                backend=backends.default_backend())
 
         # We are going to fake out the sealing the signup data.
         signup_data = {
@@ -112,12 +147,15 @@ class ValidatorRegistryMessageFactory(object):
             'nonce': most_recent_wait_certificate_id
         }
 
+        verification_report_json = json.dumps(verification_report)
+        signature = \
+            _report_private_key.sign(
+                verification_report_json.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
         proof_data_dict = {
-            'verification_report': json.dumps(verification_report),
-            'signature':
-                signing.sign(
-                    json.dumps(verification_report),
-                    _report_private_key)
+            'verification_report': verification_report_json,
+            'signature': base64.b64encode(signature).decode()
         }
         proof_data = json.dumps(proof_data_dict)
 

--- a/validator/sawtooth_validator/journal/consensus/poet/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/validator/sawtooth_validator/journal/consensus/poet/poet_enclave_simulator/poet_enclave_simulator.py
@@ -22,6 +22,12 @@ import hashlib
 import base64
 import time
 
+from cryptography.hazmat import backends
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.exceptions import InvalidSignature
+
 from sawtooth_signing import secp256k1_signer as signing
 
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
@@ -53,15 +59,60 @@ class _PoetEnclaveSimulator(object):
     _seal_private_key = signing.generate_privkey()
     _seal_public_key = signing.generate_pubkey(_seal_private_key)
 
-    # The WIF-encoded private report key.  From it, we will create private
-    # key we can use for signing attestation verification reports.
-    __REPORT_PRIVATE_KEY_WIF = \
-        '5Jz5Kaiy3kCiHE537uXcQnJuiNJshf2bZZn43CrALMGoCd3zRuo'
+    # We use the report private key PEM to create the private key used to
+    # sign attestation verification reports.  On the flip side, the report
+    # public key PEM is used to create the public key used to verify the
+    # signature on the attestation verification reports.
+    __REPORT_PRIVATE_KEY_PEM__ = \
+        '-----BEGIN PRIVATE KEY-----\n' \
+        'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCsy/NmLwZP6Uj0\n' \
+        'p5mIiefgK8VOK7KJ34g3h0/X6aFOd/Ff4j+e23wtQpkxsjVHWLM5SjElGhfpVDhL\n' \
+        '1WAMsQI9bpCWR4sjV6p7gOJhv34nkA2Grj5eSHCAJRQXCl+pJ9dYIeKaNoaxkdtq\n' \
+        '+Xme//ohtkkv/ZjMTfsjMl0RLXokJ+YhSuTpNSovRaCtZfLB5MihVJuV3Qzb2ROh\n' \
+        'KQxcuyPy9tBtOIrBWJaFiXOLRxAijs+ICyzrqUBbRfoAztkljIBx9KNItHiC4zPv\n' \
+        'o6DxpGSO2yMQSSrs13PkfyGWVZSgenEYOouEz07X+H5B29PPuW5mCl4nkoH3a9gv\n' \
+        'rI6VLEx9AgMBAAECggEAImfFge4RCq4/eX85gcc7pRXyBjuLJAqe+7d0fWAmXxJg\n' \
+        'vB+3XTEEi5p8GDoMg7U0kk6kdGe6pRnAz9CffEduU78FCPcbzCCzcD3cVWwkeUok\n' \
+        'd1GQV4OC6vD3DBNjsrGdHg45KU18CjUphCZCQhdjvXynG+gZmWxZecuYXkg4zqPT\n' \
+        'LwOkcdWBPhJ9CbjtiYOtKDZbhcbdfnb2fkxmvnAoz1OWNfVFXh+x7651FrmL2Pga\n' \
+        'xGz5XoxFYYT6DWW1fL6GNuVrd97wkcYUcjazMgunuUMC+6XFxqK+BoqnxeaxnsSt\n' \
+        'G2r0sdVaCyK1sU41ftbEQsc5oYeQ3v5frGZL+BgrYQKBgQDgZnjqnVI/B+9iarx1\n' \
+        'MjAFyhurcKvFvlBtGKUg9Q62V6wI4VZvPnzA2zEaR1J0cZPB1lCcMsFACpuQF2Mr\n' \
+        '3VDyJbnpSG9q05POBtfLjGQdXKtGb8cfXY2SwjzLH/tvxHm3SP+RxvLICQcLX2/y\n' \
+        'GTJ+mY9C6Hs6jIVLOnMWkRWamQKBgQDFITE3Qs3Y0ZwkKfGQMKuqJLRw29Tyzw0n\n' \
+        'XKaVmO/pEzYcXZMPBrFhGvdmNcJLo2fcsmGZnmit8RP4ChwHUlD11dH1Ffqw9FWc\n' \
+        '387i0chlE5FhQPirSM8sWFVmjt2sxC4qFWJoAD/COQtKHgEaVKVc4sH/yRostL1C\n' \
+        'r+7aWuqzhQKBgQDcuC5LJr8VPGrbtPz1kY3mw+r/cG2krRNSm6Egj6oO9KFEgtCP\n' \
+        'zzjKQU9E985EtsqNKI5VdR7cLRLiYf6r0J6j7zO0IAlnXADP768miUqYDuRw/dUw\n' \
+        'JsbwCZneefDI+Mp325d1/egjla2WJCNqUBp4p/Zf62f6KOmbGzzEf6RuUQKBgG2y\n' \
+        'E8YRiaTOt5m0MXUwcEZk2Hg5DF31c/dkalqy2UYU57aPJ8djzQ8hR2x8G9ulWaWJ\n' \
+        'KiCm8s9gaOFNFt3II785NfWxPmh7/qwmKuUzIdWFNxAsbHQ8NvURTqyccaSzIpFO\n' \
+        'hw0inlhBEBQ1cB2r3r06fgQNb2BTT0Itzrd5gkNVAoGBAJcMgeKdBMukT8dKxb4R\n' \
+        '1PgQtFlR3COu2+B00pDyUpROFhHYLw/KlUv5TKrH1k3+E0KM+winVUIcZHlmFyuy\n' \
+        'Ilquaova1YSFXP5cpD+PKtxRV76Qlqt6o+aPywm81licdOAXotT4JyJhrgz9ISnn\n' \
+        'J13KkHoAZ9qd0rX7s37czb3O\n' \
+        '-----END PRIVATE KEY-----'
 
-    # Since signing works with WIF-encoded private keys, we don't have to
-    # decode the encoded key string.
-    _report_private_key = __REPORT_PRIVATE_KEY_WIF
-    _report_public_key = signing.generate_pubkey(_report_private_key)
+    __REPORT_PUBLIC_KEY_PEM__ = \
+        '-----BEGIN PUBLIC KEY-----\n' \
+        'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArMvzZi8GT+lI9KeZiInn\n' \
+        '4CvFTiuyid+IN4dP1+mhTnfxX+I/ntt8LUKZMbI1R1izOUoxJRoX6VQ4S9VgDLEC\n' \
+        'PW6QlkeLI1eqe4DiYb9+J5ANhq4+XkhwgCUUFwpfqSfXWCHimjaGsZHbavl5nv/6\n' \
+        'IbZJL/2YzE37IzJdES16JCfmIUrk6TUqL0WgrWXyweTIoVSbld0M29kToSkMXLsj\n' \
+        '8vbQbTiKwViWhYlzi0cQIo7PiAss66lAW0X6AM7ZJYyAcfSjSLR4guMz76Og8aRk\n' \
+        'jtsjEEkq7Ndz5H8hllWUoHpxGDqLhM9O1/h+QdvTz7luZgpeJ5KB92vYL6yOlSxM\n' \
+        'fQIDAQAB\n' \
+        '-----END PUBLIC KEY-----'
+
+    _report_private_key = \
+        serialization.load_pem_private_key(
+            __REPORT_PRIVATE_KEY_PEM__.encode(),
+            password=None,
+            backend=backends.default_backend())
+    _report_public_key = \
+        serialization.load_pem_public_key(
+            __REPORT_PUBLIC_KEY_PEM__.encode(),
+            backend=backends.default_backend())
 
     # The anti-sybil ID for this particular validator.  This will get set when
     # the enclave is initialized
@@ -138,12 +189,18 @@ class _PoetEnclaveSimulator(object):
                 'nonce': most_recent_wait_certificate_id
             }
 
+            # Serialize the verification report, sign it, and then put
+            # in the proof data
+            verification_report_json = dict2json(verification_report)
+            signature = \
+                cls._report_private_key.sign(
+                    verification_report_json.encode(),
+                    padding.PKCS1v15(),
+                    hashes.SHA256())
+
             proof_data_dict = {
-                'verification_report': dict2json(verification_report),
-                'signature':
-                    signing.sign(
-                        dict2json(verification_report),
-                        cls._report_private_key)
+                'verification_report': verification_report_json,
+                'signature': base64.b64encode(signature).decode()
             }
             proof_data = dict2json(proof_data_dict)
 
@@ -206,10 +263,13 @@ class _PoetEnclaveSimulator(object):
         if signature is None:
             raise ValueError('Signature is missing from proof data')
 
-        if not signing.verify(
-                verification_report,
-                signature,
-                cls._report_public_key):
+        try:
+            cls._report_public_key.verify(
+                base64.b64decode(signature.encode()),
+                verification_report.encode(),
+                padding.PKCS1v15(),
+                hashes.SHA256())
+        except InvalidSignature:
             raise ValueError('Verification report signature is invalid')
 
         verification_report_dict = json2dict(verification_report)

--- a/validator/sawtooth_validator/journal/consensus/poet/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/validator/sawtooth_validator/journal/consensus/poet/poet_enclave_simulator/poet_enclave_simulator.py
@@ -169,12 +169,19 @@ class _PoetEnclaveSimulator(object):
                     dict2json(report_data).encode()).hexdigest()
             }
 
+            # Create a fake PSE manifest.  A base64 encoding of the
+            # originator public key hash should suffice.
+            pse_manifest = \
+                base64.b64encode(originator_public_key_hash.encode())
+
+            timestamp = datetime.datetime.now().isoformat()
+
             # Fake our "proof" data.
             verification_report = {
+                'epidPseudonym': originator_public_key_hash,
                 'id': base64.b64encode(
-                    bytes(hashlib.sha256(
-                        datetime.datetime.now().isoformat().encode())
-                        .hexdigest().encode())).decode(),
+                    hashlib.sha256(
+                        timestamp.encode()).hexdigest().encode()).decode(),
                 'isvEnclaveQuoteStatus': 'OK',
                 'isvEnclaveQuoteBody':
                     base64.b64encode(
@@ -183,10 +190,9 @@ class _PoetEnclaveSimulator(object):
                 'pseManifestHash':
                     base64.b64encode(
                         hashlib.sha256(
-                            bytes(b'Do you believe in '
-                                  b'manifest destiny?')).hexdigest()
-                        .encode()).decode(),
-                'nonce': most_recent_wait_certificate_id
+                            pse_manifest).hexdigest().encode()).decode(),
+                'nonce': most_recent_wait_certificate_id,
+                'timestamp': timestamp
             }
 
             # Serialize the verification report, sign it, and then put
@@ -199,6 +205,9 @@ class _PoetEnclaveSimulator(object):
                     hashes.SHA256())
 
             proof_data_dict = {
+                'evidence_payload': {
+                    'pse_manifest': pse_manifest.decode()
+                },
                 'verification_report': verification_report_json,
                 'signature': base64.b64encode(signature).decode()
             }
@@ -274,6 +283,27 @@ class _PoetEnclaveSimulator(object):
 
         verification_report_dict = json2dict(verification_report)
 
+        # Verify that the verification report contains an ID field
+        if 'id' not in verification_report_dict:
+            raise ValueError('Verification report does not contain an ID')
+
+        # Verify that the verification report contains an EPID pseudonym and
+        # that it matches the anti-Sybil ID
+        epid_pseudonym = verification_report_dict.get('epidPseudonym')
+        if epid_pseudonym is None:
+            raise \
+                ValueError(
+                    'Verification report does not contain an EPID pseudonym')
+
+        if epid_pseudonym != signup_info.anti_sybil_id:
+            raise \
+                ValueError(
+                    'The anti-Sybil ID in the verification report [{0}] does '
+                    'not match the one contained in the signup information '
+                    '[{1}]'.format(
+                        epid_pseudonym,
+                        signup_info.anti_sybil_id))
+
         # Verify that the verification report contains a PSE manifest status
         # and it is OK
         pse_manifest_status = \
@@ -283,14 +313,13 @@ class _PoetEnclaveSimulator(object):
                 ValueError(
                     'Verification report does not contain a PSE manifest '
                     'status')
-        if pse_manifest_status != 'OK':
+        if pse_manifest_status.upper() != 'OK':
             raise \
                 ValueError(
                     'PSE manifest status is {} (i.e., not OK)'.format(
                         pse_manifest_status))
 
         # Verify that the verification report contains a PSE manifest hash
-        # and it is the value we expect
         pse_manifest_hash = \
             verification_report_dict.get('pseManifestHash')
         if pse_manifest_hash is None:
@@ -299,22 +328,31 @@ class _PoetEnclaveSimulator(object):
                     'Verification report does not contain a PSE manifest '
                     'hash')
 
+        # Verify that the proof data contains evidence payload
+        evidence_payload = proof_data_dict.get('evidence_payload')
+        if evidence_payload is None:
+            raise ValueError('Evidence payload is missing from proof data')
+
+        # Verify that the evidence payload contains a PSE manifest and then
+        # use it to make sure that the PSE manifest hash is what we expect
+        pse_manifest = evidence_payload.get('pse_manifest')
+        if pse_manifest is None:
+            raise ValueError('Evidence payload does not include PSE manifest')
+
         expected_pse_manifest_hash = \
             base64.b64encode(
                 hashlib.sha256(
-                    bytes(b'Do you believe in '
-                          b'manifest destiny?')).hexdigest()
-                .encode()).decode()
+                    pse_manifest.encode()).hexdigest().encode()).decode()
 
-        if pse_manifest_hash != expected_pse_manifest_hash:
+        if pse_manifest_hash.upper() != expected_pse_manifest_hash.upper():
             raise \
                 ValueError(
                     'PSE manifest hash {0} does not match {1}'.format(
                         pse_manifest_hash,
                         expected_pse_manifest_hash))
 
-        # Verify that the verification report contains an enclave quote and
-        # that its status is OK
+        # Verify that the verification report contains an enclave quote status
+        # and the status is OK
         enclave_quote_status = \
             verification_report_dict.get('isvEnclaveQuoteStatus')
         if enclave_quote_status is None:
@@ -322,12 +360,13 @@ class _PoetEnclaveSimulator(object):
                 ValueError(
                     'Verification report does not contain an enclave quote '
                     'status')
-        if enclave_quote_status != 'OK':
+        if enclave_quote_status.upper() != 'OK':
             raise \
                 ValueError(
                     'Enclave quote status is {} (i.e., not OK)'.format(
                         enclave_quote_status))
 
+        # Verify that the verification report contains an enclave quote
         enclave_quote = verification_report_dict.get('isvEnclaveQuoteBody')
         if enclave_quote is None:
             raise \
@@ -349,7 +388,7 @@ class _PoetEnclaveSimulator(object):
         if report_body is None:
             raise ValueError('Enclave quote does not contain a report body')
 
-        if report_body != expected_report_body:
+        if report_body.upper() != expected_report_body.upper():
             raise \
                 ValueError(
                     'Enclave quote report body {0} does not match {1}'.format(


### PR DESCRIPTION
Update brings both PoET simulator and validator registry transaction processor closer to IAS:

* Uses same method (RSA-SHA256) to sign attestation verification report
* Adds fields to attestation verification report and proof data to bring into alignment with response from IAS.
* Updates validator registry transaction processor unit tests for new signing and fields

Note - the enclave report body in the simulated attestation report has not been updated yet to mimic the sgx_quote_t structure used by the real IAS report.  That is a PR to follow later once the sgx_structs Python module is available to this repo.