### PR TITLE
Fix conflict new cli test

### DIFF
--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -16,10 +16,11 @@
 import argparse
 import os
 import unittest
+import sys
 
 from sawtooth_signing import secp256k1_signer as signing
 from sawtooth_cli.admin_command import keygen
-from sawtooth_cli.admin_command.utils import ensure_directory
+from sawtooth_cli.admin_command.config import get_key_dir
 from sawtooth_cli.exceptions import CliException
 
 
@@ -28,12 +29,19 @@ class TestKeygen(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls._parser = None
-        cls._key_dir = ensure_directory('etc/keys', '/etc/sawtooth/keys')
+        cls._key_dir = get_key_dir()
         cls._key_name = 'test_key'
         cls._wif_filename = os.path.join(cls._key_dir,
                                          cls._key_name + '.wif')
         cls._addr_filename = os.path.join(cls._key_dir,
                                           cls._key_name + '.addr')
+        if not os.path.exists(cls._key_dir):
+            try:
+                os.makedirs(cls._key_dir, exist_ok=True)
+            except OSError as e:
+                print('Unable to create {}: {}'.format(cls._key_dir, e),
+                      file=sys.stderr)
+                sys.exit(1)
 
     def setUp(self):
         self._parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
Fix conflict caused by test_admin_keygen test
    
    The test_admin_keygen test caused a test failure, due
    to the fact that a utility had been moved after the
    PR was submitted.
    
    Test now uses new utility get_key_dir instead
    of ensure_directory.
    
    Signed-off-by: Todd Ojala <todd@bitwise.io>
