### PR TITLE
Add crypto deb

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,10 +100,5 @@ node ('master') {
             archiveArtifacts artifacts: 'build/debs/*.deb'
             archiveArtifacts artifacts: 'docs/build/html/**, docs/build/latex/*.pdf'
         }
-
-        stage("Clean up") {
-            sh 'docker rmi sawtooth-build-debs:$ISOLATION_ID'
-            sh 'docker rmi sawtooth-build-docs:$ISOLATION_ID'
-        }
     }
 }

--- a/bin/build_ext_debs
+++ b/bin/build_ext_debs
@@ -22,8 +22,8 @@
 
 set -e
 
-build_dir=./projects
-pkg_dir=./packages
+build_dir=$(pwd)/projects
+pkg_dir=$(pwd)/packages
 
 while getopts :p:b:h opt
 do
@@ -51,82 +51,129 @@ do
     esac
 done
 
-mkdir -p ${build_dir} && mkdir -p ${pkg_dir}
+main() {
 
-# WARNING: Order is important
-pip_pkgs='
-chardet
-multidict
-async_timeout
-yarl
-aiohttp
-grpcio
-protobuf
-six
-grpcio-tools
-bitcoin
-setuptools_scm
-pytest-runner==2.6.2
-secp256k1
-'
+    info "Building debs in $build_dir and storing in $pkg_dir"
 
-# secp256k1 needs a couple of libraries not readily available
-libsecp256k1_debs='
-libsecp256k1-0_0.1~20161228-1_amd64.deb
-libsecp256k1-dev_0.1~20161228-1_amd64.deb
-'
+    mkdir -p ${build_dir} && mkdir -p ${pkg_dir}
 
-# Download and install additional secp256k dependencies
-for deb in $libsecp256k1_debs; do
-    wget http://ftp.br.debian.org/debian/pool/main/libs/libsecp256k1/$deb
-    sudo dpkg -i $deb
-    mv $deb $pkg_dir
-done
+    # WARNING: Order is important
+    pip_pkgs='
+    chardet
+    multidict
+    async_timeout
+    yarl
+    aiohttp
+    grpcio
+    protobuf
+    six
+    grpcio-tools
+    bitcoin
+    setuptools_scm
+    pytest-runner==2.6.2
+    secp256k1
+    '
 
-# Install packages so pip doesn't blow up while trying to download
-sudo pip3 install $pip_pkgs
+    # secp256k1 needs a couple of libraries not readily available
+    libsecp256k1_debs='
+    libsecp256k1-0_0.1~20161228-1_amd64.deb
+    libsecp256k1-dev_0.1~20161228-1_amd64.deb
+    '
 
-cd $build_dir
+    # Download and install additional secp256k dependencies
+    info "Downloading and installing libsecp256k1 debs"
+    for deb in $libsecp256k1_debs; do
+        if [[ -e $pkg_dir/$deb ]]
+        then
+            warn "Skipping $deb, already exists at $pkg_dir/$deb"
+        else
+            wget http://ftp.br.debian.org/debian/pool/main/libs/libsecp256k1/$deb
+            sudo dpkg -i $deb
+            mv $deb $pkg_dir
+        fi
+    done
 
-# Download and extract pip packages
-pip3 download --no-binary :all: \
-    --disable-pip-version-check \
-    --no-deps $pip_pkgs
+    info "Installing all pip packages for building"
+    sudo pip3 install $pip_pkgs
 
-# Unpack tarballs
-for file in *.tar.gz; do
-    tar xfz $file;
-done
-rm -f *.tar.gz
+    for pkg in $pip_pkgs; do
+        build_deb $pkg
+    done
 
-for pkg in $pip_pkgs; do
-    # Remove version fixing and fix async-timeout inconsistency
-    pkg=$(echo "$pkg" | sed -e 's/==.*//' -e 's/async_/async-/')
+    info "Uninstalling packages installed by pip"
+    sudo pip3 uninstall -y $pip_pkgs
 
-    cd $build_dir/$pkg*
+    info "Done building packages"
+    echo $(ls -1 $pkg_dir/*.deb)
+}
 
-    # Arcane wizadry to get protobuf to build right
-    if [ $pkg = 'protobuf' ]; then
-        # Grab protoc and .proto files expected by protobuf
-        wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
+info() {
+    echo -e "\033[0;36m\n[--- $1 ---]\n\033[0m"
+}
 
-        # Unpack and relocate
-        mkdir src
-        unzip protoc-3.2.0-linux-x86_64.zip -d src
-        mv src/include/* src/ && mv src/bin/* src/
+warn() {
+    echo -e "\033[0;31m\n[--- $1 ---]\n\033[0m"
+}
 
-        # Patch bad relative paths
-        sed 's/\.\.\/src/\.\.\/\.\.\/src/' < setup.py > patch.py && mv patch.py setup.py
+build_deb() {
+    cd $build_dir
+
+    pip_pkg_name=$1
+    tar_pkg_name=$(echo "$pip_pkg_name" | \
+        sed -e 's/==.*//' \
+            -e 's/async_/async-/' \
+            -e 's/cryptography-/cryptography_/')
+
+    deb_pkg_name=$(echo "$tar_pkg_name" | \
+        sed -e 's/setuptools_/setuptools-/' \
+            -e 's/cryptography_/cryptography-/')
+
+    if [ -z $(find $pkg_dir -name "*$deb_pkg_name\_*.deb") ]
+    then
+        info "Downloading source code for $pip_pkg_name"
+        pip3 download --no-binary :all: \
+            --disable-pip-version-check \
+            --no-deps $pip_pkg_name
+
+        tarball=$tar_pkg_name*.tar.gz
+        info "Extracting $tarball"
+        tar xfz $tarball;
+        rm -f $tarball 
+
+        info "Building $deb_pkg_name deb"
+        # Remove version fixing and fix async-timeout inconsistency
+
+        cd $build_dir/$tar_pkg_name*
+
+        # Arcane wizadry to get protobuf to build right
+        if [ $tar_pkg_name = 'protobuf' ]; then
+            # Grab protoc and .proto files expected by protobuf
+            wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
+
+            # Unpack and relocate
+            mkdir src
+            unzip protoc-3.2.0-linux-x86_64.zip -d src
+            mv src/include/* src/ && mv src/bin/* src/
+
+            # Patch bad relative paths
+            sed 's/\.\.\/src/\.\.\/\.\.\/src/' < setup.py > patch.py && mv patch.py setup.py
+        fi
+
+        # Build the package
+        sudo python3 setup.py --command-packages=stdeb.command bdist_deb
+        info "Finished building $deb_pkg_name deb"
+
+        info "Installing $deb_pkg_name deb"
+        # Install the package
+        sudo dpkg -i deb_dist/*.deb
+
+        info "Saving $deb_pkg_name deb to $pkg_dir"
+        # Save the package
+        cp deb_dist/*.deb $pkg_dir
+    else
+        warn "Skipping $deb_pkg_name, already exists in $pkg_dir"
     fi
 
-    # Build the package
-    sudo python3 setup.py --command-packages=stdeb.command bdist_deb
+}
 
-    # Install the package
-    sudo dpkg -i deb_dist/*.deb
-
-    # Save the package
-    cp deb_dist/*.deb $pkg_dir
-
-    cd $build_dir
-done
+main

--- a/bin/build_ext_debs
+++ b/bin/build_ext_debs
@@ -59,21 +59,21 @@ main() {
 
     # WARNING: Order is important
     pip_pkgs='
-    chardet
-    multidict
-    async_timeout
-    yarl
-    aiohttp
-    grpcio
-    protobuf
-    six
-    grpcio-tools
-    bitcoin
-    setuptools_scm
+    chardet==2.3.0
+    multidict==2.1.4
+    async_timeout==1.2.0
+    yarl==0.10.0
+    aiohttp==1.3.5
+    grpcio==1.1.3
+    protobuf==3.2.0
+    six==1.10.0
+    grpcio-tools==1.1.3
+    bitcoin==1.1.42
+    setuptools_scm==1.15.0
     pytest-runner==2.6.2
-    secp256k1
+    secp256k1==0.13.2
     cryptography-vectors==1.7.2
-    pytz
+    pytz==2016.10
     pytest==2.9.0
     cryptography==1.7.2
     '

--- a/bin/build_ext_debs
+++ b/bin/build_ext_debs
@@ -72,6 +72,10 @@ main() {
     setuptools_scm
     pytest-runner==2.6.2
     secp256k1
+    cryptography-vectors==1.7.2
+    pytz
+    pytest==2.9.0
+    cryptography==1.7.2
     '
 
     # secp256k1 needs a couple of libraries not readily available

--- a/bin/install_packaging_deps
+++ b/bin/install_packaging_deps
@@ -1,0 +1,58 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+#!/bin/bash
+apt-get install -y -q \
+    autoconf \
+    automake \
+    build-essential \
+    connect-proxy \
+    g++ \
+    git \
+    libffi-dev \
+    libgmp-dev \
+    libssl-dev \
+    libtool \
+    make \
+    pkg-config \
+    python-all-dev \
+    python3-all-dev \
+    rsync \
+    sudo \
+    wget \
+    zip unzip
+
+apt-get install -y -q \
+    python-setuptools \
+    python3-appdirs \
+    python3-cbor \
+    python3-cffi \
+    python3-cffi \
+    python3-colorlog \
+    python3-flake8 \
+    python3-hypothesis \
+    python3-idna \
+    python3-iso8601 \
+    python3-pip \
+    python3-pkgconfig \
+    python3-pretend \
+    python3-pyasn1 \
+    python3-pyasn1-modules \
+    python3-pycparser \
+    python3-pytest \
+    python3-setuptools \
+    python3-stdeb \
+    python3-yaml \
+    python3-zmq

--- a/docker/sawtooth-build-debs
+++ b/docker/sawtooth-build-debs
@@ -19,56 +19,23 @@ FROM ubuntu:xenial
 RUN sh -c "echo deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse >> /etc/apt/sources.list" && \
     sh -c "echo deb-src http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse >> /etc/apt/sources.list"
 
-# Install general build packages
-RUN apt-get update && apt-get install -y -q \
-    autoconf \
-    automake \
-    build-essential \
-    connect-proxy \
-    g++ \
-    git \
-    libffi-dev \
-    libgmp-dev \
-    libtool \
-    make \
-    pkg-config \
-    python-all-dev \
-    python3-all-dev \
-    rsync \
-    sudo \
-    wget \
-    zip unzip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install python3 packages
-RUN apt-get update && apt-get install -y -q \
-    python-setuptools \
-    python3-appdirs \
-    python3-cbor>=0.1.23 \
-    python3-cffi \
-    python3-cffi \
-    python3-colorlog \
-    python3-pip \
-    python3-pkgconfig \
-    python3-pycparser \
-    python3-pytest \
-    python3-setuptools \
-    python3-stdeb \
-    python3-yaml \
-    python3-zmq \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
 # Create build directories
 RUN mkdir -p /home/build/packages && mkdir -p /home/build/projects
 ENV build_dir=/home/build/projects pkg_dir=/home/build/packages
 
-# Copy in build script
+# Copy in build scripts
+COPY ./bin/install_packaging_deps /home/build/install_packaging_deps
 COPY ./bin/build_ext_debs /home/build/build_ext_debs
 
-# Build external debs
 WORKDIR /home/build
+
+# Install build deps
+RUN apt-get update \
+ && /home/build/install_packaging_deps \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Build external debs
 RUN /home/build/build_ext_debs -p ${pkg_dir} -b ${build_dir}
 
 # Create mount point for source

--- a/tools/plugins/build_and_install_debs.sh
+++ b/tools/plugins/build_and_install_debs.sh
@@ -4,40 +4,7 @@
 
 set -e
 
-apt-get install -y -q \
-    autoconf \
-    automake \
-    build-essential \
-    connect-proxy \
-    g++ \
-    git \
-    libffi-dev \
-    libgmp-dev \
-    libtool \
-    make \
-    pkg-config \
-    python-all-dev \
-    python3-all-dev \
-    rsync \
-    sudo \
-    wget \
-    zip unzip
-
-apt-get install -y -q \
-    python-setuptools \
-    python3-appdirs \
-    python3-cbor \
-    python3-cffi \
-    python3-cffi \
-    python3-colorlog \
-    python3-pip \
-    python3-pkgconfig \
-    python3-pycparser \
-    python3-pytest \
-    python3-setuptools \
-    python3-stdeb \
-    python3-yaml \
-    python3-zmq
+/project/sawtooth-core/bin/install_packaging_deps
 
 pkg_dir=/home/$VAGRANT_USER/packages
 build_dir=/home/$VAGRANT_USER/projects


### PR DESCRIPTION
The easiest way to test this locally is to do:

```
$ cd sawtooth-core
$ docker build . -f docker/sawtooth-build-debs -t sawtooth-build-debs
$ docker run -v $(pwd):/project/sawtooth-core sawtooth-build-debs
```

This should work from any environment with access to a docker-engine.

On success, you should see all the debs in sawtooth-core/build/debs:
```
libsecp256k1-0_0.1~20161228-1_amd64.deb
libsecp256k1-dev_0.1~20161228-1_amd64.deb
python3-aiohttp_1.3.5-1_amd64.deb
python3-async-timeout_1.2.0-1_all.deb
python3-bitcoin_1.1.42-1_all.deb
python3-chardet_2.3.0-1_all.deb
python3-cryptography-vectors_1.7.2-1_all.deb
python3-cryptography_1.7.2-1_amd64.deb
python3-grpcio-tools_1.1.3-1_amd64.deb
python3-grpcio_1.1.3-1_amd64.deb
python3-multidict_2.1.4-1_amd64.deb
python3-protobuf_3.2.0-1_all.deb
python3-pytest-runner_2.6.2-1_all.deb
python3-pytest_2.9.0-1_all.deb
python3-pytz_2016.10-1_all.deb
python3-sawtooth-cli_0.8.1~dev1-1_all.deb
python3-sawtooth-manage_0.8.1~dev1-1_all.deb
python3-sawtooth-rest-api_0.8.1~dev1-1_all.deb
python3-sawtooth-sdk_0.8.1~dev1-1_all.deb
python3-sawtooth-signing_0.8.1~dev1-1_all.deb
python3-sawtooth-validator_0.8.1~dev1-1_all.deb
python3-secp256k1_0.13.2-1_amd64.deb
python3-setuptools-scm_1.15.0-1_all.deb
python3-six_1.10.0-1_all.deb
python3-yarl_0.10.0-1_amd64.deb
```
