### PR TITLE
Add id filter parameter to /batches and /blocks, update POST

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -145,7 +145,7 @@ message ClientStateListRequest {
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NOT_READY - the validator does not yet have a genesis block
 //   * NO_ROOT - the head block or merkle_root specified was not found
-//   * NO_RESOURCE - the head/root sprecidied is valid, but contains no data
+//   * NO_RESOURCE - the head/root specified is valid, but contains no data
 
 message ClientStateListResponse {
     enum Status {
@@ -201,9 +201,10 @@ message ClientStateGetResponse {
 // A request to return a list of blocks from the validator. May include the id
 // of a particular block to be the `head` of the chain being requested. In that
 // case the list will include that block (if found), and all blocks previous
-// to it on the chain.
+// to it on the chain. Can be filtered using specific `block_ids`.
 message ClientBlockListRequest {
     string head_id = 1;
+    repeated string block_ids = 2;
 }
 
 // A response that lists a chain of blocks with the newest at the beginning,
@@ -214,12 +215,14 @@ message ClientBlockListRequest {
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NOT_READY - the validator does not yet have a genesis block
 //   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no blocks were found with the parameters specified
 message ClientBlockListResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NOT_READY = 2;
         NO_ROOT = 3;
+        NO_RESOURCE = 4;
     }
     Status status = 1;
     repeated Block blocks = 2;
@@ -253,9 +256,10 @@ message ClientBlockGetResponse {
 // A request to return a list of batches from the validator. May include the id
 // of a particular block to be the `head` of the chain being requested. In that
 // case the list will include the batches from that block, and all batches
-// previous to that block on the chain.
+// previous to that block on the chain. Filter with specific `batch_ids`.
 message ClientBatchListRequest {
     string head_id = 1;
+    repeated string batch_ids = 2;
 }
 
 // A response that lists batches with the newest to oldest.
@@ -265,12 +269,14 @@ message ClientBatchListRequest {
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NOT_READY - the validator does not yet have a genesis block
 //   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no batches were found with the parameters specified
 message ClientBatchListResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NOT_READY = 2;
         NO_ROOT = 3;
+        NO_RESOURCE = 4;
     }
     Status status = 1;
     repeated Batch batches = 2;

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -72,28 +72,25 @@ class RouteHandler(object):
             validator_query,
             error_traps)
 
-        # Build response
-        data = response['batch_statuses']
-        metadata = {
-            'link': '{}://{}/batch_status?id={}'.format(
-                request.scheme,
-                request.host,
-                ','.join(b.header_signature for b in batch_list.batches))}
+        # Build response envelope
+        data = response['batch_statuses'] or None
+        link = '{}://{}/batch_status?id={}'.format(
+            request.scheme,
+            request.host,
+            ','.join(b.header_signature for b in batch_list.batches))
 
-        if not data:
+        if data is None:
             status = 202
-            data = None
         elif any(s != 'COMMITTED' for _, s in data.items()):
             status = 200
         else:
             status = 201
             data = None
-            # Replace with /batches link when implemented
-            metadata = None
+            link = link.replace('batch_status', 'batches')
 
         return RouteHandler._wrap_response(
             data=data,
-            metadata=metadata,
+            metadata={'link': link},
             status=status)
 
     @asyncio.coroutine

--- a/rest_api/sawtooth_rest_api/routes.py
+++ b/rest_api/sawtooth_rest_api/routes.py
@@ -167,11 +167,12 @@ class RouteHandler(object):
         Fetch a particular block from the validator
         """
         head = request.url.query.get('head', '')
+        block_ids = RouteHandler._get_filter_ids(request)
 
         response = self._query_validator(
             Message.CLIENT_BLOCK_LIST_REQUEST,
             client.ClientBlockListResponse,
-            client.ClientBlockListRequest(head_id=head))
+            client.ClientBlockListRequest(head_id=head, block_ids=block_ids))
 
         blocks = [RouteHandler._expand_block(b) for b in response['blocks']]
         return RouteHandler._wrap_response(
@@ -205,11 +206,12 @@ class RouteHandler(object):
         Fetch a list of batches from the validator
         """
         head = request.url.query.get('head', '')
+        batch_ids = RouteHandler._get_filter_ids(request)
 
         response = self._query_validator(
             Message.CLIENT_BATCH_LIST_REQUEST,
             client.ClientBatchListResponse,
-            client.ClientBatchListRequest(head_id=head))
+            client.ClientBatchListRequest(head_id=head, batch_ids=batch_ids))
 
         batches = [RouteHandler._expand_batch(b) for b in response['batches']]
         return RouteHandler._wrap_response(
@@ -384,3 +386,8 @@ class RouteHandler(object):
         header.ParseFromString(header_bytes)
         obj['header'] = MessageToDict(header, preserving_proto_field_name=True)
         return obj
+
+    @staticmethod
+    def _get_filter_ids(request):
+        filter_ids = request.url.query.get('id', '')
+        return filter_ids and filter_ids.split(',')

--- a/rest_api/tests/unit/mock_stream.py
+++ b/rest_api/tests/unit/mock_stream.py
@@ -348,10 +348,19 @@ class _BlockListHandler(_MockHandler):
         blocks = store.get_blocks(request.head_id)
         if not blocks:
             return self._response_proto(status=self._response_proto.NO_ROOT)
+        head_id=blocks[0].header_signature
+
+        if request.block_ids:
+            matches = {b.header_signature: b for b in blocks
+                if b.header_signature in request.block_ids}
+            blocks = [matches[i] for i in request.block_ids if i in matches]
+            if not blocks:
+                self._response_proto(status=self._response_proto.NO_RESOURCE)
+
 
         return self._response_proto(
             status=self._response_proto.OK,
-            head_id=blocks[0].header_signature,
+            head_id=head_id,
             blocks=blocks)
 
 
@@ -395,10 +404,18 @@ class _BatchListHandler(_MockHandler):
         batches = [a for b in blocks for a in b.batches]
         if not batches:
             return self._response_proto(status=self._response_proto.NO_ROOT)
+        head_id = blocks[0].header_signature
+
+        if request.batch_ids:
+            matches = {b.header_signature: b for b in batches
+                if b.header_signature in request.batch_ids}
+            batches = [matches[i] for i in request.batch_ids if i in matches]
+            if not batches:
+                self._response_proto(status=self._response_proto.NO_RESOURCE)
 
         return self._response_proto(
             status=self._response_proto.OK,
-            head_id=blocks[0].header_signature,
+            head_id=head_id,
             batches=batches)
 
 

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -118,6 +118,7 @@ class ApiTest(AioHTTPTestCase):
         self.assertEqual(201, request.status)
 
         response = await request.json()
+        self.assert_has_valid_link(response, '/batches?id=a')
         self.assertNotIn('data', response)
 
     @unittest_run_loop

--- a/rest_api/tests/unit/test_rest_api.py
+++ b/rest_api/tests/unit/test_rest_api.py
@@ -537,6 +537,112 @@ class ApiTest(AioHTTPTestCase):
         await self.assert_404('/blocks?head=bad')
 
     @unittest_run_loop
+    async def test_block_list_with_ids(self):
+        """Verifies GET /blocks with the id parameter works properly.
+
+        Fetches blocks from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/blocks?head=2&id=0,2'
+            - a data property that:
+                * contains a list of 2 block dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/blocks?id=0,2')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/blocks?head=2&id=0,2')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_block_well_formed(response['data'][0], '0')
+
+    @unittest_run_loop
+    async def test_block_list_with_bad_ids(self):
+        """Verifies GET /blocks with a bad id parameter breaks properly.
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/blocks?head=2&id=bad,notgood'
+            - a data property that is an empty list
+        """
+        response = await self.get_json_assert_200('/blocks?id=bad,notgood')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/blocks?head=2&id=bad,notgood')
+        self.assert_has_valid_data_list(response, 0)
+
+    @unittest_run_loop
+    async def test_block_list_with_head_and_ids(self):
+        """Verifies GET /blocks with head and id parameters works properly.
+
+        Fetches blocks from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/blocks?head=1&id=0'
+            - a data property that:
+                * contains a list of 1 block dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/blocks?id=0&head=1')
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/blocks?head=1&id=0')
+        self.assert_has_valid_data_list(response, 1)
+        self.assert_block_well_formed(response['data'][0], '0')
+
+    @unittest_run_loop
+    async def test_block_list_with_id_head_mismatch(self):
+        """Verifies GET /blocks with ids missing from a specified head work.
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '0'
+            - a link property that ends in '/blocks?head=0&id=1,2'
+            - a data property that is an empty list
+        """
+        response = await self.get_json_assert_200('/blocks?id=1,2&head=0')
+
+        self.assert_has_valid_head(response, '0')
+        self.assert_has_valid_link(response, '/blocks?head=0&id=1,2')
+        self.assert_has_valid_data_list(response, 0)
+
+    @unittest_run_loop
     async def test_block_get(self):
         """Verifies a GET /blocks/{block_id} works properly.
 
@@ -668,6 +774,112 @@ class ApiTest(AioHTTPTestCase):
             - a response status of 404
         """
         await self.assert_404('/batches?head=bad')
+
+    @unittest_run_loop
+    async def test_batch_list_with_ids(self):
+        """Verifies GET /batches with the id parameter works properly.
+
+        Fetches batches from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/batches?head=2&id=0,2'
+            - a data property that:
+                * contains a list of 2 batch dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/batches?id=0,2')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/batches?head=2&id=0,2')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_batch_well_formed(response['data'][0], '0')
+
+    @unittest_run_loop
+    async def test_batch_list_with_bad_ids(self):
+        """Verifies GET /batches with a bad id parameter breaks properly.
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/batches?head=2&id=bad,notgood'
+            - a data property that is an empty list
+        """
+        response = await self.get_json_assert_200('/batches?id=bad,notgood')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/batches?head=2&id=bad,notgood')
+        self.assert_has_valid_data_list(response, 0)
+
+    @unittest_run_loop
+    async def test_batch_list_with_head_and_ids(self):
+        """Verifies GET /batches with head and id parameters works properly.
+
+        Fetches batches from default mock store:
+            {
+                header: {previous_block_id: '1', ...},
+                header_signature: '2',
+                batches: [{
+                    header: {signer_pubkey: 'pubkey', ...},
+                    header_signature: '2',
+                    transactions: [{
+                        header: {nonce: '2', ...},
+                        header_signature: '2',
+                        payload: b'payload'
+                    }]
+                }]
+            },
+            {header: {...}, header_signature: '1', batches: [{...}]},
+            {header: {...}, header_signature: '0', batches: [{...}]}
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/batches?head=1&id=0'
+            - a data property that:
+                * contains a list of 1 batch dicts with a header and batches
+                * batches with 1 batch with a header and transactions
+                * transactions with 1 transaction with a header
+        """
+        response = await self.get_json_assert_200('/batches?id=0&head=1')
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/batches?head=1&id=0')
+        self.assert_has_valid_data_list(response, 1)
+        self.assert_batch_well_formed(response['data'][0], '0')
+
+    @unittest_run_loop
+    async def test_batch_list_with_id_head_mismatch(self):
+        """Verifies GET /batches with ids missing from a specified head work.
+
+        Expects to find:
+            - a response status of 200
+            - a head property of '0'
+            - a link property that ends in '/batches?head=0&id=1,2'
+            - a data property that is an empty list
+        """
+        response = await self.get_json_assert_200('/batches?id=1,2&head=0')
+
+        self.assert_has_valid_head(response, '0')
+        self.assert_has_valid_link(response, '/batches?head=0&id=1,2')
+        self.assert_has_valid_data_list(response, 0)
 
     @unittest_run_loop
     async def test_batch_get(self):


### PR DESCRIPTION
Add an id filter parameter to the `GET /batches` and `GET /blocks` endpoints in the REST API. Allows you to fetch multiple resource by specifying arbitrary ids.

Use this parameter to update the response envelope to a `POST /batches`, so that when all batches are committed, a `/batches` link is sent, rather than a `/batch_status` link. 