### PR TITLE
Add PoET genesis CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,6 @@
 
 /manage/**/__pycache__/
 
-/poet/sawtooth_poet/protobuf
-/poet/**/__pycache__/
-
 /rest_api/build/
 /rest_api/sawtooth_rest_api/protobuf/
 /rest_api/**/__pycache__/
@@ -45,6 +42,9 @@
 /sdk/examples/sawtooth_xo/**/__pycache__/
 /sdk/examples/intkey_python/**/__pycache__/
 /sdk/examples/intkey_javascript/node_modules/
+/sdk/examples/intkey_java/dependency-reduced-pom.xml
+/sdk/examples/intkey_java/target/
+/sdk/java/target/
 
 /signing/build/
 /signing/sawtooth_signing.egg-info/

--- a/bin/poet
+++ b/bin/poet
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+import sysconfig
+
+build_str = "lib.{}-{}.{}".format(
+    sysconfig.get_platform(),
+    sys.version_info.major, sys.version_info.minor)
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'consensus', 'poet', 'cli'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'consensus', 'poet', 'common'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'consensus', 'poet', 'core'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'consensus', 'poet', 'simulator'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'validator'))
+
+from sawtooth_poet_cli.main import main_wrapper
+
+if __name__ == '__main__':
+    main_wrapper()

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -192,6 +192,14 @@ PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/simulator/tests
 export PYTHONPATH
 lint consensus/poet/simulator "$SINCE" || retval=1
 
+PYTHONPATH=$top_dir/consensus/poet/cli
+PYTHONPATH=$PYTHONPATH:$top_dir/signing
+PYTHONPATH=$PYTHONPATH:$top_dir/validator
+PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/common
+PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/core
+export PYTHONPATH
+lint consensus/poet/cli "$SINCE" || retval=1
+
 PYTHONPATH=$top_dir/cli
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/manage

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -19,6 +19,7 @@ MODULE_LIST="
 cli
 java_sdk
 javascript_sdk
+poet_cli
 poet_common
 poet_core
 poet_families
@@ -116,10 +117,14 @@ main() {
                     test_javascript_sdk
                     ;;
                 poet)
+                    test_poet_cli
                     test_poet_common
                     test_poet_core
                     test_poet_families
                     test_poet_simulator
+                    ;;
+                poet_cli)
+                    test_poet_cli
                     ;;
                 poet_common)
                     test_poet_common
@@ -164,6 +169,11 @@ test_java_sdk() {
 
 test_javascript_sdk() {
     run_docker_test tp-intkey-javascript -s validator
+}
+
+test_poet_cli(){
+    run_docker_test ./consensus/poet/cli/tests/unit_cli.yaml \
+    -s poet
 }
 
 test_poet_common(){

--- a/consensus/poet/cli/sawtooth_poet_cli/config.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/config.py
@@ -1,0 +1,87 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+import toml
+
+
+def _select_dir(sawtooth_home_dir, windows_dir, default_dir):
+    """Returns the directory value, selected using the SAWTOOTH_HOME
+    environment variable (if set) or OS defaults.
+    """
+    if 'SAWTOOTH_HOME' in os.environ:
+        return os.path.join(os.environ['SAWTOOTH_HOME'], sawtooth_home_dir)
+    elif os.name == 'nt':
+        base_dir = \
+            os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0])))
+        return os.path.join(base_dir, windows_dir)
+    else:
+        return default_dir
+
+
+def _get_config_dir():
+    """Returns the sawtooth configuration directory based on the
+    SAWTOOTH_HOME environment variable (if set) or OS defaults.
+    """
+    return _select_dir('etc', 'conf', '/etc/sawtooth')
+
+
+def _get_dir(toml_config_setting,
+             sawtooth_home_dir,
+             windows_dir,
+             default_dir):
+    """Determines the directory path based on configuration.
+
+    Arguments:
+        toml_config_setting (str): The name of the config setting related
+            to the directory which will appear in path.toml.
+        sawtooth_home_dir (str): The directory under the SAWTOOTH_HOME
+            environment variable.  For example, for 'data' if the data
+            directory is $SAWTOOTH_HOME/data.
+        windows_dir (str): The windows path relative to the computed base
+            directory.
+        default_dir (str): The default path on Linux.
+
+    Returns:
+        directory (str): The path.
+    """
+    conf_file = os.path.join(_get_config_dir(), 'path.toml')
+    if os.path.exists(conf_file):
+        with open(conf_file) as fd:
+            raw_config = fd.read()
+        toml_config = toml.loads(raw_config)
+        if toml_config_setting in toml_config:
+            return toml_config[toml_config_setting]
+
+    return _select_dir(sawtooth_home_dir, windows_dir, default_dir)
+
+
+def get_data_dir():
+    """Returns the configured data directory."""
+    return _get_dir(
+        toml_config_setting='data_dir',
+        sawtooth_home_dir='data',
+        windows_dir='data',
+        default_dir='/var/lib/sawtooth')
+
+
+def get_key_dir():
+    """Returns the configured key directory."""
+    return _get_dir(
+        toml_config_setting='key_dir',
+        sawtooth_home_dir='keys',
+        windows_dir=os.path.join('conf', 'keys'),
+        default_dir='/etc/sawtooth/keys')

--- a/consensus/poet/cli/sawtooth_poet_cli/exceptions.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/exceptions.py
@@ -1,0 +1,19 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+class CliException(Exception):
+    def __init__(self, msg):
+        super(CliException, self).__init__(msg)

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -1,0 +1,215 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+from hashlib import sha512
+from hashlib import sha256
+import importlib
+import os
+import time
+
+from sawtooth_poet_cli import config
+from sawtooth_poet_cli.exceptions import CliException
+from sawtooth_poet.poet_consensus.signup_info import SignupInfo
+import sawtooth_poet_common.protobuf.validator_registry_pb2 as vr_pb
+
+from sawtooth_signing import secp256k1_signer as signing
+
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+import sawtooth_validator.protobuf.transaction_pb2 as txn_pb
+import sawtooth_validator.protobuf.batch_pb2 as batch_pb
+
+
+SIMUATOR_MODULE = \
+    'sawtooth_poet_simulator.poet_enclave_simulator.poet_enclave_simulator'
+SGX_MODULE = 'sawtooth_poet_sgx.poet_enclave_sgx.poet_enclave'
+
+VR_NAMESPACE = sha256('validator_registry'.encode()).hexdigest()[0:6]
+VALIDATOR_MAP_ADDRESS = \
+    VR_NAMESPACE + sha256('validator_map'.encode()).hexdigest()
+
+SEALED_SIGNUP_DATA_FILE = 'poet_signup_data'
+
+
+def add_genesis_parser(subparsers, parent_parser):
+    """Add argument parser arguments for the `poet genesis` subcommand.
+    """
+    parser = subparsers.add_parser('genesis')
+
+    parser.add_argument(
+        '--enclave_module',
+        default='simulator',
+        choices=['simulator', 'sgx'],
+        type=str,
+        help='configure the enclave module to use')
+
+    parser.add_argument(
+        '-k', '--key',
+        type=str,
+        help='path to transaction signing key in WIF format')
+
+    parser.add_argument(
+        '-o', '--output',
+        default='poet-genesis.batch',
+        type=str,
+        help='the name of the file to ouput the resulting batches')
+
+
+def do_genesis(args):
+    """Executes the `poet genesis` subcommand.
+
+    This command generates a validator registry transaction and saves it to a
+    file, whose location is determined by the args.  The signup data, generated
+    by the selected enclave, is also stored in a well-known location.
+    """
+    if args.enclave_module == 'simulator':
+        module_name = SIMUATOR_MODULE
+    elif args.enclave_module == 'sgx':
+        module_name = SGX_MODULE
+    else:
+        raise AssertionError('Unknown enclave module: {}'.format(
+            args.enclave_module))
+
+    try:
+        poet_enclave_module = importlib.import_module(module_name)
+    except ImportError as e:
+        raise AssertionError(str(e))
+
+    poet_enclave_module.initialize(**{})
+
+    pubkey, signing_key = _read_signing_keys(args.key)
+
+    public_key_hash = sha256(pubkey.encode()).hexdigest()
+    signup_info = SignupInfo.create_signup_info(
+        poet_enclave_module=poet_enclave_module,
+        validator_address=pubkey,
+        originator_public_key_hash=public_key_hash,
+        most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+
+    print('Writing sealed signup data to {}'.format(SEALED_SIGNUP_DATA_FILE))
+    try:
+        seal_signup_data_path = os.path.join(config.get_data_dir(),
+                                             SEALED_SIGNUP_DATA_FILE)
+        with open(seal_signup_data_path, 'wb') as data_file:
+            data_file.write(signup_info.sealed_signup_data)
+    except IOError as e:
+        raise CliException(
+            'Unable to store sealed signup data: {}'.format(str(e)))
+
+    # Create the validator registry payload
+    payload = \
+        vr_pb.ValidatorRegistryPayload(
+            verb='register',
+            name='validator-{}'.format(pubkey[-8:]),
+            id=pubkey,
+            signup_info=vr_pb.SignUpInfo(
+                poet_public_key=signup_info.poet_public_key,
+                proof_data=signup_info.proof_data,
+                anti_sybil_id=signup_info.anti_sybil_id),
+            block_num=0)
+    serialized = payload.SerializeToString()
+
+    # Create the address that will be used to look up this validator
+    # registry transaction.  Seems like a potential for refactoring..
+    validator_entry_address = \
+        VR_NAMESPACE + sha256(pubkey.encode()).hexdigest()
+
+    # Create a transaction header and transaction for the validator
+    # registry update amd then hand it off to the batch publisher to
+    # send out.
+    addresses = [validator_entry_address, VALIDATOR_MAP_ADDRESS]
+
+    header = \
+        txn_pb.TransactionHeader(
+            signer_pubkey=pubkey,
+            family_name='sawtooth_validator_registry',
+            family_version='1.0',
+            inputs=addresses,
+            outputs=addresses,
+            dependencies=[],
+            payload_encoding="application/protobuf",
+            payload_sha512=sha512(serialized).hexdigest(),
+            batcher_pubkey=pubkey,
+            nonce=time.time().hex().encode()).SerializeToString()
+    signature = signing.sign(header, signing_key)
+
+    transaction = \
+        txn_pb.Transaction(
+            header=header,
+            payload=serialized,
+            header_signature=signature)
+
+    batch = _create_batch(pubkey, signing_key, [transaction])
+    batch_list = batch_pb.BatchList(batches=[batch])
+    try:
+        print('Generating {}'.format(args.output))
+        with open(args.output, 'wb') as batch_file:
+            batch_file.write(batch_list.SerializeToString())
+    except IOError as e:
+        raise CliException(
+            'Unable to write to batch file: {}'.format(str(e)))
+
+
+def _create_batch(pubkey, signing_key, transactions):
+    """Creates a batch from a list of transactions and a public key, and signs
+    the resulting batch with the given signing key.
+
+    Args:
+        pubkey (str): The public key associated with the signing key.
+        signing_key (str): The private key for signing the batch.
+        transactions (list of `Transaction`): The transactions to add to the
+            batch.
+
+    Returns:
+        `Batch`: The constructed and signed batch.
+    """
+    txn_ids = [txn.header_signature for txn in transactions]
+    batch_header = batch_pb.BatchHeader(
+        signer_pubkey=pubkey,
+        transaction_ids=txn_ids).SerializeToString()
+
+    return batch_pb.Batch(
+        header=batch_header,
+        header_signature=signing.sign(batch_header, signing_key),
+        transactions=transactions
+    )
+
+
+def _read_signing_keys(key_filename):
+    """Reads the given file as a WIF formatted key.
+
+    Args:
+        key_filename: The filename where the key is stored. If None,
+            defaults to the default key for the validator
+
+    Returns:
+        tuple (str, str): the public and private key pair
+
+    Raises:
+        CliException: If unable to read the file.
+    """
+    filename = key_filename
+    if key_filename is None:
+        filename = os.path.join(config.get_key_dir(), 'validator.wif')
+
+    try:
+        with open(filename, 'r') as key_file:
+            wif_key = key_file.read().strip()
+            signing_key = signing.encode_privkey(
+                signing.decode_privkey(wif_key, 'wif'), 'hex')
+            pubkey = signing.encode_pubkey(
+                signing.generate_pubkey(signing_key), 'hex')
+
+            return pubkey, signing_key
+    except IOError as e:
+        raise CliException('Unable to read key file: {}'.format(str(e)))

--- a/consensus/poet/cli/sawtooth_poet_cli/main.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/main.py
@@ -1,0 +1,118 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import argparse
+import logging
+import os
+import sys
+import traceback
+
+from colorlog import ColoredFormatter
+
+from sawtooth_poet_cli.exceptions import CliException
+from sawtooth_poet_cli.genesis import add_genesis_parser
+from sawtooth_poet_cli.genesis import do_genesis
+
+
+def create_console_handler(verbose_level):
+    clog = logging.StreamHandler()
+    formatter = ColoredFormatter(
+        "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
+        "%(white)s%(message)s",
+        datefmt="%H:%M:%S",
+        reset=True,
+        log_colors={
+            'DEBUG': 'cyan',
+            'INFO': 'green',
+            'WARNING': 'yellow',
+            'ERROR': 'red',
+            'CRITICAL': 'red',
+        })
+
+    clog.setFormatter(formatter)
+
+    if verbose_level == 0:
+        clog.setLevel(logging.WARN)
+    elif verbose_level == 1:
+        clog.setLevel(logging.INFO)
+    else:
+        clog.setLevel(logging.DEBUG)
+
+    return clog
+
+
+def setup_loggers(verbose_level):
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(create_console_handler(verbose_level))
+
+
+def create_parent_parser(prog_name):
+    parent_parser = argparse.ArgumentParser(prog=prog_name, add_help=False)
+    parent_parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        help='enable more verbose output')
+
+    return parent_parser
+
+
+def create_parser(prog_name):
+    parent_parser = create_parent_parser(prog_name)
+
+    parser = argparse.ArgumentParser(
+        parents=[parent_parser],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    subparsers = parser.add_subparsers(title='subcommand', dest='command')
+    subparsers.required = True
+
+    add_genesis_parser(subparsers, parent_parser)
+
+    return parser
+
+
+def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
+         with_loggers=True):
+
+    parser = create_parser(prog_name)
+    args = parser.parse_args(args)
+
+    if with_loggers is True:
+        if args.verbose is None:
+            verbose_level = 0
+        else:
+            verbose_level = args.verbose
+        setup_loggers(verbose_level=verbose_level)
+
+    if args.command == 'genesis':
+        do_genesis(args)
+    else:
+        raise AssertionError('invalid command: {}'.format(args.command))
+
+
+def main_wrapper():
+    # pylint: disable=bare-except
+    try:
+        main()
+    except CliException as e:
+        print("Error: {}".format(e), file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        pass
+    except SystemExit as e:
+        raise e
+    except:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)

--- a/consensus/poet/cli/tests/test_genesis/__init__.py
+++ b/consensus/poet/cli/tests/test_genesis/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = []

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -1,0 +1,98 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from sawtooth_signing import secp256k1_signer as signing
+
+from sawtooth_poet_cli.main import main
+import sawtooth_validator.protobuf.batch_pb2 as batch_pb
+import sawtooth_validator.protobuf.transaction_pb2 as txn_pb
+
+
+class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
+
+    def __init__(self, test_name):
+        super().__init__(test_name)
+        self._temp_dir = None
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
+
+    @patch('sawtooth_poet_cli.config.get_data_dir')
+    @patch('sawtooth_poet_cli.config.get_key_dir')
+    def test_run_simulator_genesis(self, get_data_dir_fn, get_key_dir_fn):
+        """Test generating a Validator Registry transaction, which is written
+        to a file.
+
+        This test executes the `poet genesis` command. The expected output is:
+
+        - a BatchList written to a file at <temp_dir>/poet_genesis.batch
+        - the serialized sealed signup data is written to
+          `<data_dir>/poet_signup_data`
+        """
+        get_data_dir_fn.return_value = self._temp_dir
+        get_key_dir_fn.return_value = self._temp_dir
+
+        pubkey = self._create_key()
+
+        main('poet',
+             args=['genesis',
+                   '-o', os.path.join(self._temp_dir, 'poet-genesis.batch')])
+
+        self._assert_validator_transaction(pubkey, 'poet-genesis.batch')
+        self._assert_sealed_signup_data()
+
+    def _assert_validator_transaction(self, pubkey, target_file):
+        filename = os.path.join(self._temp_dir, target_file)
+        batch_list = batch_pb.BatchList()
+        with open(filename, 'rb') as batch_file:
+            batch_list.ParseFromString(batch_file.read())
+
+        self.assertEqual(1, len(batch_list.batches))
+
+        batch = batch_list.batches[0]
+        self.assertEqual(1, len(batch.transactions))
+        batch_header = batch_pb.BatchHeader()
+        batch_header.ParseFromString(batch.header)
+
+        self.assertEqual(pubkey, batch_header.signer_pubkey)
+
+        txn = batch.transactions[0]
+        txn_header = txn_pb.TransactionHeader()
+        txn_header.ParseFromString(txn.header)
+
+        self.assertEqual(pubkey, txn_header.signer_pubkey)
+        self.assertEqual('sawtooth_validator_registry', txn_header.family_name)
+
+    def _assert_sealed_signup_data(self):
+        filename = os.path.join(self._temp_dir, 'poet_signup_data')
+        with open(filename, 'rb') as data_file:
+            self.assertTrue(len(data_file.read()) > 0)
+
+    def _create_key(self, key_name='validator.wif'):
+        privkey = signing.generate_privkey()
+        wif_file = os.path.join(self._temp_dir, key_name)
+        with open(wif_file, 'w') as wif_fd:
+            wif_fd.write(signing.encode_privkey(privkey))
+
+        return signing.generate_pubkey(privkey)

--- a/consensus/poet/cli/tests/unit_cli.yaml
+++ b/consensus/poet/cli/tests/unit_cli.yaml
@@ -1,0 +1,33 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  poet:
+    image: sawtooth-test:$ISOLATION_ID
+    volumes:
+      - ../../../..:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/consensus/poet/cli
+    entrypoint: nose2-3 -s tests -v
+    environment:
+        PYTHONPATH: "\
+          /project/sawtooth-core/validator:\
+          /project/sawtooth-core/signing:\
+          /project/sawtooth-core/consensus/poet/cli:\
+          /project/sawtooth-core/consensus/poet/common:\
+          /project/sawtooth-core/consensus/poet/core:\
+          /project/sawtooth-core/consensus/poet/simulator"


### PR DESCRIPTION
Add a cli tool for creating genesis transactions, required to bootstrap the use of the PoET consensus module.  During the process to create a Validator Registry transaction, signup data is retrieved from the PoET enclave (either via the simulator or an actual SGX enclave), and stored in a well-known location (namely `<data dir>/poet_signup_data`).  This data will be used by the consensus module when it is first initialized in the validator.

Additionally:
- Clean up some git ignore needs