### PR TITLE
CLI submit command

### DIFF
--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -39,6 +39,8 @@ from sawtooth_cli.state import add_state_parser
 from sawtooth_cli.state import do_state
 from sawtooth_cli.cluster import add_cluster_parser
 from sawtooth_cli.cluster import do_cluster
+from sawtooth_cli.submit import add_submit_parser
+from sawtooth_cli.submit import do_submit
 
 
 def create_console_handler(verbose_level):
@@ -100,6 +102,7 @@ def create_parser(prog_name):
     add_batch_parser(subparsers, parent_parser)
     add_state_parser(subparsers, parent_parser)
     add_cluster_parser(subparsers, parent_parser)
+    add_submit_parser(subparsers, parent_parser)
 
     return parser
 
@@ -130,6 +133,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
         do_state(args)
     elif args.command == 'cluster':
         do_cluster(args)
+    elif args.command == 'submit':
+        do_submit(args)
     else:
         raise AssertionError("invalid command: {}".format(args.command))
 

--- a/cli/sawtooth_cli/submit.py
+++ b/cli/sawtooth_cli/submit.py
@@ -1,0 +1,77 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import time
+
+from sawtooth_cli.rest_client import RestClient
+import sawtooth_cli.protobuf.batch_pb2 as batch_pb2
+
+LOGGER = logging.getLogger(__file__)
+
+
+def _split_batch_list(args, batch_list):
+    new_list = []
+    for batch in batch_list.batches:
+        new_list.append(batch)
+        if len(new_list) == args.batch_size_limit:
+            yield batch_pb2.BatchList(batches=new_list)
+            new_list = []
+    if len(new_list) > 0:
+        yield batch_pb2.BatchList(batches=new_list)
+
+
+def do_submit(args):
+    with open(args.filename, mode='rb') as fd:
+        batches = batch_pb2.BatchList()
+        batches.ParseFromString(fd.read())
+
+    rest_client = RestClient(args.url)
+
+    start = time.time()
+
+    for batch_list in _split_batch_list(args, batches):
+        rest_client.send_batches(batch_list)
+
+    stop = time.time()
+
+    print("batches: {} batch/sec: {}".format(
+        str(len(batches.batches)),
+        len(batches.batches) / (stop - start)))
+
+
+def add_submit_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser(
+        'submit',
+        parents=[parent_parser])
+
+    parser.add_argument(
+        '-f', '--filename',
+        type=str,
+        help='location of input file',
+        default='batches.intkey')
+
+    parser.add_argument(
+        '-U', '--url',
+        type=str,
+        help='connection URL for validator',
+        default='http://localhost:8080')
+
+    parser.add_argument(
+        '--batch-size-limit',
+        type=int,
+        help='batches are split for processing if they exceed this size',
+        default=100
+    )


### PR DESCRIPTION
CLI command 'sawtooth submit' command created.
Uses rest api.
Submits batches from file, such as intkey or
config batches.

Signed-off-by: Todd Ojala <todd@bitwise.io>