### PR TITLE
Nml 2127 - Update PoET simulator and Validator Registry Transaction Processor to Support Enclave Quote Structure

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -169,6 +169,8 @@ test_javascript_sdk() {
 test_poet_common(){
     run_docker_test ./consensus/poet/common/tests/test_validator_registry_view/unit_validator_registry_view.yaml \
     -s poet
+    run_docker_test ./consensus/poet/common/tests/test_sgx_structs/unit_sgx_structs.yaml \
+    -s poet
 }
 
 test_poet_core(){

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/__init__.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/__init__.py
@@ -13,17 +13,14 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "2.1"
+from sawtooth_poet_common.sgx_structs._sgx_attributes import SgxAttributes
+from sawtooth_poet_common.sgx_structs._sgx_basename import SgxBasename
+from sawtooth_poet_common.sgx_structs._sgx_cpu_svn import SgxCpuSvn
+from sawtooth_poet_common.sgx_structs._sgx_key_id import SgxKeyId
+from sawtooth_poet_common.sgx_structs._sgx_measurement import SgxMeasurement
+from sawtooth_poet_common.sgx_structs._sgx_quote import SgxQuote
+from sawtooth_poet_common.sgx_structs._sgx_report import SgxReport
+from sawtooth_poet_common.sgx_structs._sgx_report_body import SgxReportBody
+from sawtooth_poet_common.sgx_structs._sgx_report_data import SgxReportData
 
-services:
-
-  poet:
-    image: sawtooth-test:$ISOLATION_ID
-    volumes:
-      - ../../../../..:/project/sawtooth-core
-    working_dir: /project/sawtooth-core/consensus/poet/common
-    entrypoint: nose2-3 -s tests/test_validator_registry_view -v
-    environment:
-        PYTHONPATH: "\
-          /project/sawtooth-core/consensus/poet/common:\
-          /project/sawtooth-core/consensus/poet/common/tests"
+__all__ = []

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_attributes.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_attributes.py
@@ -1,0 +1,88 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxAttributes(SgxStruct):
+    """
+    Provide a wrapper around sgx_attributes_t
+
+    typedef struct _attributes_t
+    {
+        uint64_t flags; /* 0 */
+        uint64_t xfrm;  /* 8 */
+    } sgx_attributes_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 16
+
+    _format = '<QQ'
+
+    def __init__(self, flags=0, xfrm=0):
+        """Initialize SgxAttributes object
+
+        Args:
+            flags (int): Bitmask representing SGX flags
+            xfrm (int):  Bitmask representing which states are saved
+        """
+        self.flags = flags
+        self.xfrm = xfrm
+
+    def __str__(self):
+        return \
+            'SGX_ATTRIBUTES: flags={}, xfrm={}'.format(self.flags, self.xfrm)
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: All integer struct fields are serialized to little endian
+            format
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+
+        return struct.pack(self._format, self.flags, self.xfrm)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        NOTE: All integer struct fields are parsed as little endian
+            format
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.flags, self.xfrm) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_basename.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_basename.py
@@ -1,0 +1,85 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxBasename(SgxStruct):
+    """
+    Provide a wrapper around sgx_basename_t structure
+
+    typedef struct _basename_t
+    {
+        uint8_t name[32];
+    } sgx_basename_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 32
+
+    _DEFAULT_NAME = b'\x00' * STRUCT_SIZE
+
+    _format = '<{}s'.format(STRUCT_SIZE)
+
+    def __init__(self, name=_DEFAULT_NAME):
+        """Initialize SgxBasename object
+
+        Args:
+            name (bytes): A byte array representing basename
+        """
+
+        self.name = name
+
+    def __str__(self):
+        return 'SGX_BASENAME: name={}'.format(self.name.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: If len(self.name) is less than self.STRUCT_SIZE, the
+            resulting bytes will be padded with binary zero (\x00).  If
+            len(self.name) is greater than self.STRUCT_SIZE, the
+            resulting bytes will be truncated to self.STRUCT_SIZE.
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return struct.pack(self._format, self.name)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.name,) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_cpu_svn.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_cpu_svn.py
@@ -1,0 +1,87 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxCpuSvn(SgxStruct):
+    """
+    Provide a wrapper around sgx_cpu_svn_t
+
+    #define SGX_CPUSVN_SIZE 16
+
+    typedef struct _sgx_cpu_svn_t
+    {
+        uint8_t svn[SGX_CPUSVN_SIZE];
+    } sgx_cpu_svn_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 16
+
+    _DEFAULT_SVN = b'\x00' * STRUCT_SIZE
+
+    _format = '<{}s'.format(STRUCT_SIZE)
+
+    def __init__(self, svn=_DEFAULT_SVN):
+        """Initialize SgxCpuSvn object
+
+        Args:
+            svn (bytes): CPU security version
+        """
+
+        self.svn = svn
+
+    def __str__(self):
+        return 'SGX_CPU_SVN: svn={}'.format(self.svn.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: If len(self.svn) is less than self.STRUCT_SIZE, the
+            resulting bytes will be padded with binary zero (\x00).  If
+            len(self.svn) is greater than self.STRUCT_SIZE, the
+            resulting bytes will be truncated to self.STRUCT_SIZE.
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return struct.pack(self._format, self.svn)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.svn,) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_key_id.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_key_id.py
@@ -1,0 +1,88 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxKeyId(SgxStruct):
+    """
+    Provide a wrapper around sgx_key_id_t structure
+
+    #define SGX_KEYID_SIZE 32
+
+    typedef struct _sgx_key_id_t
+    {
+        uint8_t id[SGX_KEYID_SIZE];
+    } sgx_key_id_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 32
+
+    _DEFAULT_ID = b'\x00' * STRUCT_SIZE
+
+    _format = '<{}s'.format(STRUCT_SIZE)
+
+    def __init__(self, identifier=_DEFAULT_ID):
+        """Initialize SgxKeyId object
+
+        Args:
+            id (bytes): Key id value used for key wear-out protection
+        """
+
+        # pylint: disable=invalid-name
+        self.id = identifier
+
+    def __str__(self):
+        return 'SGX_KEY_ID: id={}'.format(self.id.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: If len(self.id) is less than self.STRUCT_SIZE, the
+            resulting bytes will be padded with binary zero (\x00).  If
+            len(self.id) is greater than self.STRUCT_SIZE, the
+            resulting bytes will be truncated to self.STRUCT_SIZE.
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return struct.pack(self._format, self.id)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.id,) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_measurement.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_measurement.py
@@ -1,0 +1,88 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxMeasurement(SgxStruct):
+    """
+    Provide a wrapper around sgx_measurement_t
+
+    #define SGX_HASH_SIZE 32
+
+    typedef struct _sgx_measurement_t
+    {
+        uint8_t m[SGX_HASH_SIZE];
+    } sgx_measurement_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 32
+
+    _DEFAULT_M = b'\x00' * STRUCT_SIZE
+
+    _format = '<{}s'.format(STRUCT_SIZE)
+
+    def __init__(self, m=_DEFAULT_M):
+        """Initialize SgxMeasurement object
+
+        Args:
+            m (bytes): The enclave measurement
+        """
+
+        # pylint: disable=invalid-name
+        self.m = m
+
+    def __str__(self):
+        return 'SGX_MEASUREMENT: m={}'.format(self.m.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: If len(self.m) is less than self.STRUCT_SIZE, the
+            resulting bytes will be padded with binary zero (\x00).  If
+            len(self.m) is greater than self.STRUCT_SIZE, the
+            resulting bytes will be truncated to self.STRUCT_SIZE.
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return struct.pack(self._format, self.m)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.m,) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_quote.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_quote.py
@@ -1,0 +1,206 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+from sawtooth_poet_common.sgx_structs._sgx_basename import SgxBasename
+from sawtooth_poet_common.sgx_structs._sgx_report_body import SgxReportBody
+
+
+class SgxQuote(SgxStruct):
+    """
+    Provide a wrapper around sgx_quote_t structure
+
+    typedef uint8_t sgx_epid_group_id_t[4];
+    typedef uint16_t sgx_isv_svn_t;
+
+    typedef struct _quote_t
+    {
+        uint16_t            version;                /* 0   */
+        uint16_t            sign_type;              /* 2   */
+        sgx_epid_group_id_t epid_group_id;          /* 4   */
+        sgx_isv_svn_t       qe_svn;                 /* 8   */
+        sgx_isv_svn_t       pce_svn;                /* 10  */
+        uint32_t            extended_epid_group_id; /* 12  */
+        sgx_basename_t      basename;               /* 16  */
+        sgx_report_body_t   report_body;            /* 48  */
+        uint32_t            signature_len;          /* 432 */
+        uint8_t             signature[];            /* 436 */
+    } sgx_quote_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+    FIXED_STRUCT_SIZE = 432
+
+    _DEFAULT_EPID_GROUP_ID = b'\x00' * 4
+    _DEFAULT_SIGNATURE = b''
+
+    _fixed_format = \
+        '<HH4sHHL{0}s{1}s'.format(
+            SgxBasename.STRUCT_SIZE,
+            SgxReportBody.STRUCT_SIZE)
+    _variable_format = '<L{}s'
+
+    def __init__(self,
+                 version=0,
+                 sign_type=0,
+                 epid_group_id=_DEFAULT_EPID_GROUP_ID,
+                 qe_svn=0,
+                 pce_svn=0,
+                 extended_epid_group_id=0,
+                 basename=SgxBasename(),
+                 report_body=SgxReportBody(),
+                 signature_len=0,
+                 signature=_DEFAULT_SIGNATURE):
+        """Initialize SgxQuote object
+
+        Args:
+            version (int): The version of the quote structure
+            sign_type (int): The EPID signature type
+                0 - Unlinkable signature
+                1 - Linkable signature
+            epid_group_id (bytes): The EPID group id of the platform
+            qe_svn (int): The quoting enclave security version
+            pce_svn (int): The provisioning certification enclave security
+                version
+            extended_epid_group_id (int): The extended EPID group ID
+            basename (SgxBasename): The basename used in the enclave quote
+            report_body (SgxReportBody): The report body of the application
+                enclave
+            signature_len (int): The size, in bytes, of the signature
+            signature(bytes): The signature
+        """
+        self.version = version
+        self.sign_type = sign_type
+        self.epid_group_id = epid_group_id
+        self.qe_svn = qe_svn
+        self.pce_svn = pce_svn
+        self.extended_epid_group_id = extended_epid_group_id
+        self.basename = basename
+        self.report_body = report_body
+        self.signature_len = signature_len
+        self.signature = signature
+
+    def __str__(self):
+        return \
+            'SGX_QUOTE: version={}, sign_type={}, epid_group_id={}, '\
+            'qe_svn={}, pce_svn={}, extended_epid_group_id={}, '\
+            'basename={{{}}}, report_body={{{}}}, signature_len={}, '\
+            'signature={}'.format(
+                self.version,
+                self.sign_type,
+                self.epid_group_id.hex(),
+                self.qe_svn,
+                self.pce_svn,
+                self.extended_epid_group_id,
+                self.basename,
+                self.report_body,
+                self.signature_len,
+                self.signature.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: All integer struct fields are serialized to little endian
+            format
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        fixed_bytes = \
+            struct.pack(
+                self._fixed_format,
+                self.version,
+                self.sign_type,
+                self.epid_group_id,
+                self.qe_svn,
+                self.pce_svn,
+                self.extended_epid_group_id,
+                self.basename.serialize_to_bytes(),
+                self.report_body.serialize_to_bytes())
+        variable_bytes =\
+            struct.pack(
+                self._variable_format.format(self.signature_len),
+                self.signature_len,
+                self.signature)
+        return fixed_bytes + variable_bytes
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        NOTE: All integer struct fields are parsed as little endian
+            format
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            # First unpack the fixed portion of the structure
+            (self.version,
+             self.sign_type,
+             self.epid_group_id,
+             self.qe_svn,
+             self.pce_svn,
+             self.extended_epid_group_id,
+             basename,
+             report_body) = \
+                struct.unpack(
+                    '<HH4sHHL{0}s{1}s'.format(
+                        SgxBasename.STRUCT_SIZE,
+                        SgxReportBody.STRUCT_SIZE),
+                    raw_buffer[:self.FIXED_STRUCT_SIZE])
+
+            # Further parse embedded structures
+            self.basename.parse_from_bytes(basename)
+            self.report_body.parse_from_bytes(report_body)
+
+            # Set default values for signature
+            self.signature_len = 0
+            self.signature = self._DEFAULT_SIGNATURE
+
+            # It appears from empirical testing that if there is no signature
+            # then in some cases, specifically when receiving a quote from
+            # IAS, the signature length field appears to not be included.
+            if len(raw_buffer) > self.FIXED_STRUCT_SIZE:
+                (self.signature_len,) = \
+                    struct.unpack(
+                        '<L',
+                        raw_buffer[
+                            self.FIXED_STRUCT_SIZE:
+                            self.FIXED_STRUCT_SIZE + 4])
+
+                # If the signature length is non-zero, then the rest of the
+                # buffer is the signature.  We are still going to use
+                # struct.unpack in order to verify the length, etc.
+                if self.signature_len != 0:
+                    (self.signature,) = \
+                        struct.unpack(
+                            '<{}s'.format(self.signature_len),
+                            raw_buffer[self.FIXED_STRUCT_SIZE + 4:])
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report.py
@@ -1,0 +1,116 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+from sawtooth_poet_common.sgx_structs._sgx_report_body import SgxReportBody
+from sawtooth_poet_common.sgx_structs._sgx_key_id import SgxKeyId
+
+
+class SgxReport(SgxStruct):
+    """
+    Provide a wrapper around sgx_report_t structure
+
+    #define SGX_MAC_SIZE 16
+    typedef uint8_t sgx_mac_t[SGX_MAC_SIZE];
+
+    typedef struct _report_t
+    {
+        sgx_report_body_t   body;   /* 0   */
+        sgx_key_id_t        key_id; /* 384 */
+        sgx_mac_t           mac;    /* 416 */
+    } sgx_report_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 432
+
+    _DEFAULT_MAC = b'\x00' * 16
+
+    _format = \
+        '<{}s{}s{}s'.format(
+            SgxReportBody.STRUCT_SIZE,
+            SgxKeyId.STRUCT_SIZE,
+            len(_DEFAULT_MAC))
+
+    def __init__(self,
+                 body=SgxReportBody(),
+                 key_id=SgxKeyId(),
+                 mac=_DEFAULT_MAC):
+        """Initialize SgxReport object
+
+        Args:
+            body (SgxReportBody): Information about the enclave
+            key_id (SgxKeyId): Value for the key wear-out protection
+            mac (bytes): The CMAC value of the report data
+        """
+        self.body = body
+        self.key_id = key_id
+        self.mac = mac
+
+    def __str__(self):
+        return \
+            'SGX_REPORT: body={{{}}}, key_id={{{}}}, mac={}'.format(
+                self.body,
+                self.key_id,
+                self.mac.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: All integer struct fields are serialized to little endian
+            format
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return \
+            struct.pack(
+                self._format,
+                self.body.serialize_to_bytes(),
+                self.key_id.serialize_to_bytes(),
+                self.mac)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        NOTE: All integer struct fields are parsed as little endian
+            format
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (body, key_id, self.mac) = struct.unpack(self._format, raw_buffer)
+
+            # Further parse embedded structures
+            self.body.parse_from_bytes(body)
+            self.key_id.parse_from_bytes(key_id)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report_body.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report_body.py
@@ -1,0 +1,176 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+from sawtooth_poet_common.sgx_structs._sgx_cpu_svn import SgxCpuSvn
+from sawtooth_poet_common.sgx_structs._sgx_attributes import SgxAttributes
+from sawtooth_poet_common.sgx_structs._sgx_measurement import SgxMeasurement
+from sawtooth_poet_common.sgx_structs._sgx_report_data import SgxReportData
+
+
+class SgxReportBody(SgxStruct):
+    """
+    Provide a wrapper around sgx_report_body_t structure
+
+    typedef uint32_t sgx_misc_select_t;
+    typedef uint16_t sgx_prod_id_t;
+    typedef uint16_t sgx_isv_svn_t;
+
+    typedef struct _report_body_t
+    {
+        sgx_cpu_svn_t           cpu_svn;        /* 0   */
+        sgx_misc_select_t       misc_select;    /* 16  */
+        uint8_t                 reserved1[28];  /* 20  */
+        sgx_attributes_t        attributes;     /* 48  */
+        sgx_measurement_t       mr_enclave;     /* 64  */
+        uint8_t                 reserved2[32];  /* 96  */
+        sgx_measurement_t       mr_signer;      /* 128 */
+        uint8_t                 reserved3[96];  /* 160 */
+        sgx_prod_id_t           isv_prod_id;    /* 256 */
+        sgx_isv_svn_t           isv_svn;        /* 258 */
+        uint8_t                 reserved4[60];  /* 260 */
+        sgx_report_data_t       report_data;    /* 320 */
+    } sgx_report_body_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 384
+
+    _RESERVED_1 = b'\x00' * 28
+    _RESERVED_2 = b'\x00' * 32
+    _RESERVED_3 = b'\x00' * 96
+    _RESERVED_4 = b'\x00' * 60
+
+    _format = \
+        '<{0}sL28s{1}s{2}s32s{2}s96sHH60s{3}s'.format(
+            SgxCpuSvn.STRUCT_SIZE,
+            SgxAttributes.STRUCT_SIZE,
+            SgxMeasurement.STRUCT_SIZE,
+            SgxReportData.STRUCT_SIZE)
+
+    def __init__(self,
+                 cpu_svn=SgxCpuSvn(),
+                 misc_select=0,
+                 attributes=SgxAttributes(),
+                 mr_enclave=SgxMeasurement(),
+                 mr_signer=SgxMeasurement(),
+                 isv_prod_id=0,
+                 isv_svn=0,
+                 report_data=SgxReportData()):
+        """Initialize SgxReportBody object
+
+        Args:
+            cpu_svn (SgxCpuSvn): Security version number of host system CPU
+            misc_select (int): The miscellaneous select bits for the enclave
+            attributes (SgxAttributes): The attributes for the enclave
+            mr_enclave (SgxMeasurement): The measurement value of the enclave
+            mr_signer (SgxMeasurement): The measurement value of the public
+                key that verified the enclave
+            isv_prod_id (int): The ISV product ID of the enclave
+            isv_svn (int): The ISV security version number of the enclave
+            report_data (SgxReportData):
+        """
+        self.cpu_svn = cpu_svn
+        self.misc_select = misc_select
+        self.attributes = attributes
+        self.mr_enclave = mr_enclave
+        self.mr_signer = mr_signer
+        self.isv_prod_id = isv_prod_id
+        self.isv_svn = isv_svn
+        self.report_data = report_data
+
+    def __str__(self):
+        return \
+            'SGX_REPORT_BODY: cpu_svn={{{}}}, misc_select={}, ' \
+            'attributes={{{}}}, mr_enclave={{{}}}, mr_signer={{{}}}, ' \
+            'isv_prod_id={}, isv_svn={}, report_data={{{}}}'.format(
+                self.cpu_svn,
+                self.misc_select,
+                self.attributes,
+                self.mr_enclave,
+                self.mr_signer,
+                self.isv_prod_id,
+                self.isv_svn,
+                self.report_data)
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: All integer struct fields are serialized to little endian
+            format
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return \
+            struct.pack(
+                self._format,
+                self.cpu_svn.serialize_to_bytes(),
+                self.misc_select,
+                self._RESERVED_1,
+                self.attributes.serialize_to_bytes(),
+                self.mr_enclave.serialize_to_bytes(),
+                self._RESERVED_2,
+                self.mr_signer.serialize_to_bytes(),
+                self._RESERVED_3,
+                self.isv_prod_id,
+                self.isv_svn,
+                self._RESERVED_4,
+                self.report_data.serialize_to_bytes())
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (cpu_svn,
+             self.misc_select,
+             _,
+             attributes,
+             mr_enclave,
+             _,
+             mr_signer,
+             _,
+             self.isv_prod_id,
+             self.isv_svn,
+             _,
+             report_data) = \
+                struct.unpack(self._format, raw_buffer)
+
+            # Further parse embedded structures
+            self.cpu_svn.parse_from_bytes(cpu_svn)
+            self.attributes.parse_from_bytes(attributes)
+            self.mr_enclave.parse_from_bytes(mr_enclave)
+            self.mr_signer.parse_from_bytes(mr_signer)
+            self.report_data.parse_from_bytes(report_data)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report_data.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_report_data.py
@@ -1,0 +1,88 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import struct
+
+from sawtooth_poet_common.sgx_structs._sgx_struct import SgxStruct
+
+
+class SgxReportData(SgxStruct):
+    """
+    Provide a wrapper around sgx_report_data_t
+
+    #define SGX_REPORT_DATA_SIZE 64
+
+    typedef struct _sgx_report_data_t
+    {
+        uint8_t d[SGX_REPORT_DATA_SIZE];
+    } sgx_report_data_t;
+
+    See: https://01.org/sites/default/files/documentation/
+                intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf
+    """
+
+    STRUCT_SIZE = 64
+
+    _DEFAULT_D = b'\x00' * STRUCT_SIZE
+
+    _format = '<{}s'.format(STRUCT_SIZE)
+
+    def __init__(self, d=_DEFAULT_D):
+        """Initialize SgxReportData object
+
+        Args:
+            d (bytes): Report data exchanged between enclaves
+        """
+
+        # pylint: disable=invalid-name
+        self.d = d
+
+    def __str__(self):
+        return 'SGX_REPORT_DATA: d={}'.format(self.d.hex())
+
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: If len(self.d) is less than self.STRUCT_SIZE, the
+            resulting bytes will be padded with binary zero (\x00).  If
+            len(self.d) is greater than self.STRUCT_SIZE, the
+            resulting bytes will be truncated to self.STRUCT_SIZE.
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        return struct.pack(self._format, self.d)
+
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+
+        try:
+            (self.d,) = struct.unpack(self._format, raw_buffer)
+        except struct.error as se:
+            raise ValueError('Unable to parse: {}'.format(se))

--- a/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_struct.py
+++ b/consensus/poet/common/sawtooth_poet_common/sgx_structs/_sgx_struct.py
@@ -1,0 +1,57 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+
+class SgxStruct(metaclass=ABCMeta):
+    """SgxStruct defines the base class that all Sgx* structures must
+    implement
+    """
+
+    @abstractmethod
+    def serialize_to_bytes(self):
+        """Serializes a object representing an SGX structure to bytes
+        laid out in its corresponding C/C++ format.
+
+        NOTE: All integer struct fields are serialized to little endian
+            format
+
+        Returns:
+            bytes: The C/C++ representation of the object as a struct
+        """
+        pass
+
+    @abstractmethod
+    def parse_from_bytes(self, raw_buffer):
+        """Parses a byte array and creates the Sgx* object corresponding
+        to the C/C++ struct.
+
+        NOTE: All integer struct fields are parsed as little endian
+            format
+
+        Args:
+            raw_buffer (bytes): A byte array representing the corresponding
+                C/C++ struct used to parse into the object
+
+        Returns:
+            None
+
+        Raises:
+            TypeError: raw_buffer is not a byte array (aka, bytes)
+            ValueError: raw_buffer is not a valid C/C++ struct layout
+        """
+        pass

--- a/consensus/poet/common/tests/test_sgx_structs/__init__.py
+++ b/consensus/poet/common/tests/test_sgx_structs/__init__.py
@@ -12,18 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-
-version: "2.1"
-
-services:
-
-  poet:
-    image: sawtooth-test:$ISOLATION_ID
-    volumes:
-      - ../../../../..:/project/sawtooth-core
-    working_dir: /project/sawtooth-core/consensus/poet/common
-    entrypoint: nose2-3 -s tests/test_validator_registry_view -v
-    environment:
-        PYTHONPATH: "\
-          /project/sawtooth-core/consensus/poet/common:\
-          /project/sawtooth-core/consensus/poet/common/tests"

--- a/consensus/poet/common/tests/test_sgx_structs/tests.py
+++ b/consensus/poet/common/tests/test_sgx_structs/tests.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+import struct
+import os
+
+from sawtooth_poet_common import sgx_structs
+
+# NOTE - all of the tests below that unpack a buffer into an integer (16-, 32-,
+# or 64-bit) assume that the unsigned integer is in little endian (i.e., if the
+# buffer is '00112233', the integer value is actually 0x33221100) as these
+# structures are meant to be used with data being returned from IAS and in
+# their documentation, all integers in structures are assumed to be laid out as
+# little endian.
+
+
+class TestSgxStructs(unittest.TestCase):
+
+    @staticmethod
+    def create_random_buffer(length):
+        return os.urandom(length)
+
+    def test_sgx_cpu_svn(self):
+        sgx_cpu_svn = sgx_structs.SgxCpuSvn()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_cpu_svn.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_cpu_svn.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_cpu_svn.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxCpuSvn.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_cpu_svn.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxCpuSvn.STRUCT_SIZE + 1))
+
+        # Verify sgx_cpu_svn unpacks properly
+        cpu_svn = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxCpuSvn.STRUCT_SIZE)
+
+        sgx_cpu_svn.parse_from_bytes(cpu_svn)
+        self.assertTrue(sgx_cpu_svn.svn == cpu_svn)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_cpu_svn = sgx_structs.SgxCpuSvn(svn=cpu_svn)
+        self.assertEqual(cpu_svn, sgx_cpu_svn.serialize_to_bytes())
+
+    def test_sgx_attributes(self):
+        sgx_attributes = sgx_structs.SgxAttributes()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_attributes.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_attributes.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_attributes.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxAttributes.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_attributes.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxAttributes.STRUCT_SIZE + 1))
+
+        # Simply verify that buffer of correct size unpacks without error
+        sgx_attributes.parse_from_bytes(
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxAttributes.STRUCT_SIZE))
+
+        # Verify sgx_attributes unpacks properly.
+        flags = 0x0001020304050607
+        xfrm = 0x08090a0b0c0d0e0f
+        attributes = struct.pack(b'<QQ', flags, xfrm)
+        sgx_attributes.parse_from_bytes(attributes)
+
+        self.assertTrue(sgx_attributes.flags == flags)
+        self.assertTrue(sgx_attributes.xfrm == xfrm)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_attributes = sgx_structs.SgxAttributes(flags=flags, xfrm=xfrm)
+        self.assertEqual(attributes, sgx_attributes.serialize_to_bytes())
+
+    def test_sgx_measurement(self):
+        sgx_measurement = sgx_structs.SgxMeasurement()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_measurement.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_measurement.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_measurement.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxMeasurement.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_measurement.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxMeasurement.STRUCT_SIZE + 1))
+
+        # Verify sgx_measurement unpacks properly
+        measurement = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        sgx_measurement.parse_from_bytes(measurement)
+
+        self.assertTrue(sgx_measurement.m == measurement)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_measurement = sgx_structs.SgxMeasurement(m=measurement)
+        self.assertEqual(measurement, sgx_measurement.serialize_to_bytes())
+
+    def test_sgx_report_data(self):
+        sgx_report_data = sgx_structs.SgxReportData()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_report_data.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_report_data.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_report_data.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReportData.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_report_data.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReportData.STRUCT_SIZE + 1))
+
+        # Verify sgx_report_data unpacks properly
+        report_data = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReportData.STRUCT_SIZE)
+        sgx_report_data.parse_from_bytes(report_data)
+
+        self.assertTrue(sgx_report_data.d == report_data)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_report_data = sgx_structs.SgxReportData(d=report_data)
+        self.assertEqual(report_data, sgx_report_data.serialize_to_bytes())
+
+    def test_sgx_report_body(self):
+        sgx_report_body = sgx_structs.SgxReportBody()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_report_body.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_report_body.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_report_body.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReportBody.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_report_body.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReportBody.STRUCT_SIZE + 1))
+
+        # Simply verify that buffer of correct size unpacks without error
+        sgx_report_body.parse_from_bytes(
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReportBody.STRUCT_SIZE))
+
+        # The report body is laid out as follows:
+        #
+        # sgx_cpu_svn_t           cpu_svn;        /* 0   */
+        # sgx_misc_select_t       misc_select;    /* 16  */
+        # uint8_t                 reserved1[28];  /* 20  */
+        # sgx_attributes_t        attributes;     /* 48  */
+        # sgx_measurement_t       mr_enclave;     /* 64  */
+        # uint8_t                 reserved2[32];  /* 96  */
+        # sgx_measurement_t       mr_signer;      /* 128 */
+        # uint8_t                 reserved3[96];  /* 160 */
+        # sgx_prod_id_t           isv_prod_id;    /* 256 */
+        # sgx_isv_svn_t           isv_svn;        /* 258 */
+        # uint8_t                 reserved4[60];  /* 260 */
+        # sgx_report_data_t       report_data;    /* 320 */
+
+        # sgx_cpu_svn = sgx_structs.SgxCpuSvn(cpu_svn=svn)
+        # sgx_attributes = sgx_structs.SgxAttributes(flags=flags, xfrm=xfrm)
+        # sgx_measurement_mr_enclave = sgx_structs.SgxMeasurement(m=mr_enclave)
+        # sgx_measurement_mr_signer = sgx_structs.SgxMeasurement(m=mr_signer)
+        # sgx_report_data = sgx_structs.SgxReportData(d=report_data)
+
+        # Verify sgx_report_body unpacks properly
+        svn = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxCpuSvn.STRUCT_SIZE)
+        misc_select = 0x00010203
+        reserved1 = b'\x00' * 28
+        flags = 0x0405060708090a0b
+        xfrm = 0x0c0d0e0f10111213
+        mr_enclave = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved2 = b'\x00' * 32
+        mr_signer = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved3 = b'\x00' * 96
+        isv_prod_id = 0x1415
+        isv_svn = 0x1617
+        reserved4 = b'\x00' * 60
+        report_data = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReportData.STRUCT_SIZE)
+        report_body = \
+            struct.pack(
+                '<{}sL{}sQQ{}s{}s{}s{}sHH{}s{}s'.format(
+                    len(svn),
+                    len(reserved1),
+                    len(mr_enclave),
+                    len(reserved2),
+                    len(mr_signer),
+                    len(reserved3),
+                    len(reserved4),
+                    len(report_data)
+                ),
+                svn,
+                misc_select,
+                reserved1,
+                flags,
+                xfrm,
+                mr_enclave,
+                reserved2,
+                mr_signer,
+                reserved3,
+                isv_prod_id,
+                isv_svn,
+                reserved4,
+                report_data)
+
+        sgx_report_body.parse_from_bytes(report_body)
+
+        self.assertTrue(sgx_report_body.cpu_svn.svn == svn)
+        self.assertTrue(sgx_report_body.misc_select == misc_select)
+        self.assertTrue(sgx_report_body.attributes.flags == flags)
+        self.assertTrue(sgx_report_body.attributes.xfrm == xfrm)
+        self.assertTrue(sgx_report_body.mr_enclave.m == mr_enclave)
+        self.assertTrue(sgx_report_body.mr_signer.m == mr_signer)
+        self.assertTrue(sgx_report_body.isv_prod_id == isv_prod_id)
+        self.assertTrue(sgx_report_body.isv_svn == isv_svn)
+        self.assertTrue(sgx_report_body.report_data.d == report_data)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_cpu_svn = sgx_structs.SgxCpuSvn(svn=svn)
+        sgx_attributes = sgx_structs.SgxAttributes(flags=flags, xfrm=xfrm)
+        sgx_measurement_mr_enclave = sgx_structs.SgxMeasurement(m=mr_enclave)
+        sgx_measurement_mr_signer = sgx_structs.SgxMeasurement(m=mr_signer)
+        sgx_report_data = sgx_structs.SgxReportData(d=report_data)
+        sgx_report_body = \
+            sgx_structs.SgxReportBody(
+                cpu_svn=sgx_cpu_svn,
+                misc_select=misc_select,
+                attributes=sgx_attributes,
+                mr_enclave=sgx_measurement_mr_enclave,
+                mr_signer=sgx_measurement_mr_signer,
+                isv_prod_id=isv_prod_id,
+                isv_svn=isv_svn,
+                report_data=sgx_report_data)
+        self.assertEqual(report_body, sgx_report_body.serialize_to_bytes())
+
+    def test_sgx_key_id(self):
+        sgx_key_id = sgx_structs.SgxKeyId()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_key_id.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_key_id.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_key_id.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxKeyId.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_key_id.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxKeyId.STRUCT_SIZE + 1))
+
+        # Verify sgx_key_id unpacks properly
+        key_id = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxKeyId.STRUCT_SIZE)
+        sgx_key_id.parse_from_bytes(key_id)
+
+        self.assertTrue(sgx_key_id.id == key_id)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_key_id = sgx_structs.SgxKeyId(identifier=key_id)
+        self.assertEqual(key_id, sgx_key_id.serialize_to_bytes())
+
+    def test_sgx_report(self):
+        sgx_report = sgx_structs.SgxReport()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_report.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_report.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_report.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReport.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_report.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxReport.STRUCT_SIZE + 1))
+
+        # Simply verify that buffer of correct size unpacks without error
+        sgx_report.parse_from_bytes(
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReport.STRUCT_SIZE))
+
+        # The report body is laid out as follows:
+        #
+        # sgx_report_body_t   body;   /* 0   */
+        # sgx_key_id_t        key_id; /* 384 */
+        # sgx_mac_t           mac;    /* 416 */
+
+        # Verify sgx_report unpacks properly
+        svn = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxCpuSvn.STRUCT_SIZE)
+        misc_select = 0x00010203
+        reserved1 = b'\x00' * 28
+        flags = 0x0405060708090a0b
+        xfrm = 0x0c0d0e0f10111213
+        mr_enclave = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved2 = b'\x00' * 32
+        mr_signer = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved3 = b'\x00' * 96
+        isv_prod_id = 0x1415
+        isv_svn = 0x1617
+        reserved4 = b'\x00' * 60
+        report_data = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReportData.STRUCT_SIZE)
+        report_body = \
+            struct.pack(
+                '<{}sL{}sQQ{}s{}s{}s{}sHH{}s{}s'.format(
+                    len(svn),
+                    len(reserved1),
+                    len(mr_enclave),
+                    len(reserved2),
+                    len(mr_signer),
+                    len(reserved3),
+                    len(reserved4),
+                    len(report_data)
+                ),
+                svn,
+                misc_select,
+                reserved1,
+                flags,
+                xfrm,
+                mr_enclave,
+                reserved2,
+                mr_signer,
+                reserved3,
+                isv_prod_id,
+                isv_svn,
+                reserved4,
+                report_data)
+        key_id = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxKeyId.STRUCT_SIZE)
+        mac = TestSgxStructs.create_random_buffer(16)
+        report = \
+            struct.pack(
+                '<{}s{}s{}s'.format(
+                    len(report_body),
+                    len(key_id),
+                    len(mac)),
+                report_body,
+                key_id,
+                mac)
+
+        sgx_report.parse_from_bytes(report)
+
+        self.assertTrue(sgx_report.body.cpu_svn.svn == svn)
+        self.assertTrue(sgx_report.body.misc_select == misc_select)
+        self.assertTrue(sgx_report.body.attributes.flags == flags)
+        self.assertTrue(sgx_report.body.attributes.xfrm == xfrm)
+        self.assertTrue(sgx_report.body.mr_enclave.m == mr_enclave)
+        self.assertTrue(sgx_report.body.mr_signer.m == mr_signer)
+        self.assertTrue(sgx_report.body.isv_prod_id == isv_prod_id)
+        self.assertTrue(sgx_report.body.isv_svn == isv_svn)
+        self.assertTrue(sgx_report.body.report_data.d == report_data)
+        self.assertTrue(sgx_report.key_id.id == key_id)
+        self.assertTrue(sgx_report.mac == mac)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_cpu_svn = sgx_structs.SgxCpuSvn(svn=svn)
+        sgx_attributes = sgx_structs.SgxAttributes(flags=flags, xfrm=xfrm)
+        sgx_measurement_mr_enclave = sgx_structs.SgxMeasurement(m=mr_enclave)
+        sgx_measurement_mr_signer = sgx_structs.SgxMeasurement(m=mr_signer)
+        sgx_report_data = sgx_structs.SgxReportData(d=report_data)
+        sgx_report_body = \
+            sgx_structs.SgxReportBody(
+                cpu_svn=sgx_cpu_svn,
+                misc_select=misc_select,
+                attributes=sgx_attributes,
+                mr_enclave=sgx_measurement_mr_enclave,
+                mr_signer=sgx_measurement_mr_signer,
+                isv_prod_id=isv_prod_id,
+                isv_svn=isv_svn,
+                report_data=sgx_report_data)
+        sgx_key_id = sgx_structs.SgxKeyId(identifier=key_id)
+        sgx_report = \
+            sgx_structs.SgxReport(
+                body=sgx_report_body,
+                key_id=sgx_key_id,
+                mac=mac)
+        self.assertEqual(report, sgx_report.serialize_to_bytes())
+
+    def test_sgx_basename(self):
+        sgx_basename = sgx_structs.SgxBasename()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_basename.parse_from_bytes('')
+
+        # Test an empty string, a string that is one too short, and a string
+        # that is one too long
+        with self.assertRaises(ValueError):
+            sgx_basename.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_basename.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxBasename.STRUCT_SIZE - 1))
+        with self.assertRaises(ValueError):
+            sgx_basename.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxBasename.STRUCT_SIZE + 1))
+
+        # Verify sgx_basename unpacks properly
+        basename = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxBasename.STRUCT_SIZE)
+        sgx_basename.parse_from_bytes(basename)
+
+        self.assertTrue(sgx_basename.name == basename)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_basename = sgx_structs.SgxBasename(name=basename)
+        self.assertEqual(basename, sgx_basename.serialize_to_bytes())
+
+    def test_sgx_quote(self):
+        sgx_quote = sgx_structs.SgxQuote()
+
+        # Test with None and invalid types
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes(None)
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes([])
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes({})
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes(1)
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes(1.0)
+        with self.assertRaises(TypeError):
+            sgx_quote.parse_from_bytes('')
+
+        # Test an empty string and a buffer one too small
+        with self.assertRaises(ValueError):
+            sgx_quote.parse_from_bytes(b'')
+        with self.assertRaises(ValueError):
+            sgx_quote.parse_from_bytes(
+                b'\x00' * (sgx_structs.SgxQuote.FIXED_STRUCT_SIZE - 1))
+
+        # typedef uint8_t sgx_epid_group_id_t[4];
+        # typedef uint16_t sgx_isv_svn_t;
+
+        # uint16_t            version;                /* 0   */
+        # uint16_t            sign_type;              /* 2   */
+        # sgx_epid_group_id_t epid_group_id;          /* 4   */
+        # sgx_isv_svn_t       qe_svn;                 /* 8   */
+        # sgx_isv_svn_t       pce_svn;                /* 10  */
+        # uint32_t            extended_epid_group_id; /* 12  */
+        # sgx_basename_t      basename;               /* 16  */
+        # sgx_report_body_t   report_body;            /* 48  */
+        # uint32_t            signature_len;          /* 432 */
+        # uint8_t             signature[];            /* 436 */
+
+        # Verify sgx_quote unpacks properly
+        version = 0x0102
+        sign_type = 0x0304
+        epid_group_id = TestSgxStructs.create_random_buffer(4)
+        qe_svn = 0x0506
+        pce_svn = 0x0708
+        extended_epid_group_id = 0x090a0b0c
+        basename = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxBasename.STRUCT_SIZE)
+        svn = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxCpuSvn.STRUCT_SIZE)
+        misc_select = 0x0d0e0f10
+        reserved1 = b'\x00' * 28
+        flags = 0x1112131415161718
+        xfrm = 0x191a1b1c1d1e1f20
+        mr_enclave = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved2 = b'\x00' * 32
+        mr_signer = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxMeasurement.STRUCT_SIZE)
+        reserved3 = b'\x00' * 96
+        isv_prod_id = 0x2122
+        isv_svn = 0x2324
+        reserved4 = b'\x00' * 60
+        report_data = \
+            TestSgxStructs.create_random_buffer(
+                sgx_structs.SgxReportData.STRUCT_SIZE)
+        report_body = \
+            struct.pack(
+                '<{}sL{}sQQ{}s{}s{}s{}sHH{}s{}s'.format(
+                    len(svn),
+                    len(reserved1),
+                    len(mr_enclave),
+                    len(reserved2),
+                    len(mr_signer),
+                    len(reserved3),
+                    len(reserved4),
+                    len(report_data)
+                ),
+                svn,
+                misc_select,
+                reserved1,
+                flags,
+                xfrm,
+                mr_enclave,
+                reserved2,
+                mr_signer,
+                reserved3,
+                isv_prod_id,
+                isv_svn,
+                reserved4,
+                report_data)
+        quote = \
+            struct.pack(
+                '<HH{}sHHL{}s{}s'.format(
+                    len(epid_group_id),
+                    len(basename),
+                    len(report_body)),
+                version,
+                sign_type,
+                epid_group_id,
+                qe_svn,
+                pce_svn,
+                extended_epid_group_id,
+                basename,
+                report_body)
+
+        sgx_quote.parse_from_bytes(quote)
+
+        self.assertTrue(sgx_quote.version == version)
+        self.assertTrue(sgx_quote.sign_type == sign_type)
+        self.assertTrue(sgx_quote.epid_group_id == epid_group_id)
+        self.assertTrue(sgx_quote.qe_svn == qe_svn)
+        self.assertTrue(sgx_quote.pce_svn == pce_svn)
+        self.assertTrue(sgx_quote.basename.name == basename)
+        self.assertTrue(sgx_quote.report_body.cpu_svn.svn == svn)
+        self.assertTrue(sgx_quote.report_body.misc_select == misc_select)
+        self.assertTrue(sgx_quote.report_body.attributes.flags == flags)
+        self.assertTrue(sgx_quote.report_body.attributes.xfrm == xfrm)
+        self.assertTrue(sgx_quote.report_body.mr_enclave.m == mr_enclave)
+        self.assertTrue(sgx_quote.report_body.mr_signer.m == mr_signer)
+        self.assertTrue(sgx_quote.report_body.isv_prod_id == isv_prod_id)
+        self.assertTrue(sgx_quote.report_body.isv_svn == isv_svn)
+        self.assertTrue(sgx_quote.report_body.report_data.d == report_data)
+
+        # Add a few bytes so that the signature length is partial.  Should
+        # fail.
+        bad_quote = quote[:]
+        for _ in range(3):
+            bad_quote += TestSgxStructs.create_random_buffer(1)
+            with self.assertRaises(ValueError):
+                sgx_quote.parse_from_bytes(bad_quote)
+
+        # Add a non-zero signature length, but don't add a signature.  Should
+        # fail.
+        bad_quote = struct.pack('<{}sL'.format(len(quote)), quote, 4)
+        with self.assertRaises(ValueError):
+            sgx_quote.parse_from_bytes(bad_quote)
+
+        # Add a signature that is too short
+        short_signature = TestSgxStructs.create_random_buffer(31)
+        bad_quote = \
+            struct.pack(
+                '<{}sL{}s'.format(
+                    len(quote),
+                    len(short_signature)),
+                quote,
+                len(short_signature) + 1,
+                short_signature)
+        with self.assertRaises(ValueError):
+            sgx_quote.parse_from_bytes(bad_quote)
+
+        # Add a signature length of zero without a signature and verify
+        unsigned_quote = struct.pack('<{}sL'.format(len(quote)), quote, 0)
+
+        sgx_quote.parse_from_bytes(unsigned_quote)
+
+        self.assertTrue(sgx_quote.version == version)
+        self.assertTrue(sgx_quote.sign_type == sign_type)
+        self.assertTrue(sgx_quote.epid_group_id == epid_group_id)
+        self.assertTrue(sgx_quote.qe_svn == qe_svn)
+        self.assertTrue(sgx_quote.pce_svn == pce_svn)
+        self.assertTrue(sgx_quote.basename.name == basename)
+        self.assertTrue(sgx_quote.report_body.cpu_svn.svn == svn)
+        self.assertTrue(sgx_quote.report_body.misc_select == misc_select)
+        self.assertTrue(sgx_quote.report_body.attributes.flags == flags)
+        self.assertTrue(sgx_quote.report_body.attributes.xfrm == xfrm)
+        self.assertTrue(sgx_quote.report_body.mr_enclave.m == mr_enclave)
+        self.assertTrue(sgx_quote.report_body.mr_signer.m == mr_signer)
+        self.assertTrue(sgx_quote.report_body.isv_prod_id == isv_prod_id)
+        self.assertTrue(sgx_quote.report_body.isv_svn == isv_svn)
+        self.assertTrue(sgx_quote.report_body.report_data.d == report_data)
+        self.assertTrue(sgx_quote.signature_len == 0)
+
+        # Add a good signature and verify
+        signature = TestSgxStructs.create_random_buffer(32)
+        signed_quote = \
+            struct.pack(
+                '<{}sL{}s'.format(
+                    len(quote),
+                    len(signature)),
+                quote,
+                len(signature),
+                signature)
+
+        sgx_quote.parse_from_bytes(signed_quote)
+
+        self.assertTrue(sgx_quote.version == version)
+        self.assertTrue(sgx_quote.sign_type == sign_type)
+        self.assertTrue(sgx_quote.epid_group_id == epid_group_id)
+        self.assertTrue(sgx_quote.qe_svn == qe_svn)
+        self.assertTrue(sgx_quote.pce_svn == pce_svn)
+        self.assertTrue(sgx_quote.basename.name == basename)
+        self.assertTrue(sgx_quote.report_body.cpu_svn.svn == svn)
+        self.assertTrue(sgx_quote.report_body.misc_select == misc_select)
+        self.assertTrue(sgx_quote.report_body.attributes.flags == flags)
+        self.assertTrue(sgx_quote.report_body.attributes.xfrm == xfrm)
+        self.assertTrue(sgx_quote.report_body.mr_enclave.m == mr_enclave)
+        self.assertTrue(sgx_quote.report_body.mr_signer.m == mr_signer)
+        self.assertTrue(sgx_quote.report_body.isv_prod_id == isv_prod_id)
+        self.assertTrue(sgx_quote.report_body.isv_svn == isv_svn)
+        self.assertTrue(sgx_quote.report_body.report_data.d == report_data)
+        self.assertTrue(sgx_quote.signature_len == len(signature))
+        self.assertTrue(sgx_quote.signature == signature)
+
+        # Reset the object using the field values and verify that we
+        # get expected serialized buffer
+        sgx_basename = sgx_structs.SgxBasename(name=basename)
+        sgx_cpu_svn = sgx_structs.SgxCpuSvn(svn=svn)
+        sgx_attributes = sgx_structs.SgxAttributes(flags=flags, xfrm=xfrm)
+        sgx_measurement_mr_enclave = sgx_structs.SgxMeasurement(m=mr_enclave)
+        sgx_measurement_mr_signer = sgx_structs.SgxMeasurement(m=mr_signer)
+        sgx_report_data = sgx_structs.SgxReportData(d=report_data)
+        sgx_report_body = \
+            sgx_structs.SgxReportBody(
+                cpu_svn=sgx_cpu_svn,
+                misc_select=misc_select,
+                attributes=sgx_attributes,
+                mr_enclave=sgx_measurement_mr_enclave,
+                mr_signer=sgx_measurement_mr_signer,
+                isv_prod_id=isv_prod_id,
+                isv_svn=isv_svn,
+                report_data=sgx_report_data)
+        sgx_quote = sgx_structs.SgxQuote(
+            version=version,
+            sign_type=sign_type,
+            epid_group_id=epid_group_id,
+            qe_svn=qe_svn,
+            pce_svn=pce_svn,
+            extended_epid_group_id=extended_epid_group_id,
+            basename=sgx_basename,
+            report_body=sgx_report_body)
+
+        self.assertEqual(quote, sgx_quote.serialize_to_bytes()[:len(quote)])
+
+        # Verify that zero signature serializes successfully
+        zero_sign_quote = struct.pack('<{}sL'.format(len(quote)), quote, 0)
+
+        self.assertEqual(zero_sign_quote, sgx_quote.serialize_to_bytes())
+
+        # Verify that non-zero signature serializes successfully
+        non_zero_sign_quote = \
+            struct.pack(
+                '<{}sL{}s'.format(
+                    len(quote),
+                    len(signature)),
+                quote,
+                len(signature),
+                signature)
+        sgx_quote.signature_len = len(signature)
+        sgx_quote.signature = signature
+        self.assertEqual(non_zero_sign_quote, sgx_quote.serialize_to_bytes())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/consensus/poet/common/tests/test_sgx_structs/unit_sgx_structs.yaml
+++ b/consensus/poet/common/tests/test_sgx_structs/unit_sgx_structs.yaml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ../../../../..:/project/sawtooth-core
     working_dir: /project/sawtooth-core/consensus/poet/common
-    entrypoint: nose2-3 -s tests/test_validator_registry_view -v
+    entrypoint: nose2-3 -s tests/test_sgx_structs -v
     environment:
         PYTHONPATH: "\
           /project/sawtooth-core/consensus/poet/common:\


### PR DESCRIPTION
Updates the PoET simulator and validator registry transaction processor:

* Python wrapper classes created for supporting the enlcave quote and embedded structures found in IAS attestation verification report. Classes support serializing/deserializing between Python objects and binary layout of corresponding C/C++ structs.
* Simulator uses SGX structs wrapper to create enclave quote layout the same as used by SGX enclave implementation
* Simulator and validator registry transaction processor verify enclave quote in attestation verification report in the same was as SGX enclave implementation
* Validator registry transaction processor unit tests updated for new enclave quote layout