### PR TITLE
Replace block_num with transaction_id in ValidatorInfo.

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -116,7 +116,7 @@ def do_genesis(args):
                 poet_public_key=signup_info.poet_public_key,
                 proof_data=signup_info.proof_data,
                 anti_sybil_id=signup_info.anti_sybil_id),
-            block_num=0)
+        )
     serialized = payload.SerializeToString()
 
     # Create the address that will be used to look up this validator

--- a/consensus/poet/common/tests/test_validator_registry_view/tests.py
+++ b/consensus/poet/common/tests/test_validator_registry_view/tests.py
@@ -38,7 +38,7 @@ class TestValidatorRegistryView(unittest.TestCase):
                 signup_info=SignUpInfo(poet_public_key='my_pubkey',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
-                block_num=123
+                transaction_id="signature"
             ).SerializeToString()
         })
         validator_registry_view = ValidatorRegistryView(state_view)
@@ -47,7 +47,7 @@ class TestValidatorRegistryView(unittest.TestCase):
         self.assertEqual('my_id', info.id)
         self.assertEqual('my_validator', info.name)
         self.assertEqual('sure', info.registered)
-        self.assertEqual(123, info.block_num)
+        self.assertEqual("signature", info.transaction_id)
         self.assertEqual('my_pubkey', info.signup_info.poet_public_key)
         self.assertEqual('beleive me', info.signup_info.proof_data)
         self.assertEqual('no sybil', info.signup_info.anti_sybil_id)
@@ -75,7 +75,7 @@ class TestValidatorRegistryView(unittest.TestCase):
                 signup_info=SignUpInfo(poet_public_key='my_pubkey',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
-                block_num=123
+                transaction_id="signature"
             ).SerializeToString()
         })
         validator_registry_view = ValidatorRegistryView(state_view)
@@ -106,7 +106,7 @@ class TestValidatorRegistryView(unittest.TestCase):
                 signup_info=SignUpInfo(poet_public_key='my_pubkey',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
-                block_num=123
+                transaction_id="signature"
             ).SerializeToString(),
             to_address('another_id'): ValidatorInfo(
                 registered='yep',
@@ -115,7 +115,7 @@ class TestValidatorRegistryView(unittest.TestCase):
                 signup_info=SignUpInfo(poet_public_key='your_pubkey',
                                        proof_data='you betcha',
                                        anti_sybil_id='poor sybil'),
-                block_num=100
+                transaction_id="signature"
             ).SerializeToString()
         })
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -120,7 +120,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     poet_public_key=signup_info.poet_public_key,
                     proof_data=signup_info.proof_data,
                     anti_sybil_id=signup_info.anti_sybil_id),
-                block_num=block_header.block_num)
+            )
         serialized = payload.SerializeToString()
 
         # Create the address that will be used to look up this validator

--- a/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
+++ b/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
@@ -32,9 +32,9 @@ message ValidatorInfo {
     // This is the protocol buffer described below.
     SignUpInfo signup_info = 4;
 
-    // The block number that this ValidatorInfo was set on.
-    // This is used as a form of time to help with the enforcement of the C test.
-    int32 block_num = 5;
+    // The header signature for the ValidatorRegistryPayload transaction. This
+    // will be used to look up the block the ValidatorInfo was committed on.
+    string transaction_id = 5;
 }
 
 
@@ -79,9 +79,5 @@ message ValidatorRegistryPayload {
 
     // This is the protocol buffer described above.
     SignUpInfo signup_info = 4;
-
-    // The block that this transaction is stored on.
-    // This is used as a form of time to help with the enforcement of the C test.
-    int32 block_num = 5;
 
 }

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -405,7 +405,7 @@ class ValidatorRegistryTransactionHandler(object):
             name=validator_name,
             id=validator_id,
             signup_info=val_reg_payload.signup_info,
-            block_num=val_reg_payload.block_num
+            transaction_id=transaction.signature
         )
 
         _update_validator_state(state,

--- a/consensus/poet/families/tests/test_validator_registry/tests.py
+++ b/consensus/poet/families/tests/test_validator_registry/tests.py
@@ -19,6 +19,7 @@ import base64
 import hashlib
 
 from sawtooth_signing import secp256k1_signer as signing
+
 from test_validator_registry.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory
 
@@ -36,9 +37,10 @@ class TestValidatorRegistry(unittest.TestCase):
     def __init__(self, test_name, tester):
         super().__init__(test_name)
         self.tester = tester
-        self.private_key = signing.generate_privkey()
-        self.public_key = signing.encode_pubkey(
-            signing.generate_pubkey(self.private_key), "hex")
+        self.private_key = '5HsjpyQzpeoGAAvNeG5PzQsn1Ght18GgSmDaEUCd1c1HpA2a'\
+                           'vzc'
+        self.public_key = '02f3d385777ab35888fc47af6d123bba6f8b04817a4746e97'\
+                          '446ce1562fc4307d7'
         self.factory = ValidatorRegistryMessageFactory(
             private=self.private_key, public=self.public_key)
 
@@ -59,8 +61,7 @@ class TestValidatorRegistry(unittest.TestCase):
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
-            signup_info=signup_info, block_num=0)
-
+            signup_info=signup_info)
         # Send validator registry payload
         self.tester.send(
             self.factory.create_tp_process_request(payload.id, payload))
@@ -99,7 +100,7 @@ class TestValidatorRegistry(unittest.TestCase):
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
-            signup_info=signup_info, block_num=0)
+            signup_info=signup_info)
 
         # Send validator registry payload
         self.tester.send(
@@ -157,8 +158,7 @@ class TestValidatorRegistry(unittest.TestCase):
             name="val_11111111111111111111111111111111111111111111111111111111"
                  "11111",
             id=self.factory.public_key,
-            signup_info=signup_info,
-            block_num=0)
+            signup_info=signup_info)
 
         # Send validator registry payload
         self.tester.send(
@@ -179,8 +179,8 @@ class TestValidatorRegistry(unittest.TestCase):
             verb="reg",
             name="val_1",
             id="bad",
-            signup_info=signup_info,
-            block_num=0)
+            signup_info=signup_info
+        )
 
         # Send validator registry payload
         self.tester.send(
@@ -202,8 +202,7 @@ class TestValidatorRegistry(unittest.TestCase):
             verb="reg",
             name="val_1",
             id=self.factory.public_key,
-            signup_info=signup_info,
-            block_num=0)
+            signup_info=signup_info)
 
         # Send validator registry payload
         self.tester.send(
@@ -216,8 +215,7 @@ class TestValidatorRegistry(unittest.TestCase):
             verb="reg",
             name="val_1",
             id=self.factory.public_key,
-            signup_info=signup_info,
-            block_num=0)
+            signup_info=signup_info)
 
         # Send validator registry payload
         self.tester.send(

--- a/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
@@ -16,6 +16,8 @@ import base64
 import json
 import hashlib
 
+from collections import OrderedDict
+
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
@@ -123,11 +125,11 @@ class ValidatorRegistryMessageFactory(object):
                 verification_report_json.encode(),
                 padding.PKCS1v15(),
                 hashes.SHA256())
-        proof_data_dict = {
-            'evidence_payload': evidence_payload,
-            'verification_report': verification_report_json,
-            'signature': base64.b64encode(signature).decode()
-        }
+        proof_data_dict = OrderedDict([
+            ('evidence_payload', evidence_payload),
+            ('verification_report', verification_report_json),
+            ('signature', base64.b64encode(signature).decode())]
+        )
 
         return json.dumps(proof_data_dict)
 
@@ -185,22 +187,22 @@ class ValidatorRegistryMessageFactory(object):
         timestamp = '2017-02-16T15:21:24.437048'
 
         # Fake our "proof" data.
-        verification_report = {
-            'epidPseudonym': originator_public_key_hash,
-            'id': base64.b64encode(
+        verification_report = OrderedDict([
+            ('epidPseudonym', originator_public_key_hash),
+            ('id', base64.b64encode(
                 hashlib.sha256(
-                    timestamp.encode()).hexdigest().encode()).decode(),
-            'isvEnclaveQuoteStatus': 'OK',
-            'isvEnclaveQuoteBody':
-                base64.b64encode(sgx_quote.serialize_to_bytes()).decode(),
-            'pseManifestStatus': 'OK',
-            'pseManifestHash':
+                    timestamp.encode()).hexdigest().encode()).decode()),
+            ('isvEnclaveQuoteStatus', 'OK'),
+            ('isvEnclaveQuoteBody',
+                base64.b64encode(sgx_quote.serialize_to_bytes()).decode()),
+            ('pseManifestStatus', 'OK'),
+            ('pseManifestHash',
                 base64.b64encode(
                     hashlib.sha256(
-                        pse_manifest).hexdigest().encode()).decode(),
-            'nonce': most_recent_wait_certificate_id,
-            'timestamp': timestamp
-        }
+                        pse_manifest).hexdigest().encode()).decode()),
+            ('nonce', most_recent_wait_certificate_id),
+            ('timestamp', timestamp)
+        ])
 
         proof_data = \
             self.create_proof_data(
@@ -226,7 +228,7 @@ class ValidatorRegistryMessageFactory(object):
         ]
 
         return self._factory.create_tp_process_request(
-            payload.SerializeToString(), inputs, outputs, [])
+            payload.SerializeToString(), inputs, outputs, [], False)
 
     def create_get_request_validator_info(self):
         addresses = [self._key_to_address(self.public_key)]
@@ -239,7 +241,9 @@ class ValidatorRegistryMessageFactory(object):
             name=validator_name,
             id=self.public_key,
             signup_info=signup_info,
-            block_num=0
+            transaction_id="7a79305e9734fd511386ae877da8770d66c22e4c7b18db8eb2"
+                           "ff6ec16f5a3452749ee49a04ea8a805ec5ec8b5d1fdfbcc6f3"
+                           "bf6374c99c9a906bc2837d0ad25a"
         ).SerializeToString()
 
         address = self._key_to_address(self.public_key)
@@ -252,7 +256,9 @@ class ValidatorRegistryMessageFactory(object):
             name=validator_name,
             id=self.public_key,
             signup_info=signup_info,
-            block_num=0
+            transaction_id="7a79305e9734fd511386ae877da8770d66c22e4c7b18db8eb2"
+                           "ff6ec16f5a3452749ee49a04ea8a805ec5ec8b5d1fdfbcc6f3"
+                           "bf6374c99c9a906bc2837d0ad25a"
         ).SerializeToString()
 
         address = self._key_to_address(self.public_key)

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -163,9 +163,9 @@ protocol buffers code:
     // This is the protocol buffer described above.
     SignUpInfo signup_info = 4;
 
-    // The block that this transaction is stored on.
-    // This is used as a form of time to help with the enforcement of the C test.
-    int32 block_num = 5;
+    // The header signature for the ValidatorRegistryPayload transaction. This
+    // will be used to look up the block the ValidatorInfo was committed on.
+    string transaction_id = 5;
 
   }
 

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -196,7 +196,7 @@ class BlockStore(MutableMapping):
             for batch in block.batches:
                 batch_header = BatchHeader()
                 batch_header.ParseFromString(batch.header)
-                if transaction_id in batch_header.transactions_ids:
+                if transaction_id in batch_header.transaction_ids:
                     return batch
         else:
             raise ValueError("Transaction_id %s not found in BlockStore.",


### PR DESCRIPTION
Update the testing framework to allow for consistent transaction.header_signatures. 
Remove block_num from ValidatorRegistryPayload.
Fix small typo in the block store. 