### PR TITLE
Return Authorization Error status to Transaction Processor

### DIFF
--- a/bin/build_intkey_javascript
+++ b/bin/build_intkey_javascript
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 cd $top_dir/sdk/examples/intkey_javascript
-yarn install --force --no-bin-links
+yarn cache clean && yarn install --force --no-bin-links

--- a/bin/build_javascript_sdk
+++ b/bin/build_javascript_sdk
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 cd $top_dir/sdk/javascript
-yarn install --force --no-bin-links
+yarn cache clean && yarn install --force --no-bin-links

--- a/protos/state_context.proto
+++ b/protos/state_context.proto
@@ -32,7 +32,13 @@ message TpStateGetRequest {
 
 // A response from the contextmanager/validator with a series of State entries
 message TpStateGetResponse {
+    enum Status {
+        OK = 0;
+        AUTHORIZATION_ERROR = 1;
+    }
+
     repeated Entry entries = 1;
+    Status status = 2;
 }
 
 // A request from the handler/tp to put entries in the state of a context
@@ -43,7 +49,13 @@ message TpStateSetRequest {
 
 // A response from the contextmanager/validator with the addresses that were set
 message TpStateSetResponse {
+  enum Status {
+      OK = 0;
+      AUTHORIZATION_ERROR = 1;
+  }
+
     repeated string addresses = 1;
+    Status status = 2;
 }
 
 // A request from the handler/tp to delete state entries at an collection of addresses

--- a/sdk/javascript/protobuf/index.js
+++ b/sdk/javascript/protobuf/index.js
@@ -30,6 +30,12 @@ TpProcessResponse.Status = TpProcessResponse.nested.Status.values
 const TpUnregisterResponse = root.lookup('TpUnregisterResponse')
 TpUnregisterResponse.Status = TpUnregisterResponse.nested.Status.values
 
+const TpStateSetResponse = root.lookup('TpStateSetResponse')
+TpStateSetResponse.Status = TpStateSetResponse.nested.Status.values
+
+const TpStateGetResponse = root.lookup('TpStateGetResponse')
+TpStateGetResponse.Status = TpStateGetResponse.nested.Status.values
+
 const Message = root.lookup('Message')
 Message.MessageType = Message.nested.MessageType.values
 
@@ -61,11 +67,11 @@ module.exports = {
 
   TpStateGetRequest: root.lookup('TpStateGetRequest'),
 
-  TpStateGetResponse: root.lookup('TpStateGetResponse'),
+  TpStateGetResponse,
 
   TpStateSetRequest: root.lookup('TpStateSetRequest'),
 
-  TpStateSetResponse: root.lookup('TpStateSetResponse'),
+  TpStateSetResponse,
 
   //
   // Transaction

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -149,7 +149,7 @@ class StateContext(object):
         found_values = []
         for address in address_list:
             if address not in self._read_list:
-                LOGGER.warning("Authorization exception, address: %s", address)
+                LOGGER.debug("Authorization exception, address: %s", address)
                 raise AuthorizationException(address)
             found_values.append((address,
                                 self._state.get(address)))
@@ -159,6 +159,8 @@ class StateContext(object):
         for add_value_dict in address_value_list:
             for address in add_value_dict.keys():
                 if address not in self._write_list:
+                    LOGGER.debug("Authorization exception, address: %s",
+                                 address)
                     raise AuthorizationException(address)
 
 


### PR DESCRIPTION
When the context_manager returns an AuthorizationException, TpStateGetResponse and TpStateSetResponse will set have the status of AUTHORIZATION_ERROR. The sdk's version of state should then throw an InvalidTransactionError. 

Also add a missing logging statement in context manager and missing step when building javascript.