### PR TITLE
Mark the schedule as complete on set response

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -88,8 +88,10 @@ class SerialScheduler(Scheduler):
                             is_valid=is_valid,
                             state_hash=self._last_state_hash)
 
-            if self._final and self._txn_queue.empty():
-                self._complete = True
+                is_last_batch = \
+                    len(self._batch_statuses) == len(self._last_in_batch)
+                if self._final and is_last_batch:
+                    self._complete = True
             self._condition.notify_all()
 
     def add_batch(self, batch, state_hash=None):
@@ -137,7 +139,7 @@ class SerialScheduler(Scheduler):
     def finalize(self):
         with self._condition:
             self._final = True
-            if self._txn_queue.empty():
+            if len(self._batch_statuses) == len(self._last_in_batch):
                 self._complete = True
             self._condition.notify_all()
 


### PR DESCRIPTION
The serial scheduler marks the schedule as complete when it recieves
responses, not when its queue is empty.  If the queue size is used to
determine comleteness, the schedule is marked as complete before a
transaction processor has replied with a result - this results in
genesis batch processing failing.

Signed-off-by: Peter Schwarz <peterx.schwarz@intel.com>