### PR TITLE
Add graceful error handling when finding handlers in TP

### DIFF
--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
@@ -75,10 +75,10 @@ class IntKeyWorkload(Workload):
         self._streams.append(stream)
 
     def on_validator_removed(self, url):
-        with self.lock:
+        with self._lock:
             self._streams = [s for s in self._streams if s.url != url]
             self._pending_batches = \
-                {t: g for t, g in self._pending_batches.iteritems()
+                {t: g for t, g in self._pending_batches.items()
                  if g.stream.url != url}
 
     def on_all_batches_committed(self):

--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -173,7 +173,8 @@ class WorkloadGenerator(object):
             self._workload.on_validator_discovered(validator)
 
     def _remove_unresponsive_validator(self, validator):
-        self._validator.remove(validator)
+        if validator in self._validators:
+            self._validators.remove(validator)
         self._workload.on_validator_removed(validator)
 
     def on_new_batch(self, batch_id, stream):
@@ -211,8 +212,8 @@ class WorkloadGenerator(object):
                 response.batch_statuses[batch_id])
 
         except ValidatorConnectionError:
-            LOGGER.warnig("The validator at %s is no longer connected. "
-                          "Removing Validator.", stream.url)
+            LOGGER.warning("The validator at %s is no longer connected. "
+                           "Removing Validator.", stream.url)
             self._remove_unresponsive_validator(stream.url)
             return "UNKNOWN"
 


### PR DESCRIPTION
Logs if the wrong type of message is received by the transaction processor or if we do not have a handler to deal with the header family, encoding, and version. 

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>