### PR TITLE
Add security report to pipeline (won't fail build)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,6 +71,10 @@ node ('master') {
             sh 'docker run --rm -v $(pwd):/project/sawtooth-core sawtooth-build-python:$ISOLATION_ID ./bin/run_lint'
         }
 
+        stage("Run Bandit") {
+            sh 'docker run --rm -v $(pwd):/project/sawtooth-core sawtooth-build-python:$ISOLATION_ID ./bin/run_bandit || $TRUE'
+        }
+
         // Run the tests
         stage("Run Tests") {
             sh './bin/run_tests -x java_sdk'

--- a/bin/run_bandit
+++ b/bin/run_bandit
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+
+bandit -ll -r .

--- a/docker/sawtooth-build-python
+++ b/docker/sawtooth-build-python
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y -q \
 
 RUN pip3 install \
     aiohttp==1.3.5 \
+    bandit \
     cryptography \
     grpcio-tools \
     lmdb \

--- a/tools/bootstrap.d/30-python-lib-install.sh
+++ b/tools/bootstrap.d/30-python-lib-install.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-pip3 install pylint
+pip3 install pylint bandit


### PR DESCRIPTION
Installs bandit in vagrant and sawtooth-build-python.

Turns on security linting through bandit for python code. Only reports
security issues of severity MEDIUM or higher. Does not fail the build
yet, because there are issues that need fixing first.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>