### PR TITLE
Add paging controls and responses to client list request handlers

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -28,6 +28,34 @@ message Leaf {
     bytes data = 2;
 }
 
+// Paging controls to be sent with List requests.
+// Attributes:
+//     start_id: The id of a resource to start the page with
+//     end_id: The id of a resource to end the page with
+//     min_index: A resource index relative to the query, the newest being 0
+//     count: The number of results per page, defaults to and maxes out at 1000
+message PagingControls {
+    oneof location_marker {
+        string start_id = 1;
+        string end_id = 2;
+        int32 start_index = 3;
+    }
+    int32 count = 4;
+}
+
+// Information about the pagination used, sent back with List responses.
+// Attributes:
+//     next_id: The id of the first resource in the next page
+//     previous_id: The id of the last resource in the previous page
+//     start_index: The index of the first resource in this page
+//     total_resources: The total resources available from the requested query
+message PagingResponse {
+    string next_id = 1;
+    string previous_id = 2;
+    int32 start_index = 3;
+    int32 total_resources = 4;
+}
+
 // Submits a list of Batches to be added to the blockchain.
 // If `wait_for_commit` is set to true, the validator will wait to respond
 // until all batches are committed, or until the specified `timeout`
@@ -134,6 +162,7 @@ message ClientStateListRequest {
         string head_id = 2;
     }
     string address = 3;
+    PagingControls paging = 4;
 }
 
 // A response that lists the data Entries from the state's merkle tree,
@@ -158,6 +187,7 @@ message ClientStateListResponse {
     Status status = 1;
     repeated Leaf leaves = 2;
     string head_id = 3;
+    PagingResponse paging = 4;
 }
 
 // A request from a client for a particular entry in the merkle tree.
@@ -205,6 +235,7 @@ message ClientStateGetResponse {
 message ClientBlockListRequest {
     string head_id = 1;
     repeated string block_ids = 2;
+    PagingControls paging = 3;
 }
 
 // A response that lists a chain of blocks with the newest at the beginning,
@@ -227,6 +258,7 @@ message ClientBlockListResponse {
     Status status = 1;
     repeated Block blocks = 2;
     string head_id = 3;
+    PagingResponse paging = 4;
 }
 
 // A request to return a specific block from the validator. The block must be
@@ -260,6 +292,7 @@ message ClientBlockGetResponse {
 message ClientBatchListRequest {
     string head_id = 1;
     repeated string batch_ids = 2;
+    PagingControls paging = 3;
 }
 
 // A response that lists batches with the newest to oldest.
@@ -281,6 +314,7 @@ message ClientBatchListResponse {
     Status status = 1;
     repeated Batch batches = 2;
     string head_id = 3;
+    PagingResponse paging = 4;
 }
 
 // Fetches a specific batch by its id (header_signature) from the blockchain.

--- a/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
@@ -40,6 +40,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'B-2' (the latest)
+            - the default paging response, showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
             - the first item has a header_signature of 'b-2'
@@ -48,6 +49,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-2', response.batches[0].header_signature)
@@ -57,12 +59,13 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of INTERNAL_ERROR
-            - that batches and head_id are missing
+            - that head_id, paging, and batches are missing
         """
         response = self.make_bad_request(head_id='B-1')
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
     def test_batch_list_bad_request(self):
@@ -70,13 +73,14 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of NOT_READY
-            - that batches and head_id are missing
+            - that head_id, paging, and batches are missing
         """
         self.break_genesis()
         response = self.make_request()
 
         self.assertEqual(self.status.NOT_READY, response.status)
         self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
     def test_batch_list_with_head(self):
@@ -89,6 +93,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'B-1'
+            - a paging response showing all 2 resources returned
             - a list of batches with 2 items
             - the items are instances of Batch
             - the first item has a header_signature of 'b-1'
@@ -97,6 +102,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-1', response.batches[0].header_signature)
@@ -106,12 +112,13 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of NO_ROOT
-            - that batches and head_id are missing
+            - that head_id, paging, and batches are missing
         """
         response = self.make_request(head_id='bad')
 
         self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
     def test_batch_list_filtered_by_ids(self):
@@ -125,6 +132,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'B-2', the latest
+            - a paging response showing all 2 resources returned
             - a list of batches with 2 items
             - the items are instances of Batch
             - the first item has a header_signature of 'b-0'
@@ -134,6 +142,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-0', response.batches[0].header_signature)
@@ -150,12 +159,13 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of NO_RESOURCE
             - a head_id of 'B-2', the latest
-            - that batches is missing
+            - that paging and batches are missing
         """
         response = self.make_request(batch_ids=['bad', 'also-bad'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual('B-2', response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
     def test_batch_list_by_good_and_bad_ids(self):
@@ -169,6 +179,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'B-2', the latest
+            - a paging response showing all 1 resources returned
             - a list of batches with 1 items
             - that item is an instances of Batch
             - that item has a header_signature of 'b-1'
@@ -177,6 +188,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-1', response.batches[0].header_signature)
@@ -191,6 +203,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'B-1'
+            - a paging response showing all 1 resources returned
             - a list of batches with 1 item
             - that item is an instance of Batch
             - that item has a header_signature of 'b-0'
@@ -199,6 +212,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-0', response.batches[0].header_signature)
@@ -212,12 +226,13 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of NO_RESOURCE
             - a head_id of 'B-0'
-            - that batches is missing
+            - that paging and batches are missing
         """
         response = self.make_request(head_id='B-0', batch_ids=['b-1', 'b-2'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual('B-0', response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
     def test_batch_list_paginated(self):

--- a/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
@@ -251,6 +251,177 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual('B-1', response.head_id)
         self.assertFalse(response.leaves)
 
+    def test_state_list_paginated(self):
+        """Verifies requests for data lists work when paginated just by count.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with a next_id of 'c'
+            - a list of leaves with 2 items
+            - those items are instances of Leaf
+        """
+        response = self.make_paged_request(count=2)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, next_id='c')
+        self.assertEqual(2, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+
+    def test_state_list_paginated_by_start_id (self):
+        """Verifies data list requests work paginated by count and start_id.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with:
+                * a next_id of 'c'
+                * a previous_id of 'a'
+                * a start_index of 1
+                * the default total resource count of 3
+            - a list of leaves with 1 item
+            - that item is an instance of Leaf
+            - that Leaf has an address of 'b' and data of b'5'
+        """
+        response = self.make_paged_request(count=1, start_id='b')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, 'c', 'a', 1)
+        self.assertEqual(1, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('b', response.leaves[0].address)
+        self.assertEqual(b'5', response.leaves[0].data)
+
+    def test_state_list_paginated_by_end_id (self):
+        """Verifies data list requests work paginated by count and end_id.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with:
+                * the default empty next_id
+                * a previous_id of 'a'
+                * a start_index of 1
+                * the default total resource count of 3
+            - a list of leaves with 2 items
+            - those items are instances of Leaf
+            - the last leaf has an address of 'c' and data of b'7'
+        """
+        response = self.make_paged_request(count=2, end_id='c')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, previous_id='a', start_index=1)
+        self.assertEqual(2, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('c', response.leaves[1].address)
+        self.assertEqual(b'7', response.leaves[1].data)
+
+    def test_state_list_paginated_by_index (self):
+        """Verifies data list requests work paginated by count and min_index.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with a next_id of 'b'
+            - a list of leaves with 1 item
+            - that item is an instance of Leaf
+            - that Leaf has an address of 'a' and data of b'3'
+        """
+        response = self.make_paged_request(count=1, start_index=0)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, next_id='b')
+        self.assertEqual(1, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('a', response.leaves[0].address)
+        self.assertEqual(b'3', response.leaves[0].data)
+
+    def test_state_list_with_bad_pagination(self):
+        """Verifies data requests break when paging specifies missing leaves.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - a head_id of 'B-2', the latest
+            - that paging and leaves are missing
+        """
+        response = self.make_paged_request(count=3, start_id='bad')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.leaves)
+
+    def test_state_list_paginated_with_head (self):
+        """Verifies data list requests work with both paging and a head id.
+
+        Queries the second state in the default mock db:
+            {'a': b'2', 'b': b'4'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-1'
+            - a paging response with:
+                * an empty next_id
+                * a previous_id of 'a'
+                * a start_index of 1
+                * a total resource count of 2
+            - a list of leaves with 1 item
+            - that item is an instance of Leaf
+            - that has a header_signature of 'b-0'
+        """
+        response = self.make_paged_request(count=1, start_index=1, head_id='B-1')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, '', 'a', 1, 2)
+        self.assertEqual(1, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('b', response.leaves[0].address)
+        self.assertEqual(b'4', response.leaves[0].data)
+
+    def test_state_list_paginated_with_address (self):
+        """Verifies data list requests work with both paging and an address.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with a total resource count of 1
+            - a list of leaves with 1 item
+            - that item is an instance of Leaf
+            - that has a header_signature of 'b-0'
+        """
+        response = self.make_paged_request(count=1, start_index=0, address='b')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, total=1)
+        self.assertEqual(1, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('b', response.leaves[0].address)
+        self.assertEqual(b'5', response.leaves[0].data)
+
 
 class TestStateGetRequests(ClientHandlerTestCase):
     def setUp(self):


### PR DESCRIPTION
Allows clients to send in a `PagingControls` object with their "List" requests, which allow using either ids or indexes to navigate variably sized pages of results.
    
Sends back a `PagingResponse` object with the information needed to construct further PagingControl queries.