### PR TITLE
Updated consensus module interfaces

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -24,10 +24,26 @@ LOGGER = logging.getLogger(__name__)
 class PoetForkResolver(ForkResolverInterface):
     # Provides the fork resolution interface for the BlockValidator to use
     # when deciding between 2 forks.
-    def __init__(self, block_cache, data_dir):
-        super().__init__(block_cache, data_dir)
+    def __init__(self, block_cache, state_view_factory, data_dir):
+        """Initialize the object, is passed (read-only) state access objects.
+            Args:
+                block_cache (BlockCache): Dict interface to the block cache.
+                    Any predecessor block to blocks handed to this object will
+                    be present in this dict.
+                state_view_factory (StateViewFactory): A factory that can be
+                    used to create read-only views of state for a particular
+                    merkle root, in particular the state as it existed when a
+                    particular block was the chain head.
+                data_dir (str): path to location where persistent data for the
+                    consensus module can be stored.
+            Returns:
+                none.
+        """
+        super().__init__(block_cache, state_view_factory, data_dir)
 
         self._block_cache = block_cache
+        self._state_view_factory = state_view_factory
+        self._data_dir = data_dir
 
     def compare_forks(self, cur_fork_head, new_fork_head):
         """Given the head of two forks, return which should be the fork that
@@ -38,8 +54,6 @@ class PoetForkResolver(ForkResolverInterface):
             cur_fork_head (Block): The current head of the block chain.
             new_fork_head (Block): The head of the fork that is being
             evaluated.
-            data_dir: path to location where persistent data for the consensus
-            module can be stored.
         Returns:
             Boolean: True if the new chain should replace the current chain.
             False if the new chain should be discarded.

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/wait_timer.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/wait_timer.py
@@ -42,7 +42,7 @@ class WaitTimer(object):
             wait timer
     """
     minimum_wait_time = 1.0
-    target_wait_time = 30.0
+    target_wait_time = 20.0
     initial_wait_time = 3000.0
     certificate_sample_length = 50
     fixed_duration_blocks = certificate_sample_length

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -46,7 +46,7 @@ from sawtooth_poet_simulator.poet_enclave_simulator.enclave_wait_certificate \
 
 LOGGER = logging.getLogger(__name__)
 
-TIMER_TIMEOUT_PERIOD = 3.0
+TIMER_TIMEOUT_PERIOD = 30.0
 
 
 class _PoetEnclaveSimulator(object):

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -188,12 +188,9 @@ class BlockValidator(object):
             else:
                 valid = True
 
-                prev_state = self._get_previous_block_root_state_hash(blkw)
-                state_view = self._state_view_factory.\
-                    create_view(prev_state)
                 consensus = self._consensus_module.\
                     BlockVerifier(block_cache=self._block_cache,
-                                  state_view=state_view,
+                                  state_view_factory=self._state_view_factory,
                                   data_dir=self._data_dir)
 
                 if valid:
@@ -291,6 +288,7 @@ class BlockValidator(object):
         """
         fork_resolver = self._consensus_module.\
             ForkResolver(block_cache=self._block_cache,
+                         state_view_factory=self._state_view_factory,
                          data_dir=self._data_dir)
 
         return fork_resolver.compare_forks(self._chain_head, self._new_block)

--- a/validator/sawtooth_validator/journal/consensus/consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus.py
@@ -26,15 +26,20 @@ class BlockPublisherInterface(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def __init__(self, block_cache, state_view, batch_publisher, data_dir):
+    def __init__(self,
+                 block_cache,
+                 state_view_factory,
+                 batch_publisher,
+                 data_dir):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
                 block_cache: Dict interface to the block cache. Any predecessor
                 block to blocks handed to this object will be present in this
                 dict.
-                state_view: A read only view of state for the last committed
-                block in the chain. For the block publisher this is the block
-                we are building on top of.
+                state_view_factory: A factory that can be used to create read-
+                only views of state for a particular merkle root, in
+                particular the state as it existed when a particular block
+                was the chain head.
                 batch_publisher: An interface implementing send(txn_list)
                 which wrap the transactions in a batch and broadcast that
                 batch to the network.
@@ -98,15 +103,16 @@ class BlockVerifierInterface(metaclass=ABCMeta):
     # considered as part of the fork being  evaluate. BlockVerifier must be
     # independent of block publishing activities.
     @abstractmethod
-    def __init__(self, block_cache, state_view, data_dir):
+    def __init__(self, block_cache, state_view_factory, data_dir):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
                 block_cache: Dict interface to the block cache. Any predecessor
                 block to blocks handed to this object will be present in this
                 dict.
-                state_view: A read only view of state for the last committed
-                block in the chain. For the BlockVerifier this is the previous
-                block in the chain.
+                state_view_factory: A factory that can be used to create read-
+                only views of state for a particular merkle root, in
+                particular the state as it existed when a particular block
+                was the chain head.
                 data_dir: path to location where persistent data for the
                 consensus module can be stored.
             Returns:
@@ -130,7 +136,7 @@ class ForkResolverInterface(metaclass=ABCMeta):
     # Provides the fork resolution interface for the BlockValidator to use
     # when deciding between two forks.
     @abstractmethod
-    def __init__(self, block_cache, data_dir):
+    def __init__(self, block_cache, state_view_factory, data_dir):
         """Initialize the object, is passed (read-only) state access objects.
         StateView is not passed to this object as it is ambiguous as to which
         state it is and all state dependent calculations should have been
@@ -140,6 +146,10 @@ class ForkResolverInterface(metaclass=ABCMeta):
                 block_cache: Dict interface to the block cache. Any predecessor
                 block to blocks handed to this object will be present in this
                 dict.
+                state_view_factory: A factory that can be used to create read-
+                only views of state for a particular merkle root, in
+                particular the state as it existed when a particular block
+                was the chain head.
                 data_dir: path to location where persistent data for the
                 consensus module can be stored.
             Returns:

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -234,7 +234,7 @@ class GenesisController(object):
                 state_view)
             return consensus.BlockPublisher(
                 BlockCache(self._block_store),
-                state_view=state_view,
+                state_view_factory=self._state_view_factory,
                 batch_publisher=BatchPublisher(),
                 data_dir=self._data_dir)
         except UnknownConsensusModuleError as e:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -122,7 +122,7 @@ class BlockPublisher(object):
 
         self._consensus = consensus_module.\
             BlockPublisher(block_cache=self._block_cache,
-                           state_view=state_view,
+                           state_view_factory=self._state_view_factory,
                            batch_publisher=self._batch_publisher,
                            data_dir=self._data_dir)
 

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -23,10 +23,16 @@ from sawtooth_validator.journal.consensus.consensus\
 class BlockPublisher(BlockPublisherInterface):
     """ MockConsensus BlockPublisher
     """
-    def __init__(self, block_cache, state_view, batch_publisher, data_dir):
-        self._block_cache = block_cache
-        self._state_view = state_view
-        self.batch_publisher = batch_publisher
+    def __init__(self,
+                 block_cache,
+                 state_view_factory,
+                 batch_publisher,
+                 data_dir):
+        super().__init__(
+            block_cache,
+            state_view_factory,
+            batch_publisher,
+            data_dir)
 
     def initialize_block(self, block_header):
         """
@@ -61,9 +67,11 @@ class BlockPublisher(BlockPublisherInterface):
 class BlockVerifier(BlockVerifierInterface):
     """MockConsensus BlockVerifier implementation
     """
-    def __init__(self, block_cache, state_view, data_dir):
-        self._block_cache = block_cache
-        self._state_view = state_view
+    def __init__(self, block_cache, state_view_factory, data_dir):
+        super().__init__(
+            block_cache,
+            state_view_factory,
+            data_dir)
 
     def verify_block(self, block_wrapper):
         return block_wrapper.consensus == b"test_mode"
@@ -72,8 +80,11 @@ class BlockVerifier(BlockVerifierInterface):
 class ForkResolver(ForkResolverInterface):
     """MockConsensus ForkResolver implementation
     """
-    def __init__(self, block_cache, data_dir):
-        self._block_cache = block_cache
+    def __init__(self, block_cache, state_view_factory, data_dir):
+        super().__init__(
+            block_cache,
+            state_view_factory,
+            data_dir)
 
     def compare_forks(self, cur_fork_head, new_fork_head):
         """


### PR DESCRIPTION
This update changes the consensus module interface for BlockPublisher, BlockVerifier, and ForkResolver to take a state view factory object on creation instead of a state view object.  It allows them to be able to create an arbitrary state view based upon that state root hash of any block in the store.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>