### PR TITLE
Add --wait flag to sawtooth cli submit command

### DIFF
--- a/cli/sawtooth_cli/submit.py
+++ b/cli/sawtooth_cli/submit.py
@@ -15,6 +15,7 @@
 
 import logging
 import time
+from sys import maxsize
 
 from sawtooth_cli.rest_client import RestClient
 import sawtooth_cli.protobuf.batch_pb2 as batch_pb2
@@ -47,15 +48,45 @@ def do_submit(args):
 
     stop = time.time()
 
-    print("batches: {} batch/sec: {}".format(
+    print('batches: {},  batch/sec: {}'.format(
         str(len(batches.batches)),
         len(batches.batches) / (stop - start)))
+
+    if args.wait and args.wait > 0:
+        batch_ids = [b.header_signature for b in batches.batches]
+        wait_time = 0
+        start_time = time.time()
+
+        while wait_time < args.wait:
+            statuses = rest_client.get_statuses(
+                batch_ids,
+                args.wait - int(wait_time))
+            wait_time = time.time() - start_time
+
+            if all(s == 'COMMITTED' for s in statuses.values()):
+                print('All batches committed in {:.6} sec'.format(wait_time))
+                return
+
+            # Wait a moment so as not to hammer the Rest Api
+            time.sleep(0.2)
+
+        print('Wait timed out! Some batches have not yet been committed...')
+        for batch_id, status in statuses.items():
+            print('{:128.128}  {:8.8}'.format(batch_id, status))
+        exit(1)
 
 
 def add_submit_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'submit',
         parents=[parent_parser])
+
+    parser.add_argument(
+        '--wait',
+        nargs='?',
+        const=maxsize,
+        type=int,
+        help='wait for batches to commit, set an integer to specify a timeout')
 
     parser.add_argument(
         '-f', '--filename',

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -34,6 +34,12 @@ class BadProtobuf(web.HTTPBadRequest):
         super().__init__(reason=message)
 
 
+class BadStatusBody(web.HTTPBadRequest):
+    def __init__(self):
+        message = 'Expected a json formatted array of id strings'
+        super().__init__(reason=message)
+
+
 class MissingStatusId(web.HTTPBadRequest):
     def __init__(self):
         message = 'At least one batch id must be specified to check status'

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -561,10 +561,10 @@ parameters:
 definitions:
   Head:
     type: string
-    example: HOAHrdXa1MUUbScI4eF0wVuzg4v5wYKZz6j7rsrWSwLKWUd/cO/XhKOd5oe/PeXKhhS+Tv6nRFxIwFHrrIddlsY=
+    example: 65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
   Link:
     type: string
-    example: https://api.sawtooth.com/state?head=HOAHrdXa1MUUbScI4eF0wVuzg4v5wYKZz6j7rsrWSwLKWUd/cO/XhKOd5oe/PeXKhhS+Tv6nRFxIwFHrrIddlsY=&min_position=1001
+    example: https://api.sawtooth.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd&min_position=1001
   Paging:
     properties:
       next_position:
@@ -662,7 +662,7 @@ definitions:
         $ref: "#/definitions/TransactionHeader"
       header_signature:
         type: string
-        example: GwW07DtqHLEM0gEP/V7LkyGdcbHpAp9aAVSr6Kc3da7jKhqh7F4LVQcRMAstfEkr3gHqUovEg38TczxtBuctC8c=
+        example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
       payload:
         type: string
         format: binary
@@ -676,14 +676,14 @@ definitions:
         type: array
         items:
           type: string
-          example: GwW07DtqHLEM0gEP/V7LkyGdcbHpAp9aAVSr6Kc3da7jKhqh7F4LVQcRMAstfEkr3gHqUovEg38TczxtBuctC8c=
+          example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
   Batch:
     properties:
       header:
         $ref: "#/definitions/BatchHeader"
       header_signature:
         type: string
-        example: G6aZORKtrD3KJP0Xii6Y0ahFqAADnUAKdflo6NQNWV9bLljoOI3YOlPMduHwIPgUSBAVU7sEpUtjPpOwfMWEWkM=
+        example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
       transactions:
         type: array
         items:
@@ -702,7 +702,7 @@ definitions:
         example: 12345
       previous_block_id:
         type: string
-        example: HOAHrdXa1MUUbScI4eF0wVuzg4v5wYKZz6j7rsrWSwLKWUd/cO/XhKOd5oe/PeXKhhS+Tv6nRFxIwFHrrIddlsY=
+        example: 65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
       signer_pubkey:
         type: string
         example: 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM
@@ -710,7 +710,7 @@ definitions:
         type: array
         items:
           type: string
-          example: G6aZORKtrD3KJP0Xii6Y0ahFqAADnUAKdflo6NQNWV9bLljoOI3YOlPMduHwIPgUSBAVU7sEpUtjPpOwfMWEWkM=
+          example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
       consensus:
         type: string
         format: binary
@@ -723,7 +723,7 @@ definitions:
         $ref: "#/definitions/BlockHeader"
       header_signature:
         type: string
-        example: HOAHrdXa1MUUbScI4eF0wVuzg4v5wYKZz6j7rsrWSwLKWUd/cO/XhKOd5oe/PeXKhhS+Tv6nRFxIwFHrrIddlsY=
+        example: 65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
       batches:
         type: array
         items:

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -177,6 +177,42 @@ paths:
         503:
           $ref: "#/responses/503ServiceUnavailable"
 
+    post:
+      summary: Fetches the committed statuses for a set of batches
+      description: |
+        Identical to `GET /batch_status`, but takes ids of batches as a JSON
+        formatted POST body rather than a query parameter. This allows for many
+        more batches to be checked and should be used for more than 15 ids.
+
+        Note that since query information is not encoded in the URL, no `link`
+        will be returned with this query.
+      consumes:
+        - application/json
+      parameters:
+        - name: Batch Ids
+          in: body
+          description: A JSON array of batch id strings
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
+        - $ref: "#/parameters/wait"
+      responses:
+        200:
+          description: Successfully retrieved statuses
+          schema:
+            properties:
+              data:
+                $ref: "#/definitions/BatchStatuses"
+        400:
+          $ref: "#/responses/400BadRequest"
+        500:
+          $ref: "#/responses/500ServerError"
+        503:
+          $ref: "#/responses/503ServiceUnavailable"
+
   /state:
     get:
       summary: Fetches the data for the current state

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -53,6 +53,7 @@ def start_rest_api(host, port, stream_url, timeout):
     # Add routes to the web app
     app.router.add_post('/batches', handler.batches_post)
     app.router.add_get('/batch_status', handler.status_list)
+    app.router.add_post('/batch_status', handler.status_list)
 
     app.router.add_get('/state', handler.state_list)
     app.router.add_get('/state/{address}', handler.state_get)


### PR DESCRIPTION
If `--wait` is set on `sawtooth submit`, the CLI will waits for commit before printing the timestamp. If the Api times out before the batches commit, it will print a table with the batch ids and their statuses.