### PR TITLE
Fix shutdown smoke

### DIFF
--- a/bin/run_docker_test
+++ b/bin/run_docker_test
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from subprocess import run, PIPE, CalledProcessError, Popen
+from subprocess import run, PIPE, CalledProcessError
 import os
 import sys
 import argparse
@@ -46,13 +46,12 @@ def main():
     ]
 
     compose_up = compose + [
-        'up', '-d'
+        'up', '--abort-on-container-exit'
     ]
 
-    docker_wait = ['docker', 'wait',
-                    "{}_{}_1".format(isolation_id, args.test_service)]
-
     compose_down = compose + ['down', '--remove-orphans']
+
+    compose_kill = compose + ['kill']
 
     inspect = [
         'docker', 'inspect',
@@ -66,9 +65,6 @@ def main():
             "Test service '{}' does not exist in compose file: '{}'".format(
                 args.test_service, compose_file))
 
-    compose_logs = compose + ['logs', '--follow'] + \
-                   [s for s in compose_dict['services']]
-
     start_time = time.time()
     timeout = args.timeout
 
@@ -80,12 +76,6 @@ def main():
         try:
             print("Running: {}".format(compose_up))
             run(compose_up, check=True, timeout=timeout)
-            handle = Popen(args=compose_logs, stdout=PIPE,
-                           stderr=PIPE,
-                           universal_newlines=True)
-            print("Running: {}".format(docker_wait))
-            run(docker_wait, check=True, timeout=timeout)
-
         except CalledProcessError:
             raise RunDockerTestError(
                 "Failed to start all docker containers. Do `docker ps -a` to "
@@ -123,8 +113,6 @@ def main():
                 "Failed to remove all docker containers. Do `docker ps -a` to "
                 "list residual containers.")
 
-        sys.stdout.write(handle.stdout.read())
-        sys.stdout.write(handle.stderr.read())
         exit(int(success))
 
     except KeyboardInterrupt:

--- a/integration/sawtooth_integration/docker/shutdown-smoke.yaml
+++ b/integration/sawtooth_integration/docker/shutdown-smoke.yaml
@@ -16,57 +16,14 @@
 version: "2.1"
 
 services:
-
-  genesis:
-    image: sawtooth-dev-validator:$ISOLATION_ID
-    container_name: genesis
-    volumes:
-      - ../../../:/project/sawtooth-core
-      - /var/lib/sawtooth
-      - /etc/sawtooth
-    entrypoint: "bash -c \"
-      bin/sawtooth admin keygen --force &&
-      bin/sawtooth admin genesis\""
-
-  validator-genesis:
-    image: sawtooth-dev-validator:$ISOLATION_ID
-    container_name: validator-genesis
-    volumes:
-      - ../../../:/project/sawtooth-core
-    volumes_from:
-      - genesis
-    entrypoint: bin/validator -v
-
-  keygen:
-    image: sawtooth-dev-validator:$ISOLATION_ID
-    container_name: keygen
-    volumes:
-      - ../../../:/project/sawtooth-core
-      - /etc/sawtooth
-    entrypoint: bin/sawtooth admin keygen --force
-
-  validator-non-genesis:
-    image: sawtooth-dev-validator:$ISOLATION_ID
-    container_name: validator-non-genesis
-    depends_on:
-     - validator-genesis
-    volumes_from:
-     - keygen
-    volumes:
-      - ../../../:/project/sawtooth-core
-    entrypoint: bin/validator -v --peers tcp://validator-genesis:8800
-
   integration_test:
     image: sawtooth-dev-test:$ISOLATION_ID
     volumes:
       - ../../../:/project/sawtooth-core
       - /var/run/docker.sock:/var/run/docker.sock
     working_dir: /project/sawtooth-core/integration/sawtooth_integration/tests
-    depends_on:
-      - validator-non-genesis
-      - validator-genesis
-    entrypoint: "bash -c \"
-      sleep 5 && \
-      nose2-3 -v test_shutdown_smoke.TestShutdownSmoke\""
+    entrypoint: "nose2-3 -v test_shutdown_smoke.TestShutdownSmoke"
     environment:
       PYTHONPATH: "/project/sawtooth-core/integration"
+      ISOLATION_ID: ${ISOLATION_ID}
+      VALIDATOR_IMAGE_NAME: "sawtooth-dev-validator"


### PR DESCRIPTION
This reverts the changes to run_docker_test that were made in a prior pr. Also rewrites shutdown-smoke to not require containers to be named.