### PR TITLE
Simplify Sawtooth Signing API

### DIFF
--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -18,7 +18,7 @@ import sys
 
 from sawtooth_cli.exceptions import CliException
 from sawtooth_cli.admin_command.config import get_key_dir
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 
 def add_keygen_parser(subparsers, parent_parser):

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -79,7 +79,6 @@ def do_keygen(args):
                 'files exist, rerun with --force to overwrite existing files')
 
     privkey = signing.generate_privkey()
-    encoded = signing.encode_privkey(privkey)
     pubkey = signing.generate_pubkey(privkey)
     addr = signing.generate_identifier(pubkey)
 
@@ -91,7 +90,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(wif_filename))
                 else:
                     print('writing file: {}'.format(wif_filename))
-            wif_fd.write(encoded)
+            wif_fd.write(privkey)
             wif_fd.write('\n')
 
         addr_exists = os.path.exists(addr_filename)

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -36,7 +36,7 @@ from sawtooth_cli.protobuf.batch_pb2 import BatchHeader
 from sawtooth_cli.protobuf.batch_pb2 import Batch
 from sawtooth_cli.protobuf.batch_pb2 import BatchList
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 
 CONFIG_NAMESPACE = '000000'

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -411,11 +411,8 @@ def _read_signing_keys(key_filename):
 
     try:
         with open(filename, 'r') as key_file:
-            wif_key = key_file.read().strip()
-            signing_key = signing.encode_privkey(
-                signing.decode_privkey(wif_key, 'wif'), 'hex')
-            pubkey = signing.encode_pubkey(
-                signing.generate_pubkey(signing_key), 'hex')
+            signing_key = key_file.read().strip()
+            pubkey = signing.generate_pubkey(signing_key)
 
             return pubkey, signing_key
     except IOError as e:

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -81,7 +81,6 @@ def do_keygen(args):
                 'files exist, rerun with --force to overwrite existing files')
 
     privkey = signing.generate_privkey()
-    encoded = signing.encode_privkey(privkey)
     pubkey = signing.generate_pubkey(privkey)
     addr = signing.generate_identifier(pubkey)
 
@@ -93,7 +92,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(wif_filename))
                 else:
                     print('writing file: {}'.format(wif_filename))
-            wif_fd.write(encoded)
+            wif_fd.write(privkey)
             wif_fd.write('\n')
 
         addr_exists = os.path.exists(addr_filename)

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -20,7 +20,7 @@ import os
 import sys
 
 from sawtooth_cli.exceptions import CliException
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 
 def add_keygen_parser(subparsers, parent_parser):

--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -18,7 +18,7 @@ import os
 import unittest
 import sys
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_cli.admin_command import keygen
 from sawtooth_cli.admin_command.config import get_key_dir
 from sawtooth_cli.exceptions import CliException

--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -117,11 +117,8 @@ def _read_signing_keys(key_filename):
 
     try:
         with open(filename, 'r') as key_file:
-            wif_key = key_file.read().strip()
-            signing_key = signing.encode_privkey(
-                signing.decode_privkey(wif_key, 'wif'), 'hex')
-            pubkey = signing.encode_pubkey(
-                signing.generate_pubkey(signing_key), 'hex')
+            signing_key = key_file.read().strip()
+            pubkey = signing.generate_pubkey(signing_key)
 
             return pubkey, signing_key
     except IOError as e:

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -23,7 +23,7 @@ from sawtooth_poet_cli.exceptions import CliException
 from sawtooth_poet.poet_consensus.signup_info import SignupInfo
 import sawtooth_poet_common.protobuf.validator_registry_pb2 as vr_pb
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 import sawtooth_validator.protobuf.transaction_pb2 as txn_pb

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -204,11 +204,8 @@ def _read_signing_keys(key_filename):
 
     try:
         with open(filename, 'r') as key_file:
-            wif_key = key_file.read().strip()
-            signing_key = signing.encode_privkey(
-                signing.decode_privkey(wif_key, 'wif'), 'hex')
-            pubkey = signing.encode_pubkey(
-                signing.generate_pubkey(signing_key), 'hex')
+            signing_key = key_file.read().strip()
+            pubkey = signing.generate_pubkey(signing_key)
 
             return pubkey, signing_key
     except IOError as e:

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_poet_cli.main import main
 import sawtooth_validator.protobuf.batch_pb2 as batch_pb

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -93,6 +93,6 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         privkey = signing.generate_privkey()
         wif_file = os.path.join(self._temp_dir, key_name)
         with open(wif_file, 'w') as wif_fd:
-            wif_fd.write(signing.encode_privkey(privkey))
+            wif_fd.write(privkey)
 
         return signing.generate_pubkey(privkey)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -18,7 +18,7 @@ import hashlib
 import time
 import json
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.journal.consensus.consensus \
     import BlockPublisherInterface

--- a/consensus/poet/core/tests/test_consensus/utils.py
+++ b/consensus/poet/core/tests/test_consensus/utils.py
@@ -44,8 +44,4 @@ def create_random_public_key():
 
 
 def create_random_public_key_hash():
-    return \
-        hashlib.sha256(
-            signing.encode_pubkey(
-                create_random_public_key(),
-                'hex').encode('ascii')).hexdigest()
+    return hashlib.sha256(create_random_public_key().encode()).hexdigest()

--- a/consensus/poet/core/tests/test_consensus/utils.py
+++ b/consensus/poet/core/tests/test_consensus/utils.py
@@ -16,7 +16,7 @@ import hashlib
 import random
 import string
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 
 class AttrDict(dict):

--- a/consensus/poet/families/tests/test_validator_registry/tests.py
+++ b/consensus/poet/families/tests/test_validator_registry/tests.py
@@ -18,8 +18,6 @@ import json
 import base64
 import hashlib
 
-import sawtooth_signing as signing
-
 from test_validator_registry.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory
 
@@ -489,9 +487,7 @@ class TestValidatorRegistry(unittest.TestCase):
         hash_input = \
             '{0}{1}'.format(
                 'Not a valid OPK Hash',
-                signing.encode_pubkey(
-                    self.factory.poet_public_key,
-                    'hex').upper()).encode()
+                self.factory.poet_public_key).upper().encode()
         sgx_quote.report_body.report_data.d = \
             hashlib.sha256(hash_input).digest()
 

--- a/consensus/poet/families/tests/test_validator_registry/tests.py
+++ b/consensus/poet/families/tests/test_validator_registry/tests.py
@@ -18,7 +18,7 @@ import json
 import base64
 import hashlib
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from test_validator_registry.validator_reg_message_factory \
     import ValidatorRegistryMessageFactory

--- a/consensus/poet/families/tests/test_validator_registry/tests.py
+++ b/consensus/poet/families/tests/test_validator_registry/tests.py
@@ -72,7 +72,7 @@ class TestValidatorRegistry(unittest.TestCase):
 
         # Respond with a empty validator Map
         self.tester.respond(
-            self.factory.create_get_empty_resposne_validator_map(), received)
+            self.factory.create_get_empty_response_validator_map(), received)
 
         # Expect a set the new validator to the ValidatorMap
         received = self.tester.expect(

--- a/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
@@ -273,7 +273,7 @@ class ValidatorRegistryMessageFactory(object):
         addresses = [address]
         return self._factory.create_get_request(addresses)
 
-    def create_get_empty_resposne_validator_map(self):
+    def create_get_empty_response_validator_map(self):
         address = self._key_to_address("validator_map")
         data = ValidatorMap().SerializeToString()
         return self._factory.create_get_response({address: data})

--- a/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
@@ -23,7 +23,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_processor_test.message_factory import MessageFactory
 

--- a/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/test_validator_registry/validator_reg_message_factory.py
@@ -141,12 +141,8 @@ class ValidatorRegistryMessageFactory(object):
 
         # We are going to fake out the sealing the signup data.
         signup_data = {
-            'poet_public_key':
-                signing.encode_pubkey(self.poet_public_key, 'hex'),
-            'poet_private_key':
-                signing.encode_privkey(
-                    self._poet_private_key,
-                    'hex')
+            'poet_public_key': self.poet_public_key,
+            'poet_private_key': self._poet_private_key
         }
 
         # Build up a fake SGX quote containing:
@@ -163,9 +159,7 @@ class ValidatorRegistryMessageFactory(object):
         hash_input = \
             '{0}{1}'.format(
                 originator_public_key_hash.upper(),
-                signing.encode_pubkey(
-                    self.poet_public_key,
-                    'hex').upper()).encode()
+                self.poet_public_key.upper()).encode()
         report_data = hashlib.sha256(hash_input).digest()
 
         sgx_report_data = sgx_structs.SgxReportData(d=report_data)

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -28,7 +28,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.exceptions import InvalidSignature
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 

--- a/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_certificate.py
+++ b/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_certificate.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_poet_simulator.poet_enclave_simulator.enclave_wait_timer \
     import EnclaveWaitTimer

--- a/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_timer.py
+++ b/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_timer.py
@@ -16,7 +16,7 @@
 import unittest
 import time
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_poet_simulator.poet_enclave_simulator.enclave_wait_timer \
     import EnclaveWaitTimer

--- a/core/sawtooth/client.py
+++ b/core/sawtooth/client.py
@@ -54,8 +54,8 @@ def _sign_message_with_transaction(transaction, message_type, key):
     of a sha256 hexdigest.
     """
     transaction['Nonce'] = time.time()
-    pub = signing.encode_pubkey(signing.generate_pubkey(key), "hex")
-    transaction["PublicKey"] = pub
+    pub = signing.generate_pubkey(key)
+    transaction['PublicKey'] = pub
     sig = signing.sign(_dict2cbor(transaction), key)
     transaction['Signature'] = sig
 
@@ -389,14 +389,11 @@ class SawtoothClient(object):
 
         if keystring:
             LOGGER.debug("set signing key from string\n%s", keystring)
-            self._signing_key = signing.encode_privkey(
-                signing.decode_privkey(keystring, 'wif'), 'hex')
+            self._signing_key = keystring
         elif keyfile:
             LOGGER.debug("set signing key from file %s", keyfile)
             try:
-                self._signing_key = signing.encode_privkey(
-                    signing.decode_privkey(
-                        open(keyfile, "r").read().strip(), 'wif'), 'hex')
+                self._signing_key = open(keyfile, "r").read().strip()
             except IOError as ex:
                 raise ClientException(
                     "Failed to load key file: {}".format(str(ex)))

--- a/core/sawtooth/client.py
+++ b/core/sawtooth/client.py
@@ -30,7 +30,7 @@ import cbor
 from sawtooth.exceptions import ClientException
 from sawtooth.exceptions import InvalidTransactionError
 from sawtooth.exceptions import MessageException
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 
 LOGGER = logging.getLogger(__name__)

--- a/extensions/arcade/sawtooth_battleship/battleship_cli.py
+++ b/extensions/arcade/sawtooth_battleship/battleship_cli.py
@@ -28,7 +28,7 @@ import sys
 
 from colorlog import ColoredFormatter
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth.exceptions import ClientException
 from sawtooth.exceptions import InvalidTransactionError
 

--- a/extensions/arcade/sawtooth_battleship/battleship_cli.py
+++ b/extensions/arcade/sawtooth_battleship/battleship_cli.py
@@ -239,13 +239,12 @@ def do_init(args, config):
                 os.makedirs(os.path.dirname(wif_filename))
 
             privkey = signing.generate_privkey()
-            encoded = signing.encode_privkey(privkey, 'wif')
             pubkey = signing.generate_pubkey(privkey)
             addr = signing.generate_identifier(pubkey)
 
             with open(wif_filename, "w") as wif_fd:
                 print("writing file: {}".format(wif_filename))
-                wif_fd.write(encoded)
+                wif_fd.write(privkey)
                 wif_fd.write("\n")
 
             with open(addr_filename, "w") as addr_fd:

--- a/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
+++ b/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
@@ -22,7 +22,7 @@ import time
 import cProfile
 import argparse
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 from sawtooth_sdk.protobuf import jvm_sc_pb2

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -23,7 +23,7 @@ import random
 import string
 import time
 import cbor
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
@@ -25,7 +25,7 @@ import time
 
 import cbor
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_sdk.protobuf import transaction_pb2
 from sawtooth_sdk.protobuf import batch_pb2
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
@@ -25,7 +25,7 @@ import time
 
 import cbor
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
@@ -21,7 +21,7 @@ import time
 from collections import namedtuple
 from datetime import datetime
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_sdk.workload.workload_generator import WorkloadGenerator
 from sawtooth_sdk.workload.sawtooth_workload import Workload
 from sawtooth_sdk.client.stream import Stream

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -188,13 +188,12 @@ def do_init(args, config):
                 os.makedirs(os.path.dirname(wif_filename))
 
             privkey = signing.generate_privkey()
-            encoded = signing.encode_privkey(privkey, 'wif')
             pubkey = signing.generate_pubkey(privkey)
             addr = signing.generate_identifier(pubkey)
 
             with open(wif_filename, "w") as wif_fd:
                 print("writing file: {}".format(wif_filename))
-                wif_fd.write(encoded)
+                wif_fd.write(privkey)
                 wif_fd.write("\n")
 
             with open(addr_filename, "w") as addr_fd:

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -16,7 +16,7 @@
 import hashlib
 import time
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_sdk.protobuf.processor_pb2 import TpRegisterRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse

--- a/signing/sawtooth_signing/__init__.py
+++ b/signing/sawtooth_signing/__init__.py
@@ -17,6 +17,26 @@
 
     This module provides an interface to signing operations that insulates
     the caller from decisions on the underlying crypto system.
+    All keys are returned as serialized strings.
+    All methods expect that serialized format.
+
+    Basic Usage:
+        import sawtooth_signing as signing
+
+        msg = 'this is a message'
+        priv = signing.generate_privkey()
+        pub = signing.generate_pubkey(priv)
+        sig = signing.sign(msg, priv)
+        ver = signing.verify(msg, sig, pub)
+
+        # Store Private Key
+        keyfile = open(filename, 'w')
+        keyfile.write(priv)
+        keyfile.close()
+
+        # Retrieve Private Key
+        keyfile = open(filename, 'r')
+        priv = keyfile.readline()
 
     As new crypto packages are implemented this package serves as a build
     time switch to select the crypto package for that sawtooth network.

--- a/signing/sawtooth_signing/__init__.py
+++ b/signing/sawtooth_signing/__init__.py
@@ -12,5 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-__all__ = [
-    'pbct']
+
+""" Sawtooth Signing API
+
+    This module provides an interface to signing operations that insulates
+    the caller from decisions on the underlying crypto system.
+
+    As new crypto packages are implemented this package serves as a build
+    time switch to select the crypto package for that sawtooth network.
+
+    For example 'from ed25519_signer import *' would change sawtooth's
+    crypto selection without requiring changes to the API consumers.
+"""
+# pylint: disable=wildcard-import
+from sawtooth_signing.secp256k1_signer import *

--- a/signing/sawtooth_signing/secp256k1_signer.py
+++ b/signing/sawtooth_signing/secp256k1_signer.py
@@ -33,23 +33,11 @@ __CTX__ = __CONTEXTBASE__.ctx
 
 
 def generate_privkey():
-    return _encode_privkey(secp256k1.PrivateKey(ctx=__CTX__))
-
-
-def encode_privkey(privkey, encoding_format='wif'):
-    """Encodes a provided wif encoded privkey in the requested
-    encoding format.
-
-    Args:
-        privkey (str): A wif-encoded private key string
-        encoding_format (str): One of the pybitcointools supported
-            encoding formats
-
+    """ Create a random private key
     Returns:
-        str: An encoded private key in the requested format
+        Serialized private key suitable for subsequent calls to e.g. sign().
     """
-    return _encode_privkey(_decode_privkey(privkey, 'wif'),
-                           encoding_format)
+    return _encode_privkey(secp256k1.PrivateKey(ctx=__CTX__))
 
 
 def _encode_privkey(privkey, encoding_format='wif'):
@@ -63,7 +51,7 @@ def _encode_privkey(privkey, encoding_format='wif'):
     return encoded
 
 
-def _decode_privkey_to_bytes(encoded_privkey, encoding_format='wif'):
+def _decode_privkey(encoded_privkey, encoding_format='wif'):
     """
     Args:
         encoded_privkey: an encoded private key string
@@ -88,59 +76,17 @@ def _decode_privkey_to_bytes(encoded_privkey, encoding_format='wif'):
     else:
         raise TypeError("unsupported private key format")
 
-    return priv
-
-
-def decode_privkey(encoded_privkey, encoding_format='wif'):
-    """Decodes a provided encoded privkey to a secp256k1 bytes representation
-
-    Args:
-        encoded_privkey (str): An encoded private key string
-        encoding_format (str): The encoded format of the provided
-            private key. Must be either 'wif' or 'hex'.
-
-    Returns:
-        bytes: A private key in native bytes format
-    """
-    return _decode_privkey_to_bytes(encoded_privkey, encoding_format)
-
-
-def _decode_privkey(encoded_privkey, encoding_format='wif'):
-    """
-    Args:
-        encoded_privkey: an encoded private key string
-        encoding_format: string indicating format such as 'wif'
-
-    Returns:
-        private key object useable with this module
-    """
-    priv = _decode_privkey_to_bytes(encoded_privkey, encoding_format)
     return secp256k1.PrivateKey(priv, ctx=__CTX__)
 
 
 def generate_pubkey(privkey):
-    """
+    """ Generate the public key based on a given private key
     Args:
         privkey: a serialized private key string
     Returns:
         pubkey: a serialized public key string
      """
     return _encode_pubkey(_decode_privkey(privkey).pubkey, 'hex')
-
-
-def encode_pubkey(pubkey, encoding_format='hex'):
-    """Encodes a provided encoded pubkey to a supported encoding_format
-
-    Args:
-        pubkey (str): An encoded public key string
-        encoding_format (str): The encoded format of the provided
-            private key. Must be 'hex'.
-
-    Returns:
-        str: A public key in the requested format
-    """
-    return _encode_pubkey(_decode_pubkey(pubkey, encoding_format),
-                          encoding_format)
 
 
 def _encode_pubkey(pubkey, encoding_format='hex'):
@@ -154,25 +100,6 @@ def _encode_pubkey(pubkey, encoding_format='hex'):
     return enc
 
 
-def decode_pubkey(serialized_pubkey, encoding_format='hex'):
-    """Decodes a provided public key into the requested format
-
-    Args:
-        serialized_pubkey (str): The encoded public key
-        encoding_format (str): The format of the provided encoded
-            public key. Must be 'hex'.
-
-    Returns:
-        bytes: The native bytes representation of the public key
-    """
-    if encoding_format == 'hex':
-        serialized_pubkey = binascii.unhexlify(serialized_pubkey)
-    else:
-        raise ValueError("Unrecognized pubkey encoding format")
-
-    return serialized_pubkey
-
-
 def _decode_pubkey(serialized_pubkey, encoding_format='hex'):
     if encoding_format == 'hex':
         serialized_pubkey = binascii.unhexlify(serialized_pubkey)
@@ -184,7 +111,7 @@ def _decode_pubkey(serialized_pubkey, encoding_format='hex'):
 
 
 def generate_identifier(pubkey):
-    """
+    """ Generate an identifier based on the public key
     Args:
         pubkey: a serialized public key string
 
@@ -195,7 +122,7 @@ def generate_identifier(pubkey):
 
 
 def sign(message, privkey):
-    """
+    """ Signs a message using the specified private key
     Args:
         message: Message string
         privkey: A serialized private key string
@@ -216,7 +143,7 @@ def sign(message, privkey):
 
 
 def verify(message, signature, pubkey):
-    """
+    """ Verification of signature based on message and pubkey
     Args:
         message: Message string
         signature: DER encoded compact signature

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -18,7 +18,7 @@ import logging
 # needed for google.protobuf import
 from google.protobuf.message import DecodeError
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.protobuf import client_pb2
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -15,7 +15,7 @@
 import logging
 from threading import RLock
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER

--- a/validator/sawtooth_validator/journal/consensus/batch_publisher.py
+++ b/validator/sawtooth_validator/journal/consensus/batch_publisher.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -17,7 +17,7 @@ import logging
 import os
 from pathlib import Path
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.exceptions import InvalidGenesisStateError
 from sawtooth_validator.exceptions import InvalidGenesisConsensusError

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -15,7 +15,7 @@
 import logging
 from threading import RLock
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.execution.scheduler_exceptions import SchedulerError
 

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -15,9 +15,6 @@
 
 import logging
 import os
-import sys
-
-import sawtooth_signing as signing
 
 from sawtooth_validator.exceptions import LocalConfigurationError
 
@@ -47,24 +44,9 @@ def load_identity_signing_key(key_dir, key_name):
     LOGGER.info('Loading signing key: %s', key_path)
     try:
         with open(key_path, 'r') as key_file:
-            wif_key = key_file.read().strip()
+            privkey = key_file.read().strip()
     except IOError as e:
         raise LocalConfigurationError(
             "Could not load key file: {}".format(str(e)))
 
-    try:
-        decoded_key = signing.decode_privkey(wif_key)
-    except AssertionError:
-        # The underlying bitcoin library used by sawtooth_signing asserts to
-        # verify correctness of the format.  While we would not normally both
-        # log the error and raise an exception, in this case we may need the
-        # stacktrace to determine the root cause of the AssertionError, since
-        # there is no message provided as part of it.  We log it as debug,
-        # while the exception is probably handled by the caller as a fatal
-        # startup error.
-        LOGGER.debug(
-            "AssertionError while decoding wif key", exc_info=sys.exc_info())
-        raise LocalConfigurationError(
-            "Could not decode key contained in file (AssertionError): "
-            "{}".format(key_path))
-    return signing.encode_privkey(decoded_key)
+    return privkey

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -17,7 +17,7 @@ import logging
 import os
 import sys
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.exceptions import LocalConfigurationError
 

--- a/validator/tests/unit3/test_completer/test.py
+++ b/validator/tests/unit3/test_completer/test.py
@@ -17,7 +17,7 @@ import random
 import hashlib
 import cbor
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_validator.journal.completer import Completer
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -39,8 +39,7 @@ class TestGenesisController(unittest.TestCase):
 
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
-        self._identity_key = signing.encode_privkey(
-            signing.generate_privkey(), 'hex')
+        self._identity_key = signing.generate_privkey()
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir)

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -20,7 +20,7 @@ import unittest
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
 from sawtooth_validator.journal.block_store import BlockStore

--- a/validator/tests/unit3/test_journal/block_tree_manager.py
+++ b/validator/tests/unit3/test_journal/block_tree_manager.py
@@ -18,7 +18,7 @@ import pprint
 import random
 import string
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 
 from sawtooth_validator.database.dict_database import DictDatabase
 

--- a/validator/tests/unit3/test_message_validation/tests.py
+++ b/validator/tests/unit3/test_message_validation/tests.py
@@ -20,7 +20,7 @@ import queue
 import string
 
 from threading import Condition
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader, \
     Transaction
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader, Batch

--- a/validator/tests/unit3/test_scheduler/tests.py
+++ b/validator/tests/unit3/test_scheduler/tests.py
@@ -19,7 +19,7 @@ import hashlib
 import threading
 import time
 
-from sawtooth_signing import secp256k1_signer as signing
+import sawtooth_signing as signing
 import sawtooth_validator.protobuf.batch_pb2 as batch_pb2
 import sawtooth_validator.protobuf.transaction_pb2 as transaction_pb2
 


### PR DESCRIPTION
Simplify API
Updated all callers.

    API implicitly encodes and decodes parameters.
    Format parameters removed from API.

    Basic usage:
        import sawtooth_signing as signing

        msg = 'this is a message'
        priv = signing.generate_privkey()
        pub = signing.generate_pubkey(priv)
        sig = signing.sign(msg, priv)
        ver = signing.verify(msg, sig, pub)

    Storing / Retrieving:
        keyfile = open(filename, 'w')
        keyfile.write(priv)
        keyfile.close()

        keyfile = open(filename, 'r')
        priv = keyfile.readline()
        pub = signing.generate_pubkey(priv)
        sig = signing.sign(msg, priv)
        send_foo(msg, sig, pub)

        def receive_foo(msg, sig, pub):
                if signing.verify(msg, sig, pub):
                        # rely on message authenticity
                else:
                        # reject
