### PR TITLE
Add Genesis Consensus Module

### DIFF
--- a/validator/sawtooth_validator/journal/consensus/consensus_factory.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus_factory.py
@@ -15,6 +15,7 @@
 import importlib
 
 from sawtooth_validator.exceptions import UnknownConsensusModuleError
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.state.config_view import ConfigView
 
 
@@ -37,7 +38,11 @@ class ConsensusFactory(object):
                 not correspond to a consensus implementation.
         """
         module_package = module_name
-        if module_name == 'devmode':
+        if module_name == 'genesis':
+            module_package = \
+                'sawtooth_validator.journal.consensus.genesis.'\
+                'genesis_consensus'
+        elif module_name == 'devmode':
             module_package = \
                 'sawtooth_validator.journal.consensus.dev_mode.'\
                 'dev_mode_consensus'
@@ -51,22 +56,23 @@ class ConsensusFactory(object):
                 'Consensus module "{}" does not exist.'.format(module_name))
 
     @staticmethod
-    def get_configured_consensus_module(state_view):
+    def get_configured_consensus_module(block_id, state_view):
         """Returns the consensus_module based on the consensus module set by the
         "sawtooth_config" transaction family.
 
         Args:
-            state_view_factory (:obj:`StateViewFactory`): The state view
-                factory for reading the configuration
-            state_hash (str): The current state root hash for reading settings.
-
+            block_id (str): the block id associated with the current state_view
+            state_view (:obj:`StateView`): the current state view to use for
+                setting values
         Raises:
             UnknownConsensusModuleError: Thrown when an invalid consensus
                 module has been configured.
         """
         config_view = ConfigView(state_view)
 
+        default_consensus = \
+            'genesis' if block_id == NULL_BLOCK_IDENTIFIER else 'devmode'
         consensus_module_name = config_view.get_setting(
-            'sawtooth.consensus.algorithm', default_value='devmode')
+            'sawtooth.consensus.algorithm', default_value=default_consensus)
         return ConsensusFactory.get_consensus_module(
             consensus_module_name)

--- a/validator/sawtooth_validator/journal/consensus/genesis/__init__.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -1,0 +1,86 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.consensus.consensus import \
+    BlockPublisherInterface
+from sawtooth_validator.journal.consensus.consensus import \
+    BlockVerifierInterface
+from sawtooth_validator.journal.consensus.consensus import \
+    ForkResolverInterface
+
+
+class BlockPublisher(BlockPublisherInterface):
+    """The Genesis BlockPublisher is the basic publisher used only during the
+    production of a genesis block. This block is marked with consensus field of
+    `'Genesis'` and finalized as such.
+    """
+    def __init__(self,
+                 block_cache,
+                 state_view_factory,
+                 batch_publisher,
+                 data_dir):
+        super().__init__(block_cache,
+                         state_view_factory,
+                         batch_publisher,
+                         data_dir)
+
+    def initialize_block(self, block_header):
+        """Initializes the given block header with the consensus field set to
+        `'Genesis'`.
+        Args:
+            block_header (BlockHeader): the BlockHeader to initialize.
+        Returns:
+            Boolean: `True` as the candidate block should always be built.
+        """
+        block_header.consensus = b"Genesis"
+        return block_header.previous_block_id == NULL_BLOCK_IDENTIFIER
+
+    def check_publish_block(self, block_header):
+        """Returns True, as the genesis node can alway produce the  block.
+        """
+        return block_header.previous_block_id == NULL_BLOCK_IDENTIFIER
+
+    def finalize_block(self, block_header):
+        """Returns `True`, as the genesis block is always considered good by the
+        genesis node.
+        """
+        return block_header.previous_block_id == NULL_BLOCK_IDENTIFIER
+
+
+class BlockVerifier(BlockVerifierInterface):
+    """The Genesis BlockVerifier validates that this consensus is only used in
+    instances where the previous block id is the NULL_BLOCK_IDENTIFIER. In any
+    other case, verification will fail.  This requires that any block beyond
+    the genesis block must use a proper consensus module.
+    """
+    def __init__(self, block_cache, state_view_factory, data_dir):
+        super().__init__(block_cache, state_view_factory, data_dir)
+
+    def verify_block(self, block_wrapper):
+        """Returns `True` if the previous block id is the NULL_BLOCK_IDENTIFIER
+        """
+        return block_wrapper.header.previous_block_id == NULL_BLOCK_IDENTIFIER
+
+
+class ForkResolver(ForkResolverInterface):
+    """The genesis ForkResolver should not ever be used.
+    """
+    def __init__(self, block_cache, data_dir):
+        super().__init__(block_cache, data_dir)
+
+    def compare_forks(self, cur_fork_head, new_fork_head):
+        """Returns False, acception only the current fork.
+        """
+        return False

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -174,7 +174,7 @@ class GenesisController(object):
         block_builder.add_batches(genesis_batches)
         block_builder.set_state_hash(state_hash)
 
-        block_publisher = self._get_block_publisher(state_hash)
+        block_publisher = self._get_block_publisher(initial_state_root)
         if not block_publisher.initialize_block(block_builder.block_header):
             LOGGER.error('Consensus refused to initialize consensus block.')
             raise InvalidGenesisConsensusError(
@@ -231,6 +231,7 @@ class GenesisController(object):
                         'Consensus cannot send transactions during genesis.')
 
             consensus = ConsensusFactory.get_configured_consensus_module(
+                NULL_BLOCK_IDENTIFIER,
                 state_view)
             return consensus.BlockPublisher(
                 BlockCache(self._block_store),

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -118,6 +118,7 @@ class BlockPublisher(object):
         state_view = \
             self._state_view_factory.create_view(chain_head.state_root_hash)
         consensus_module = ConsensusFactory.get_configured_consensus_module(
+            chain_head.header_signature,
             state_view)
 
         self._consensus = consensus_module.\

--- a/validator/tests/unit3/test_genesis_consensus/__init__.py
+++ b/validator/tests/unit3/test_genesis_consensus/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/tests/unit3/test_genesis_consensus/tests.py
+++ b/validator/tests/unit3/test_genesis_consensus/tests.py
@@ -1,0 +1,198 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
+from sawtooth_validator.journal.consensus.genesis.genesis_consensus import \
+    BlockPublisher
+from sawtooth_validator.journal.consensus.genesis.genesis_consensus import \
+    BlockVerifier
+
+from sawtooth_validator.protobuf.block_pb2 import Block
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+
+
+class TestGenesisBlockPublisher(unittest.TestCase):
+
+    def __init__(self, test_name):
+        super().__init__(test_name)
+
+    def test_initialize_block(self):
+        """
+        Create a block header and initialize it using the genesis consensus
+        BlockPublisher.
+
+        This test should verify that the appropriate header fields are set and
+        the consensus module returns that the block should be built.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        batch_publisher = Mock()
+        data_dir = 'mock_dir'
+        block_publisher = BlockPublisher(block_cache,
+                                         state_view_factory,
+                                         batch_publisher,
+                                         data_dir)
+
+        block_header = BlockHeader(
+            previous_block_id=NULL_BLOCK_IDENTIFIER)
+
+        result = block_publisher.initialize_block(block_header)
+        self.assertTrue(result)
+        self.assertEqual(b'Genesis', block_header.consensus)
+
+    def test_check_publish_valid(self):
+        """
+        Create a block header with the NULL_BLOCK_IDENTIFIER as previous id and
+        check that it can be published.
+
+        This test should verify that only blocks with the NULL_BLOCK_IDENTIFIER
+        as previous should be allowed to be published with this consensus
+        module.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        batch_publisher = Mock()
+        data_dir = 'mock_dir'
+        block_publisher = BlockPublisher(block_cache,
+                                         state_view_factory,
+                                         batch_publisher,
+                                         data_dir)
+
+        block_header = BlockHeader(
+            consensus=b'Genesis',
+            previous_block_id=NULL_BLOCK_IDENTIFIER)
+
+        result = block_publisher.check_publish_block(block_header)
+        self.assertTrue(result)
+
+    def test_check_publish_invalid(self):
+        """
+        Create a block header with some other block id as the previous id and
+        check that it can be published.
+
+        This test should verify that only blocks with the NULL_BLOCK_IDENTIFIER
+        as previous should be allowed to be published with this consensus
+        module.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        batch_publisher = Mock()
+        data_dir = 'mock_dir'
+        block_publisher = BlockPublisher(block_cache,
+                                         state_view_factory,
+                                         batch_publisher,
+                                         data_dir)
+
+        block_header = BlockHeader(
+            consensus=b'Genesis',
+            previous_block_id='some_other_id')
+
+        result = block_publisher.check_publish_block(block_header)
+        self.assertFalse(result)
+
+    def test_finalize_block_valid(self):
+        """
+        Create a block header with the NULL_BLOCK_IDENTIFIER as the previous id
+        and check that it can be properly finalized.
+
+        This test should verify that only blocks with the NULL_BLOCK_IDENTIFIER
+        as previous should be allowed to be finalized with this consensus
+        module.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        batch_publisher = Mock()
+        data_dir = 'mock_dir'
+        block_publisher = BlockPublisher(block_cache,
+                                         state_view_factory,
+                                         batch_publisher,
+                                         data_dir)
+
+        block_header = BlockHeader(
+            consensus=b'Genesis',
+            previous_block_id=NULL_BLOCK_IDENTIFIER)
+
+        result = block_publisher.finalize_block(block_header)
+        self.assertTrue(result)
+
+    def test_finalize_block_invalid(self):
+        """
+        Create a block header with some other block id as the previous id
+        and check that it can be properly finalized.
+
+        This test should verify that only blocks with the NULL_BLOCK_IDENTIFIER
+        as previous should be allowed to be finalized with this consensus
+        module.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        batch_publisher = Mock()
+        data_dir = 'mock_dir'
+        block_publisher = BlockPublisher(block_cache,
+                                         state_view_factory,
+                                         batch_publisher,
+                                         data_dir)
+
+        block_header = BlockHeader(
+            consensus=b'Genesis',
+            previous_block_id='some_other_id')
+
+        result = block_publisher.finalize_block(block_header)
+        self.assertFalse(result)
+
+
+class TestGenesisBlockVerifier(unittest.TestCase):
+
+    def __init__(self, test_name):
+        super().__init__(test_name)
+
+    def test_verify_genesis_block(self):
+        """This test should verify that a block with the NULL_BLOCK_IDENTIFIER
+        should be considered a valid block using this consensus module.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        data_dir = 'mock_dir'
+        block_verifier = BlockVerifier(block_cache,
+                                       state_view_factory,
+                                       data_dir)
+
+        block = Block(header=BlockHeader(
+            previous_block_id=NULL_BLOCK_IDENTIFIER).SerializeToString())
+        block_wrapper = BlockWrapper(block)
+
+        result = block_verifier.verify_block(block_wrapper)
+        self.assertTrue(result)
+
+    def test_reject_non_genesis_block(self):
+        """This test should show that a block with any previous blocks should
+        fail verification.
+        """
+        block_cache = Mock()
+        state_view_factory = Mock()
+        data_dir = 'mock_dir'
+        block_verifier = BlockVerifier(block_cache,
+                                       state_view_factory,
+                                       data_dir)
+
+        block = Block(header=BlockHeader(
+            previous_block_id='some_prev_block_id').SerializeToString())
+        block_wrapper = BlockWrapper(block)
+
+        result = block_verifier.verify_block(block_wrapper)
+        self.assertFalse(result)


### PR DESCRIPTION
### 	Add genesis consensus module

Add a consensus module for handling consensus of genesis blocks only. These blocks have no state associated with them, and therefore have no special information needed during block publishing or validation.

### Add block id to consensus selection

Add block id to the consensus selection to facilitate the defaults at the boundaries of the genesis block and genesis+1 blocks. In the case of the `NULL_BLOCK_IDENTIFIER`, the genesis consensus is the default. After that, `devmode` is the default.