### PR TITLE
Disable port forwarding, due to vagrant error on windows.

### DIFF
--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -8,18 +8,18 @@ require 'yaml'
 crlf_count=0
 
 Dir.glob('*.sh') do |item|
- if open(item).grep(/\r/).length > 0 
+ if open(item).grep(/\r/).length > 0
   crlf_count+=1
- end 
+ end
 end
 
 Dir.glob('bootstrap.d/*.sh') do |item|
- if open(item).grep(/\r/).length > 0 
+ if open(item).grep(/\r/).length > 0
   crlf_count+=1
- end 
+ end
 end
 
-if crlf_count > 0 
+if crlf_count > 0
   puts "One or more bash scripts contain CRLF line endings. Please check out"
   puts "Sawtooth Lake again with the git setting 'core.autocrlf' set to false"
   puts "in your git configuration."
@@ -100,16 +100,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = conf['VAGRANT_BOX']
 
-  if conf['VAGRANT_FORWARD_PORTS']
-      config.vm.network "forwarded_port", guest: 8800, host: 8800
-      config.vm.network "forwarded_port", guest: 8900, host: 8900
+#  if conf['VAGRANT_FORWARD_PORTS']
+#      config.vm.network "forwarded_port", guest: 8800, host: 8800
+#      config.vm.network "forwarded_port", guest: 8900, host: 8900
 
-      # rethinkdb
-      config.vm.network "forwarded_port", guest: 18080, host: 18080
+#      # rethinkdb
+#      config.vm.network "forwarded_port", guest: 18080, host: 18080
 
       # nodejs
-      config.vm.network "forwarded_port", guest: 3000, host: 3000
-  end
+#      config.vm.network "forwarded_port", guest: 3000, host: 3000
+#  end
   config.vm.provision :shell, path: "bootstrap.sh"
 
   config.vm.synced_folder "../../", "/project"


### PR DESCRIPTION
Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>


Would rather have a fix to have the port forwarding work, but need we need vagrant up to work on windows.
here is the error, my experience is the is 100% repeatable with VirtualBox 5.1.18 and Vagrant 1.9.3(The latest of both)

VAGRANT_BOX = ubuntu/xenial64
VAGRANT_FORWARD_PORTS = true
VAGRANT_MEMORY = 2048
VAGRANT_CPUS = 2
Configuring proxyconf plugin!
http_proxy: http://proxy-us.intel.com:911
https_proxy: http://proxy-us.intel.com:912
no_proxy: intel.com,.intel.com,10.0.0.0,10.0.0.8,192.168.0.0,192.168.0.16,localhost,127.0.0.0,127.0.0.8,134.134.0.0,134.134.0.16,172.16.0.0,172.16.0.20
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/xenial64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/xenial64' is up to date...
==> default: Setting the name of the VM: sawtooth
==> default: Destroying VM and associated drives...
C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.9.3/lib/vagrant/util/is_port_open.rb:21:in `initialize': The requested address is not valid in its context. - connect(2) for "0.0.0.0" port 8800 (Errno::EADDRNOTAVAIL)
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.9.3/lib/vagrant/util/is_port_open.rb:21:in `new'
