### PR TITLE
Set host_ip in Vagrantfile to 127.0.0.1

### DIFF
--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -101,14 +101,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = conf['VAGRANT_BOX']
 
   if conf['VAGRANT_FORWARD_PORTS']
-      config.vm.network "forwarded_port", guest: 8800, host: 8800
-      config.vm.network "forwarded_port", guest: 8900, host: 8900
+      config.vm.network "forwarded_port", guest: 8800, host: 8800, host_ip: "127.0.0.1"
+      config.vm.network "forwarded_port", guest: 8900, host: 8900, host_ip: "127.0.0.1"
 
       # rethinkdb
-      config.vm.network "forwarded_port", guest: 18080, host: 18080
+      config.vm.network "forwarded_port", guest: 18080, host: 18080, host_ip: "127.0.0.1"
 
       # nodejs
-      config.vm.network "forwarded_port", guest: 3000, host: 3000
+      config.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"
   end
   config.vm.provision :shell, path: "bootstrap.sh"
 


### PR DESCRIPTION
Fixes a bug with vagrant 1.9.3 on Windows

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>