### PR TITLE
Update the PoET consensus module so that it stops on non-PoET block

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -103,10 +103,12 @@ class PoetBlockPublisher(BlockPublisherInterface):
         wait_certificate_id = NULL_BLOCK_IDENTIFIER
         most_recent_block = self._block_cache.block_store.chain_head
         if most_recent_block is not None:
-            wait_certificate_id = \
+            wait_certificate = \
                 utils.deserialize_wait_certificate(
                     block=most_recent_block,
-                    poet_enclave_module=poet_enclave_module).identifier
+                    poet_enclave_module=poet_enclave_module)
+            if wait_certificate is not None:
+                wait_certificate_id = wait_certificate.identifier
 
         # Create signup information for this validator
         public_key_hash = \


### PR DESCRIPTION
This updates the PoET consensus module so that if it encounters a block not created by a PoET consensus module, it will stop walking back the block chain.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>