### PR TITLE
Fix Dropping batches that have satisfied dependencies

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -323,8 +323,7 @@ class BlockPublisher(object):
                     # we don't have a chain head, we cannot build blocks
                     self._candidate_block = None
                     self._consensus = None
-                    self._committed_txn_cache =\
-                        TransactionCache(self._block_cache.block_store)
+
                     for batch in self._pending_batches:
                         self._committed_txn_cache.add_batch(batch)
                 else:
@@ -375,9 +374,12 @@ class BlockPublisher(object):
                                  block)
                     pending_batches.remove(batch)
                     self._pending_batches = pending_batches
+                    self._committed_txn_cache = \
+                        TransactionCache(self._block_cache.block_store)
                     return False
                 else:
                     block.add_batch(batch)
+                    self._committed_txn_cache.add_batch(batch)
                 state_hash = result.state_hash
             else:
                 committed_txn_cache.uncommit_batch(batch)


### PR DESCRIPTION
While the publisher is waiting for the last block to be committed,
the publisher was throwing away batches that have dependencies
present in that block. This adds the batches in the block to the
committed_txn_cache so when the dependencies are checked the
soon to be comitted batches are accounted for.

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>