### PR TITLE
Make it a little easier to get state view for corresponding block

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -20,9 +20,10 @@ import json
 
 import sawtooth_signing as signing
 
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus \
     import BlockPublisherInterface
-from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 import sawtooth_validator.protobuf.transaction_pb2 as txn_pb
 
 from sawtooth_poet.poet_consensus import poet_enclave_factory as factory
@@ -198,14 +199,11 @@ class PoetBlockPublisher(BlockPublisherInterface):
         """
 
         # Using the current chain head, we need to create a state view so we
-        # can create a PoET enclave.  We are going to special case this until
-        # the genesis consensus is available.  We know that the genesis block
-        # is special cased to have a state view constructed for it.
-        state_root_hash = \
-            self._block_cache.block_store.chain_head.state_root_hash \
-            if self._block_cache.block_store.chain_head is not None \
-            else block_header.state_root_hash
-        state_view = self._state_view_factory.create_view(state_root_hash)
+        # can create a PoET enclave.
+        state_view = \
+            BlockWrapper.state_view_for_block(
+                block_wrapper=self._block_cache.block_store.chain_head,
+                state_view_factory=self._state_view_factory)
 
         poet_enclave_module = \
             factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
@@ -294,14 +292,11 @@ class PoetBlockPublisher(BlockPublisherInterface):
         block_hash = hasher.hexdigest()
 
         # Using the current chain head, we need to create a state view so we
-        # can create a PoET enclave.  We are going to special case this until
-        # the genesis consensus is available.  We know that the genesis block
-        # is special cased to have a state view constructed for it.
-        state_root_hash = \
-            self._block_cache.block_store.chain_head.state_root_hash \
-            if self._block_cache.block_store.chain_head is not None \
-            else block_header.state_root_hash
-        state_view = self._state_view_factory.create_view(state_root_hash)
+        # can create a PoET enclave.
+        state_view = \
+            BlockWrapper.state_view_for_block(
+                block_wrapper=self._block_cache.block_store.chain_head,
+                state_view_factory=self._state_view_factory)
 
         poet_enclave_module = \
             factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -110,6 +110,39 @@ class BlockWrapper(object):
         """
         return self.header.previous_block_id
 
+    @staticmethod
+    def state_view_for_block(block_wrapper, state_view_factory):
+        """
+        Returns the state view for an arbitrary block.
+
+        Args:
+            block_wrapper (BlockWrapper): The block for which a state
+                view is to be returned
+            state_view_factory (StateViewFactory): The state view factory
+                used to create the StateView object
+
+        Returns:
+            StateView object associated with the block
+        """
+        state_root_hash = \
+            block_wrapper.state_root_hash \
+            if block_wrapper is not None else None
+
+        return state_view_factory.create_view(state_root_hash)
+
+    def get_state_view(self, state_view_factory):
+        """
+        Returns the state view associated with this block
+
+        Args:
+            state_view_factory (StateViewFactory): The state view factory
+                used to create the StateView object
+
+        Returns:
+            StateView object
+        """
+        return BlockWrapper.state_view_for_block(self, state_view_factory)
+
     def __repr__(self):
         return "{}({}, S:{}, P:{})". \
             format(self.identifier, self.block_num,

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -18,6 +18,7 @@ from threading import RLock
 import sawtooth_signing as signing
 
 from sawtooth_validator.journal.block_wrapper import BlockStatus
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.consensus.consensus_factory import \
     ConsensusFactory
@@ -452,8 +453,9 @@ class ChainController(object):
         return self._chain_head
 
     def _verify_block(self, blkw):
-        state_view = self._state_view_factory.create_view(
-            self.chain_head.header.state_root_hash)
+        state_view = BlockWrapper.state_view_for_block(
+            self.chain_head,
+            self._state_view_factory)
         consensus_module = ConsensusFactory.get_configured_consensus_module(
             self.chain_head.header_signature,
             state_view)
@@ -563,7 +565,7 @@ class ChainController(object):
                                "Cannot set initial chain head.: %s",
                                block.identifier)
 
-            state_view = self._state_view_factory.create_view(INIT_ROOT_KEY)
+            state_view = self._state_view_factory.create_view()
             consensus_module = \
                 ConsensusFactory.get_configured_consensus_module(
                     NULL_BLOCK_IDENTIFIER,

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -17,6 +17,7 @@ import time
 import random
 import hashlib
 
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus\
     import BlockPublisherInterface
 from sawtooth_validator.journal.consensus.consensus\
@@ -69,14 +70,11 @@ class BlockPublisher(BlockPublisherInterface):
             True
         """
         # Using the current chain head, we need to create a state view so we
-        # can get our config values.  We are going to special case this until
-        # the genesis consensus is available.  We know that the genesis block
-        # is special cased to have a state view constructed for it.
-        state_root_hash = \
-            self._block_cache.block_store.chain_head.state_root_hash \
-            if self._block_cache.block_store.chain_head is not None \
-            else block_header.state_root_hash
-        state_view = self._state_view_factory.create_view(state_root_hash)
+        # can get our config values.
+        state_view = \
+            BlockWrapper.state_view_for_block(
+                self._block_cache.block_store.chain_head,
+                self._state_view_factory)
 
         config_view = ConfigView(state_view)
         self._min_wait_time = config_view.get_setting(

--- a/validator/sawtooth_validator/state/state_view.py
+++ b/validator/sawtooth_validator/state/state_view.py
@@ -32,13 +32,22 @@ class StateViewFactory(object):
         """
         self._database = database
 
-    def create_view(self, state_root_hash):
+    def create_view(self, state_root_hash=None):
         """Creates a StateView for the given state root hash.
 
+        Args:
+            state_root_hash (str): The state root hash of the state view
+                to return.  If None, returns the state view for the
         Returns:
             StateView: state view locked to the given root hash.
         """
-        return StateView(MerkleDatabase(self._database, state_root_hash))
+        # Create a default Merkle database and if we have a state root hash,
+        # update the Merkle database's root to that
+        merkle_db = MerkleDatabase(self._database)
+        if state_root_hash is not None:
+            merkle_db.set_merkle_root(state_root_hash)
+
+        return StateView(merkle_db)
 
 
 class StateView(object):


### PR DESCRIPTION
* Added member and static methods to the `BlockWrapper` class to make it a little easier for code to get the state view associated with a particular block.
* Updated `StateViewFactory.create_view` to default the state hash to `None` if not provided and also to return the default Merkle database is the state root hash is `None`.  This hopefully will alleviate some of the code from having to know about/use `INIT_ROOT_KEY`

Signed-off-by: Jamie Jason <jamie.jason@intel.com>