### PR TITLE
Add rest_api startup to cluster command

### DIFF
--- a/cli/sawtooth_cli/cluster.py
+++ b/cli/sawtooth_cli/cluster.py
@@ -352,7 +352,7 @@ def do_cluster_stop(args):
 
     # Force kill any targeted nodes that are still up
     for node_name in find_still_up(node_names):
-        print("Node name still up: killling {}".format(node_name))
+        print("Node name still up: killing {}".format(node_name))
         node_controller.kill(node_name)
 
 

--- a/manage/sawtooth_manage/subproc.py
+++ b/manage/sawtooth_manage/subproc.py
@@ -88,7 +88,7 @@ class SubprocessNodeController(NodeController):
 
         commands = ['validator'] + state['Processors']
         if node_args.genesis:
-            commands = ['sawtooth'] + commands
+            commands = ['sawtooth'] + commands + ['rest_api']
             # clean data dir of existing genesis node artifacts
             data_dir = os.path.join(os.path.expanduser("~"),
                                     'sawtooth', 'data')
@@ -115,6 +115,8 @@ class SubprocessNodeController(NodeController):
 
             elif cmd == 'sawtooth':
                 flags = 'admin', 'genesis'
+            elif cmd == 'rest_api':
+                flags = '--stream-url', url
             else:
                 flags = (url,)
             handle = subprocess.Popen((executable,) + flags)


### PR DESCRIPTION
The cluster start command (sawtooth cluster start) now starts one instance of the 
rest_api. 
Added to both docker and subprocess. 