### PR TITLE
Stop publisher from calling check_claim_block() if initialize_block() returns False

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -134,6 +134,7 @@ class BlockPublisher(object):
         block_builder = BlockBuilder(block_header)
         if not self._consensus.initialize_block(block_builder.block_header):
             LOGGER.debug("Consensus not ready to build candidate block.")
+            return None
 
         # create a new scheduler
         self._scheduler = self._transaction_executor.create_scheduler(


### PR DESCRIPTION
The publisher should not call `check_claim_block()` if the consensus module returns False from `initialize_block()`.  `Publisher._build_block()` is now returning `None` in this case so that it doesn't think that it has a block it should try to claim.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>