### PR TITLE
Fix CLI epilogs to diplay properly

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -16,6 +16,7 @@
 import sys
 import csv
 import json
+import argparse
 import yaml
 
 from sawtooth_cli import tty
@@ -40,7 +41,9 @@ def add_batch_parser(subparsers, parent_parser):
     header signature), transaction count, and their signer's public key.
     '''
 
-    list_parser = grand_parsers.add_parser('list', epilog=epilog)
+    list_parser = grand_parsers.add_parser(
+        'list', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     list_parser.add_argument(
         '--url',
         type=str,
@@ -56,7 +59,9 @@ def add_batch_parser(subparsers, parent_parser):
         Shows the data for a single batch, or for a particular property within
     that batch or its header. Displays data in YAML (default), or JSON formats.
     '''
-    show_parser = grand_parsers.add_parser('show', epilog=epilog)
+    show_parser = grand_parsers.add_parser(
+        'show', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'batch_id',
         type=str,

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -16,6 +16,7 @@
 import sys
 import csv
 import json
+import argparse
 import yaml
 
 from sawtooth_cli import tty
@@ -41,7 +42,9 @@ def add_block_parser(subparsers, parent_parser):
     their signer's public key.
     '''
 
-    list_parser = grand_parsers.add_parser('list', epilog=epilog)
+    list_parser = grand_parsers.add_parser(
+        'list', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     list_parser.add_argument(
         '--url',
         type=str,
@@ -57,7 +60,9 @@ def add_block_parser(subparsers, parent_parser):
         Shows the data for a single block, or for a particular property within
     that block or its header. Displays data in YAML (default), or JSON formats.
     '''
-    show_parser = grand_parsers.add_parser('show', epilog=epilog)
+    show_parser = grand_parsers.add_parser(
+        'show', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'block_id',
         type=str,

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -18,6 +18,7 @@ from base64 import b64decode
 
 import csv
 import json
+import argparse
 import yaml
 
 from sawtooth_cli import tty
@@ -42,7 +43,9 @@ def add_state_parser(subparsers, parent_parser):
     narrowed using the address of a subtree.
     '''
 
-    list_parser = grand_parsers.add_parser('list', epilog=epilog)
+    list_parser = grand_parsers.add_parser(
+        'list', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     list_parser.add_argument(
         'subtree',
         type=str,
@@ -68,7 +71,9 @@ def add_state_parser(subparsers, parent_parser):
     epilog = '''details:
         Shows the data for a single leaf on the merkle tree.
     '''
-    show_parser = grand_parsers.add_parser('show', epilog=epilog)
+    show_parser = grand_parsers.add_parser(
+        'show', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'address',
         type=str,


### PR DESCRIPTION
Used argparse formatter_class.RawDescriptionHelpFormatter
to cause epilogs for cli commands with epilogs to display
properly. The epilogs are formatted correctly and should not
wrap.

Signed-off-by: Todd Ojala <todd@bitwise.io>