### PR TITLE
Update to Java TransactionProcessor to shutdown gracefully. 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node ('master') {
 
         // Run the tests
         stage("Run Tests") {
-            sh './bin/run_tests -x java_sdk'
+            sh './bin/run_tests'
         }
 
         stage("Create git archive") {

--- a/sdk/examples/intkey_java/IntegerKeyHandler.java
+++ b/sdk/examples/intkey_java/IntegerKeyHandler.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright 2016, 2017 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -90,6 +90,9 @@ public class IntegerKeyHandler implements TransactionHandler {
      * same address
      */
     try {
+      if (transactionRequest.getPayload().size() == 0) {
+        throw new InvalidTransactionException("Payload is required.");
+      }
       HashMap updateMap = this.mapper.readValue(
               transactionRequest.getPayload().toByteArray(), HashMap.class);
       String name = updateMap.get("Name").toString();

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -53,10 +53,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.5.0</version>
                 <configuration>
-                    <pluginId>grpc-java</pluginId>
-                    <protocArtifact>com.google.protobuf:protoc:3.0.0-beta-2:exe:${os.detected.classifier}</protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.0.1:exe:${os.detected.classifier}</pluginArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.2.0:exe:${os.detected.classifier}</protocArtifact>
                     <protoSourceRoot>/project/sawtooth-core/protos</protoSourceRoot>
                 </configuration>
                 <executions>
@@ -64,7 +61,6 @@
                         <phase>generate-sources</phase>
                         <goals>
                             <goal>compile</goal>
-                            <goal>compile-custom</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -80,7 +76,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.0.0</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/sdk/java/src/main/java/sawtooth/sdk/client/Future.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/Future.java
@@ -16,12 +16,13 @@ package sawtooth.sdk.client;
 
 import com.google.protobuf.ByteString;
 
-import sawtooth.sdk.processor.exceptions.TimeoutError;
 import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+
 
 
 public interface Future{
@@ -29,7 +30,7 @@ public interface Future{
   ByteString getResult() throws InterruptedException,
       ValidatorConnectionError;
 
-  ByteString getResult(long timeout) throws InterruptedException, TimeoutError,
+  ByteString getResult(long timeout) throws InterruptedException, TimeoutException,
       ValidatorConnectionError;
 
   void setResult(ByteString byteString) throws ValidatorConnectionError;

--- a/sdk/java/src/main/java/sawtooth/sdk/client/Future.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/Future.java
@@ -1,0 +1,39 @@
+/* Copyright 2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package sawtooth.sdk.client;
+
+import com.google.protobuf.ByteString;
+
+import sawtooth.sdk.processor.exceptions.TimeoutError;
+import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+public interface Future{
+
+  ByteString getResult() throws InterruptedException,
+      ValidatorConnectionError;
+
+  ByteString getResult(long timeout) throws InterruptedException, TimeoutError,
+      ValidatorConnectionError;
+
+  void setResult(ByteString byteString) throws ValidatorConnectionError;
+
+  boolean isDone() throws ValidatorConnectionError;
+
+}

--- a/sdk/java/src/main/java/sawtooth/sdk/client/FutureByteString.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/FutureByteString.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright 2016, 2017 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -16,13 +16,13 @@ package sawtooth.sdk.client;
 
 import com.google.protobuf.ByteString;
 
-import java.util.concurrent.Future;
+import sawtooth.sdk.processor.exceptions.TimeoutError;
+
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class FutureByteString {
+public class FutureByteString implements Future{
 
   private ByteString result;
   private String correlationId;
@@ -45,8 +45,7 @@ public class FutureByteString {
    * Returns the ByteString result, waiting for it to not be null.
    * @return ByteString protobuf
    */
-  public ByteString getResult() throws InterruptedException,
-      TimeoutException {
+  public ByteString getResult() throws InterruptedException {
     ByteString byteString = null;
     lock.lock();
     try {
@@ -58,6 +57,28 @@ public class FutureByteString {
       lock.unlock();
     }
 
+    return byteString;
+  }
+
+  /**
+   * Returns the ByteString result. If the timeout expires, throws TimeoutError.
+   * @param timeout time to wait for a result.
+   * @return ByteString protobuf
+   */
+  public ByteString getResult(long timeout) throws InterruptedException, TimeoutError {
+    ByteString byteString = null;
+    lock.lock();
+    try {
+      if (result == null) {
+        condition.await(timeout, TimeUnit.SECONDS);
+      }
+      byteString = result;
+    } finally {
+      lock.unlock();
+    }
+    if (byteString == null) {
+      throw new TimeoutError("Future Timed out");
+    }
     return byteString;
   }
 
@@ -89,7 +110,5 @@ public class FutureByteString {
     }
     return answer;
   }
-
-
 
 }

--- a/sdk/java/src/main/java/sawtooth/sdk/client/FutureByteString.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/FutureByteString.java
@@ -16,11 +16,12 @@ package sawtooth.sdk.client;
 
 import com.google.protobuf.ByteString;
 
-import sawtooth.sdk.processor.exceptions.TimeoutError;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+
 
 public class FutureByteString implements Future{
 
@@ -61,11 +62,11 @@ public class FutureByteString implements Future{
   }
 
   /**
-   * Returns the ByteString result. If the timeout expires, throws TimeoutError.
+   * Returns the ByteString result. If the timeout expires, throws TimeoutException.
    * @param timeout time to wait for a result.
    * @return ByteString protobuf
    */
-  public ByteString getResult(long timeout) throws InterruptedException, TimeoutError {
+  public ByteString getResult(long timeout) throws InterruptedException, TimeoutException {
     ByteString byteString = null;
     lock.lock();
     try {
@@ -77,7 +78,7 @@ public class FutureByteString implements Future{
       lock.unlock();
     }
     if (byteString == null) {
-      throw new TimeoutError("Future Timed out");
+      throw new TimeoutException("Future Timed out");
     }
     return byteString;
   }

--- a/sdk/java/src/main/java/sawtooth/sdk/client/FutureError.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/FutureError.java
@@ -1,0 +1,63 @@
+/* Copyright 2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package sawtooth.sdk.client;
+
+import com.google.protobuf.ByteString;
+
+import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class FutureError implements Future{
+
+  /**
+   * Constructor.
+   */
+  public FutureError() {
+  }
+
+  /**
+   * Always raises ValidatorConnectionError.
+   */
+  public ByteString getResult() throws InterruptedException,
+      ValidatorConnectionError {
+    throw new ValidatorConnectionError();
+  }
+
+  /**
+   * Always raises ValidatorConnectionError.
+   */
+  public ByteString getResult(long time) throws InterruptedException,
+     ValidatorConnectionError {
+    throw new ValidatorConnectionError();
+  }
+
+  /**
+   * Always raises ValidatorConnectionError.
+   */
+  public void setResult(ByteString byteString) throws ValidatorConnectionError {
+    throw new ValidatorConnectionError();
+  }
+
+  /**
+   * Always raises ValidatorConnectionError.
+   */
+  public boolean isDone() throws ValidatorConnectionError {
+    throw new ValidatorConnectionError();
+  }
+
+}

--- a/sdk/java/src/main/java/sawtooth/sdk/client/Stream.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/Stream.java
@@ -65,10 +65,9 @@ public class Stream {
             .setCorrelationId(this.generateId())
             .setMessageType(destination).setContent(contents).build();
 
-    this.sendReceiveThread.sendMessage(message);
     FutureByteString future = new FutureByteString(message.getCorrelationId());
     this.futureHashMap.put(message.getCorrelationId(), future);
-
+    this.sendReceiveThread.sendMessage(message);
     return future;
   }
 

--- a/sdk/java/src/main/java/sawtooth/sdk/client/Stream.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/Stream.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright 2016,  2017 Intel Corporation
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
@@ -25,13 +25,15 @@ import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * The client networking class.
  */
 public class Stream {
-  private ConcurrentHashMap<String, FutureByteString> futureHashMap;
-  private LinkedBlockingQueue<Message> receiveQueue;
+  private ConcurrentHashMap<String, Future> futureHashMap;
+  private LinkedBlockingQueue<SendReceiveThread.MessageWrapper> receiveQueue;
   private SendReceiveThread sendReceiveThread;
   private Thread thread;
 
@@ -42,8 +44,8 @@ public class Stream {
    *
    */
   public Stream(String address) {
-    this.futureHashMap = new ConcurrentHashMap<String, FutureByteString>();
-    this.receiveQueue = new LinkedBlockingQueue<Message>();
+    this.futureHashMap = new ConcurrentHashMap<String, Future>();
+    this.receiveQueue = new LinkedBlockingQueue<SendReceiveThread.MessageWrapper>();
     this.sendReceiveThread = new SendReceiveThread(address,
         futureHashMap, this.receiveQueue);
     this.thread = new Thread(sendReceiveThread);
@@ -57,7 +59,7 @@ public class Stream {
    * @return future a future that will have ByteString that can be deserialized into a,
    *         for example, GetResponse
    */
-  public FutureByteString send(Message.MessageType destination, ByteString contents) {
+  public Future send(Message.MessageType destination, ByteString contents) {
 
     Message message = Message.newBuilder()
             .setCorrelationId(this.generateId())
@@ -102,14 +104,31 @@ public class Stream {
    * @return result, a protobuf Message
    */
   public Message receive() {
-
-    Message result = null;
+    SendReceiveThread.MessageWrapper result = null;
     try {
       result = this.receiveQueue.take();
     } catch (InterruptedException ie) {
       ie.printStackTrace();
     }
-    return result;
+    return result.message;
+  }
+
+  /**
+   * Get a message that has been received. If the timeout is expired, throws TimeoutException.
+   * @param timeout time to wait for a message.
+   * @return result, a protobuf Message
+   */
+  public Message receive(long timeout) throws TimeoutException {
+    SendReceiveThread.MessageWrapper result = null;
+    try {
+      result = this.receiveQueue.poll(timeout, TimeUnit.SECONDS);
+      if (result == null) {
+        throw new TimeoutException("The recieve queue timed out.");
+      }
+    } catch (InterruptedException ie) {
+      ie.printStackTrace();
+    }
+    return result.message;
   }
 
   /**

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/ValidatorConnectionError.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/ValidatorConnectionError.java
@@ -1,0 +1,22 @@
+/* Copyright 2017 Intel Corporation
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+------------------------------------------------------------------------------*/
+
+package sawtooth.sdk.processor.exceptions;
+
+public class ValidatorConnectionError extends Exception {
+
+  public ValidatorConnectionError() {
+    super("The connection to the validator was lost");
+  }
+}


### PR DESCRIPTION
TransactionProcessor should do the following:
On TP shutdown: TransactionProcessor will finish handling messages and send an unregister request. Finally shutdown.
On ValidatorShutdown: Set any futures to FutureError (which will throw ValidatorConnectionError if accessed) and try to reregister all handlers.

Also some include some fixups to the java sdk, add multiple handler functionally with find_handler, and added timeout to futures. 

