### PR TITLE
Create PoET consensus state store

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -1,0 +1,228 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from collections import namedtuple
+
+import cbor
+
+ValidatorState = \
+    namedtuple(
+        'ValidatorState',
+        ['key_block_claim_count',
+         'poet_public_key',
+         'total_block_claim_count'
+         ])
+""" Instead of creating a full-fledged class, let's use a named tuple for
+the validator state.  The validator state represents the state for a single
+validator at a point in time.  A validator state object contains:
+
+key_block_claim_count (int): The number of blocks that the validator has
+claimed using the current PoET public key
+poet_public_key (str): The current PoET public key for the validator
+total_block_claim_count (int): The total number of the blocks that the
+    validator has claimed
+"""
+
+
+class ConsensusState(object):
+    """Represents the consensus state at a particular point in time (i.e.,
+    when the block that this consensus state corresponds to was committed to
+    the block chain).
+
+    Attributes:
+        sealed_signup_data (str): The encoded sealed signup data that was
+            received from the most recent creation of signup information
+            for the validator
+        expected_block_claim_count (float): The number of blocks that a
+            validator, based upon the population estimate, would be expected
+            to have claimed
+    """
+    def __init__(self):
+        """Initialize a ConsensusState object
+
+        Returns:
+            None
+        """
+        self.sealed_signup_data = None
+        self.expected_block_claim_count = 0.0
+        self._validators = {}
+
+    @staticmethod
+    def _check_validator_state(validator_state):
+        if not isinstance(
+                validator_state.key_block_claim_count, int) \
+                or validator_state.key_block_claim_count < 0:
+            raise \
+                ValueError(
+                    'key_block_claim_count ({}) is invalid'.format(
+                        validator_state.key_block_claim_count))
+
+        if not isinstance(
+                validator_state.poet_public_key, str) \
+                or len(validator_state.poet_public_key) < 1:
+            raise \
+                ValueError(
+                    'poet_public_key ({}) is invalid'.format(
+                        validator_state.poet_public_key))
+        if not isinstance(
+                validator_state.total_block_claim_count, int) \
+                or validator_state.total_block_claim_count < 0:
+            raise \
+                ValueError(
+                    'total_block_claim_count ({}) is invalid'.format(
+                        validator_state.total_block_claim_count))
+
+        if validator_state.key_block_claim_count > \
+                validator_state.total_block_claim_count:
+            raise \
+                ValueError(
+                    'total_block_claim_count ({}) is less than '
+                    'key_block_claim_count ({})'.format(
+                        validator_state.total_block_claim_count,
+                        validator_state.key_block_claim_count))
+
+    def get_validator_state(self, validator_id, default=None):
+        """Return the consensus state for a particular validator
+
+        Args:
+            validator_id (str): The ID of the validator for which consensus
+                state information is being requested
+            default (ValidatorState): The default state to return if the
+                validator ID is not in the list of known validators
+
+        Returns:
+            ValidatorState: object corresponding to the validator or the
+                value provided in the default parameter if there is no
+                validator state information for the ID provided
+        """
+
+        assert default is None or isinstance(default, ValidatorState)
+
+        return self._validators.get(validator_id, default)
+
+    def set_validator_state(self, validator_id, validator_state):
+        """Sets the consensus state for a particular validator.
+
+        Args:
+            validator_id (str): The ID of the validator for which consensus
+                state information is being set
+            validator_state (ValidatorState): The validator state information
+                for the validator
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: Validator state is invalid
+        """
+
+        assert isinstance(validator_state, ValidatorState)
+
+        self._check_validator_state(validator_state)
+        self._validators[validator_id] = validator_state
+
+    def serialize_to_bytes(self):
+        """Serialized the consensus state object to a byte string suitable
+        for storage
+
+        Returns:
+            bytes: serialized version of the consensus state object
+        """
+        # For serialization, the easiest thing to do is to convert ourself to
+        # a dictionary and convert to CBOR.
+        return cbor.dumps(self.__dict__)
+
+    def parse_from_bytes(self, buffer):
+        """Returns a consensus state object re-created from the serialized
+        consensus state provided.
+
+        Args:
+            buffer (bytes): A byte string representing the serialized
+                version of a consensus state to re-create.  This was created
+                by a previous call to serialize_to_bytes
+
+        Returns:
+            ConsensusState: object representing the serialized byte string
+                provided
+
+        Raises:
+            ValueError: failure to parse into a valid ConsensusState object
+        """
+        try:
+            # Deserialize the CBOR back into a dictionary and set the simple
+            # fields, doing our best to check validity
+            self_dict = cbor.loads(buffer)
+
+            if not isinstance(self_dict, dict):
+                raise \
+                    ValueError(
+                        'buffer is not a valid serialization of a '
+                        'ConsensusState object')
+
+            self.sealed_signup_data = \
+                self_dict.get('sealed_signup_data', None)
+            self.expected_block_claim_count = \
+                float(self_dict['expected_block_claim_count'])
+            validators = self_dict['_validators']
+
+            if self.expected_block_claim_count < 0:
+                raise \
+                    ValueError(
+                        'expected_block_claim_count ({}) is invalid'.format(
+                            self.expected_block_claim_count))
+
+            if not isinstance(validators, dict):
+                raise ValueError('_validators is not a dict')
+
+            # Now walk through all of the key/value pairs in the the
+            # validators dictionary and reconstitute the validator state from
+            # them, again trying to validate the data the best we can.  The
+            # only catch is that because the validator state objects are named
+            # tuples, cbor.dumps() treated them as such and so we lost the
+            # named part.  When re-creating the validator state, are going to
+            # leverage the namedtuple's _make method.
+
+            self._validators = {}
+            for key, value in validators.items():
+                validator_state = ValidatorState._make(value)
+
+                self._check_validator_state(validator_state)
+                self._validators[str(key)] = validator_state
+
+        except (LookupError, ValueError, KeyError, TypeError) as error:
+            raise \
+                ValueError(
+                    'Error parsing ConsensusState buffer: {}'.format(error))
+
+    def __str__(self):
+        sealed_signup_data = \
+            '0' * 16 if self.sealed_signup_data is None \
+            else self.sealed_signup_data
+        validators = \
+            ['{}...{}: {{KBCC: {}, PPK: {}...{}, TBCC: {}}}'.format(
+                key[:8],
+                key[-8:],
+                value.key_block_claim_count,
+                value.poet_public_key[:8],
+                value.poet_public_key[-8:],
+                value.total_block_claim_count) for
+             key, value in self._validators.items()]
+
+        return \
+            'SSD: {}...{}, EBCC: {}, V: {}'.format(
+                sealed_signup_data[:8],
+                sealed_signup_data[-8:],
+                self.expected_block_claim_count,
+                validators)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state_store.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state_store.py
@@ -1,0 +1,160 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import threading
+import logging
+import os
+
+# pylint: disable=no-name-in-module
+from collections.abc import MutableMapping
+
+from sawtooth_poet.poet_consensus.consensus_state import ConsensusState
+
+from sawtooth_validator.database.lmdb_nolock_database \
+    import LMDBNoLockDatabase
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConsensusStateStore(MutableMapping):
+    """Manages access to the underlying database holding per-block consensus
+    state information.  Note that because of the architectural model around
+    the consensus objects, all ConsensusStateStore objects actually reference
+    a single underlying database.  Provides a dict-like interface to the
+    consensus state, mapping block IDs to their corresponding consensus state.
+    """
+
+    _store_dbs = {}
+    _lock = threading.Lock()
+
+    def __init__(self, data_dir, validator_id):
+        """Initialize the consensus state store
+
+        Args:
+            data_dir (str): The directory where underlying database file will
+                be stored
+            validator_id (str): A unique ID for the validator for which the
+                consensus state store is being created
+
+        Returns:
+            None
+        """
+        with ConsensusStateStore._lock:
+            # Create an underlying LMDB database file for the validator if
+            # there already isn't one.  We will create the LMDB with the 'c'
+            # flag so that it will open if already exists.
+            self._store_db = ConsensusStateStore._store_dbs.get(validator_id)
+            if self._store_db is None:
+                db_file_name = \
+                    os.path.join(
+                        data_dir,
+                        'poet_consensus_state-{}.lmdb'.format(
+                            validator_id[:8]))
+                LOGGER.debug('Create consensus store: %s', db_file_name)
+                self._store_db = LMDBNoLockDatabase(db_file_name, 'c')
+                ConsensusStateStore._store_dbs[validator_id] = self._store_db
+
+    def __setitem__(self, block_id, consensus_state):
+        """Adds/updates an item in the consensus state store
+
+        Args:
+            block_id (str): The ID of the block that this consensus state
+                corresponds to
+            consensus_state (ConsensusState): The consensus state
+
+        Returns:
+            None
+        """
+        self._store_db[block_id] = consensus_state.serialize_to_bytes()
+
+    def __getitem__(self, block_id):
+        """Return the consensus state corresponding to the block ID
+
+        Args:
+            block_id (str): The ID of the block for which consensus state
+                is being requested
+
+        Returns:
+            ConsensusState object
+
+        Raises:
+            KeyError if the block ID is not in the store
+        """
+        serialized_consensus_state = self._store_db[block_id]
+        if serialized_consensus_state is None:
+            raise KeyError('Block ID {} not found'.format(block_id))
+
+        try:
+            consensus_state = ConsensusState()
+            consensus_state.parse_from_bytes(
+                buffer=serialized_consensus_state)
+            return consensus_state
+        except ValueError as error:
+            raise \
+                KeyError(
+                    'Cannot return block with ID {}: {}'.format(
+                        block_id,
+                        error))
+
+    def __delitem__(self, block_id):
+        del self._store_db[block_id]
+
+    def __contains__(self, block_id):
+        return block_id in self._store_db
+
+    def __iter__(self):
+        # Required by abstract base class, but implementing is non-trivial
+        raise NotImplementedError('ConsensusState is not iterable')
+
+    def __len__(self):
+        return len(self._store_db)
+
+    def __str__(self):
+        out = []
+        for block_id in self._store_db.keys():
+            try:
+                serialized_consensus_state = self._store_db[block_id]
+                consensus_state = ConsensusState()
+                consensus_state.parse_from_bytes(
+                    buffer=serialized_consensus_state)
+                out.append(
+                    '{}...{}: {{{}}}'.format(
+                        block_id[:8],
+                        block_id[-8:],
+                        consensus_state))
+            except ValueError:
+                pass
+
+        return ', '.join(out)
+
+    def get(self, block_id, default=None):
+        """Return the consensus state corresponding to block ID or the default
+        value if none exists
+
+        Args:
+            block_id (str):  The ID of the block for which consensus state
+                is being requested
+            default (ConsensusState): The default value to return if there
+                is no consensus state associated with the block ID
+
+        Returns:
+            ConsensusState object or default if no state for key
+        """
+        try:
+            return self.__getitem__(block_id)
+        except KeyError:
+            pass
+
+        return default

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -15,6 +15,14 @@
 
 import logging
 
+from sawtooth_poet.poet_consensus.consensus_state_store \
+    import ConsensusStateStore
+from sawtooth_poet.poet_consensus import poet_enclave_factory as factory
+from sawtooth_poet.poet_consensus import utils
+from sawtooth_poet_common.validator_registry_view.validator_registry_view \
+    import ValidatorRegistryView
+
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus \
     import ForkResolverInterface
 
@@ -54,6 +62,10 @@ class PoetForkResolver(ForkResolverInterface):
         self._state_view_factory = state_view_factory
         self._data_dir = data_dir
         self._validator_id = validator_id
+        self._consensus_state_store = \
+            ConsensusStateStore(
+                data_dir=self._data_dir,
+                validator_id=self._validator_id)
 
     def compare_forks(self, cur_fork_head, new_fork_head):
         """Given the head of two forks, return which should be the fork that
@@ -68,6 +80,8 @@ class PoetForkResolver(ForkResolverInterface):
             Boolean: True if the new chain should replace the current chain.
             False if the new chain should be discarded.
         """
+        chosen_fork_head = None
+
         if new_fork_head.block_num > cur_fork_head.block_num:
             LOGGER.info(
                 'Chain with new fork head %s...%s longer (%d) than current '
@@ -78,7 +92,7 @@ class PoetForkResolver(ForkResolverInterface):
                 cur_fork_head.header_signature[:8],
                 cur_fork_head.header_signature[-8:],
                 cur_fork_head.block_num)
-            return True
+            chosen_fork_head = new_fork_head
         elif new_fork_head.block_num < cur_fork_head.block_num:
             LOGGER.info(
                 'Chain with current head %s...%s longer (%d) than new fork '
@@ -89,7 +103,7 @@ class PoetForkResolver(ForkResolverInterface):
                 new_fork_head.header_signature[:8],
                 new_fork_head.header_signature[-8:],
                 new_fork_head.block_num)
-            return False
+            chosen_fork_head = cur_fork_head
         elif new_fork_head.header_signature > cur_fork_head.header_signature:
             LOGGER.info(
                 'Signature of new fork head (%s...%s) > than current '
@@ -98,7 +112,7 @@ class PoetForkResolver(ForkResolverInterface):
                 new_fork_head.header_signature[-8:],
                 cur_fork_head.header_signature[:8],
                 cur_fork_head.header_signature[-8:])
-            return True
+            chosen_fork_head = new_fork_head
         else:
             LOGGER.info(
                 'Signature of current fork head (%s...%s) >= than new '
@@ -107,4 +121,75 @@ class PoetForkResolver(ForkResolverInterface):
                 cur_fork_head.header_signature[-8:],
                 new_fork_head.header_signature[:8],
                 new_fork_head.header_signature[-8:])
-            return False
+            chosen_fork_head = cur_fork_head
+
+        # Now that we have chosen a fork for the chain head, if
+        # we chose the new fork, we need to create consensus state
+        # store information for the new fork's chain head.
+        if chosen_fork_head == new_fork_head:
+            # Get the state view for the previous block in the chain so we can
+            # create a PoET enclave
+            previous_block = None
+            try:
+                previous_block = \
+                    self._block_cache[new_fork_head.previous_block_id]
+            except KeyError:
+                pass
+
+            state_view = \
+                BlockWrapper.state_view_for_block(
+                    block_wrapper=previous_block,
+                    state_view_factory=self._state_view_factory)
+
+            poet_enclave_module = \
+                factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
+
+            validator_registry_view = ValidatorRegistryView(state_view)
+            try:
+                # Get the validator info for the validator that claimed the
+                # fork head
+                validator_info = \
+                    validator_registry_view.get_validator_info(
+                        new_fork_head.header.signer_pubkey)
+
+                # Get the consensus state for the new fork head's previous
+                # block, update the validator state for the new fork head,
+                # and then store the updated consensus state for this block.
+                consensus_state = \
+                    utils.get_consensus_state_for_block_id(
+                        block_id=new_fork_head.previous_block_id,
+                        block_cache=self._block_cache,
+                        state_view_factory=self._state_view_factory,
+                        consensus_state_store=self._consensus_state_store,
+                        poet_enclave_module=poet_enclave_module)
+
+                validator_state = \
+                    consensus_state.get_validator_state(
+                        validator_id=validator_info.id)
+                consensus_state.set_validator_state(
+                    validator_id=validator_info.id,
+                    validator_state=utils.create_validator_state(
+                        validator_info=validator_info,
+                        current_validator_state=validator_state))
+
+                LOGGER.debug(
+                    'Store consensus state for block ID %s...%s',
+                    new_fork_head.identifier[:8],
+                    new_fork_head.identifier[-8:])
+
+                self._consensus_state_store[new_fork_head.identifier] = \
+                    consensus_state
+            except KeyError:
+                # This _should_ never happen.  The new potential fork head
+                # has to have been a PoET block and for it to be verified
+                # by the PoET block verifier, it must have been signed by
+                # validator in the validator registry.  If not found, we
+                # are going to just stick with the current fork head.
+                LOGGER.error(
+                    'New fork head claimed by validator not in validator '
+                    'registry: %s...%s',
+                    new_fork_head.header.signer_pubkey[:8],
+                    new_fork_head.header.signer_pubkey[-8:])
+                chosen_fork_head = cur_fork_head
+
+        return chosen_fork_head == new_fork_head

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -19,7 +19,12 @@ import logging
 
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 
+from sawtooth_poet_common.validator_registry_view.validator_registry_view \
+    import ValidatorRegistryView
+
 from sawtooth_poet.poet_consensus.wait_certificate import WaitCertificate
+from sawtooth_poet.poet_consensus.consensus_state import ConsensusState
+from sawtooth_poet.poet_consensus.consensus_state import ValidatorState
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,3 +118,155 @@ def build_certificate_list(block_header,
         LOGGER.error('Error getting block: %s', ke)
 
     return list(certificates)
+
+
+def create_validator_state(validator_info, current_validator_state):
+    """Starting with the current validator state (or None), create validator
+     validator state for the validator.
+
+    Args:
+        validator_info (ValidatorInfo): Information about the validator
+        current_validator_state (ValidatorState): The current validator
+            state we are going to update or None if there isn't any and
+            we are to create default validator state
+
+    Returns:
+        ValidatorState object
+    """
+
+    # Start with the default validator state (i.e., assuming that none existed
+    # to start with) and update accordingly.  If it does exist and the PoET
+    # public key is the same, then we are just going to update counts.  If it
+    # does exist but the PoET public key has changed, we need to update
+    # statistics and take note of the new key.
+    key_block_claim_count = 1
+    poet_public_key = validator_info.signup_info.poet_public_key
+    total_block_claim_count = 1
+
+    if current_validator_state is not None:
+        total_block_claim_count = \
+            current_validator_state.total_block_claim_count + 1
+
+        if validator_info.signup_info.poet_public_key == \
+                current_validator_state.poet_public_key:
+            key_block_claim_count = \
+                current_validator_state.key_block_claim_count + 1
+
+    LOGGER.debug(
+        'Create validator state for %s: PPK=%s...%s, KBCC=%d, TBCC=%d',
+        validator_info.name,
+        poet_public_key[:8],
+        poet_public_key[-8:],
+        key_block_claim_count,
+        total_block_claim_count)
+
+    return \
+        ValidatorState(
+            key_block_claim_count=key_block_claim_count,
+            poet_public_key=poet_public_key,
+            total_block_claim_count=total_block_claim_count)
+
+
+def get_consensus_state_for_block_id(
+        block_id,
+        block_cache,
+        state_view_factory,
+        consensus_state_store,
+        poet_enclave_module):
+    """Returns the consensus state for the block referenced by block ID,
+        creating it from the consensus state history if necessary.
+
+    Args:
+        block_id (str): The ID of the block for which consensus state will
+            be returned.
+        block_cache (BlockCache): The block store cache
+        state_view_factory (StateViewFactory): A factory that can be used
+            to create state view object corresponding to blocks
+        consensus_state_store (ConsensusStateStore): The consensus state
+            store
+        poet_enclave_module (module): The PoET enclave module
+
+    Returns:
+        ConsensusState object representing the consensus state for the block
+            referenced by block_id
+    """
+
+    # Starting at the chain head, walk the block store backwards until we
+    # either get to the root or we get a block for which we have already
+    # created consensus state
+    block = \
+        block_cache[block_id] if block_id != NULL_BLOCK_IDENTIFIER else None
+    consensus_state = None
+    block_ids = collections.deque()
+
+    while block is not None:
+        # Try to fetch the consensus state.  If that succeeds, we can
+        # stop walking back as we can now build on that consensus
+        # state.
+        consensus_state = consensus_state_store.get(block.identifier)
+        if consensus_state is not None:
+            break
+
+        # If this is a PoET block, then we want to create consensus state
+        # for it when we are done
+        if deserialize_wait_certificate(block, poet_enclave_module):
+            LOGGER.debug(
+                'We need to build consensus state for block ID %s...%s',
+                block.identifier[:8],
+                block.identifier[-8:])
+            block_ids.appendleft(block.identifier)
+
+        # Move to the previous block
+        block = \
+            block_cache[block.previous_block_id] \
+            if block.previous_block_id != NULL_BLOCK_IDENTIFIER else None
+
+    # If didn't find any consensus state, see if there is any "before" any
+    # blocks were created (this might be because we are the first validator
+    # and PoET signup information was created, including sealed signup data
+    # that was saved in the consensus state store).
+    if consensus_state is None:
+        consensus_state = consensus_state_store.get(NULL_BLOCK_IDENTIFIER)
+
+    # At this point, if we have not found any consensus state, we need to
+    # create default state from which we can build upon
+    if consensus_state is None:
+        consensus_state = ConsensusState()
+
+    # Now, walking forward through the blocks for which we were supposed to
+    # create consensus state, we are going to create and store state for each
+    # one so that the next time we don't have to walk so far back through the
+    # block chain.
+    for identifier in block_ids:
+        block = block_cache[identifier]
+
+        # Get the validator registry view for this block's state view and
+        # then fetch the validator info for the validator that signed this
+        # block.
+        state_view = state_view_factory.create_view(block.state_root_hash)
+        validator_registry_view = ValidatorRegistryView(state_view)
+
+        validator_id = block.header.signer_pubkey
+        validator_info = \
+            validator_registry_view.get_validator_info(
+                validator_id=validator_id)
+
+        # Fetch the current validator state, set/update the validator state
+        # in the consensus state object, and then create the consensus state
+        # in the consensus state store and associate it with this block
+        validator_state = \
+            consensus_state.get_validator_state(validator_id=validator_id)
+        consensus_state.set_validator_state(
+            validator_id=validator_id,
+            validator_state=create_validator_state(
+                validator_info=validator_info,
+                current_validator_state=validator_state))
+
+        LOGGER.debug(
+            'Store consensus state for block ID %s...%s',
+            identifier[:8],
+            identifier[-8:])
+
+        consensus_state_store[identifier] = consensus_state
+
+    return consensus_state

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -74,7 +74,7 @@ def build_certificate_list(block_header,
 
     Args:
         block_header (BlockHeader): The header for the block
-        block_cache (BlockCache): The cache of blcoks that are predecessors
+        block_cache (BlockCache): The cache of blocks that are predecessors
             to the block represented by block_header
         poet_enclave_module (module): The PoET enclave module
         maximum_number (int): The maximum number of certificates to return

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -1,0 +1,312 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+from unittest import mock
+
+import cbor
+
+from sawtooth_poet.poet_consensus import consensus_state
+
+
+class TestConsensusState(unittest.TestCase):
+    def test_get_missing_validator_state(self):
+        """Verify that retrieving missing validator state returns appropriate
+        default values.
+        """
+        state = consensus_state.ConsensusState()
+
+        # Try to get a non-existent validator ID and verify it returns default
+        # value
+        validator_state = \
+            state.get_validator_state(validator_id='Bond, James Bond')
+        self.assertIsNone(validator_state)
+
+        validator_state = \
+            state.get_validator_state(
+                validator_id='Bond, James Bond',
+                default=consensus_state.ValidatorState(
+                    key_block_claim_count=1,
+                    poet_public_key='my key',
+                    total_block_claim_count=2))
+        self.assertEqual(validator_state.key_block_claim_count, 1)
+        self.assertEqual(validator_state.poet_public_key, 'my key')
+        self.assertEqual(validator_state.total_block_claim_count, 2)
+
+    def test_set_validator_state(self):
+        """Verify that trying to set validator state with invalid validator
+        state values/types fail.  Verifying that doing a get after a
+        successful set returns the expected data.
+        """
+        state = consensus_state.ConsensusState()
+
+        # Test invalid key block claim counts in validator state
+        for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
+            with self.assertRaises(ValueError):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=invalid_kbcc,
+                        poet_public_key='my key',
+                        total_block_claim_count=0))
+
+        # Test invalid PoET public key in validator state
+        for invalid_ppk in [None, (), [], {}, 1, 1.1, '']:
+            with self.assertRaises(ValueError):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=0,
+                        poet_public_key=invalid_ppk,
+                        total_block_claim_count=0))
+
+        # Test total block claim count in validator state
+        for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
+            with self.assertRaises(ValueError):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=0,
+                        poet_public_key='my key',
+                        total_block_claim_count=invalid_tbcc))
+
+        # Test with total block claim count < key block claim count
+        with self.assertRaises(ValueError):
+            state.set_validator_state(
+                validator_id='Bond, James Bond',
+                validator_state=consensus_state.ValidatorState(
+                    key_block_claim_count=2,
+                    poet_public_key='my key',
+                    total_block_claim_count=1))
+
+        # Verify that can retrieve after set and validator state matches
+        validator_state = \
+            consensus_state.ValidatorState(
+                key_block_claim_count=0,
+                poet_public_key='my key',
+                total_block_claim_count=0)
+        state.set_validator_state(
+            validator_id='Bond, James Bond',
+            validator_state=validator_state)
+
+        retrieved_validator_state = \
+            state.get_validator_state(validator_id='Bond, James Bond')
+
+        self.assertEqual(
+            validator_state.key_block_claim_count,
+            retrieved_validator_state.key_block_claim_count)
+        self.assertEqual(
+            validator_state.poet_public_key,
+            retrieved_validator_state.poet_public_key)
+        self.assertEqual(
+            validator_state.total_block_claim_count,
+            retrieved_validator_state.total_block_claim_count)
+
+        # Verify that updating an existing validator state matches on get
+        validator_state = \
+            consensus_state.ValidatorState(
+                key_block_claim_count=1,
+                poet_public_key='my new key',
+                total_block_claim_count=2)
+        state.set_validator_state(
+            validator_id='Bond, James Bond',
+            validator_state=validator_state)
+
+        retrieved_validator_state = \
+            state.get_validator_state(validator_id='Bond, James Bond')
+
+        self.assertEqual(
+            validator_state.key_block_claim_count,
+            retrieved_validator_state.key_block_claim_count)
+        self.assertEqual(
+            validator_state.poet_public_key,
+            retrieved_validator_state.poet_public_key)
+        self.assertEqual(
+            validator_state.total_block_claim_count,
+            retrieved_validator_state.total_block_claim_count)
+
+    def test_serialize(self):
+        """Verify that deserializing invalid data results in the appropriate
+        error.  Verify that serializing state and then deserializing results
+        in the same state values.
+        """
+        # Simple deserialization check of buffer
+        for invalid_state in [None, '', 1, 1.1, (), [], {}]:
+            state = consensus_state.ConsensusState()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(cbor.dumps(invalid_state))
+
+        # Invalid expected block count
+        for invalid_ebc in [None, 'not a float', (), [], {}]:
+            state = consensus_state.ConsensusState()
+            state.expected_block_claim_count = invalid_ebc
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(state.serialize_to_bytes())
+
+        # Invalid expected block count
+        for invalid_validators in [None, '', 1, 1.1, (), []]:
+            state = consensus_state.ConsensusState()
+            # pylint: disable=protected-access
+            state._validators = invalid_validators
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(state.serialize_to_bytes())
+
+        state = consensus_state.ConsensusState()
+        state.set_validator_state(
+            validator_id='Bond, James Bond',
+            validator_state=consensus_state.ValidatorState(
+                key_block_claim_count=1,
+                poet_public_key='key',
+                total_block_claim_count=1))
+        doppelganger_state = consensus_state.ConsensusState()
+
+        # Truncate the serialized value on purpose
+        with self.assertRaises(ValueError):
+            doppelganger_state.parse_from_bytes(
+                state.serialize_to_bytes()[:-1])
+        with self.assertRaises(ValueError):
+            doppelganger_state.parse_from_bytes(
+                state.serialize_to_bytes()[1:])
+
+        # Circumvent testing of validator state validity so that we can
+        # serialize to invalid data to verify deserializing
+
+        # Test invalid key block claim counts in validator state
+        for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
+            state = consensus_state.ConsensusState()
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.'
+                    'ConsensusState._check_validator_state'):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=invalid_kbcc,
+                        poet_public_key='key 1',
+                        total_block_claim_count=1))
+
+            serialized = state.serialize_to_bytes()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(serialized)
+
+        # Test invalid PoET public key in validator state
+        for invalid_ppk in [None, (), [], {}, 1, 1.1, '']:
+            state = consensus_state.ConsensusState()
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.'
+                    'ConsensusState._check_validator_state'):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=1,
+                        poet_public_key=invalid_ppk,
+                        total_block_claim_count=1))
+
+            serialized = state.serialize_to_bytes()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(serialized)
+
+        # Test total block claim count in validator state
+        for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
+            state = consensus_state.ConsensusState()
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.'
+                    'ConsensusState._check_validator_state'):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        key_block_claim_count=1,
+                        poet_public_key='key',
+                        total_block_claim_count=invalid_tbcc))
+
+            serialized = state.serialize_to_bytes()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(serialized)
+
+        # Test with total block claim count < key block claim count
+        with mock.patch(
+                'sawtooth_poet.poet_consensus.consensus_state.'
+                'ConsensusState._check_validator_state'):
+            state.set_validator_state(
+                validator_id='Bond, James Bond',
+                validator_state=consensus_state.ValidatorState(
+                    key_block_claim_count=2,
+                    poet_public_key='key',
+                    total_block_claim_count=1))
+
+        state = consensus_state.ConsensusState()
+
+        # Simple serialization of new consensus state and then deserialize
+        # and compare
+
+        doppelganger_state = consensus_state.ConsensusState()
+        doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
+
+        self.assertEqual(
+            state.sealed_signup_data,
+            doppelganger_state.sealed_signup_data)
+        self.assertEqual(
+            state.expected_block_claim_count,
+            doppelganger_state.expected_block_claim_count)
+
+        # Now put a couple of validators in, serialize, deserialize, and
+        # verify they are in deserialized
+        validator_state_1 = \
+            consensus_state.ValidatorState(
+                key_block_claim_count=1,
+                poet_public_key='key 1',
+                total_block_claim_count=2)
+        validator_state_2 = \
+            consensus_state.ValidatorState(
+                key_block_claim_count=3,
+                poet_public_key='key 2',
+                total_block_claim_count=4)
+
+        state.set_validator_state(
+            validator_id='Bond, James Bond',
+            validator_state=validator_state_1)
+        state.set_validator_state(
+            validator_id='Smart, Maxwell Smart',
+            validator_state=validator_state_2)
+
+        doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
+
+        validator_state = \
+            doppelganger_state.get_validator_state(
+                validator_id='Bond, James Bond')
+
+        self.assertEqual(
+            validator_state.key_block_claim_count,
+            validator_state_1.key_block_claim_count)
+        self.assertEqual(
+            validator_state.poet_public_key,
+            validator_state_1.poet_public_key)
+        self.assertEqual(
+            validator_state.total_block_claim_count,
+            validator_state_1.total_block_claim_count)
+
+        validator_state = \
+            doppelganger_state.get_validator_state(
+                validator_id='Smart, Maxwell Smart')
+
+        self.assertEqual(
+            validator_state.key_block_claim_count,
+            validator_state_2.key_block_claim_count)
+        self.assertEqual(
+            validator_state.poet_public_key,
+            validator_state_2.poet_public_key)
+        self.assertEqual(
+            validator_state.total_block_claim_count,
+            validator_state_2.total_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -1,0 +1,154 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+from unittest import mock
+import tempfile
+import os
+from importlib import reload
+
+import cbor
+
+from sawtooth_poet.poet_consensus import consensus_state
+from sawtooth_poet.poet_consensus import consensus_state_store
+
+
+class TestConsensusStateStore(unittest.TestCase):
+    def setUp(self):
+        # pylint: disable=invalid-name,global-statement
+        global consensus_state_store
+        # Because ConsensusStateStore uses class variables to hold state
+        # we need to reload the module after each test to clear state
+        consensus_state_store = reload(consensus_state_store)
+
+    @mock.patch('sawtooth_poet.poet_consensus.consensus_state_store.'
+                'LMDBNoLockDatabase')
+    def test_verify_db_creation(self, mock_lmdb):
+        """Verify that the underlying consensus state store LMDB file is
+        created underneath the provided data directory and with the correct
+        file creation flag.
+        """
+        consensus_state_store.ConsensusStateStore(
+            data_dir=tempfile.gettempdir(),
+            validator_id='0123456789abcdef')
+
+        # Verify that the database is created in the directory provided
+        # and that it is created with the anydb flag for open if exists,
+        # create if doesn't exist
+        (filename, flag), _ = mock_lmdb.call_args
+
+        self.assertTrue(filename.startswith(tempfile.gettempdir() + os.sep))
+        self.assertEqual(flag, 'c')
+
+    @mock.patch('sawtooth_poet.poet_consensus.consensus_state_store.'
+                'LMDBNoLockDatabase')
+    def test_nonexistent_key(self, mock_lmdb):
+        """Verify that retrieval of a non-existent key raises the appropriate
+        exception.
+        """
+        # Make LMDB return None for all keys
+        mock_lmdb.return_value.__getitem__.return_value = None
+        store = \
+            consensus_state_store.ConsensusStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        with self.assertRaises(KeyError):
+            _ = store['bad key']
+
+    @mock.patch('sawtooth_poet.poet_consensus.consensus_state_store.'
+                'LMDBNoLockDatabase')
+    def test_malformed_consensus_state(self, mock_lmdb):
+        """Verify the a malformed consensus state that cannot be properly
+        deserialized to a consensus state object raises the appropriate
+        exception.
+        """
+        # Make LMDB return CBOR serialization of a non-dict
+        mock_lmdb.return_value.__getitem__.return_value = cbor.dumps('bad')
+        store = \
+            consensus_state_store.ConsensusStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        with self.assertRaises(KeyError):
+            _ = store['bad key']
+
+    @mock.patch('sawtooth_poet.poet_consensus.consensus_state_store.'
+                'LMDBNoLockDatabase')
+    def test_consensus_store_set_get(self, mock_lmdb):
+        """Verify that externally visible state (len, etc.) of the consensus
+        state store after set is expected.  Verify that retrieving a
+        previously set consensus state object results in the same values
+        set.
+        """
+        # Make LMDB return empty dict
+        my_dict = {}
+        mock_lmdb.return_value = my_dict
+
+        store = \
+            consensus_state_store.ConsensusStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Verify the length is zero and doesn't contain key
+        self.assertEqual(len(store), 0)
+        self.assertTrue('key' not in store)
+
+        # Store consensus state
+        state = consensus_state.ConsensusState()
+        state.sealed_signup_data = 'Our sealed signup data'
+        state.expected_block_claim_count = 3.14
+        state.set_validator_state(
+            validator_id='Bond, James Bond',
+            validator_state=consensus_state.ValidatorState(
+                key_block_claim_count=1,
+                poet_public_key='skeleton key',
+                total_block_claim_count=2))
+
+        store['key'] = state
+
+        # Verify the length and contains key
+        self.assertEqual(len(store), 1)
+        self.assertEqual(len(my_dict), 1)
+        self.assertTrue('key' in store)
+        self.assertTrue('key' in my_dict)
+
+        # Retrieve the state and verify equality
+        retrieved_state = store['key']
+
+        self.assertEqual(
+            state.sealed_signup_data,
+            retrieved_state.sealed_signup_data)
+        self.assertEqual(
+            state.expected_block_claim_count,
+            retrieved_state.expected_block_claim_count)
+
+        validator_state = \
+            retrieved_state.get_validator_state(
+                validator_id='Bond, James Bond')
+
+        self.assertEqual(validator_state.key_block_claim_count, 1)
+        self.assertEqual(validator_state.poet_public_key, 'skeleton key')
+        self.assertEqual(validator_state.total_block_claim_count, 2)
+
+        # Delete the key and then verify length and does not contain key
+        del store['key']
+        self.assertEqual(len(store), 0)
+        self.assertEqual(len(my_dict), 0)
+        self.assertTrue('key' not in store)
+        self.assertTrue('key' not in my_dict)
+
+        with self.assertRaises(KeyError):
+            state = store['key']

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -151,7 +151,7 @@ class BlockValidator(object):
         chain.
 
         :param batch: the batch to verify
-        :param committed_txn(TransactionCache): Current set of commited
+        :param committed_txn(TransactionCache): Current set of committed
         transaction, updated during processing.
         :return:
         Boolean: True if all dependencies are present.
@@ -509,7 +509,7 @@ class ChainController(object):
         """Message back from the block validator, that the validation is
         complete
         Args:
-        commit_new_block (Boolean): wether the new block should become the
+        commit_new_block (Boolean): whether the new block should become the
         chain head or not.
         result (Dict): Map of the results of the fork resolution.
         Returns:
@@ -586,7 +586,7 @@ class ChainController(object):
             LOGGER.exception(exc)
 
     def _set_genesis(self, block):
-        # This is used by a non-genesis journal when it has recieved the
+        # This is used by a non-genesis journal when it has received the
         # genesis block from the genesis validator
         if block.previous_block_id == NULL_BLOCK_IDENTIFIER:
             chain_id = self._chain_id_manager.get_block_chain_id()

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -70,7 +70,7 @@ class BlockPublisher(object):
              consensus module can be stored.
         """
         self._lock = RLock()
-        self._candidate_block = None  # the next block in potentia
+        self._candidate_block = None  # the next block in potential chain
         self._consensus = None
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory


### PR DESCRIPTION
This PR:

* Creates PoET consensus state class to manage per-block consensus state
* Creates PoET consensus state store for managing consensus stat objects, mapping a block ID to the consensus state at that point in time
* Updates the PoET block verifier to create consensus state for a block if it successfully verifies it
* Updates the PoET genesis tool to persist the sealed signup data in the consensus store at a well-known location
* Updates the PoET block publisher to look in the consensus store for sealed signup data so that it can give it to the PoET enclave