### PR TITLE
Only write to state on genesis and block validation

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -231,8 +231,13 @@ class TransactionExecutor(object):
         self._alive_threads = []
         self._lock = threading.Lock()
 
-    def create_scheduler(self, squash_handler, first_state_root):
-        return SerialScheduler(squash_handler, first_state_root)
+    def create_scheduler(self,
+                         squash_handler,
+                         first_state_root,
+                         always_persist=False):
+        return SerialScheduler(squash_handler=squash_handler,
+                               first_state_hash=first_state_root,
+                               always_persist=always_persist)
 
     def _remove_done_threads(self):
         for t in self._alive_threads.copy():

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -104,6 +104,10 @@ class Scheduler(object, metaclass=ABCMeta):
     def complete(self, block):
         """Returns True if all transactions have been marked as applied.
 
+        Args:
+            block (bool): If True, block until complete, or if False return
+                the completion status.
+
         Returns:
             True if all transactions have been marked as applied and that the
             finalize() has been called.
@@ -207,9 +211,11 @@ class BatchExecutionResult(object):
 
     Attributes:
         is_valid (bool): True if the batch is valid, False otherwise.
-        state_hash (str): the resulting state hash after all transactions in
-            the batch were successfully executed.  If is_valid is False, then
-            this field is set to None as final state was obtained.
+        state_hash (str): The state hash from applying the state changes from
+            the transactions in this batch and all prior transactions in valid
+            batches since the last state hash was returned. Will always be
+            in the BatchExecutionResult for batches that were added to
+            add_batch with a state hash.
     """
     def __init__(self, is_valid, state_hash):
         self.is_valid = is_valid

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -33,7 +33,7 @@ class SerialScheduler(Scheduler):
     This scheduler is intended to be used for comparison to more complex
     schedulers - for tests related to performance, correctness, etc.
     """
-    def __init__(self, squash_handler, first_state_hash):
+    def __init__(self, squash_handler, first_state_hash, always_persist):
         self._txn_queue = queue.Queue()
         self._scheduled_transactions = []
         self._batch_statuses = {}
@@ -42,12 +42,18 @@ class SerialScheduler(Scheduler):
         self._final = False
         self._complete = False
         self._cancelled = False
+        self._previous_context_id = None
+        self._previous_valid_batch_c_id = None
         self._squash = squash_handler
         self._condition = Condition()
         # contains all txn.signatures where txn is
         # last in it's associated batch
         self._last_in_batch = []
-        self._last_state_hash = first_state_hash
+        self._previous_state_hash = first_state_hash
+        # The state hashes here are the ones added in add_batch, and
+        # are the state hashes that correspond with block boundaries.
+        self._required_state_hashes = {}
+        self._always_persist = always_persist
 
     def __del__(self):
         self.cancel()
@@ -57,42 +63,46 @@ class SerialScheduler(Scheduler):
 
     def set_transaction_execution_result(
             self, txn_signature, is_valid, context_id):
-        """the control flow is that on every valid txn a new state root is
-        generated. If the txn is invalid the batch status is set,
-        if the txn is the last txn in the batch, is valid, and no
-         prior txn failed the batch, the
-        batch is valid
-        """
         with self._condition:
             if (self._in_progress_transaction is None or
                     self._in_progress_transaction != txn_signature):
-                raise ValueError("transaction not in progress: {}",
-                                 txn_signature)
+                raise ValueError("transaction not in progress: {}".format(
+                                 txn_signature))
             self._in_progress_transaction = None
 
             if txn_signature not in self._txn_to_batch:
                 raise ValueError("transaction not in any batches: {}".format(
                     txn_signature))
+
+            batch_signature = self._txn_to_batch[txn_signature]
             if is_valid:
-                # txn is valid, get a new state hash
-                state_hash = self._squash(self._last_state_hash, [context_id])
-                self._last_state_hash = state_hash
+                self._previous_context_id = context_id
+
             else:
                 # txn is invalid, preemptively fail the batch
-                batch_signature = self._txn_to_batch[txn_signature]
                 self._batch_statuses[batch_signature] = \
                     BatchExecutionResult(is_valid=is_valid, state_hash=None)
             if txn_signature in self._last_in_batch:
-                batch_signature = self._txn_to_batch[txn_signature]
                 if batch_signature not in self._batch_statuses:
                     # because of the else clause above, txn is valid here
+                    self._previous_valid_batch_c_id = self._previous_context_id
+                    state_hash = None
+                    required_state_hash = self._required_state_hashes.get(
+                        batch_signature)
+                    if required_state_hash is not None \
+                            or self._last_in_batch[-1] == txn_signature:
+                        state_hash = self._compute_merkle_root(
+                            required_state_hash)
                     self._batch_statuses[batch_signature] = \
                         BatchExecutionResult(
                             is_valid=is_valid,
-                            state_hash=self._last_state_hash)
+                            state_hash=state_hash)
+                else:
+                    self._previous_context_id = self._previous_valid_batch_c_id
 
                 is_last_batch = \
                     len(self._batch_statuses) == len(self._last_in_batch)
+
                 if self._final and is_last_batch:
                     self._complete = True
             self._condition.notify_all()
@@ -103,6 +113,8 @@ class SerialScheduler(Scheduler):
                 raise SchedulerError("Scheduler is finalized. Cannnot take"
                                      " new batches")
             batch_signature = batch.header_signature
+            if state_hash is not None:
+                self._required_state_hashes[batch_signature] = state_hash
             batch_length = len(batch.transactions)
             for idx, txn in enumerate(batch.transactions):
                 if idx == batch_length - 1:
@@ -133,9 +145,11 @@ class SerialScheduler(Scheduler):
                 return None
 
             self._in_progress_transaction = txn.header_signature
+            base_contexts = [] if self._previous_context_id is None \
+                else [self._previous_context_id]
             txn_info = TxnInformation(txn=txn,
-                                      state_hash=self._last_state_hash,
-                                      base_context_ids=[])
+                                      state_hash=self._previous_state_hash,
+                                      base_context_ids=base_contexts)
             self._scheduled_transactions.append(txn_info)
             return txn_info
 
@@ -145,6 +159,31 @@ class SerialScheduler(Scheduler):
             if len(self._batch_statuses) == len(self._last_in_batch):
                 self._complete = True
             self._condition.notify_all()
+
+    def _compute_merkle_root(self, required_state_root):
+        """Computes the merkle root of the state changes in the context
+        corresponding with _last_valid_batch_c_id as applied to
+        _previous_state_hash.
+
+        Args:
+            required_state_root (str): The merkle root that these txns
+                should equal.
+
+        Returns:
+            state_hash (str): The merkle root calculated from the previous
+                state hash and the state changes from the context_id
+        """
+        state_hash = self._squash(
+            state_root=self._previous_state_hash,
+            context_ids=[self._previous_valid_batch_c_id],
+            persist=self._always_persist)
+        if self._always_persist is True:
+            return state_hash
+        if state_hash == required_state_root:
+            self._squash(state_root=self._previous_state_hash,
+                         context_ids=[self._previous_valid_batch_c_id],
+                         persist=True)
+        return state_hash
 
     def complete(self, block):
         with self._condition:

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -148,7 +148,8 @@ class GenesisController(object):
         if len(genesis_batches) > 0:
             scheduler = SerialScheduler(
                 self._context_manager.get_squash_handler(),
-                initial_state_root)
+                initial_state_root,
+                always_persist=True)
 
             LOGGER.debug('Adding %s batches', len(genesis_data.batches))
             for batch in genesis_data.batches:
@@ -167,8 +168,8 @@ class GenesisController(object):
                 raise InvalidGenesisStateError(
                     'Unable to create genesis block, due to batch {}'
                     .format(batch.header_signature))
-
-            state_hash = result.state_hash
+            if result.state_hash is not None:
+                state_hash = result.state_hash
         LOGGER.debug('Produced state hash %s for genesis block.',
                      state_hash)
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -231,7 +231,8 @@ class _CandidateBlock(object):
                 else:
                     builder.add_batch(batch)
                     committed_txn_cache.add_batch(batch)
-                state_hash = result.state_hash
+                if result.state_hash is not None:
+                    state_hash = result.state_hash
             else:
                 LOGGER.debug("Batch %s invalid, not added to block.",
                              batch.header_signature)

--- a/validator/tests/unit3/test_context_manager/tests.py
+++ b/validator/tests/unit3/test_context_manager/tests.py
@@ -69,7 +69,8 @@ class TestContextManager(unittest.TestCase):
 
         # 2)
         squash = self.context_manager.get_squash_handler()
-        resulting_state_hash = squash(self.first_state_hash, [context_id])
+        resulting_state_hash = squash(self.first_state_hash, [context_id],
+                                      persist=True)
 
         # 3)
         final_state_to_update = {

--- a/validator/tests/unit3/test_scheduler/tests.py
+++ b/validator/tests/unit3/test_scheduler/tests.py
@@ -27,6 +27,7 @@ from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.execution.scheduler_serial import SerialScheduler
 from sawtooth_validator.database import dict_database
 from sawtooth_validator.execution.scheduler_parallel import PredecessorTree
+from sawtooth_validator.state.merkle import MerkleDatabase
 
 
 LOGGER = logging.getLogger(__name__)
@@ -83,10 +84,19 @@ class TestSerialScheduler(unittest.TestCase):
         self.context_manager = ContextManager(dict_database.DictDatabase())
         squash_handler = self.context_manager.get_squash_handler()
         self.first_state_root = self.context_manager.get_first_root()
-        self.scheduler = SerialScheduler(squash_handler, self.first_state_root)
+        self.scheduler = SerialScheduler(squash_handler,
+                                         self.first_state_root,
+                                         always_persist=False)
 
     def tearDown(self):
         self.context_manager.stop()
+
+    def _get_address_from_txn(self, txn_info):
+        txn_header = transaction_pb2.TransactionHeader()
+        txn_header.ParseFromString(txn_info.txn.header)
+        inputs_or_outputs = list(txn_header.inputs)
+        address_b = inputs_or_outputs[0]
+        return address_b
 
     def test_transaction_order(self):
         """Tests the that transactions are returned in order added.
@@ -424,8 +434,8 @@ class TestSerialScheduler(unittest.TestCase):
                and one where one of the txns is invalid.
             2. Run through the scheduler executor interaction
                as txns are processed.
-            3. Verify that the valid state root is obtained
-               through the squash function.
+            3. Verify that the state root obtained through the squash function
+               is the same as directly updating the merkle tree.
             4. Verify that correct batch statuses are set
         """
         private_key = signing.generate_privkey()
@@ -433,7 +443,7 @@ class TestSerialScheduler(unittest.TestCase):
 
         # 1)
         batch_signatures = []
-        for names in [['a', 'b'], ['invalid', 'c']]:
+        for names in [['a', 'b'], ['invalid', 'c'], ['d', 'e']]:
             batch_txns = []
             for name in names:
                 txn = create_transaction(
@@ -475,50 +485,42 @@ class TestSerialScheduler(unittest.TestCase):
         sched2 = iter(self.scheduler)
         # 3)
         txn_info_a = next(sched2)
-        self.assertEquals(self.first_state_root, txn_info_a.state_hash)
-
         txn_a_header = transaction_pb2.TransactionHeader()
         txn_a_header.ParseFromString(txn_info_a.txn.header)
         inputs_or_outputs = list(txn_a_header.inputs)
         address_a = inputs_or_outputs[0]
-        c_id_a = self.context_manager.create_context(
-            state_hash=self.first_state_root,
-            inputs=inputs_or_outputs,
-            outputs=inputs_or_outputs,
-            base_contexts=txn_info_a.base_context_ids)
-        self.context_manager.set(c_id_a, [{address_a: 1}])
-        state_root2 = self.context_manager.commit_context([c_id_a], virtual=False)
+
         txn_info_b = next(sched2)
+        address_b = self._get_address_from_txn(txn_info_b)
 
-        self.assertEquals(txn_info_b.state_hash, state_root2)
-
-        txn_b_header = transaction_pb2.TransactionHeader()
-        txn_b_header.ParseFromString(txn_info_b.txn.header)
-        inputs_or_outputs = list(txn_b_header.inputs)
-        address_b = inputs_or_outputs[0]
-        c_id_b = self.context_manager.create_context(
-            state_hash=state_root2,
-            inputs=inputs_or_outputs,
-            outputs=inputs_or_outputs,
-            base_contexts=txn_info_b.base_context_ids)
-        self.context_manager.set(c_id_b, [{address_b: 1}])
-        state_root3 = self.context_manager.commit_context([c_id_b], virtual=False)
         txn_infoInvalid = next(sched2)
-
-        self.assertEquals(txn_infoInvalid.state_hash, state_root3)
-
         txn_info_c = next(sched2)
-        self.assertEquals(txn_info_c.state_hash, state_root3)
+
+        txn_info_d = next(sched2)
+        address_d = self._get_address_from_txn(txn_info_d)
+
+        txn_info_e = next(sched2)
+        address_e = self._get_address_from_txn(txn_info_e)
+
+        merkle_database = MerkleDatabase(dict_database.DictDatabase())
+        state_root_end = merkle_database.update(
+            {address_a: 1, address_b: 1,
+             address_d: 1, address_e: 1},
+            virtual=False)
+
         # 4)
         batch1_result = self.scheduler.get_batch_execution_result(
             batch_signatures[0])
         self.assertTrue(batch1_result.is_valid)
-        self.assertEquals(batch1_result.state_hash, state_root3)
 
         batch2_result = self.scheduler.get_batch_execution_result(
             batch_signatures[1])
         self.assertFalse(batch2_result.is_valid)
-        self.assertIsNone(batch2_result.state_hash)
+
+        batch3_result = self.scheduler.get_batch_execution_result(
+            batch_signatures[2])
+        self.assertTrue(batch3_result.is_valid)
+        self.assertEqual(batch3_result.state_hash, state_root_end)
 
 
 class TestPredecessorTree(unittest.TestCase):


### PR DESCRIPTION
The constructor to the SerialScheduler is changed in this PR, to accept the optional keyword argument always_persist, which can be used in genesis block construction to write the state change to the underlying database no matter what the resulting merkle hash is. When always_persist is False, the only time the state change is written to the underlying database is when the merkle root provided on the block boundary in add_batch equals the computed merkle root from the state changes.