### PR TITLE
Preserve LMDB files

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -79,7 +79,7 @@ class Validator(object):
                                        network_endpoint[-2:]))
         LOGGER.debug('database file is %s', db_filename)
 
-        merkle_db = LMDBNoLockDatabase(db_filename, 'n')
+        merkle_db = LMDBNoLockDatabase(db_filename, 'c')
 
         context_manager = ContextManager(merkle_db)
         self._context_manager = context_manager
@@ -90,7 +90,7 @@ class Validator(object):
                                          network_endpoint[-2:]))
         LOGGER.debug('block store file is %s', block_db_filename)
 
-        block_db = LMDBNoLockDatabase(block_db_filename, 'n')
+        block_db = LMDBNoLockDatabase(block_db_filename, 'c')
         block_store = BlockStore(block_db)
 
         # setup network


### PR DESCRIPTION
Preserve the LMDB files for the merkle tree and the block store across
restarts of the validator.  Prior to this commit, these databases were
in use, and persisting to disk, but being deleted at startup time.

Signed-off-by: Peter Schwarz <peterx.schwarz@intel.com>