### PR TITLE
Fix chain controller block processing issues

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -627,6 +627,11 @@ class ChainController(object):
                     self._set_genesis(block)
                     return
 
+                # If we are already currently processing this block, then
+                # don't bother trying to schedule it again.
+                if block.identifier in self._blocks_processing:
+                    return
+
                 self._block_cache[block.identifier] = block
                 self._blocks_pending[block.identifier] = []
                 LOGGER.debug("Block received: %s", block)

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -406,8 +406,8 @@ class BlockValidator(object):
             LOGGER.error("Block validation failed with unexpected error: %s",
                          self._new_block)
             LOGGER.exception(exc)
-            self._done_cb(False)  # callback to clean up the block out of the
-            # processing list.
+            # callback to clean up the block out of the processing list.
+            self._done_cb(False, self._result)
 
 
 class ChainController(object):

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -162,9 +162,9 @@ class BlockValidator(object):
             for dep in txn_hdr.dependencies:
                 if dep not in committed_txn:
                     LOGGER.debug("Block rejected due missing" +
-                                 " transaction dependency, transaction {}"
-                                 " depends on {}",
-                                 txn.header_signature, dep)
+                                 " transaction dependency, transaction %s"
+                                 " depends on %s",
+                                 txn.header_signature[:8], dep[:8])
                     return False
             committed_txn.add_txn(txn.header_signature)
         return True


### PR DESCRIPTION
Updated `ChainController.on_block_validated()` to properly manage the pending blocks queue based upon the result of the block validation.

To test this fix:

1.  In `validator/sawtooth_validator/execution/executor.py` line 230, replace:

`self._executing_threadpool = ThreadPoolExecutor(max_workers=5)`

with

`self._executing_threadpool = ThreadPoolExecutor(max_workers=100)`

2.  In `integration/sawtooth_integration/docker/poet-smoke.yaml`, after the line:

`sawtooth.consensus.algorithm=poet \`

 add the following lines:

`sawtooth.poet.target_wait_time=5 \`
`sawtooth.poet.initial_wait_time=0 \`

3.  Run the PoET smoke test:

`cd integration/sawtooth_integration/docker`
`run_docker_test poet-smoke.yaml`

Hopefully test will pass.