### PR TITLE
Fix bug where Rest Api was unable to handle concurrent requests

### DIFF
--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import asyncio
 import argparse
 import sys
 from aiohttp import web
@@ -54,10 +55,11 @@ async def logging_middleware(app, handler):
 def start_rest_api(host, port, stream_url, timeout):
     """Builds the web app, adds route handlers, and finally starts the app.
     """
-    app = web.Application(middlewares=[logging_middleware])
+    loop = asyncio.get_event_loop()
+    app = web.Application(loop=loop, middlewares=[logging_middleware])
 
     # Add routes to the web app
-    handler = RouteHandler(stream_url, timeout)
+    handler = RouteHandler(loop, stream_url, timeout)
 
     app.router.add_post('/batches', handler.submit_batches)
     app.router.add_get('/batch_status', handler.list_statuses)

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -148,7 +148,7 @@ class BaseApiTest(AioHTTPTestCase):
         self.stream = MockStream(self, req_type, req_proto, resp_proto)
 
     @staticmethod
-    def build_handlers(stream):
+    def build_handlers(loop, stream):
         """Returns Rest Api route handlers modified with some a mock stream.
 
         Args:
@@ -157,7 +157,7 @@ class BaseApiTest(AioHTTPTestCase):
         Returns:
             RouteHandler: The route handlers to handle test queries
         """
-        handlers = RouteHandler('tcp://0.0.0.0:40404', TEST_TIMEOUT)
+        handlers = RouteHandler(loop, 'tcp://0.0.0.0:40404', TEST_TIMEOUT)
         handlers._stream = stream
         return handlers
 

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -31,6 +31,9 @@ from sawtooth_rest_api.protobuf.transaction_pb2 import Transaction
 from sawtooth_rest_api.protobuf.transaction_pb2 import TransactionHeader
 
 
+TEST_TIMEOUT = 5
+
+
 class MockStream(object):
     """Replaces a route handler's stream to allow tests to preset the response
     to send back as well as run asserts on the protobufs sent to the stream.
@@ -154,7 +157,7 @@ class BaseApiTest(AioHTTPTestCase):
         Returns:
             RouteHandler: The route handlers to handle test queries
         """
-        handlers = RouteHandler('tcp://0.0.0.0:40404', 5)
+        handlers = RouteHandler('tcp://0.0.0.0:40404', TEST_TIMEOUT)
         handlers._stream = stream
         return handlers
 

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -27,7 +27,7 @@ class BatchListTests(BaseApiTest):
             client_pb2.ClientBatchListRequest,
             client_pb2.ClientBatchListResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/batches', handlers.list_batches)
 
     @unittest_run_loop
@@ -489,7 +489,7 @@ class BatchGetTests(BaseApiTest):
             client_pb2.ClientBatchGetRequest,
             client_pb2.ClientBatchGetResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/batches/{batch_id}', handlers.fetch_batch)
 
     @unittest_run_loop

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -27,7 +27,7 @@ class BlockListTests(BaseApiTest):
             client_pb2.ClientBlockListRequest,
             client_pb2.ClientBlockListResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/blocks', handlers.list_blocks)
 
     @unittest_run_loop
@@ -488,7 +488,7 @@ class BlockGetTests(BaseApiTest):
             client_pb2.ClientBlockGetRequest,
             client_pb2.ClientBlockGetResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/blocks/{block_id}', handlers.fetch_block)
 
     @unittest_run_loop

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -28,7 +28,7 @@ class StateListTests(BaseApiTest):
             client_pb2.ClientStateListRequest,
             client_pb2.ClientStateListResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/state', handlers.list_state)
 
     @unittest_run_loop
@@ -494,7 +494,7 @@ class StateGetTests(BaseApiTest):
             client_pb2.ClientStateGetRequest,
             client_pb2.ClientStateGetResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/state/{address}', handlers.fetch_state)
 
     @unittest_run_loop

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -28,7 +28,7 @@ class PostBatchTests(BaseApiTest):
             client_pb2.ClientBatchSubmitRequest,
             client_pb2.ClientBatchSubmitResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/batches', handlers.submit_batches)
 
     @unittest_run_loop
@@ -211,7 +211,7 @@ class BatchStatusTests(BaseApiTest):
             client_pb2.ClientBatchStatusRequest,
             client_pb2.ClientBatchStatusResponse)
 
-        handlers = self.build_handlers(self.stream)
+        handlers = self.build_handlers(loop, self.stream)
         return self.build_app(loop, '/batch_status', handlers.list_statuses)
 
     @unittest_run_loop


### PR DESCRIPTION
The python SDK defined futures are not asynchronous, and resolving one's `result` for a single request was blocking the entire Rest Api. Wrap that synchronous call in an asynchronous `Executor` to free up the Rest Api's event loop for other requests.

Also includes a small tweak to Rest Api tests to remove a magic number.
