### PR TITLE
Fix the exhaustion of ThreadPool in TransactionExecutor

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -210,9 +210,7 @@ test_python_sdk() {
     run_docker_test intkey-smoke -s integration_test
     run_docker_test xo-smoke -s integration_test
     run_docker_test two_families -s integration_test
-    # JLJ - Temporarily disable this test while debugging fork resolution
-    # problem when using PoET consensus
-    #run_docker_test poet-smoke -s integration_test
+    run_docker_test poet-smoke -s integration_test
 }
 
 test_rest_api() {

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -185,6 +185,7 @@ class BlockValidator(object):
 
             batch = blkw.batches[-1]
             if not self._verify_batches_dependencies(batch, committed_txn):
+                scheduler.cancel()
                 return False
             scheduler.add_batch(batch,
                                 blkw.state_root_hash)

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -125,6 +125,11 @@ class BlockPublisher(object):
             LOGGER.debug("Consensus not ready to build candidate block.")
             return None
 
+        # Cancel the previous scheduler if it did not complete.
+        if self._scheduler is not None \
+                and not self._scheduler.complete(block=False):
+            self._scheduler.cancel()
+
         # create a new scheduler
         self._scheduler = self._transaction_executor.create_scheduler(
             self._squash_handler, chain_head.state_root_hash)


### PR DESCRIPTION
As was obliquely mentioned in hyperledger/sawtooth-core#297 the thread pool in the TransactionExecutor would get exhausted with lower PoET wait times and stop processing. I tested this fix by setting sawtooth.poet.wait_time=2 and sawtooth.poet.initial_wait_time=0 in the poet-smoke.yaml test.