### PR TITLE
Enforce and abide by PoET key block claim limit

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -42,9 +42,6 @@ class ConsensusState(object):
     the block chain).
 
     Attributes:
-        sealed_signup_data (str): The encoded sealed signup data that was
-            received from the most recent creation of signup information
-            for the validator
         expected_block_claim_count (float): The number of blocks that a
             validator, based upon the population estimate, would be expected
             to have claimed
@@ -55,7 +52,6 @@ class ConsensusState(object):
         Returns:
             None
         """
-        self.sealed_signup_data = None
         self.expected_block_claim_count = 0.0
         self._validators = {}
 
@@ -171,8 +167,6 @@ class ConsensusState(object):
                         'buffer is not a valid serialization of a '
                         'ConsensusState object')
 
-            self.sealed_signup_data = \
-                self_dict.get('sealed_signup_data', None)
             self.expected_block_claim_count = \
                 float(self_dict['expected_block_claim_count'])
             validators = self_dict['_validators']
@@ -207,9 +201,6 @@ class ConsensusState(object):
                     'Error parsing ConsensusState buffer: {}'.format(error))
 
     def __str__(self):
-        sealed_signup_data = \
-            '0' * 16 if self.sealed_signup_data is None \
-            else self.sealed_signup_data
         validators = \
             ['{}...{}: {{KBCC: {}, PPK: {}...{}, TBCC: {}}}'.format(
                 key[:8],
@@ -221,8 +212,6 @@ class ConsensusState(object):
              key, value in self._validators.items()]
 
         return \
-            'SSD: {}...{}, EBCC: {}, V: {}'.format(
-                sealed_signup_data[:8],
-                sealed_signup_data[-8:],
+            'EBCC: {}, V: {}'.format(
                 self.expected_block_claim_count,
                 validators)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -1,0 +1,96 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+
+from sawtooth_validator.state.config_view import ConfigView
+
+LOGGER = logging.getLogger(__name__)
+
+
+class PoetConfigView(object):
+    """A class to wrap the retrieval of PoET configuration settings from the
+    configuration view.  For values that are not in the current state view
+    or that are invalid, default values are returned.
+    """
+
+    _DEFAULT_KEY_CLAIM_LIMIT_ = 25
+
+    def __init__(self, state_view):
+        """Initialize a PoetConfigView object.
+
+        Args:
+            state_view (StateView): The current state view.
+
+        Returns:
+            None
+        """
+
+        self._config_view = ConfigView(state_view)
+
+    def _get_config_setting(self,
+                            name,
+                            value_type,
+                            default_value,
+                            validate_function=None):
+        """Retrieves a value from the config view, returning the default value
+        if does not exist in the current state view or if the value is
+        invalid.
+
+        Args:
+            name (str): The config setting to return.
+            value_type (type): The value type, for example, int, float, etc.,
+                of config value.
+            default_value (object): The default value to be used if no value
+                found or if value in config is invalid, for example, a
+                non-integer value for an int config setting.
+            validate_function (function): An optional function that can be
+                applied to the setting to determine validity.  The function
+                should return True if setting is valid, False otherwise.
+
+        Returns:
+            The value for the config setting.
+        """
+
+        try:
+            value = \
+                self._config_view.get_setting(
+                    key=name,
+                    default_value=default_value,
+                    value_type=value_type)
+
+            if validate_function is not None:
+                if not validate_function(value):
+                    raise \
+                        ValueError(
+                            'Value ({}) for {} is not valid'.format(
+                                value,
+                                name))
+        except ValueError:
+            value = default_value
+
+        return value
+
+    @property
+    def key_block_claim_limit(self):
+        """Return the key block claim limit if config setting exists or
+        default if not or value is invalid.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.key_block_claim_limit',
+                value_type=int,
+                default_value=PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_,
+                validate_function=lambda value: value > 0)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -153,8 +153,7 @@ class PoetForkResolver(ForkResolverInterface):
                         new_fork_head.header.signer_pubkey)
 
                 # Get the consensus state for the new fork head's previous
-                # block, update the validator state for the new fork head,
-                # and then store the updated consensus state for this block.
+                # block, update the validator state for the new fork head
                 consensus_state = \
                     utils.get_consensus_state_for_block_id(
                         block_id=new_fork_head.previous_block_id,
@@ -172,11 +171,7 @@ class PoetForkResolver(ForkResolverInterface):
                         validator_info=validator_info,
                         current_validator_state=validator_state))
 
-                LOGGER.debug(
-                    'Store consensus state for block ID %s...%s',
-                    new_fork_head.identifier[:8],
-                    new_fork_head.identifier[-8:])
-
+                # Store the updated consensus state for this block.
                 self._consensus_state_store[new_fork_head.identifier] = \
                     consensus_state
             except KeyError:

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
@@ -1,0 +1,217 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import threading
+import logging
+import os
+import base64
+import binascii
+
+from collections import namedtuple
+# pylint: disable=no-name-in-module
+from collections.abc import MutableMapping
+
+from sawtooth_validator.database.lmdb_nolock_database \
+    import LMDBNoLockDatabase
+
+LOGGER = logging.getLogger(__name__)
+
+PoetKeyState = \
+    namedtuple(
+        'PoetKeyState',
+        ['sealed_signup_data', 'has_been_refreshed'])
+""" Instead of creating a full-fledged class, let's use a named tuple for
+the PoET key state.  The PoET key state represents the state for a
+validator's key that is stored in the PoET key state store.  A PoET key state
+object contains:
+
+sealed_signup_data (bytes): The sealed signup data associated with the
+    PoET key.  This must be a byte string containing the base-64 encoded
+    sealed signup data.
+has_been_refreshed (bool): If this PoET has been used to create the key
+    block claim limit number of blocks and a new key pair has been created
+    to replace it.
+"""
+
+
+class PoetKeyStateStore(MutableMapping):
+    """Manages access to the underlying database holding state associated with
+    a PoET public key.  PoetKeyStateStore provides a dict-like interface to
+    the PoET key state, mapping a PoET public key to its corresponding state.
+    """
+
+    _store_dbs = {}
+    _lock = threading.Lock()
+
+    @property
+    def poet_public_keys(self):
+        """Returns the PoET public keys in the store
+
+        Returns:
+            list: The PoET public keys in the store
+        """
+        return self._store_db.keys()
+
+    def __init__(self, data_dir, validator_id):
+        """Initialize the store
+
+        Args:
+            data_dir (str): The directory where underlying database file will
+                be stored
+            validator_id (str): A unique ID for the validator for which the
+                store is being created
+
+        Returns:
+            None
+        """
+        with PoetKeyStateStore._lock:
+            # Create an underlying LMDB database file for the validator if
+            # there already isn't one.  We will create the LMDB with the 'c'
+            # flag so that it will open if already exists.
+            self._store_db = PoetKeyStateStore._store_dbs.get(validator_id)
+            if self._store_db is None:
+                db_file_name = \
+                    os.path.join(
+                        data_dir,
+                        'poet-key-state-{}.lmdb'.format(
+                            validator_id[:8]))
+
+                LOGGER.debug('Create PoET key state store: %s', db_file_name)
+
+                self._store_db = \
+                    LMDBNoLockDatabase(
+                        filename=db_file_name,
+                        flag='c')
+                PoetKeyStateStore._store_dbs[validator_id] = self._store_db
+
+    @staticmethod
+    def _check_poet_key_state(poet_key_state):
+        try:
+            if not isinstance(poet_key_state.sealed_signup_data, bytes):
+                raise ValueError('sealed_signup_data must be a byte string')
+            elif len(poet_key_state.sealed_signup_data) == 0:
+                raise ValueError('sealed_signup_data must not be empty')
+
+            # Although this won't catch everything, verify that the sealed
+            # signup data at least decodes successfully
+            base64.b64decode(poet_key_state.sealed_signup_data)
+
+            if not isinstance(poet_key_state.has_been_refreshed, bool):
+                raise ValueError('has_been_refreshed must be a bool')
+        except (AttributeError, binascii.Error) as error:
+            raise ValueError('poet_key_state is invalid: {}'.format(error))
+
+    def __setitem__(self, poet_public_key, poet_key_state):
+        """Adds/updates an item in the store
+
+        Args:
+            poet_public_key (str): The PoET public key for which key state
+                will be stored
+            poet_key_state (PoetKeyState): The key state
+
+        Returns:
+            None
+
+        Raises:
+            ValueError if key state object is not a valid
+        """
+        PoetKeyStateStore._check_poet_key_state(poet_key_state)
+        self._store_db[poet_public_key] = poet_key_state
+
+    def __getitem__(self, poet_public_key):
+        """Return the key state corresponding to the PoET public key
+
+        Args:
+            poet_public_key (str): The PoET public key for which key state
+                will be retrieved
+
+        Returns:
+            PoET key state (PoetKeyState)
+
+        Raises:
+            KeyError if the PoET public key is not in the store
+            ValueError if the key state object is not valid
+        """
+        # Get the PoET key state from the underlying LMDB.  The only catch is
+        # that the data was stored using cbor.dumps().  When this happens, it
+        # gets stored as a tuple and so we lost the named part.  When
+        # re-creating the poet key state we are going to leverage the
+        # namedtuple's _make method.
+        try:
+            poet_key_state = \
+                PoetKeyState._make(self._store_db[poet_public_key])
+        except (AttributeError, ValueError, TypeError) as error:
+            raise ValueError('poet_key_state is invalid: {}'.format(error))
+
+        PoetKeyStateStore._check_poet_key_state(poet_key_state)
+        return poet_key_state
+
+    def __delitem__(self, poet_public_key):
+        """Remove key state for PoET public key
+
+        Args:
+            poet_public_key (str): The PoET public key for which key state
+                will be removed
+
+        Returns:
+            None
+        """
+        try:
+            del self._store_db[poet_public_key]
+        except KeyError:
+            pass
+
+    def __contains__(self, poet_public_key):
+        """Determines if key state exists for PoET public key
+
+        Args:
+            poet_public_key (str): The PoET public key for which key state
+                will be checked
+
+        Returns:
+            True if there is key state for PoET public key, False otherwise
+        """
+        return poet_public_key in self._store_db
+
+    def __iter__(self):
+        """Allows for iteration, for example 'for ppk in store:', over PoET
+        public keys in store
+
+        Returns:
+            iterator
+        """
+        return iter(self.poet_public_keys)
+
+    def __len__(self):
+        """Returns number of PoET public keys in store
+
+        Returns:
+            Number of PoET public keys in store
+        """
+        return len(self._store_db)
+
+    def __str__(self):
+        out = []
+        for poet_public_key in self:
+            poet_key_state = self[poet_public_key]
+            out.append(
+                '{}...{}: {{SSD: {}...{}, Refreshed: {}}}'.format(
+                    poet_public_key[:8],
+                    poet_public_key[-8:],
+                    poet_key_state.sealed_signup_data[:8],
+                    poet_key_state.sealed_signup_data[-8:],
+                    poet_key_state.has_been_refreshed))
+
+        return ', '.join(out)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -292,14 +292,6 @@ def get_consensus_state_for_block_id(
         # Move to the previous block
         block_id = block.previous_block_id
 
-    # If we didn't find any consensus state, see if there is any "before" any
-    # blocks were created (this might be because we are the first validator
-    # and PoET signup information was created, including sealed signup data
-    # that was saved in the consensus state store).
-    if consensus_state is None:
-        consensus_state = \
-            consensus_state_store.get(block_id=NULL_BLOCK_IDENTIFIER)
-
     # At this point, if we have not found any consensus state, we need to
     # create default state from which we can build upon
     if consensus_state is None:
@@ -311,14 +303,11 @@ def get_consensus_state_for_block_id(
     # time we don't have to walk so far back through the block chain.
     for block_id, block_info in reversed(blocks.items()):
         # If the block was not a PoET block (i.e., didn't have a wait
-        # certificate), reset the consensus state statistics, but retain
-        # any sealed signup data we might have.  We are not going to store
-        # this in the consensus state store, but we will use it as the
-        # starting for the next PoET block.
+        # certificate), reset the consensus state statistics.  We are not
+        # going to store this in the consensus state store, but we will use it
+        # as the starting for the next PoET block.
         if block_info.wait_certificate is None:
-            sealed_signup_data = consensus_state.sealed_signup_data
             consensus_state = ConsensusState()
-            consensus_state.sealed_signup_data = sealed_signup_data
 
         # Otherwise, we need to fetch the current validator state for the
         # validator which claimed the block, set/update the consensus state

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -255,9 +255,6 @@ class TestConsensusState(unittest.TestCase):
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
 
         self.assertEqual(
-            state.sealed_signup_data,
-            doppelganger_state.sealed_signup_data)
-        self.assertEqual(
             state.expected_block_claim_count,
             doppelganger_state.expected_block_claim_count)
 

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -108,7 +108,6 @@ class TestConsensusStateStore(unittest.TestCase):
 
         # Store consensus state
         state = consensus_state.ConsensusState()
-        state.sealed_signup_data = 'Our sealed signup data'
         state.expected_block_claim_count = 3.14
         state.set_validator_state(
             validator_id='Bond, James Bond',
@@ -128,9 +127,6 @@ class TestConsensusStateStore(unittest.TestCase):
         # Retrieve the state and verify equality
         retrieved_state = store['key']
 
-        self.assertEqual(
-            state.sealed_signup_data,
-            retrieved_state.sealed_signup_data)
         self.assertEqual(
             state.expected_block_claim_count,
             retrieved_state.expected_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -1,0 +1,69 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import patch
+
+from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
+
+
+@patch('sawtooth_poet.poet_consensus.poet_config_view.ConfigView')
+class TestPoetConfigView(unittest.TestCase):
+
+    def test_key_block_claim_limit(self, mock_config_view):
+        """Verify that retrieving key block claim limit works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.key_block_claim_limit')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            kwargs['default_value'],
+            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+
+        mock_config_view.return_value.get_setting.return_value = 0
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            1)

--- a/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
@@ -1,0 +1,433 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import patch
+import tempfile
+import os
+import base64
+from importlib import reload
+
+from sawtooth_poet.poet_consensus import poet_key_state_store
+
+
+class TestPoetKeyStateStore(unittest.TestCase):
+    def setUp(self):
+        # pylint: disable=invalid-name,global-statement
+        global poet_key_state_store
+        # Because PoetKeyStateStore uses class variables to hold state
+        # we need to reload the module after each test to clear state
+        poet_key_state_store = reload(poet_key_state_store)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_verify_db_creation(self, mock_lmdb):
+        """Verify that the underlying store LMDB file is created underneath
+        the provided data directory and with the correct file creation flag.
+        """
+        _ = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Verify that the database is created in the directory provided
+        # and that it is created with the anydb flag for open if exists,
+        # create if doesn't exist
+        _, kwargs = mock_lmdb.call_args
+
+        self.assertTrue(
+            kwargs.get('filename', '').startswith(
+                tempfile.gettempdir() + os.sep))
+        self.assertEqual(kwargs.get('flag'), 'c')
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_nonexistent_key(self, mock_lmdb):
+        """Verify that retrieval of a non-existent key raises the appropriate
+        exception.
+        """
+        # Make LMDB return None for all keys
+        mock_lmdb.return_value.__getitem__.side_effect = KeyError('bad key')
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        with self.assertRaises(KeyError):
+            _ = store['bad key']
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_len(self, mock_lmdb):
+        """Verify that len() returns correct values for store.
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Verify that an empty database returns 0
+        self.assertEqual(len(store), 0)
+
+        # Set some values and verify that the length reflects it
+        store['ppk_1'] = \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_1'),
+                has_been_refreshed=False)
+        self.assertEqual(len(store), 1)
+        store['ppk_2'] =  \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_2'),
+                has_been_refreshed=False)
+        self.assertEqual(len(store), 2)
+
+        # Delete values and verify that the length reflects it
+        del store['ppk_1']
+        self.assertEqual(len(store), 1)
+        del store['ppk_1']
+        self.assertEqual(len(store), 1)
+        del store['ppk_2']
+        self.assertEqual(len(store), 0)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_del(self, mock_lmdb):
+        """Verify that del removes entries from the store
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Delete from an empty store
+        del store['ppk_1']
+
+        # Set some values, do some deletes and verify store state is valid
+        store['ppk_1'] = \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_1'),
+                has_been_refreshed=False)
+        store['ppk_2'] =  \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_2'),
+                has_been_refreshed=False)
+
+        del store['ppk_1']
+        self.assertFalse('ppk_1' in store)
+        self.assertTrue('ppk_2' in store)
+
+        del store['ppk_2']
+        self.assertFalse('ppk_2' in store)
+
+        # Delete already deleted keys
+        del store['ppk_1']
+        self.assertFalse('ppk_1' in store)
+        self.assertFalse('ppk_2' in store)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_contains(self, mock_lmdb):
+        """Verify that in, i.e., key in store, returns correct values
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Verify empty store
+        self.assertFalse('ppk_1' in store)
+
+        # Set some values and verify that store has keys
+        store['ppk_1'] = \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_1'),
+                has_been_refreshed=False)
+        self.assertTrue('ppk_1' in store)
+        store['ppk_2'] =  \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_2'),
+                has_been_refreshed=False)
+        self.assertTrue('ppk_1' in store)
+        self.assertTrue('ppk_2' in store)
+
+        # Delete values and verify that store does not have keys
+        del store['ppk_2']
+        self.assertFalse('ppk_2' in store)
+        self.assertTrue('ppk_1' in store)
+        del store['ppk_1']
+        self.assertFalse('ppk_1' in store)
+        self.assertFalse('ppk_2' in store)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_iter(self, mock_lmdb):
+        """Verify that iterating over store, i.e., for key in store:, iterates
+        over all keys.
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Verify empty store
+        iterated_ppks = []
+        for ppk in store:
+            iterated_ppks.append(ppk)
+
+        self.assertEqual(len(iterated_ppks), 0)
+
+        # Add some keys and verify iteration
+        ppks = ['ppk_1', 'ppk_2', 'ppk_3', 'ppk_4']
+        for ppk in ppks:
+            store[ppk] = \
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(
+                        'sealed for {}'.format(ppk).encode()),
+                    has_been_refreshed=False)
+
+        iterated_ppks = []
+        for ppk in store:
+            iterated_ppks.append(ppk)
+
+        self.assertEqual(len(iterated_ppks), len(store))
+        self.assertEqual(sorted(iterated_ppks), sorted(ppks))
+
+        # Delete some keys and verify iteration
+        ppks.remove('ppk_1')
+        del store['ppk_1']
+        ppks.remove('ppk_3')
+        del store['ppk_3']
+
+        iterated_ppks = []
+        for ppk in store:
+            iterated_ppks.append(ppk)
+
+        self.assertEqual(len(iterated_ppks), len(store))
+        self.assertEqual(sorted(iterated_ppks), sorted(ppks))
+
+        # Delete remaining keys and verify iteration
+        ppks.remove('ppk_2')
+        del store['ppk_2']
+        ppks.remove('ppk_4')
+        del store['ppk_4']
+
+        iterated_ppks = []
+        for ppk in store:
+            iterated_ppks.append(ppk)
+
+        self.assertEqual(len(iterated_ppks), 0)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_poet_public_keys(self, mock_lmdb):
+        """Verify that poet_public_keys property returns a list of the expected
+        keys.
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        self.assertEqual(len(store.poet_public_keys), 0)
+
+        # Add some keys and verify
+        ppks = ['ppk_1', 'ppk_2', 'ppk_3', 'ppk_4']
+        for ppk in ppks:
+            store[ppk] = \
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(
+                        'sealed for {}'.format(ppk).encode()),
+                    has_been_refreshed=False)
+
+        self.assertEqual(len(store.poet_public_keys), len(ppks))
+        self.assertEqual(sorted(ppks), sorted(store.poet_public_keys))
+
+        # Delete some keys and verify
+        ppks.remove('ppk_1')
+        del store['ppk_1']
+        ppks.remove('ppk_3')
+        del store['ppk_3']
+
+        self.assertEqual(len(store.poet_public_keys), len(ppks))
+        self.assertEqual(sorted(ppks), sorted(store.poet_public_keys))
+
+        # Delete remaining keys and verify
+        ppks.remove('ppk_2')
+        del store['ppk_2']
+        ppks.remove('ppk_4')
+        del store['ppk_4']
+
+        self.assertEqual(len(store.poet_public_keys), 0)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_set_get(self, mock_lmdb):
+        """Verify that retrieving a previously set PoET public key results in
+        the same value set.
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Store a key and verify that returns correct value
+        store['ppk_1'] = \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_1'),
+                has_been_refreshed=False)
+        poet_key_state = store['ppk_1']
+        self.assertEqual(
+            poet_key_state.sealed_signup_data,
+            base64.b64encode(b'sealed_1'))
+        self.assertFalse(poet_key_state.has_been_refreshed)
+
+        # Store another key and verify that returns correct value
+        store['ppk_2'] =  \
+            poet_key_state_store.PoetKeyState(
+                sealed_signup_data=base64.b64encode(b'sealed_2'),
+                has_been_refreshed=True)
+
+        poet_key_state = store['ppk_2']
+        self.assertEqual(
+            poet_key_state.sealed_signup_data,
+            base64.b64encode(b'sealed_2'))
+        self.assertTrue(poet_key_state.has_been_refreshed)
+
+        poet_key_state = store['ppk_1']
+        self.assertEqual(
+            poet_key_state.sealed_signup_data,
+            base64.b64encode(b'sealed_1'))
+        self.assertFalse(poet_key_state.has_been_refreshed)
+
+        # Delete a key and verify that existing key still returns correct
+        # value
+        del store['ppk_1']
+        poet_key_state = store['ppk_2']
+        self.assertEqual(
+            poet_key_state.sealed_signup_data,
+            base64.b64encode(b'sealed_2'))
+        self.assertTrue(poet_key_state.has_been_refreshed)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_set_invalid_data(self, mock_lmdb):
+        """Verify that attempting to set invalid data fails
+        """
+        # Make LMDB return empty dict
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Store a non-PoetKeyState object
+        for poet_key_state in [[], {}, (), 1, 1.0, '', False]:
+            with self.assertRaises(ValueError):
+                store['ppk_1'] = poet_key_state
+
+        # Store invalid sealed_signup_data field
+        for sealed_signup_data in [[], {}, (), 1, 1.0, '', True]:
+            with self.assertRaises(ValueError):
+                store['ppk_1'] = \
+                    poet_key_state_store.PoetKeyState(
+                        sealed_signup_data=sealed_signup_data,
+                        has_been_refreshed=False)
+
+        # Store corrupted base64 sealed signup data
+        with self.assertRaises(ValueError):
+            store['ppk_1'] = \
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(b'sealed_1')[1:],
+                    has_been_refreshed=False)
+
+        # Store non-bool has_been_refreshed field
+        sealed_signup_data = base64.b64encode(b'sealed')
+        for has_been_refreshed in [[], {}, (), 1, 1.0, '']:
+            with self.assertRaises(ValueError):
+                store['ppk_1'] = \
+                    poet_key_state_store.PoetKeyState(
+                        sealed_signup_data=sealed_signup_data,
+                        has_been_refreshed=has_been_refreshed)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_store_get_invalid_data(self, mock_lmdb):
+        """Verify that attempting to get invalid data fails
+        """
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        # Underlying data is not a PoetKeyState (or valid tuple)
+        for poet_key_state in [[], {}, (), (1,), 1, 1.0, '', False]:
+            mock_lmdb.return_value.__getitem__.return_value = poet_key_state
+            with self.assertRaises(ValueError):
+                _ = store['ppk']
+
+        # Verify an invalid deserialization of sealed signup data
+        for sealed_signup_data in [[], {}, (), 1, 1.0, '', True]:
+            mock_lmdb.return_value.__getitem__.return_value = \
+                (sealed_signup_data, False)
+            with self.assertRaises(ValueError):
+                _ = store['ppk']
+
+        # Verify corrupted base64 sealed signup data
+        mock_lmdb.return_value.__getitem__.return_value = \
+            (base64.b64encode(b'sealed_1')[1:], False)
+        with self.assertRaises(ValueError):
+            _ = store['ppk']
+
+        # Verify an invalid deserialization of has been revoked
+        sealed_signup_data = base64.b64encode(b'sealed')
+        for has_been_refreshed in [[], {}, (), 1, 1.0, '']:
+            mock_lmdb.return_value.__getitem__.return_value = \
+                (sealed_signup_data, has_been_refreshed)
+            with self.assertRaises(ValueError):
+                _ = store['ppk']
+
+        # Simulate underlying cbor or namedtuple throwing ValueError,
+        # TypeError, or AttributeError
+        mock_lmdb.return_value.__getitem__.side_effect = ValueError()
+        with self.assertRaises(ValueError):
+            _ = store['ppk']
+        # pylint: disable=redefined-variable-type
+        mock_lmdb.return_value.__getitem__.side_effect = TypeError()
+        with self.assertRaises(ValueError):
+            _ = store['ppk']
+        # pylint: disable=redefined-variable-type
+        mock_lmdb.return_value.__getitem__.side_effect = AttributeError()
+        with self.assertRaises(ValueError):
+            _ = store['ppk']


### PR DESCRIPTION
Introduces the following changes:

* PoET consensus state statistics are now reset whenever a non-PoET block is encountered in the chain and the sealed signup data is removed from the consensus state as that needs to be maintained on a per-PoET public key basis.
* A utility class to manage and persist locally on a validator key state for its PoET key.  This includes the sealed signup data associated with it as well as whether or not it has been refreshed because the block claim limit has been reached with that key.
* The PoET genesis CLI and block publisher have been changed to use the PoET key state store for sealed signup data.
* A utility class to query PoET configuration settings.
* The PoET block verifier now enforces the key block claim limit when determining the validity of a block.
* The PoET block publisher abides by the key block claim limit when being asked to initialize a block.  If the limit has been reached with its current key, it will fail to initialize the block and if appropriate will create and register new signup information.

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`-k /etc/sawtooth/keys/validator.wif \`

Add:

```
sawtooth.consensus.algorithm=poet \
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
sawtooth.poet.key_block_claim_limit=2 \
```

This should result in a bunch of blocks and validators having to refresh after successfully claiming 2 blocks.

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.