### PR TITLE
Add transaction fetching to Rest Api, ZMQ Api, and CLI

### DIFF
--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -13,13 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import sys
-import csv
-import json
 import argparse
-import yaml
-
-from sawtooth_cli import tty
+from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
 from sawtooth_cli.exceptions import CliException
 
@@ -91,22 +86,12 @@ def do_block(args):
     """
     rest_client = RestClient(args.url)
 
-    def print_json(data):
-        print(json.dumps(
-            data,
-            indent=2,
-            separators=(',', ': '),
-            sort_keys=True))
-
-    def print_yaml(data):
-        print(yaml.dump(data, default_flow_style=False)[0:-1])
-
     if args.subcommand == 'list':
         blocks = rest_client.list_blocks()
         keys = ('num', 'block_id', 'batches', 'txns', 'signer')
-        headers = (k.upper() if k != 'batches' else 'BATS' for k in keys)
+        headers = tuple(k.upper() if k != 'batches' else 'BATS' for k in keys)
 
-        def get_data(block):
+        def parse_block_row(block):
             batches = block.get('batches', [])
             txns = [t for b in batches for t in b['transactions']]
             return (
@@ -117,48 +102,19 @@ def do_block(args):
                 block['header']['signer_pubkey'])
 
         if args.format == 'default':
-            # Set column widths based on window and data size
-            window_width = tty.width()
-
-            try:
-                id_width = len(blocks[0]['header_signature'])
-                sign_width = len(blocks[0]['header']['signer_pubkey'])
-            except IndexError:
-                # if no data was returned, use short default widths
-                id_width = 30
-                sign_width = 15
-
-            if sys.stdout.isatty():
-                adjusted = int(window_width) - id_width - 22
-                adjusted = 6 if adjusted < 6 else adjusted
-            else:
-                adjusted = sign_width
-
-            fmts = '{{:<3}}  {{:{i}.{i}}}  {{:<4}}  {{:<4}}  {{:{a}.{a}}}'\
-                .format(i=id_width, a=adjusted)
-
-            # Print data in rows and columns
-            print(fmts.format(*headers))
-            for block in blocks:
-                print(fmts.format(*get_data(block)) +
-                      ('...' if adjusted < sign_width and sign_width else ''))
+            fmt.print_terminal_table(headers, blocks, parse_block_row)
 
         elif args.format == 'csv':
-            try:
-                writer = csv.writer(sys.stdout)
-                writer.writerow(headers)
-                for block in blocks:
-                    writer.writerow(get_data(block))
-            except csv.Error as e:
-                raise CliException('Error writing CSV: {}'.format(e))
+            fmt.print_csv(headers, blocks, parse_block_row)
 
         elif args.format == 'json' or args.format == 'yaml':
-            data = [{k: d for k, d in zip(keys, get_data(b))} for b in blocks]
+            data = [{k: d for k, d in zip(keys, parse_block_row(b))}
+                    for b in blocks]
 
             if args.format == 'yaml':
-                print_yaml(data)
+                fmt.print_yaml(data)
             elif args.format == 'json':
-                print_json(data)
+                fmt.print_json(data)
             else:
                 raise AssertionError('Missing handler: {}'.format(args.format))
 
@@ -166,20 +122,20 @@ def do_block(args):
             raise AssertionError('Missing handler: {}'.format(args.format))
 
     if args.subcommand == 'show':
-        block = rest_client.get_block(args.block_id)
+        output = rest_client.get_block(args.block_id)
 
         if args.key:
-            if args.key in block:
-                print(block[args.key])
-            elif args.key in block['header']:
-                print(block['header'][args.key])
+            if args.key in output:
+                output = output[args.key]
+            elif args.key in output['header']:
+                output = output['header'][args.key]
             else:
                 raise CliException(
                     'key "{}" not found in block or header'.format(args.key))
+
+        if args.format == 'yaml':
+            fmt.print_yaml(output)
+        elif args.format == 'json':
+            fmt.print_json(output)
         else:
-            if args.format == 'yaml':
-                print_yaml(block)
-            elif args.format == 'json':
-                print_json(block)
-            else:
-                raise AssertionError('Missing handler: {}'.format(args.format))
+            raise AssertionError('Missing handler: {}'.format(args.format))

--- a/cli/sawtooth_cli/format_utils.py
+++ b/cli/sawtooth_cli/format_utils.py
@@ -1,0 +1,112 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import sys
+import csv
+import json
+import yaml
+
+from sawtooth_cli import tty
+from sawtooth_cli.exceptions import CliException
+
+
+def format_terminal_row(headers, example_row):
+    """Uses headers and a row of example data to generate a format string
+    for printing a single row of data.
+
+    Args:
+        headers (tuple of strings): The headers for each column of data
+        example_row (tuple): A representative tuple of strings or ints
+
+    Returns
+        string: A format string with a size for each column
+    """
+    def format_column(col):
+        if isinstance(col, str):
+            return '{{:{w}.{w}}}'
+        return '{{:<{w}}}'
+
+    widths = [max(len(h), len(str(d))) for h, d in zip(headers, example_row)]
+
+    # Truncate last column to fit terminal width
+    original_last_width = widths[-1]
+    if sys.stdout.isatty():
+        widths[-1] = max(
+            len(headers[-1]),
+            # console width - width of other columns and gutters - 3 for '...'
+            tty.width() - sum(w + 2 for w in widths[0:-1]) - 3)
+
+    # Build format string
+    cols = [format_column(c).format(w=w) for c, w in zip(example_row, widths)]
+    format_string = '  '.join(cols)
+    if original_last_width > widths[-1]:
+        format_string += '...'
+
+    return format_string
+
+
+def print_terminal_table(headers, data_list, parse_row_fn):
+    """Uses a set of headers, raw data, and a row parsing function, to print
+    data to the terminal in a table of rows and columns.
+
+    Args:
+        headers (tuple of strings): The headers for each column of data
+        data_list (list of dicts): Raw response data from the validator
+        parse_row_fn (function): Parses a dict of data into a tuple of columns
+            Expected args:
+                data (dict): A single response object from the validator
+            Expected return:
+                cols (tuple): The properties to display in each column
+    """
+    try:
+        example_row = parse_row_fn(data_list[0])
+    except IndexError:
+        example_row = [''] * len(headers)
+
+    format_string = format_terminal_row(headers, example_row)
+
+    top_row = format_string.format(*headers)
+    print(top_row[0:-3] if top_row.endswith('...') else top_row)
+    for data in data_list:
+        print(format_string.format(*parse_row_fn(data)))
+
+
+def print_csv(headers, data_list, parse_row_fn):
+    """Takes headers, data, and a row parsing function, and prints data
+    to the console in a csv format.
+    """
+    try:
+        writer = csv.writer(sys.stdout)
+        writer.writerow(headers)
+        for data in data_list:
+            writer.writerow(parse_row_fn(data))
+    except csv.Error as e:
+        raise CliException('Error writing CSV: {}'.format(e))
+
+
+def print_json(data):
+    """Takes any JSON serializable data and prints it to the console.
+    """
+    print(json.dumps(
+        data,
+        indent=2,
+        separators=(',', ': '),
+        sort_keys=True))
+
+
+def print_yaml(data):
+    """Takes any YAML serializable data and prints it to the console.
+    """
+    print(yaml.dump(data, default_flow_style=False)[0:-1])

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -35,6 +35,8 @@ from sawtooth_cli.block import add_block_parser
 from sawtooth_cli.block import do_block
 from sawtooth_cli.batch import add_batch_parser
 from sawtooth_cli.batch import do_batch
+from sawtooth_cli.transaction import add_transaction_parser
+from sawtooth_cli.transaction import do_transaction
 from sawtooth_cli.state import add_state_parser
 from sawtooth_cli.state import do_state
 from sawtooth_cli.cluster import add_cluster_parser
@@ -100,6 +102,7 @@ def create_parser(prog_name):
     add_config_parser(subparsers, parent_parser)
     add_block_parser(subparsers, parent_parser)
     add_batch_parser(subparsers, parent_parser)
+    add_transaction_parser(subparsers, parent_parser)
     add_state_parser(subparsers, parent_parser)
     add_cluster_parser(subparsers, parent_parser)
     add_submit_parser(subparsers, parent_parser)
@@ -129,6 +132,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
         do_block(args)
     elif args.command == 'batch':
         do_batch(args)
+    elif args.command == 'transaction':
+        do_transaction(args)
     elif args.command == 'state':
         do_state(args)
     elif args.command == 'cluster':

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -43,6 +43,13 @@ class RestClient(object):
         safe_id = urllib.quote(batch_id, safe='')
         return self._get('/batches/' + safe_id)['data']
 
+    def list_transactions(self):
+        return self._get('/transactions')['data']
+
+    def get_transaction(self, transaction_id):
+        safe_id = urllib.quote(transaction_id, safe='')
+        return self._get('/transactions/' + safe_id)['data']
+
     def list_state(self, subtree=None, head=None):
         return self._get('/state', address=subtree, head=head)
 

--- a/cli/sawtooth_cli/transaction.py
+++ b/cli/sawtooth_cli/transaction.py
@@ -1,0 +1,144 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import argparse
+from base64 import b64decode
+from sawtooth_cli import format_utils as fmt
+from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli.exceptions import CliException
+
+
+def add_transaction_parser(subparsers, parent_parser):
+    """Adds argument parsers for the transaction list and show commands
+
+        Args:
+            subparsers: Add parsers to this subparser object
+            parent_parser: The parent argparse.ArgumentParser object
+    """
+    parser = subparsers.add_parser('transaction')
+
+    grand_parsers = parser.add_subparsers(title='grandchildcommands',
+                                          dest='subcommand')
+    grand_parsers.required = True
+    epilog = '''details:
+        Lists committed transactions from newest to oldest, including their id
+    (i.e. header_signature), transaction family and version, and their payload.
+    '''
+
+    list_parser = grand_parsers.add_parser(
+        'list', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    list_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    list_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='default',
+        choices=['csv', 'json', 'yaml', 'default'],
+        help='the format of the output, options: csv, json or yaml')
+
+    epilog = '''details:
+        Shows the data for a single transaction, or for a particular property
+    within that transaction or its header. Displays data in YAML (default),
+    or JSON formats.
+    '''
+    show_parser = grand_parsers.add_parser(
+        'show', epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    show_parser.add_argument(
+        'transaction_id',
+        type=str,
+        help='the id (i.e. header_signature) of the transaction')
+    show_parser.add_argument(
+        '--url',
+        type=str,
+        help="the URL of the validator's REST API")
+    show_parser.add_argument(
+        '-k', '--key',
+        type=str,
+        help='specify to show one property from the transaction or header')
+    show_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='yaml',
+        choices=['yaml', 'json'],
+        help='the format of the output, options: yaml (default), or json')
+
+
+def do_transaction(args):
+    """Runs the transaction list or show command, printing to the console
+
+        Args:
+            args: The parsed arguments sent to the command at runtime
+    """
+    rest_client = RestClient(args.url)
+
+    if args.subcommand == 'list':
+        transactions = rest_client.list_transactions()
+        keys = ('transaction_id', 'family', 'version', 'size', 'payload')
+        headers = tuple(k.upper() if k != 'version' else 'VERS' for k in keys)
+
+        def parse_txn_row(transaction, decode=True):
+            decoded = b64decode(transaction['payload'])
+            return (
+                transaction['header_signature'],
+                transaction['header']['family_name'],
+                transaction['header']['family_version'],
+                len(decoded),
+                str(decoded) if decode else transaction['payload'])
+
+        if args.format == 'default':
+            fmt.print_terminal_table(headers, transactions, parse_txn_row)
+
+        elif args.format == 'csv':
+            fmt.print_csv(headers, transactions, parse_txn_row)
+
+        elif args.format == 'json' or args.format == 'yaml':
+            data = [{k: d for k, d in zip(keys, parse_txn_row(b, False))}
+                    for b in transactions]
+
+            if args.format == 'yaml':
+                fmt.print_yaml(data)
+            elif args.format == 'json':
+                fmt.print_json(data)
+            else:
+                raise AssertionError('Missing handler: {}'.format(args.format))
+
+        else:
+            raise AssertionError('Missing handler: {}'.format(args.format))
+
+    if args.subcommand == 'show':
+        output = rest_client.get_transaction(args.transaction_id)
+
+        if args.key:
+            if args.key == 'payload':
+                output = b64decode(output['payload'])
+            elif args.key in output:
+                output = output[args.key]
+            elif args.key in output['header']:
+                output = output['header'][args.key]
+            else:
+                raise CliException(
+                    'Key "{}" not found in transaction or header'.format(
+                        args.key))
+
+        if args.format == 'yaml':
+            fmt.print_yaml(output)
+        elif args.format == 'json':
+            fmt.print_json(output)
+        else:
+            raise AssertionError('Missing handler: {}'.format(args.format))

--- a/cli/sawtooth_cli/tty.py
+++ b/cli/sawtooth_cli/tty.py
@@ -34,7 +34,7 @@ def size():
         # in case of failure, use dimensions of a full screen 13" laptop
         rows, columns = DEFAULT_HEIGHT, DEFAULT_WIDTH
 
-    return rows, columns
+    return int(rows), int(columns)
 
 
 def height():

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -18,8 +18,9 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "sawtooth.sdk.protobuf";
 
-import "batch.proto";
 import "block.proto";
+import "batch.proto";
+import "transaction.proto";
 
 
 // An entry in the State
@@ -297,7 +298,7 @@ message ClientBatchListRequest {
     PagingControls paging = 3;
 }
 
-// A response that lists batches with the newest to oldest.
+// A response that lists batches from newest to oldest.
 //
 // Statuses:
 //   * OK - everything worked as expected
@@ -340,4 +341,59 @@ message ClientBatchGetResponse {
     }
     Status status = 1;
     Batch batch = 2;
+}
+
+// A request to return a list of txns from the validator. May include the id
+// of a particular block to be the `head` of the chain being requested. In that
+// case the list will include the txns from that block, and all txns
+// previous to that block on the chain. Filter with specific `transaction_ids`.
+message ClientTransactionListRequest {
+    string head_id = 1;
+    repeated string transaction_ids = 2;
+    PagingControls paging = 3;
+}
+
+// A response that lists transactions from newest to oldest.
+//
+// Statuses:
+//   * OK - everything worked as expected
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NOT_READY - the validator does not yet have a genesis block
+//   * NO_ROOT - the head block specified was not found
+//   * NO_RESOURCE - no txns were found with the parameters specified
+//   * INVALID_PAGING - the paging controls were malformed or out of range
+message ClientTransactionListResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NOT_READY = 2;
+        NO_ROOT = 3;
+        NO_RESOURCE = 4;
+        INVALID_PAGING = 5;
+    }
+    Status status = 1;
+    repeated Transaction transactions = 2;
+    string head_id = 3;
+    PagingResponse paging = 4;
+}
+
+// Fetches a specific txn by its id (header_signature) from the blockchain.
+message ClientTransactionGetRequest {
+    string transaction_id = 1;
+}
+
+// A response that returns the txn specified by a ClientTransactionGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, txn has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no txn with the specified id exists
+message ClientTransactionGetResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NO_RESOURCE = 4;
+    }
+    Status status = 1;
+    Transaction transaction = 2;
 }

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -277,13 +277,11 @@ message ClientBlockGetRequest {
 //   * OK - everything worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NO_RESOURCE - no block with the specified id exists
-//   * INVALID_ID - id isn't a valid, it may actually be a batch or txn
 message ClientBlockGetResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NO_RESOURCE = 4;
-        INVALID_ID = 5;
     }
     Status status = 1;
     Block block = 2;
@@ -334,13 +332,11 @@ message ClientBatchGetRequest {
 //   * OK - everything worked as expected, batch has been fetched
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NO_RESOURCE - no batch with the specified id exists
-//   * INVALID_ID - id isn't a valid, possibly because it is actually a block
 message ClientBatchGetResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NO_RESOURCE = 4;
-        INVALID_ID = 5;
     }
     Status status = 1;
     Batch batch = 2;

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -100,30 +100,12 @@ class MissingBlock(_ErrorTrap):
             message='There is no block with that id')
 
 
-class InvalidBlockId(_ErrorTrap):
-    def __init__(self):
-        super().__init__(
-            trigger=client.ClientBlockGetResponse.INVALID_ID,
-            error=web.HTTPBadRequest,
-            message='''The specified id is not a valid block id.
-                Did you mean to send this to /batches?''')
-
-
 class MissingBatch(_ErrorTrap):
     def __init__(self):
         super().__init__(
             trigger=client.ClientBatchGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no batch with that id')
-
-
-class InvalidBatchId(_ErrorTrap):
-    def __init__(self):
-        super().__init__(
-            trigger=client.ClientBatchGetResponse.INVALID_ID,
-            error=web.HTTPBadRequest,
-            message='''The specified id is not a valid batch id.
-                Did you mean to send this to /blocks?''')
 
 
 class BadAddress(_ErrorTrap):

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -14,7 +14,7 @@
 # ------------------------------------------------------------------------------
 
 from aiohttp import web
-from sawtooth_rest_api.protobuf import client_pb2 as client
+from sawtooth_rest_api.protobuf import client_pb2
 
 
 class _ErrorTrap(object):
@@ -71,7 +71,7 @@ class InvalidPaging(_ErrorTrap):
 class InvalidBatch(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientBatchSubmitResponse.INVALID_BATCH,
+            trigger=client_pb2.ClientBatchSubmitResponse.INVALID_BATCH,
             error=web.HTTPBadRequest,
             message='A submitted batch had an invalid signature')
 
@@ -79,7 +79,7 @@ class InvalidBatch(_ErrorTrap):
 class StatusesNotReturned(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientBatchStatusResponse.NO_RESOURCE,
+            trigger=client_pb2.ClientBatchStatusResponse.NO_RESOURCE,
             error=web.HTTPInternalServerError,
             message='Something went wrong when looking for these statuses')
 
@@ -87,7 +87,7 @@ class StatusesNotReturned(_ErrorTrap):
 class MissingLeaf(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientStateGetResponse.NO_RESOURCE,
+            trigger=client_pb2.ClientStateGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no leaf at that address')
 
@@ -95,7 +95,7 @@ class MissingLeaf(_ErrorTrap):
 class MissingBlock(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientBlockGetResponse.NO_RESOURCE,
+            trigger=client_pb2.ClientBlockGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no block with that id')
 
@@ -103,7 +103,7 @@ class MissingBlock(_ErrorTrap):
 class MissingBatch(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientBatchGetResponse.NO_RESOURCE,
+            trigger=client_pb2.ClientBatchGetResponse.NO_RESOURCE,
             error=web.HTTPNotFound,
             message='There is no batch with that id')
 
@@ -111,6 +111,6 @@ class MissingBatch(_ErrorTrap):
 class BadAddress(_ErrorTrap):
     def __init__(self):
         super().__init__(
-            trigger=client.ClientStateGetResponse.INVALID_ADDRESS,
+            trigger=client_pb2.ClientStateGetResponse.INVALID_ADDRESS,
             error=web.HTTPBadRequest,
             message='Expected a leaf address, but received a subtree instead')

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -108,6 +108,14 @@ class MissingBatch(_ErrorTrap):
             message='There is no batch with that id')
 
 
+class MissingTransaction(_ErrorTrap):
+    def __init__(self):
+        super().__init__(
+            trigger=client_pb2.ClientTransactionGetResponse.NO_RESOURCE,
+            error=web.HTTPNotFound,
+            message='There is no batch with that id')
+
+
 class BadAddress(_ErrorTrap):
     def __init__(self):
         super().__init__(

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -74,6 +74,11 @@ def start_rest_api(host, port, stream_url, timeout):
     app.router.add_get('/batches', handler.list_batches)
     app.router.add_get('/batches/{batch_id}', handler.fetch_batch)
 
+    app.router.add_get('/transactions', handler.list_transactions)
+    app.router.add_get(
+        '/transactions/{transaction_id}',
+        handler.fetch_transaction)
+
     # Start app
     web.run_app(app, host=host, port=port)
 

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -331,9 +331,10 @@ class RouteHandler(object):
 
     async def fetch_batch(self, request):
         """Fetches a specific batch from the validator, specified by id.
+
         Request:
             path:
-                - batch_id: The 128-character id of the block to be fetched
+                - batch_id: The 128-character id of the batch to be fetched
 
         Response:
             data: A JSON object with the data from the fully expanded Batch

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -284,9 +284,7 @@ class RouteHandler(object):
             data: A JSON object with the data from the fully expanded Block
             link: The link to this exact query
         """
-        error_traps = [
-            error_handlers.MissingBlock(),
-            error_handlers.InvalidBlockId()]
+        error_traps = [error_handlers.MissingBlock()]
 
         block_id = request.match_info.get('block_id', '')
 
@@ -341,9 +339,7 @@ class RouteHandler(object):
             data: A JSON object with the data from the fully expanded Batch
             link: The link to this exact query
         """
-        error_traps = [
-            error_handlers.MissingBatch(),
-            error_handlers.InvalidBatchId()]
+        error_traps = [error_handlers.MissingBatch()]
 
         batch_id = request.match_info.get('batch_id', '')
 

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -45,7 +45,7 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '2'
-            - a link property that ends in '/batches?head=2&min=0&count=3'
+            - a link property that ends in '/batches?head=2'
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids '2', '1', and '0'
@@ -106,7 +106,7 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '1'
-            - a link property that ends in '/batches?head=1&min=0&count=2'
+            - a link property that ends in '/batches?head=1'
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids '1' and '0'
@@ -140,7 +140,7 @@ class BatchListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_batch_list_with_ids(self):
-        """Verifies GET /batches with the id parameter works properly.
+        """Verifies GET /batches with an id filter works properly.
 
         It will receive a Protobuf response with:
             - a head id of '2'
@@ -154,7 +154,7 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '2', the latest
-            - a link property that ends in '/batches?head=2&min=0&count=2&id=0,2'
+            - a link property that ends in '/batches?head=2&id=0,2'
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids '0' and '2'
@@ -175,7 +175,7 @@ class BatchListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_batch_list_with_bad_ids(self):
-        """Verifies GET /batches with a bad id parameter breaks properly.
+        """Verifies GET /batches with a bad id filter breaks properly.
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
@@ -202,7 +202,7 @@ class BatchListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_batch_list_with_head_and_ids(self):
-        """Verifies GET /batches with head and id parameters works properly.
+        """Verifies GET /batches with head and id parameters work properly.
 
         It should send a Protobuf request with:
             - a head_id property of '1'
@@ -217,7 +217,7 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '1'
-            - a link property that ends in '/batches?head=1&min=0&count=1&id=0'
+            - a link property that ends in '/batches?head=1&id=0'
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - and that dict is a full batch with an id of '0'
@@ -249,7 +249,7 @@ class BatchListTests(BaseApiTest):
             - one batch with the id 'c'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 1, and a start_index of 1
+            - paging controls with a count of 1, and a start_index of 1
 
         It should send back a JSON response with:
             - a response status of 200
@@ -307,12 +307,12 @@ class BatchListTests(BaseApiTest):
             - two batches with the ids 'd' and 'c'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2
+            - paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=0&count=2'
+            - a link property that ends in '/batches?head=d&count=2'
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids 'd' and 'c'
@@ -342,12 +342,12 @@ class BatchListTests(BaseApiTest):
             - two batches with the ids 'b' and 'a'
 
         It should send a Protobuf request with:
-            - a paging controls with a start_index of 2
+            - paging controls with a start_index of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=2&count=2'
+            - a link property that ends in '/batches?head=d&min=2'
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids 'd' and 'c'
@@ -380,7 +380,7 @@ class BatchListTests(BaseApiTest):
             - three batches with the ids 'c', 'b' and 'a'
 
         It should send a Protobuf request with:
-            - a paging controls with a start_id of 'c'
+            - paging controls with a count of 5, and a start_id of 'c'
 
         It should send back a JSON response with:
             - a response status of 200
@@ -419,7 +419,7 @@ class BatchListTests(BaseApiTest):
             - two batches with the ids 'c' and 'b'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an end_id of 'b'
+            - paging controls with a count of 2, and an end_id of 'b'
 
         It should send back a JSON response with:
             - a response status of 200
@@ -455,7 +455,7 @@ class BatchListTests(BaseApiTest):
             - three batches with the ids 'd', 'c' and 'b'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an start_index of 0
+            - paging controls with a count of 3, and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
@@ -497,12 +497,10 @@ class BatchGetTests(BaseApiTest):
         """Verifies a GET /batches/{batch_id} works properly.
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
-            - a block_ids property of ['0']
+            - a batch_id property of '1'
 
         It will receive a Protobuf response with:
-            - a head id of '1'
-            - three batches with ids of '2', '1', and '0'
+            - a batch with an id of '1'
 
         It should send back a JSON response with:
             - a response status of 200

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -535,19 +535,6 @@ class BatchGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_batch_get_with_bad_id(self):
-        """Verifies a GET /batches/{batch_id} with invalid id breaks properly.
-
-        It will receive a Protobuf response with:
-            - a status of INVALID_ID
-
-        It should send back a JSON response with:
-            - a response status of 400
-        """
-        self.stream.preset_response(self.status.INVALID_ID)
-        await self.assert_400('/batches/bad')
-
-    @unittest_run_loop
-    async def test_batch_get_with_missing_id(self):
         """Verifies a GET /batches/{batch_id} with unfound id breaks properly.
 
         It will receive a Protobuf response with:
@@ -557,4 +544,4 @@ class BatchGetTests(BaseApiTest):
             - a response status of 404
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/batches/missing')
+        await self.assert_404('/batches/bad')

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -532,19 +532,6 @@ class BlockGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_block_get_with_bad_id(self):
-        """Verifies a GET /blocks/{block_id} with invalid id breaks properly.
-
-        It will receive a Protobuf response with:
-            - a status of INVALID_ID
-
-        It should send back a JSON response with:
-            - a response status of 400
-        """
-        self.stream.preset_response(self.status.INVALID_ID)
-        await self.assert_400('/blocks/bad')
-
-    @unittest_run_loop
-    async def test_block_get_with_missing_id(self):
         """Verifies a GET /blocks/{block_id} with unfound id breaks properly.
 
         It will receive a Protobuf response with:
@@ -554,4 +541,4 @@ class BlockGetTests(BaseApiTest):
             - a response status of 404
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/blocks/missing')
+        await self.assert_404('/blocks/bad')

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -45,7 +45,7 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a status of 200
             - a head property of '2'
-            - a link property that ends in '/blocks?head=2&min=0&count=3'
+            - a link property that ends in '/blocks?head=2'
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full blocks with ids '2', '1', and '0'
@@ -106,7 +106,7 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a status of 200
             - a head property of '1'
-            - a link property that ends in '/blocks?head=1&min=0&count=2'
+            - a link property that ends in '/blocks?head=1'
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids '1' and '0'
@@ -140,7 +140,7 @@ class BlockListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_block_list_with_ids(self):
-        """Verifies GET /blocks with the id parameter works properly.
+        """Verifies GET /blocks with an id filter works properly.
 
         It will receive a Protobuf response with:
             - a head id of '2'
@@ -154,7 +154,7 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '2', the latest
-            - a link property that ends in '/blocks?head=2&min=0&count=2&id=0,2'
+            - a link property that ends in '/blocks?head=2&id=0,2'
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids '0' and '2'
@@ -175,7 +175,7 @@ class BlockListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_block_list_with_bad_ids(self):
-        """Verifies GET /blocks with a bad id parameter breaks properly.
+        """Verifies GET /blocks with a bad id filter breaks properly.
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
@@ -202,7 +202,7 @@ class BlockListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_block_list_with_head_and_ids(self):
-        """Verifies GET /blocks with head and id parameters works properly.
+        """Verifies GET /blocks with head and id parameters work properly.
 
         It will receive a Protobuf response with:
             - a head id of '1'
@@ -217,7 +217,7 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of '1'
-            - a link property that ends in '/blocks?head=1&min=0&count=1&id=0'
+            - a link property that ends in '/blocks?head=1&id=0'
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - and that dict is a full block with an id of '0'
@@ -248,7 +248,7 @@ class BlockListTests(BaseApiTest):
             - one block with the id 'c'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 1, and a start_index of 1
+            - paging controls with a count of 1, and a start_index of 1
 
         It should send back a JSON response with:
             - a response status of 200
@@ -306,12 +306,12 @@ class BlockListTests(BaseApiTest):
             - two blocks with the ids 'd' and 'c'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2
+            - paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&min=0&count=2'
+            - a link property that ends in '/blocks?head=d'
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids 'd' and 'c'
@@ -341,7 +341,7 @@ class BlockListTests(BaseApiTest):
             - two blocks with the ids 'b' and 'a'
 
         It should send a Protobuf request with:
-            - a paging controls with a start_index of 2
+            - paging controls with a start_index of 2
 
         It should send back a JSON response with:
             - a response status of 200
@@ -379,7 +379,7 @@ class BlockListTests(BaseApiTest):
             - three blocks with the ids 'c', 'b' and 'a'
 
         It should send a Protobuf request with:
-            - a paging controls with a start_id of 'c'
+            - paging controls with a count of 5, and a start_id of 'c'
 
         It should send back a JSON response with:
             - a response status of 200
@@ -418,7 +418,7 @@ class BlockListTests(BaseApiTest):
             - two blocks with the ids 'c' and 'b'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an end_id of 'b'
+            - paging controls with a count of 2, and an end_id of 'b'
 
         It should send back a JSON response with:
             - a response status of 200
@@ -454,7 +454,7 @@ class BlockListTests(BaseApiTest):
             - three blocks with the ids 'd', 'c' and 'b'
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an start_index of 0
+            - paging controls with a count of 3, and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
@@ -496,7 +496,7 @@ class BlockGetTests(BaseApiTest):
         """Verifies a GET /blocks/{block_id} works properly.
 
         It should send a Protobuf request with:
-            - a block_ids property of '1'
+            - a block_id property of '1'
 
         It will receive a Protobuf response with:
             - a block with an id of '1'

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -1,0 +1,567 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from aiohttp.test_utils import unittest_run_loop
+from tests.unit.components import Mocks, BaseApiTest
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+from sawtooth_rest_api.protobuf import client_pb2
+
+
+class TransactionListTests(BaseApiTest):
+
+    async def get_application(self, loop):
+        self.set_status_and_stream(
+            Message.CLIENT_TRANSACTION_LIST_REQUEST,
+            client_pb2.ClientTransactionListRequest,
+            client_pb2.ClientTransactionListResponse)
+
+        handlers = self.build_handlers(loop, self.stream)
+        app = self.build_app(loop, '/transactions', handlers.list_transactions)
+        return app
+
+    @unittest_run_loop
+    async def test_txn_list(self):
+        """Verifies a GET /transactions without parameters works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids of '2', '1', and '0'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of '2'
+            - a link property that ends in '/transactions?head=2'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - those dicts are full transactions with ids '2', '1', and '0'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        self.stream.preset_response(
+            head_id='2',
+            paging=paging,
+            transactions=Mocks.make_txns('2', '1', '0'))
+
+        response = await self.get_json_assert_200('/transactions')
+        controls = Mocks.make_paging_controls()
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/transactions?head=2')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+
+    @unittest_run_loop
+    async def test_txn_list_with_validator_error(self):
+        """Verifies a GET /transactions with a validator error breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of INTERNAL_ERROR
+
+        It should send back a JSON response with:
+            - a status of 500
+        """
+        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        await self.assert_500('/transactions')
+
+    @unittest_run_loop
+    async def test_txn_list_with_no_genesis(self):
+        """Verifies GET /transactions with validator not ready breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of NOT_READY
+
+        It should send back a JSON response with:
+            - a status of 503
+        """
+        self.stream.preset_response(self.status.NOT_READY)
+        await self.assert_503('/transactions')
+
+    @unittest_run_loop
+    async def test_txn_list_with_head(self):
+        """Verifies a GET /transactions with a head parameter works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of '1'
+            - a paging response with a start of 0, and 2 total resources
+            - two transactions with ids of 1' and '0'
+
+        It should send a Protobuf request with:
+            - a head_id property of '1'
+            - empty paging controls
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/transactions?head=1'
+            - a paging property that matches the paging response
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids '1' and '0'
+        """
+        paging = Mocks.make_paging_response(0, 2)
+        self.stream.preset_response(
+            head_id='1',
+            paging=paging,
+            transactions=Mocks.make_txns('1', '0'))
+
+        response = await self.get_json_assert_200('/transactions?head=1')
+        controls = Mocks.make_paging_controls()
+        self.stream.assert_valid_request_sent(head_id='1', paging=controls)
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/transactions?head=1')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_txns_well_formed(response['data'], '1', '0')
+
+    @unittest_run_loop
+    async def test_txn_list_with_bad_head(self):
+        """Verifies a GET /transactions with a bad head id breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of NO_ROOT
+
+        It should send back a JSON response with:
+            - a response status of 404
+        """
+        self.stream.preset_response(self.status.NO_ROOT)
+        await self.assert_404('/transactions?head=bad')
+
+    @unittest_run_loop
+    async def test_txn_list_with_ids(self):
+        """Verifies GET /transactions with an id filter works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 2 total resources
+            - two transactions with ids of '0' and '2'
+
+        It should send a Protobuf request with:
+            - a transaction_ids property of ['0', '2']
+            - empty paging controls
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/transactions?head=2&id=0,2'
+            - a paging property that matches the paging response
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids '0' and '2'
+        """
+        paging = Mocks.make_paging_response(0, 2)
+        transactions = Mocks.make_txns('0', '2')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_json_assert_200('/transactions?id=0,2')
+        controls = Mocks.make_paging_controls()
+        self.stream.assert_valid_request_sent(transaction_ids=['0', '2'], paging=controls)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/transactions?head=2&id=0,2')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_txns_well_formed(response['data'], '0', '2')
+
+    @unittest_run_loop
+    async def test_txn_list_with_bad_ids(self):
+        """Verifies GET /transactions with a bad id filter breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of NO_RESOURCE
+            - a head id of '2'
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of '2', the latest
+            - a link property that ends in '/transactions?head=2&id=bad,notgood'
+            - a paging property with only a total_count of 0
+            - a data property that is an empty list
+        """
+        paging = Mocks.make_paging_response(None, 0)
+        self.stream.preset_response(
+            self.status.NO_RESOURCE,
+            head_id='2',
+            paging=paging)
+        response = await self.get_json_assert_200('/transactions?id=bad,notgood')
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response, '/transactions?head=2&id=bad,notgood')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 0)
+
+    @unittest_run_loop
+    async def test_txn_list_with_head_and_ids(self):
+        """Verifies GET /transactions with head and id parameters work properly.
+
+        It should send a Protobuf request with:
+            - a head_id property of '1'
+            - a paging response with a start of 0, and 1 total resource
+            - a transaction_ids property of ['0']
+
+        It will receive a Protobuf response with:
+            - a head id of '1'
+            - one transaction with an id of '0'
+            - empty paging controls
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of '1'
+            - a link property that ends in '/transactions?head=1&id=0'
+            - a paging property that matches the paging response
+            - a data property that is a list of 1 dict
+            - that dict is a full transaction with an id of '0'
+        """
+        paging = Mocks.make_paging_response(0, 1)
+        self.stream.preset_response(
+            head_id='1',
+            paging=paging,
+            transactions=Mocks.make_txns('0'))
+
+        response = await self.get_json_assert_200('/transactions?id=0&head=1')
+        controls = Mocks.make_paging_controls()
+        self.stream.assert_valid_request_sent(
+            head_id='1',
+            transaction_ids=['0'],
+            paging=controls)
+
+        self.assert_has_valid_head(response, '1')
+        self.assert_has_valid_link(response, '/transactions?head=1&id=0')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 1)
+        self.assert_txns_well_formed(response['data'], '0')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated(self):
+        """Verifies GET /transactions paginated by min id works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with a start of 1, and 4 total resources
+            - one transaction with the id 'c'
+
+        It should send a Protobuf request with:
+            - paging controls with a count of 1, and a start_index of 1
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&min=1&count=1'
+            - paging that matches the response, with next and previous links
+            - a data property that is a list of 1 dict
+            - that dict is a full transaction with the id 'c'
+        """
+        paging = Mocks.make_paging_response(1, 4)
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('c'))
+
+        response = await self.get_json_assert_200('/transactions?min=1&count=1')
+        controls = Mocks.make_paging_controls(1, start_index=1)
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&min=1&count=1')
+        self.assert_has_valid_paging(response, paging,
+                                     '/transactions?head=d&min=2&count=1',
+                                     '/transactions?head=d&min=0&count=1')
+        self.assert_has_valid_data_list(response, 1)
+        self.assert_txns_well_formed(response['data'], 'c')
+
+    @unittest_run_loop
+    async def test_txn_list_with_zero_count(self):
+        """Verifies a GET /transactions with a count of zero breaks properly.
+
+        It should send back a JSON response with:
+            - a response status of 400
+        """
+        await self.assert_400('/transactions?min=2&count=0')
+
+    @unittest_run_loop
+    async def test_txn_list_with_bad_paging(self):
+        """Verifies a GET /transactions with a bad paging breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of INVALID_PAGING
+
+        It should send back a JSON response with:
+            - a response status of 400
+        """
+        self.stream.preset_response(self.status.INVALID_PAGING)
+        await self.assert_400('/transactions?min=-1')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated_with_just_count(self):
+        """Verifies GET /transactions paginated just by count works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with a start of 0, and 4 total resources
+            - two transactions with the ids 'd' and 'c'
+
+        It should send a Protobuf request with:
+            - paging controls with a count of 2
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&count=2'
+            - paging that matches the response with a next link
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids 'd' and 'c'
+        """
+        paging = Mocks.make_paging_response(0, 4)
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('d', 'c'))
+
+        response = await self.get_json_assert_200('/transactions?count=2')
+        controls = Mocks.make_paging_controls(2)
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&count=2')
+        self.assert_has_valid_paging(response, paging,
+                                     '/transactions?head=d&min=2&count=2')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_txns_well_formed(response['data'], 'd', 'c')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated_without_count(self):
+        """Verifies GET /transactions paginated without count works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with a start of 2, and 4 total resources
+            - two transactions with the ids 'b' and 'a'
+
+        It should send a Protobuf request with:
+            - paging controls with a start_index of 2
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&min=2'
+            - paging that matches the response, with a previous link
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids 'd' and 'c'
+        """
+        paging = Mocks.make_paging_response(2, 4)
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('b', 'a'))
+
+        response = await self.get_json_assert_200('/transactions?min=2')
+        controls = Mocks.make_paging_controls(None, start_index=2)
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&min=2')
+        self.assert_has_valid_paging(response, paging,
+                                     previous_link='/transactions?head=d&min=0&count=2')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_txns_well_formed(response['data'], 'b', 'a')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated_by_min_id(self):
+        """Verifies GET /transactions paginated by a min id works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with:
+                * a start_index of 1
+                * total_resources of 4
+                * a previous_id of 'd'
+            - three transactions with the ids 'c', 'b' and 'a'
+
+        It should send a Protobuf request with:
+            - paging controls with a count of 5, and a start_id of 'c'
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&min=c&count=5'
+            - paging that matches the response, with a previous link
+            - a data property that is a list of 3 dicts
+            - those dicts are full transactions with ids 'c', 'b', and 'a'
+        """
+        paging = Mocks.make_paging_response(1, 4, previous_id='d')
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('c', 'b', 'a'))
+
+        response = await self.get_json_assert_200('/transactions?min=c&count=5')
+        controls = Mocks.make_paging_controls(5, start_id='c')
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&min=c&count=5')
+        self.assert_has_valid_paging(response, paging,
+                                     previous_link='/transactions?head=d&max=d&count=5')
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], 'c', 'b', 'a')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated_by_max_id(self):
+        """Verifies GET /transactions paginated by a max id works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with:
+                * a start_index of 1
+                * a total_resources of 4
+                * a previous_id of 'd'
+                * a next_id of 'a'
+            - two transactions with the ids 'c' and 'b'
+
+        It should send a Protobuf request with:
+            - paging controls with a count of 2, and an end_id of 'b'
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&max=b&count=2'
+            - paging that matches the response, with next and previous links
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids 'c' and 'b'
+        """
+        paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('c', 'b'))
+
+        response = await self.get_json_assert_200('/transactions?max=b&count=2')
+        controls = Mocks.make_paging_controls(2, end_id='b')
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&max=b&count=2')
+        self.assert_has_valid_paging(response, paging,
+                                     '/transactions?head=d&min=a&count=2',
+                                     '/transactions?head=d&max=d&count=2')
+        self.assert_has_valid_data_list(response, 2)
+        self.assert_txns_well_formed(response['data'], 'c', 'b')
+
+    @unittest_run_loop
+    async def test_txn_list_paginated_by_max_index(self):
+        """Verifies GET /transactions paginated by a max index works properly.
+
+        It will receive a Protobuf response with:
+            - a head id of 'd'
+            - a paging response with a start of 0, and 4 total resources
+            - three transactions with the ids 'd', 'c' and 'b'
+
+        It should send a Protobuf request with:
+            - paging controls with a count of 3, and an start_index of 0
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - a head property of 'd'
+            - a link property that ends in '/transactions?head=d&min=3&count=7'
+            - paging that matches the response, with a next link
+            - a data property that is a list of 2 dicts
+            - those dicts are full transactions with ids 'd', 'c', and 'b'
+        """
+        paging = Mocks.make_paging_response(0, 4)
+        self.stream.preset_response(
+            head_id='d',
+            paging=paging,
+            transactions=Mocks.make_txns('d', 'c', 'b'))
+
+        response = await self.get_json_assert_200('/transactions?max=2&count=7')
+        controls = Mocks.make_paging_controls(3, start_index=0)
+        self.stream.assert_valid_request_sent(paging=controls)
+
+        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_link(response, '/transactions?head=d&max=2&count=7')
+        self.assert_has_valid_paging(response, paging,
+                                     '/transactions?head=d&min=3&count=7')
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], 'd', 'c', 'b')
+
+
+class TransactionGetTests(BaseApiTest):
+
+    async def get_application(self, loop):
+        self.set_status_and_stream(
+            Message.CLIENT_TRANSACTION_GET_REQUEST,
+            client_pb2.ClientTransactionGetRequest,
+            client_pb2.ClientTransactionGetResponse)
+
+        handlers = self.build_handlers(loop, self.stream)
+        return self.build_app(
+            loop,
+            '/transactions/{transaction_id}',
+            handlers.fetch_transaction)
+
+    @unittest_run_loop
+    async def test_txn_get(self):
+        """Verifies a GET /transactions/{transaction_id} works properly.
+
+        It should send a Protobuf request with:
+            - a transaction_id property of '1'
+
+        It will receive a Protobuf response with:
+            - a transaction with an id of '1'
+
+        It should send back a JSON response with:
+            - a response status of 200
+            - no head property
+            - a link property that ends in '/transactions/1'
+            - a data property that is a full batch with an id of '1'
+        """
+        self.stream.preset_response(transaction=Mocks.make_txns('1')[0])
+
+        response = await self.get_json_assert_200('/transactions/1')
+        self.stream.assert_valid_request_sent(transaction_id='1')
+
+        self.assertNotIn('head', response)
+        self.assert_has_valid_link(response, '/transactions/1')
+        self.assertIn('data', response)
+        self.assert_txns_well_formed(response['data'], '1')
+
+    @unittest_run_loop
+    async def test_txn_get_with_validator_error(self):
+        """Verifies GET /transactions/{transaction_id} w/ validator error breaks.
+
+        It will receive a Protobuf response with:
+            - a status of INTERNAL_ERROR
+
+        It should send back a JSON response with:
+            - a status of 500
+        """
+        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        await self.assert_500('/transactions/1')
+
+    @unittest_run_loop
+    async def test_txn_get_with_bad_id(self):
+        """Verifies a GET /transactions/{transaction_id} with unfound id breaks.
+
+        It will receive a Protobuf response with:
+            - a status of NO_RESOURCE
+
+        It should send back a JSON response with:
+            - a response status of 404
+        """
+        self.stream.preset_response(self.status.NO_RESOURCE)
+        await self.assert_404('/transactions/bad')

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -190,17 +190,15 @@ class BlockStore(MutableMapping):
         The batch that has the transaction.
         """
         if self.has_transaction(transaction_id):
-            block = self.get_block_by_transaction_id(
-                transaction_id)
+            block = self.get_block_by_transaction_id(transaction_id)
             # Find batch in block
             for batch in block.batches:
                 batch_header = BatchHeader()
                 batch_header.ParseFromString(batch.header)
                 if transaction_id in batch_header.transaction_ids:
                     return batch
-        else:
-            raise ValueError("Transaction_id %s not found in BlockStore.",
-                             transaction_id)
+
+        raise ValueError('Transaction "%s" not in BlockStore', transaction_id)
 
     def get_batch(self, batch_id):
         """
@@ -220,3 +218,24 @@ class BlockStore(MutableMapping):
                     return batch
 
         raise ValueError("Batch_id %s not found in BlockStore.", batch_id)
+
+    def get_transaction(self, transaction_id):
+        """Returns a Transaction object from the block store by its id.
+
+        Params:
+            transaction_id (str): The header_signature of the desired txn
+
+        Returns:
+            Transaction: The specified transaction
+
+        Raises:
+            ValueError: The transaction is not in the block store
+        """
+        if self.has_transaction(transaction_id):
+            batch = self.get_batch_by_transaction(transaction_id)
+            # Find transaction in batch
+            for txn in batch.transactions:
+                if txn.header_signature == transaction_id:
+                    return txn
+
+        raise ValueError('Transaction "%s" not in BlockStore', transaction_id)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -382,6 +382,18 @@ class Validator(object):
             thread_pool)
 
         self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_TRANSACTION_LIST_REQUEST,
+            client_handlers.TransactionListRequest(
+                self._journal.get_block_store()),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_TRANSACTION_GET_REQUEST,
+            client_handlers.TransactionGetRequest(
+                self._journal.get_block_store()),
+            thread_pool)
+
+        self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_STATE_CURRENT_REQUEST,
             client_handlers.StateCurrentRequest(
                 self._journal.get_current_root), thread_pool)

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -546,12 +546,9 @@ class BlockGetRequest(_ClientRequestHandler):
     def _respond(self, request):
         try:
             block = self._block_store[request.block_id].block
-        except KeyError:
-            LOGGER.debug('No block "%s" in store', request.block_id)
+        except KeyError as e:
+            LOGGER.debug(e)
             return self._status.NO_RESOURCE
-        except TypeError:
-            LOGGER.debug('"%s" is a batch is, not block', request.block_id)
-            return self._status.INVALID_ID
         return self._wrap_response(block=block)
 
 
@@ -600,10 +597,7 @@ class BatchGetRequest(_ClientRequestHandler):
     def _respond(self, request):
         try:
             batch = self._block_store.get_batch(request.batch_id)
-        except ValueError:
-            LOGGER.debug('No batch "%s" in store', request.batch_id)
+        except ValueError as e:
+            LOGGER.debug(e)
             return self._status.NO_RESOURCE
-        except KeyError:
-            LOGGER.debug('"%s" is a block id, not batch', request.batch_id)
-            return self._status.INVALID_ID
         return self._wrap_response(batch=batch)

--- a/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
@@ -446,10 +446,10 @@ class TestBatchGetRequests(ClientHandlerTestCase):
         """Verifies requests for a batch break properly with a block id.
 
         Expects to find:
-            - a status of INVALID_ID
+            - a status of NO_RESOURCE
             - that the Batch returned, when serialized, is actually empty
         """
         response = self.make_request(batch_id='B-1')
 
-        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.batch.SerializeToString())

--- a/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_batch_handlers.py
@@ -347,7 +347,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual('b-2', response.batches[0].header_signature)
 
-    def test_block_list_with_bad_pagination(self):
+    def test_batch_list_with_bad_pagination(self):
         """Verifies batch requests break when paging specifies missing batches.
 
         Queries the default mock block store:

--- a/validator/tests/unit3/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_block_handlers.py
@@ -441,10 +441,10 @@ class TestBlockGetRequests(ClientHandlerTestCase):
         """Verifies requests for a block break properly with a batch id.
 
         Expects to find:
-            - a status of INVALID_ID
+            - a status of NO_RESOURCE
             - that the Block returned, when serialized, is empty
         """
         response = self.make_request(block_id='b-1')
 
-        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())

--- a/validator/tests/unit3/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_txn_handlers.py
@@ -1,0 +1,588 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import sawtooth_validator.state.client_handlers as handlers
+from sawtooth_validator.protobuf import client_pb2
+from sawtooth_validator.protobuf.transaction_pb2 import Transaction
+from test_client_request_handlers.base_case import ClientHandlerTestCase
+from test_client_request_handlers.mocks import MockBlockStore
+
+
+class TestTransactionListRequests(ClientHandlerTestCase):
+    def setUp(self):
+        store = MockBlockStore()
+        self.initialize(
+            handlers.TransactionListRequest(store),
+            client_pb2.ClientTransactionListRequest,
+            client_pb2.ClientTransactionListResponse,
+            store=store)
+
+    def test_txn_list_request(self):
+        """Verifies requests for txn lists without parameters work properly.
+
+        Queries the default mock block store with three blocks:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - the default paging response, showing all 3 resources returned
+            - a list of transactions with 3 items
+            - those items are instances of Transaction
+            - the first item has a header_signature of 't-2'
+        """
+        response = self.make_request()
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response)
+        self.assertEqual(3, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-2', response.transactions[0].header_signature)
+
+    def test_txn_list_bad_request(self):
+        """Verifies requests for txn lists break with bad protobufs.
+
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that head_id, paging, and transactions are missing
+        """
+        response = self.make_bad_request(head_id='B-1')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
+        self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_bad_request(self):
+        """Verifies requests for txn lists break with no genesis.
+
+        Expects to find:
+            - a status of NOT_READY
+            - that head_id, paging, and transactions are missing
+        """
+        self.break_genesis()
+        response = self.make_request()
+
+        self.assertEqual(self.status.NOT_READY, response.status)
+        self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_with_head(self):
+        """Verifies requests for txn lists work properly with a head id.
+
+        Queries the default mock block store with 'B-1' as the head:
+            {
+                header_signature: 'B-1',
+                batches: [{
+                    header_signature: 'b-1',
+                    transactions: [{
+                        header_signature: 't-1',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-1'
+            - a paging response showing all 2 resources returned
+            - a list of transactions with 2 items
+            - those items are instances of Transaction
+            - the first item has a header_signature of 't-1'
+        """
+        response = self.make_request(head_id='B-1')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, total=2)
+        self.assertEqual(2, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-1', response.transactions[0].header_signature)
+
+    def test_txn_list_with_bad_head(self):
+        """Verifies requests for txn lists break with a bad head.
+
+        Expects to find:
+            - a status of NO_ROOT
+            - that head_id, paging, and transactions are missing
+        """
+        response = self.make_request(head_id='bad')
+
+        self.assertEqual(self.status.NO_ROOT, response.status)
+        self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_filtered_by_ids(self):
+        """Verifies requests for txn lists work filtered by txn ids.
+
+        Queries the default mock block store with three blocks:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response showing all 2 resources returned
+            - a list of transactions with 2 items
+            - the items are instances of Transaction
+            - the first item has a header_signature of 't-0'
+            - the second item has a header_signature of 't-2'
+        """
+        response = self.make_request(transaction_ids=['t-0', 't-2'])
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, total=2)
+        self.assertEqual(2, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-0', response.transactions[0].header_signature)
+        self.assertEqual('t-2', response.transactions[1].header_signature)
+
+    def test_txn_list_by_bad_ids(self):
+        """Verifies txn list requests break properly when ids are not found.
+
+        Queries the default mock block store with three blocks:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - a head_id of 'B-2', the latest
+            - that paging and transactions are missing
+        """
+        response = self.make_request(transaction_ids=['bad', 'notgood'])
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_by_good_and_bad_ids(self):
+        """Verifies txn list requests work filtered by good and bad ids.
+
+        Queries the default mock block store with three blocks:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response showing all 1 resources returned
+            - a list of transactions with 1 items
+            - that item is an instances of Transaction
+            - that item has a header_signature of 't-1'
+        """
+        response = self.make_request(transaction_ids=['bad', 't-1'])
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, total=1)
+        self.assertEqual(1, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-1', response.transactions[0].header_signature)
+
+    def test_txn_list_by_head_and_ids(self):
+        """Verifies txn list requests work with both head and txn ids.
+
+        Queries the default mock block store with 'B-1' as the head:
+            {
+                header_signature: 'B-1',
+                batches: [{
+                    header_signature: 'b-1',
+                    transactions: [{
+                        header_signature: 't-1',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-1'
+            - a paging response showing all 1 resources returned
+            - a list of transactions with 1 item
+            - that item is an instance of Transaction
+            - that item has a header_signature of 't-0'
+        """
+        response = self.make_request(head_id='B-1', transaction_ids=['t-0'])
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, total=1)
+        self.assertEqual(1, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-0', response.transactions[0].header_signature)
+
+    def test_txn_list_head_ids_mismatch(self):
+        """Verifies txn list requests break when ids not found with head.
+
+        Queries the default mock block store with 'B-0' as the head:
+            {
+                header_signature: 'B-0',
+                batches: [{
+                    header_signature: 'b-0',
+                    transactions: [{
+                        header_signature: 't-0',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            }
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - a head_id of 'B-0'
+            - that paging and transactions are missing
+        """
+        response = self.make_request(head_id='B-0', transaction_ids=['t-1', 't-2'])
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertEqual('B-0', response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_paginated(self):
+        """Verifies requests for txn lists work when paginated just by count.
+
+        Queries the default mock block store:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with:
+                * a next_id of 't-0'
+                * the default empty previous_id
+                * the default start_index of 0
+                * the default total resource count of 3
+            - a list of transactions with 2 items
+            - those items are instances of Transaction
+            - the first item has a header_signature of 't-2'
+        """
+        response = self.make_paged_request(count=2)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, next_id='t-0')
+        self.assertEqual(2, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-2', response.transactions[0].header_signature)
+
+    def test_txn_list_paginated_by_start_id (self):
+        """Verifies txn list requests work paginated by count and start_id.
+
+        Queries the default mock block store:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with:
+                * a next_id of 't-0'
+                * a previous_id of 't-2'
+                * a start_index of 1
+                * the default total resource count of 3
+            - a list of transactions with 1 item
+            - that item is an instance of Transaction
+            - that item has a header_signature of 't-1'
+        """
+        response = self.make_paged_request(count=1, start_id='t-1')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, 't-0', 't-2', 1)
+        self.assertEqual(1, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-1', response.transactions[0].header_signature)
+
+    def test_txn_list_paginated_by_end_id (self):
+        """Verifies txn list requests work paginated by count and end_id.
+
+        Queries the default mock block store:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with:
+                * the default empty next_id
+                * a previous_id of 't-2'
+                * a start_index of 1
+                * the default total resource count of 3
+            - a list of transactions with 2 items
+            - those items are instances of Transaction
+            - the first item has a header_signature of 't-1'
+        """
+        response = self.make_paged_request(count=2, end_id='t-0')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, previous_id='t-2', start_index=1)
+        self.assertEqual(2, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-1', response.transactions[0].header_signature)
+
+    def test_txn_list_paginated_by_index (self):
+        """Verifies txn list requests work paginated by count and min_index.
+
+        Queries the default mock block store:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response with a next_id of 't-1'
+            - a list of transactions with 1 item
+            - that item is an instance of Transaction
+            - that item has a header_signature of 't-2'
+        """
+        response = self.make_paged_request(count=1, start_index=0)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response, next_id='t-1')
+        self.assertEqual(1, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-2', response.transactions[0].header_signature)
+
+    def test_txn_list_with_bad_pagination(self):
+        """Verifies txn requests break when paging specifies missing txns.
+
+        Queries the default mock block store:
+            {
+                header_signature: 'B-2',
+                batches: [{
+                    header_signature: 'b-2',
+                    transactions: [{
+                        header_signature: 't-2',
+                        ...
+                    }],
+                    ...
+                }],
+                ...
+            },
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of INVALID_PAGING
+            - that head_id, paging, and transactions are missing
+        """
+        response = self.make_paged_request(count=3, start_id='bad')
+
+        self.assertEqual(self.status.INVALID_PAGING, response.status)
+        self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
+    def test_txn_list_paginated_with_head (self):
+        """Verifies txn list requests work with both paging and a head id.
+
+        Queries the default mock block store with 'B-1' as the head:
+            {header_signature: 'B-1', ...},
+            {header_signature: 'B-0', ...}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-1'
+            - a paging response with:
+                * an empty next_id
+                * a previous_id of 't-1'
+                * a start_index of 1
+                * a total resource count of 2
+            - a list of transactions with 1 item
+            - that item is an instance of Transaction
+            - that has a header_signature of 't-0'
+        """
+        response = self.make_paged_request(count=1, start_index=1, head_id='B-1')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-1', response.head_id)
+        self.assert_valid_paging(response, '', 't-1', 1, 2)
+        self.assertEqual(1, len(response.transactions))
+        self.assert_all_instances(response.transactions, Transaction)
+        self.assertEqual('t-0', response.transactions[0].header_signature)
+
+
+class TestTransactionGetRequests(ClientHandlerTestCase):
+    def setUp(self):
+        store = MockBlockStore()
+        self.initialize(
+            handlers.TransactionGetRequest(store),
+            client_pb2.ClientTransactionGetRequest,
+            client_pb2.ClientTransactionGetResponse)
+
+    def test_txn_get_request(self):
+        """Verifies requests for a specific txn by id work properly.
+
+        Queries the default three block mock store for a txn id of 't-1'
+
+        Expects to find:
+            - a status of OK
+            - a transaction property which is an instances of Transaction
+            - the transaction has a header_signature of 't-1'
+        """
+        response = self.make_request(transaction_id='t-1')
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertIsInstance(response.transaction, Transaction)
+        self.assertEqual('t-1', response.transaction.header_signature)
+
+    def test_txn_get_bad_request(self):
+        """Verifies requests for a specific txn break with a bad protobuf.
+
+        Expects to find:
+            - a status of INTERNAL_ERROR
+            - that the Transaction returned, when serialized, is actually empty
+        """
+        response = self.make_bad_request(transaction_id='t-1')
+
+        self.assertEqual(self.status.INTERNAL_ERROR, response.status)
+        self.assertFalse(response.transaction.SerializeToString())
+
+    def test_txn_get_with_bad_id(self):
+        """Verifies requests for a specific txn break with a bad id.
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - that the Transaction returned, when serialized, is actually empty
+        """
+        response = self.make_request(transaction_id='bad')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.transaction.SerializeToString())
+
+    def test_txn_get_with_block_id(self):
+        """Verifies requests for a specific txn break properly with a block id.
+
+        Expects to find:
+            - a status of NO_RESOURCE
+            - that the Transaction returned, when serialized, is actually empty
+        """
+        response = self.make_request(transaction_id='B-1')
+
+        self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.transaction.SerializeToString())


### PR DESCRIPTION
- Add `get_transaction` method to block store and refactors some error handling
- Add transaction client handlers to validator with unit tests
- Add `/transactions` route to Rest Api, with unit tests
- Refactor similar CLI commands to use new `format_utils` module with common formatting logic
- Add `transaction list` and `transaction show` commands to CLI
- Correct some typos