### PR TITLE
Create tests for config CLI tool - integration test

### DIFF
--- a/integration/sawtooth_integration/docker/config-smoke.yaml
+++ b/integration/sawtooth_integration/docker/config-smoke.yaml
@@ -1,0 +1,74 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  tp_config:
+    image: sawtooth-tp_config:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    depends_on:
+      - validator
+    command: tp_config -vv tcp://validator:40000
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        validator -v --public-uri tcp://validator:8800\""
+    stop_signal: SIGKILL
+
+  rest_api:
+    image: sawtooth-rest_api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8080
+    depends_on:
+      - validator
+    command: rest_api --stream-url tcp://validator:40000
+    stop_signal: SIGKILL
+
+  integration_test:
+    image: sawtooth-dev-test:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    depends_on:
+      - validator
+      - rest_api
+    command: nose2-3 -v -s
+        /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_config_smoke.TestConfigSmoke
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli:\
+        /project/sawtooth-core/manage"

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -1,0 +1,94 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import unittest
+import traceback
+import tempfile
+import os
+import subprocess
+from sawtooth_cli.main import main
+import sys
+from io import StringIO
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.DEBUG)
+
+TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
+
+class TestConfigSmoke(unittest.TestCase):
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+        self._data_dir = os.path.join(self._temp_dir, 'data')
+        os.makedirs(self._data_dir)
+
+        # create a wif key for signing
+        self._wif_file = os.path.join(self._temp_dir, 'test.wif')
+        with open(self._wif_file, 'wb') as wif:
+            wif.write(TEST_WIF.encode())
+
+    def _run(self, args):
+        try:
+            LOGGER.debug("Running %s", " ".join(args))
+            proc = subprocess.run(
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+            LOGGER.debug(proc.stdout.decode())
+        except subprocess.CalledProcessError as err:
+            LOGGER.debug(err)
+            LOGGER.debug(err.stderr.decode())
+            traceback.print_exc()
+            self.fail(self.__class__.__name__)
+
+    def _read_from_stdout(self, cmd, args):
+        # Retrieve string of setting contents for comparison to input settings
+        backup = sys.stdout # backup the environment
+        sys.stdout = StringIO() # Capture the output of next statement
+
+        main(cmd, args)
+        settings = sys.stdout.getvalue() # release the output and store
+        sys.stdout.close()
+        # Restore the environment
+        sys.stdout = backup
+        return settings
+
+
+    def test_submit_then_list_settings(self):
+        ''' Test ability to list settings after submission of a setting.
+            Test submits a simple config transaction to the validator,
+            then confirms that the settings can be retrieved by the
+            command 'sawtooth config settings list', and that the retrieved
+            setting equals the input setting.
+            '''
+
+        # Submit transaction, then list it using subprocess
+        cmds = [
+            ['sawtooth','config', 'proposal', 'create', '-k', self._wif_file,
+             '--url', 'http://rest_api:8080', 'x=1', 'y=1'],
+            ['sawtooth', 'config', 'settings', 'list', '--url',
+             'http://rest_api:8080']
+        ]
+
+        for cmd in cmds:
+            self._run(cmd)
+
+        command = 'sawtooth'
+        args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
+        settings = self._read_from_stdout(command, args)
+
+        _expected_setting_results = 'x: 1\ny: 1\n'
+        self.assertEqual(settings, _expected_setting_results, 'Setting results did not match.' )


### PR DESCRIPTION
As part of NML-2202, create an integration test for
CLI config tool. This test is not yet complete, but
does test the ability of the tool to submit a sample
transaction to the config TP, and to list the results.
Compares resulting listing to original input.

Signed-off-by: Todd Ojala <todd@bitwise.io>