### PR TITLE
Update tutorial for validator required parameter

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -288,7 +288,7 @@ and run the following commands:
 
    $ cd sawtooth-core/
    $ sawtooth keygen --key-dir /home/ubuntu/sawtooth/keys/ validator
-   $ validator -vv
+   $ validator -vv --public-uri tcp://localhost:8800
 
 .. note::
 


### PR DESCRIPTION
Validator now requires parameter --public-uri to
start.

Signed-off-by: Todd Ojala <todd@bitwise.io>