### PR TITLE
Enforce and abide by PoET block claim delay

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -118,7 +118,7 @@ def do_genesis(args):
     payload = \
         vr_pb.ValidatorRegistryPayload(
             verb='register',
-            name='validator-{}'.format(pubkey[-8:]),
+            name='validator-{}'.format(pubkey[:8]),
             id=pubkey,
             signup_info=vr_pb.SignUpInfo(
                 poet_public_key=signup_info.poet_public_key,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -298,12 +298,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 consensus_state_store=self._consensus_state_store,
                 poet_enclave_module=poet_enclave_module)
         validator_state = \
-            consensus_state.get_validator_state(self._validator_id)
+            utils.get_current_validator_state(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_cache=self._block_cache)
         key_block_claim_limit = \
             PoetConfigView(state_view).key_block_claim_limit
 
-        if validator_state is not None and \
-                validator_state.poet_public_key == \
+        if validator_state.poet_public_key == \
                 PoetBlockPublisher._poet_public_key and \
                 validator_state.key_block_claim_count >= \
                 key_block_claim_limit:

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -166,13 +166,14 @@ class PoetBlockVerifier(BlockVerifierInterface):
                     consensus_state_store=self._consensus_state_store,
                     poet_enclave_module=poet_enclave_module)
             validator_state = \
-                consensus_state.get_validator_state(
-                    validator_id=validator_info.id)
+                utils.get_current_validator_state(
+                    validator_info=validator_info,
+                    consensus_state=consensus_state,
+                    block_cache=self._block_cache)
 
             poet_config_view = PoetConfigView(state_view=state_view)
 
-            if validator_state is not None and \
-                    validator_state.poet_public_key == poet_public_key and \
+            if validator_state.poet_public_key == poet_public_key and \
                     validator_state.key_block_claim_count >= \
                     poet_config_view.key_block_claim_limit:
                 raise \

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -27,6 +27,7 @@ class PoetConfigView(object):
     """
 
     _DEFAULT_KEY_CLAIM_LIMIT_ = 25
+    _DEFAULT_BLOCK_CLAIM_DELAY_ = 1
 
     def __init__(self, state_view):
         """Initialize a PoetConfigView object.
@@ -87,6 +88,10 @@ class PoetConfigView(object):
     def key_block_claim_limit(self):
         """Return the key block claim limit if config setting exists or
         default if not or value is invalid.
+
+        The key block claim limit is the maximum number of blocks that a
+        validator may claim with a PoET key pair before it needs to refresh
+        its signup information.
         """
         return \
             self._get_config_setting(
@@ -94,3 +99,19 @@ class PoetConfigView(object):
                 value_type=int,
                 default_value=PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
+
+    @property
+    def block_claim_delay(self):
+        """Return the block claim delay if config setting exists or
+        default if not or value is invalid.
+
+        The block claim delay is the number of blocks after a validator's
+        signup information is committed to the validator registry before
+        it can claim a block.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.block_claim_delay',
+                value_type=int,
+                default_value=PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_,
+                validate_function=lambda value: value >= 0)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -163,13 +163,16 @@ class PoetForkResolver(ForkResolverInterface):
                         poet_enclave_module=poet_enclave_module)
 
                 validator_state = \
-                    consensus_state.get_validator_state(
-                        validator_id=validator_info.id)
+                    utils.get_current_validator_state(
+                        validator_info=validator_info,
+                        consensus_state=consensus_state,
+                        block_cache=self._block_cache)
                 consensus_state.set_validator_state(
                     validator_id=validator_info.id,
-                    validator_state=utils.create_validator_state(
+                    validator_state=utils.create_next_validator_state(
                         validator_info=validator_info,
-                        current_validator_state=validator_state))
+                        current_validator_state=validator_state,
+                        block_cache=self._block_cache))
 
                 # Update the consensus-wide statistics and store the updated
                 # consensus state for this block.

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -171,9 +171,16 @@ class PoetForkResolver(ForkResolverInterface):
                         validator_info=validator_info,
                         current_validator_state=validator_state))
 
-                # Store the updated consensus state for this block.
+                # Update the consensus-wide statistics and store the updated
+                # consensus state for this block.
+                consensus_state.total_block_claim_count += 1
                 self._consensus_state_store[new_fork_head.identifier] = \
                     consensus_state
+
+                LOGGER.debug(
+                    'Update consensus state: EBC=%f, TBCC=%d',
+                    consensus_state.expected_block_claim_count,
+                    consensus_state.total_block_claim_count)
             except KeyError:
                 # This _should_ never happen.  The new potential fork head
                 # has to have been a PoET block and for it to be verified

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -309,10 +309,12 @@ def get_consensus_state_for_block_id(
         if block_info.wait_certificate is None:
             consensus_state = ConsensusState()
 
-        # Otherwise, we need to fetch the current validator state for the
-        # validator which claimed the block, set/update the consensus state
-        # object, and then associate the consensus state with the appropriate
-        # block in the consensus state store.
+        # Otherwise, update the consensus state statistics and fetch the
+        # validator state for the validator which claimed the block, create
+        # updated validator state for the validator, set/update the validator
+        # state in the consensus state object, and then associate the
+        # consensus state with the corresponding block in the consensus state
+        # store.
         else:
             validator_state = \
                 consensus_state.get_validator_state(
@@ -328,6 +330,7 @@ def get_consensus_state_for_block_id(
                 block_id[:8],
                 block_id[-8:])
 
+            consensus_state.total_block_claim_count += 1
             consensus_state_store[block_id] = consensus_state
 
     return consensus_state

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -142,7 +142,8 @@ def build_certificate_list(block_header,
     return list(certificates)
 
 
-def create_validator_state(validator_info, current_validator_state):
+def create_validator_state(validator_info,
+                           current_validator_state):
     """Starting with the current validator state (or None), create validator
      validator state for the validator.
 
@@ -175,15 +176,18 @@ def create_validator_state(validator_info, current_validator_state):
                 current_validator_state.key_block_claim_count + 1
 
     LOGGER.debug(
-        'Create validator state for %s: PPK=%s...%s, KBCC=%d, TBCC=%d',
+        'Create validator state for %s: PPK=%s...%s, KBCC=%d, TBCC=%d, '
+        'UBN=%d',
         validator_info.name,
         poet_public_key[:8],
         poet_public_key[-8:],
         key_block_claim_count,
-        total_block_claim_count)
+        total_block_claim_count,
+        0)
 
     return \
         ValidatorState(
+            commit_block_number=0,
             key_block_claim_count=key_block_claim_count,
             poet_public_key=poet_public_key,
             total_block_claim_count=total_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -39,9 +39,11 @@ class TestConsensusState(unittest.TestCase):
             state.get_validator_state(
                 validator_id='Bond, James Bond',
                 default=consensus_state.ValidatorState(
+                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=1,
                     poet_public_key='my key',
                     total_block_claim_count=2))
+        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'my key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
@@ -53,12 +55,24 @@ class TestConsensusState(unittest.TestCase):
         """
         state = consensus_state.ConsensusState()
 
+        # Test invalid commit block number in validator state
+        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
+            with self.assertRaises(ValueError):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        commit_block_number=invalid_cbn,
+                        key_block_claim_count=0,
+                        poet_public_key='my key',
+                        total_block_claim_count=0))
+
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             with self.assertRaises(ValueError):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='my key',
                         total_block_claim_count=0))
@@ -69,16 +83,18 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=0))
 
-        # Test total block claim count in validator state
+        # Test invalid total block claim count in validator state
         for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
             with self.assertRaises(ValueError):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='my key',
                         total_block_claim_count=invalid_tbcc))
@@ -88,6 +104,7 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
+                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='my key',
                     total_block_claim_count=1))
@@ -95,6 +112,7 @@ class TestConsensusState(unittest.TestCase):
         # Verify that can retrieve after set and validator state matches
         validator_state = \
             consensus_state.ValidatorState(
+                commit_block_number=0xdeadbeef,
                 key_block_claim_count=0,
                 poet_public_key='my key',
                 total_block_claim_count=0)
@@ -105,6 +123,9 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
+        self.assertEqual(
+            validator_state.commit_block_number,
+            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -118,6 +139,7 @@ class TestConsensusState(unittest.TestCase):
         # Verify that updating an existing validator state matches on get
         validator_state = \
             consensus_state.ValidatorState(
+                commit_block_number=0xfeedbeef,
                 key_block_claim_count=1,
                 poet_public_key='my new key',
                 total_block_claim_count=2)
@@ -128,6 +150,9 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
+        self.assertEqual(
+            validator_state.commit_block_number,
+            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -176,6 +201,7 @@ class TestConsensusState(unittest.TestCase):
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
+                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key',
                 total_block_claim_count=1))
@@ -192,6 +218,24 @@ class TestConsensusState(unittest.TestCase):
         # Circumvent testing of validator state validity so that we can
         # serialize to invalid data to verify deserializing
 
+        # Test invalid commit block number in validator state
+        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
+            state = consensus_state.ConsensusState()
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.'
+                    'ConsensusState._check_validator_state'):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        commit_block_number=invalid_cbn,
+                        key_block_claim_count=0,
+                        poet_public_key='key 1',
+                        total_block_claim_count=1))
+
+            serialized = state.serialize_to_bytes()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(serialized)
+
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
@@ -201,6 +245,7 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='key 1',
                         total_block_claim_count=1))
@@ -218,6 +263,7 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=1))
@@ -235,6 +281,7 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key='key',
                         total_block_claim_count=invalid_tbcc))
@@ -250,6 +297,7 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
+                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='key',
                     total_block_claim_count=1))
@@ -273,11 +321,13 @@ class TestConsensusState(unittest.TestCase):
         # verify they are in deserialized
         validator_state_1 = \
             consensus_state.ValidatorState(
+                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key 1',
                 total_block_claim_count=2)
         validator_state_2 = \
             consensus_state.ValidatorState(
+                commit_block_number=0xfeedbeef,
                 key_block_claim_count=3,
                 poet_public_key='key 2',
                 total_block_claim_count=4)
@@ -296,6 +346,9 @@ class TestConsensusState(unittest.TestCase):
                 validator_id='Bond, James Bond')
 
         self.assertEqual(
+            validator_state.commit_block_number,
+            validator_state_1.commit_block_number)
+        self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_1.key_block_claim_count)
         self.assertEqual(
@@ -309,6 +362,9 @@ class TestConsensusState(unittest.TestCase):
             doppelganger_state.get_validator_state(
                 validator_id='Smart, Maxwell Smart')
 
+        self.assertEqual(
+            validator_state.commit_block_number,
+            validator_state_2.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_2.key_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -149,14 +149,22 @@ class TestConsensusState(unittest.TestCase):
             with self.assertRaises(ValueError):
                 state.parse_from_bytes(cbor.dumps(invalid_state))
 
-        # Invalid expected block count
-        for invalid_ebc in [None, 'not a float', (), [], {}]:
+        # Invalid expected block claim count
+        for invalid_ebcc in [None, 'not a float', (), [], {}, -1,
+                             float('nan'), float('inf'), float('-inf')]:
             state = consensus_state.ConsensusState()
-            state.expected_block_claim_count = invalid_ebc
+            state.expected_block_claim_count = invalid_ebcc
             with self.assertRaises(ValueError):
                 state.parse_from_bytes(state.serialize_to_bytes())
 
-        # Invalid expected block count
+        # Invalid total block claim count
+        for invalid_tbcc in [None, 'not an int', (), [], {}, -1]:
+            state = consensus_state.ConsensusState()
+            state.total_block_claim_count = invalid_tbcc
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(state.serialize_to_bytes())
+
+        # Invalid validators
         for invalid_validators in [None, '', 1, 1.1, (), []]:
             state = consensus_state.ConsensusState()
             # pylint: disable=protected-access
@@ -257,6 +265,9 @@ class TestConsensusState(unittest.TestCase):
         self.assertEqual(
             state.expected_block_claim_count,
             doppelganger_state.expected_block_claim_count)
+        self.assertEqual(
+            state.total_block_claim_count,
+            doppelganger_state.total_block_claim_count)
 
         # Now put a couple of validators in, serialize, deserialize, and
         # verify they are in deserialized

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -112,6 +112,7 @@ class TestConsensusStateStore(unittest.TestCase):
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
+                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='skeleton key',
                 total_block_claim_count=2))
@@ -135,6 +136,7 @@ class TestConsensusStateStore(unittest.TestCase):
             retrieved_state.get_validator_state(
                 validator_id='Bond, James Bond')
 
+        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'skeleton key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
@@ -147,4 +149,4 @@ class TestConsensusStateStore(unittest.TestCase):
         self.assertTrue('key' not in my_dict)
 
         with self.assertRaises(KeyError):
-            state = store['key']
+            _ = store['key']

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -67,3 +67,47 @@ class TestPoetConfigView(unittest.TestCase):
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
             1)
+
+    def test_block_claim_delay(self, mock_config_view):
+        """Verify that retrieving block claim delay works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.block_claim_delay,
+            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.block_claim_delay')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            kwargs['default_value'],
+            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.block_claim_delay,
+            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 0
+        self.assertEqual(
+            poet_config_view.block_claim_delay,
+            0)
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(
+            poet_config_view.block_claim_delay,
+            1)


### PR DESCRIPTION
Per the PoET specification, whenever a validator adds or updates signup information to the validator registry, it is not allowed to claim a block until some number of blocks after the block in which its validator registry information was committed.  This PR:

* Updates the PoET configuration view to contain the configurable block claim delay value.
* Updates the consensus state to keep track of the total number of blocks claimed.  Note that it is not sufficient to simply rely upon a block's number as PoET consensus state statistics, etc., are reset whenever a non-PoET block is encountered.
* Updates the PoET utils to accurately keep track of the total block claim count.
* Updates the per-validator state to keep track of the block number in which a validator's current PoET public key committed to the blockchain.
* Refactors the PoET utils to make validator state and retrieval useful for enforcing both this policy as well as the other PoET policies.
* Updates the PoET block verifier to apply the block claim delay to fail verification of blocks which are attempted to be claimed before the block claim delay has been satisfied.
* Updates the PoET block publisher to apply the block claim delay to prevent initializing a block if it would be rejected by other validator's PoET block verifiers because the block was claimed before the block claim delay has been satisfied..

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`-k /etc/sawtooth/keys/validator.wif \`

Add:

```
sawtooth.consensus.algorithm=poet \
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
sawtooth.poet.key_block_claim_limit=2 \
```

This should result in a bunch of blocks and validators having to refresh after successfully claiming 2 blocks.

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.