### PR TITLE
Enforce and abide by PoET block claim frequency (zTest) restrictions

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -21,8 +21,7 @@ import cbor
 ValidatorState = \
     namedtuple(
         'ValidatorState',
-        ['commit_block_number',
-         'key_block_claim_count',
+        ['key_block_claim_count',
          'poet_public_key',
          'total_block_claim_count',
          'ztest_block_claim_count'
@@ -31,9 +30,6 @@ ValidatorState = \
 the validator state.  The validator state represents the state for a single
 validator at a point in time.  A validator state object contains:
 
-commit_block_number (int): The block number of the committed block that
-    contains the validator registry transaction which updated the validator's
-    PoET public key to the value found in poet_public_key
 key_block_claim_count (int): The number of blocks that the validator has
 claimed using the current PoET public key
 poet_public_key (str): The current PoET public key for the validator
@@ -79,13 +75,6 @@ class ConsensusState(object):
 
     @staticmethod
     def _check_validator_state(validator_state):
-        if not isinstance(validator_state.commit_block_number, int) \
-                or validator_state.commit_block_number < 0:
-            raise \
-                ValueError(
-                    'commit_block_number ({}) is invalid'.format(
-                        validator_state.commit_block_number))
-
         if not isinstance(
                 validator_state.key_block_claim_count, int) \
                 or validator_state.key_block_claim_count < 0:
@@ -271,9 +260,8 @@ class ConsensusState(object):
 
     def __str__(self):
         validators = \
-            ['{}: {{CBN: {}, KBCC: {}, PPK: {}, TBCC: {}, ZBCC: {}}}'.format(
+            ['{}: {{KBCC: {}, PPK: {}, TBCC: {}, ZBCC: {}}}'.format(
                 key[:8],
-                value.commit_block_number,
                 value.key_block_claim_count,
                 value.poet_public_key[:8],
                 value.total_block_claim_count,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -17,7 +17,6 @@ import logging
 import hashlib
 import time
 import json
-import math
 
 import sawtooth_signing as signing
 
@@ -306,11 +305,10 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # with this PoET key.  If we have hit the key block claim limit, then
         # we need to check if the key has been refreshed.
         key_block_claim_limit = poet_config_view.key_block_claim_limit
-
-        if validator_state.poet_public_key == \
-                PoetBlockPublisher._poet_public_key and \
-                validator_state.key_block_claim_count >= \
-                key_block_claim_limit:
+        if utils.validator_has_claimed_maximum_number_of_blocks(
+                validator_info=validator_info,
+                validator_state=validator_state,
+                key_block_claim_limit=key_block_claim_limit):
             # Because we have hit the limit, check to see if we have already
             # submitted a validator registry transaction with new signup
             # information, and therefore a new PoET public key.  If not, then
@@ -324,7 +322,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     PoetBlockPublisher._poet_public_key]
             if not poet_key_state.has_been_refreshed:
                 LOGGER.info(
-                    'Reached block claim limit (%d) for key for key: %s...%s',
+                    'Reached block claim limit (%d) for key: %s...%s',
                     key_block_claim_limit,
                     PoetBlockPublisher._poet_public_key[:8],
                     PoetBlockPublisher._poet_public_key[-8:])
@@ -345,41 +343,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # Verify that we are abiding by the block claim delay (i.e., waiting a
         # certain number of blocks since our validator registry was added/
         # updated).
-
-        # While having a block claim delay is nice, it turns out that in
-        # practice the claim delay should not be more than one less than
-        # the number of validators.  It helps to imagine the scenario
-        # where each validator hits their block claim limit in sequential
-        # blocks and their new validator registry information is updated
-        # in the following block by another validator, assuming that there
-        # were no forks.  If there are N validators, once all N validators
-        # have updated their validator registry information, there will
-        # have been N-1 block commits and the Nth validator will only be
-        # able to get its updated validator registry information updated
-        # if the first validator that kicked this off is now able to claim
-        # a block.  If the block claim delay was greater than or equal to
-        # the number of validators, at this point no validators would be
-        # able to claim a block.
-        number_of_validators = \
-            len(validator_registry_view.get_validators())
-        block_claim_delay = \
-            min(
-                poet_config_view.block_claim_delay,
-                number_of_validators - 1)
-
-        # While a validator network is starting up, we need to be careful
-        # about applying the block claim delay because if we are too
-        # aggressive we will get ourselves into a situation where the
-        # block claim delay will prevent any validators from claiming
-        # blocks.  So, until we get at least block_claim_delay blocks
-        # we are going to choose not to enforce the delay.
-        if consensus_state.total_block_claim_count > block_claim_delay:
-            blocks_since_registration = \
-                block_header.block_num - \
-                validator_state.commit_block_number - 1
-
-            if block_claim_delay > blocks_since_registration:
-                return False
+        if utils.validator_has_claimed_too_early(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_number=block_header.block_num,
+                validator_registry_view=validator_registry_view,
+                poet_config_view=poet_config_view,
+                block_store=self._block_cache.block_store):
+            return False
 
         # Create a list of certificates for the wait timer.  This seems to
         # have a little too much knowledge of the WaitTimer implementation,
@@ -404,39 +375,21 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # need its population estimate to see if this block would be accepted
         # by other validators based upon the zTest.
 
-        # If there are enough blocks in the block chain that we should
-        # apply the zTest (i.e., we have progressed past the blocks for
-        # which the local mean is calculated as a fixed ratio of the
-        # target to initial wait times) and this validator has already
-        # claimed more then the zTest minimum number of observable wins,
-        # then ensure that the validator that claimed this block is not
-        # winning elections more often than statistically expected
-        # (i.e., the zTest).
-        if consensus_state.total_block_claim_count >= \
-                poet_config_view.fixed_duration_block_count and \
-                validator_state.ztest_block_claim_count >= \
-                poet_config_view.ztest_minimum_win_count:
-            # Remember to account for the fact that the candidate block
-            # should be included in the zTest calculation as we want to
-            # determine if the candidate block would violate the zTest.
+        # Check to see if by chance we were to be able to claim this block
+        # if it would result in us winning more frequently than statistically
+        # expected.  If so, then refuse to initialize the block because other
+        # validators will not accept anyway.
+        if utils.validator_has_claimed_too_frequently(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                validator_state=validator_state,
+                poet_config_view=poet_config_view,
+                population_estimate=wait_timer.population_estimate):
+            return False
 
-            # If allowing the validator to claim this block would result
-            # in expected block claim count would suggest, we need to
-            # determine if its claim total is outside the allowed maximum
-            # win deviation that dictates our confidence interval that we
-            # detect claiming too often. If so, then we reject the block.
-            observed_wins = validator_state.ztest_block_claim_count + 1
-            expected_wins = \
-                consensus_state.expected_block_claim_count + \
-                1.0 / wait_timer.population_estimate
-            block_count = consensus_state.ztest_block_claim_count + 1
-            probability = expected_wins / block_count
-            standard_deviation = \
-                math.sqrt(block_count * probability * (1.0 - probability))
-            z_score = (observed_wins - expected_wins) / standard_deviation
-
-            if z_score > poet_config_view.ztest_maximum_win_deviation:
-                return False
+        # At this point, we know that if we are able to claim the block we are
+        # initializing, we will not be prevented from doing so because of PoET
+        # policies.
 
         self._wait_timer = wait_timer
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import math
 import logging
 
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
@@ -184,6 +185,12 @@ class PoetBlockVerifier(BlockVerifierInterface):
                             validator_state.key_block_claim_count,
                             poet_config_view.key_block_claim_limit))
 
+            LOGGER.debug(
+                'Validator %s has claimed %d block(s) out of limit of %d.',
+                validator_info.name,
+                validator_state.key_block_claim_count,
+                poet_config_view.key_block_claim_limit)
+
             # While having a block claim delay is nice, it turns out that in
             # practice the claim delay should not be more than one less than
             # the number of validators.  It helps to imagine the scenario
@@ -237,11 +244,66 @@ class PoetBlockVerifier(BlockVerifierInterface):
                             block_claim_delay))
 
             LOGGER.debug(
-                '%d block(s) claimed since %s was registered and block '
-                'claim delay is %d block(s). Check passed.',
-                blocks_since_registration,
+                'Validator %s has been registered for %d block(s) and block '
+                'claim delay is %d.',
                 validator_info.name,
+                blocks_since_registration,
                 block_claim_delay)
+
+            # If there are enough blocks in the block chain that we should
+            # apply the zTest (i.e., we have progressed past the blocks for
+            # which the local mean is calculated as a fixed ratio of the
+            # target to initial wait times) and this validator has already
+            # claimed more then the zTest minimum number of observable wins,
+            # then ensure that the validator that claimed this block is not
+            # winning elections more often than statistically expected
+            # (i.e., the zTest).
+            if consensus_state.total_block_claim_count >= \
+                    poet_config_view.fixed_duration_block_count and \
+                    validator_state.ztest_block_claim_count >= \
+                    poet_config_view.ztest_minimum_win_count:
+                # Remember to account for the fact that the candidate block
+                # should be included in the zTest calculation as we want to
+                # determine if the candidate block would violate the zTest.
+
+                # If allowing the validator to claim this block would result
+                # in expected block claim count would suggest, we need to
+                # determine if its claim total is outside the allowed maximum
+                # win deviation that dictates our confidence interval that we
+                # detect claiming too often. If so, then we reject the block.
+                wait_certificate = \
+                    utils.deserialize_wait_certificate(
+                        block=block_wrapper,
+                        poet_enclave_module=poet_enclave_module)
+                observed_wins = validator_state.ztest_block_claim_count + 1
+                expected_wins = \
+                    consensus_state.expected_block_claim_count + \
+                    1.0 / wait_certificate.population_estimate
+                block_count = consensus_state.ztest_block_claim_count + 1
+                probability = expected_wins / block_count
+                standard_deviation = \
+                    math.sqrt(block_count * probability * (1.0 - probability))
+                z_score = (observed_wins - expected_wins) / standard_deviation
+
+                if z_score > poet_config_view.ztest_maximum_win_deviation:
+                    raise \
+                        ValueError(
+                            'Validator {} winning too often. {:0.5f} > {:0.5f}, '
+                            'Expected Wins={:0.5f}, Observed Wins={}.'.format(
+                            validator_info.name,
+                            z_score,
+                            poet_config_view.ztest_maximum_win_deviation,
+                            expected_wins,
+                            observed_wins))
+
+                LOGGER.debug(
+                    'Validator %s: %f <= %f, Expected Wins=%f, Observed '
+                    'Wins=%d',
+                    validator_info.name,
+                    z_score,
+                    poet_config_view.ztest_maximum_win_deviation,
+                    expected_wins,
+                    observed_wins)
 
         except ValueError as error:
             LOGGER.error('Failed to verify block: %s', error)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import math
 import logging
 
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
@@ -100,213 +99,125 @@ class PoetBlockVerifier(BlockVerifierInterface):
             factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
 
         validator_registry_view = ValidatorRegistryView(state_view)
+        # Grab the validator info based upon the block signer's public
+        # key
         try:
-            # Grab the validator info based upon the block signer's public
-            # key
-            try:
-                validator_info = \
-                    validator_registry_view.get_validator_info(
-                        block_wrapper.header.signer_pubkey)
-            except KeyError:
-                raise \
-                    ValueError(
-                        'Received block from an unregistered validator '
-                        '{}...{}'.format(
-                            block_wrapper.header.signer_pubkey[:8],
-                            block_wrapper.header.signer_pubkey[-8:]))
+            validator_info = \
+                validator_registry_view.get_validator_info(
+                    block_wrapper.header.signer_pubkey)
+        except KeyError:
+            LOGGER.error(
+                'Block %s rejected: Received block from an unregistered '
+                'validator %s...%s',
+                block_wrapper.identifier[:8],
+                block_wrapper.header.signer_pubkey[:8],
+                block_wrapper.header.signer_pubkey[-8:])
+            return False
 
-            LOGGER.debug(
-                'Block Signer Name=%s, ID=%s...%s, PoET public key='
-                '%s...%s',
+        LOGGER.debug(
+            'Block Signer Name=%s, ID=%s...%s, PoET public key='
+            '%s...%s',
+            validator_info.name,
+            validator_info.id[:8],
+            validator_info.id[-8:],
+            validator_info.signup_info.poet_public_key[:8],
+            validator_info.signup_info.poet_public_key[-8:])
+
+        # Create a list of certificates leading up to this block.
+        # This seems to have a little too much knowledge of the
+        # WaitTimer implementation, but there is no use getting more
+        # than WaitTimer.certificate_sample_length wait certificates.
+        certificates = \
+            utils.build_certificate_list(
+                block_header=block_wrapper.header,
+                block_cache=self._block_cache,
+                poet_enclave_module=poet_enclave_module,
+                maximum_number=WaitTimer.certificate_sample_length)
+
+        # For the candidate block, reconstitute the wait certificate
+        # and verify that it is valid
+        wait_certificate = \
+            utils.deserialize_wait_certificate(
+                block=block_wrapper,
+                poet_enclave_module=poet_enclave_module)
+        if wait_certificate is None:
+            LOGGER.error(
+                'Block %s rejected: Block from validator %s (ID=%s...%s) was '
+                'not created by PoET consensus module',
+                block_wrapper.identifier[:8],
                 validator_info.name,
                 validator_info.id[:8],
-                validator_info.id[-8:],
-                validator_info.signup_info.poet_public_key[:8],
-                validator_info.signup_info.poet_public_key[-8:])
+                validator_info.id[-8:])
+            return False
 
-            # Create a list of certificates leading up to this block.
-            # This seems to have a little too much knowledge of the
-            # WaitTimer implementation, but there is no use getting more
-            # than WaitTimer.certificate_sample_length wait certificates.
-            certificates = \
-                utils.build_certificate_list(
-                    block_header=block_wrapper.header,
-                    block_cache=self._block_cache,
-                    poet_enclave_module=poet_enclave_module,
-                    maximum_number=WaitTimer.certificate_sample_length)
+        wait_certificate.check_valid(
+            poet_enclave_module=poet_enclave_module,
+            certificates=certificates,
+            poet_public_key=validator_info.signup_info.poet_public_key)
 
-            # For the candidate block, reconstitute the wait certificate
-            # and verify that it is valid
-            wait_certificate = \
-                utils.deserialize_wait_certificate(
-                    block=block_wrapper,
-                    poet_enclave_module=poet_enclave_module)
-            if wait_certificate is None:
-                raise \
-                    ValueError(
-                        'Being asked to verify a block that was not '
-                        'created by PoET consensus module')
+        # Get the consensus state for the block that is being built upon and
+        # then fetch the validator state for this validator
+        consensus_state = \
+            utils.get_consensus_state_for_block_id(
+                block_id=block_wrapper.previous_block_id,
+                block_cache=self._block_cache,
+                state_view_factory=self._state_view_factory,
+                consensus_state_store=self._consensus_state_store,
+                poet_enclave_module=poet_enclave_module)
+        validator_state = \
+            utils.get_current_validator_state(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_cache=self._block_cache)
+        poet_config_view = PoetConfigView(state_view=state_view)
 
-            poet_public_key = \
-                validator_info.signup_info.poet_public_key
-            wait_certificate.check_valid(
-                poet_enclave_module=poet_enclave_module,
-                certificates=certificates,
-                poet_public_key=poet_public_key)
+        # Reject the block if the validator has already claimed the key bock
+        # limit for its current PoET key pair.
+        key_block_claim_limit = poet_config_view.key_block_claim_limit
+        if utils.validator_has_claimed_maximum_number_of_blocks(
+                validator_info=validator_info,
+                validator_state=validator_state,
+                key_block_claim_limit=key_block_claim_limit):
+            LOGGER.error(
+                'Block %s rejected: Validator has reached maximum number of '
+                'blocks with key pair.',
+                block_wrapper.identifier[:8])
+            return False
 
-            # Get the consensus state for the block that is being built
-            # upon, fetch the validator state for this validator, and then
-            # see if that validator has already claimed the key bock limit
-            # for its current PoET key pair.  If so, then we reject the
-            # block.
-            consensus_state = \
-                utils.get_consensus_state_for_block_id(
-                    block_id=block_wrapper.previous_block_id,
-                    block_cache=self._block_cache,
-                    state_view_factory=self._state_view_factory,
-                    consensus_state_store=self._consensus_state_store,
-                    poet_enclave_module=poet_enclave_module)
-            validator_state = \
-                utils.get_current_validator_state(
-                    validator_info=validator_info,
-                    consensus_state=consensus_state,
-                    block_cache=self._block_cache)
+        # Reject the block if the validator has not waited the required number
+        # of blocks between when the block containing its validator registry
+        # transaction was committed to the chain and trying to claim this
+        # block
+        if utils.validator_has_claimed_too_early(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_number=block_wrapper.block_num,
+                validator_registry_view=validator_registry_view,
+                poet_config_view=poet_config_view,
+                block_store=self._block_cache.block_store):
+            LOGGER.error(
+                'Block %s rejected: Validator has not waited long enough '
+                'since registering validator information.',
+                block_wrapper.identifier[:8])
+            return False
 
-            poet_config_view = PoetConfigView(state_view=state_view)
-
-            if validator_state.poet_public_key == poet_public_key and \
-                    validator_state.key_block_claim_count >= \
-                    poet_config_view.key_block_claim_limit:
-                raise \
-                    ValueError(
-                        'Validator {} has already reached claim block limit '
-                        'for current PoET key pair: {} >= {}'.format(
-                            validator_info.name,
-                            validator_state.key_block_claim_count,
-                            poet_config_view.key_block_claim_limit))
-
-            LOGGER.debug(
-                'Validator %s has claimed %d block(s) out of limit of %d.',
-                validator_info.name,
-                validator_state.key_block_claim_count,
-                poet_config_view.key_block_claim_limit)
-
-            # While having a block claim delay is nice, it turns out that in
-            # practice the claim delay should not be more than one less than
-            # the number of validators.  It helps to imagine the scenario
-            # where each validator hits their block claim limit in sequential
-            # blocks and their new validator registry information is updated
-            # in the following block by another validator, assuming that there
-            # were no forks.  If there are N validators, once all N validators
-            # have updated their validator registry information, there will
-            # have been N-1 block commits and the Nth validator will only be
-            # able to get its updated validator registry information updated
-            # if the first validator that kicked this off is now able to claim
-            # a block.  If the block claim delay was greater than or equal to
-            # the number of validators, at this point no validators would be
-            # able to claim a block.
-            number_of_validators = \
-                len(validator_registry_view.get_validators())
-            block_claim_delay = \
-                min(
-                    poet_config_view.block_claim_delay,
-                    number_of_validators - 1)
-
-            # While a validator network is starting up, we need to be careful
-            # about applying the block claim delay because if we are too
-            # aggressive we will get ourselves into a situation where the
-            # block claim delay will prevent any validators from claiming
-            # blocks.  So, until we get at least block_claim_delay blocks
-            # we are going to choose not to enforce the delay.
-            if consensus_state.total_block_claim_count <= block_claim_delay:
-                LOGGER.debug(
-                    'Skipping block claim delay check.  Only %d block(s) in '
-                    'the chain.  Claim delay is %d block(s). %d validator(s) '
-                    'registered.',
-                    consensus_state.total_block_claim_count,
-                    block_claim_delay,
-                    number_of_validators)
-                return True
-
-            blocks_since_registration = \
-                block_wrapper.block_num - \
-                validator_state.commit_block_number - 1
-
-            if block_claim_delay > blocks_since_registration:
-                raise \
-                    ValueError(
-                        'Validator {} claiming too early. Block: {}, '
-                        'registered in: {}, wait until after: {}.'.format(
-                            validator_info.name,
-                            block_wrapper.block_num,
-                            validator_state.commit_block_number,
-                            validator_state.commit_block_number +
-                            block_claim_delay))
-
-            LOGGER.debug(
-                'Validator %s has been registered for %d block(s) and block '
-                'claim delay is %d.',
-                validator_info.name,
-                blocks_since_registration,
-                block_claim_delay)
-
-            # If there are enough blocks in the block chain that we should
-            # apply the zTest (i.e., we have progressed past the blocks for
-            # which the local mean is calculated as a fixed ratio of the
-            # target to initial wait times) and this validator has already
-            # claimed more then the zTest minimum number of observable wins,
-            # then ensure that the validator that claimed this block is not
-            # winning elections more often than statistically expected
-            # (i.e., the zTest).
-            if consensus_state.total_block_claim_count >= \
-                    poet_config_view.fixed_duration_block_count and \
-                    validator_state.ztest_block_claim_count >= \
-                    poet_config_view.ztest_minimum_win_count:
-                # Remember to account for the fact that the candidate block
-                # should be included in the zTest calculation as we want to
-                # determine if the candidate block would violate the zTest.
-
-                # If allowing the validator to claim this block would result
-                # in expected block claim count would suggest, we need to
-                # determine if its claim total is outside the allowed maximum
-                # win deviation that dictates our confidence interval that we
-                # detect claiming too often. If so, then we reject the block.
-                wait_certificate = \
-                    utils.deserialize_wait_certificate(
-                        block=block_wrapper,
-                        poet_enclave_module=poet_enclave_module)
-                observed_wins = validator_state.ztest_block_claim_count + 1
-                expected_wins = \
-                    consensus_state.expected_block_claim_count + \
-                    1.0 / wait_certificate.population_estimate
-                block_count = consensus_state.ztest_block_claim_count + 1
-                probability = expected_wins / block_count
-                standard_deviation = \
-                    math.sqrt(block_count * probability * (1.0 - probability))
-                z_score = (observed_wins - expected_wins) / standard_deviation
-
-                if z_score > poet_config_view.ztest_maximum_win_deviation:
-                    raise \
-                        ValueError(
-                            'Validator {} winning too often. {:0.5f} > {:0.5f}, '
-                            'Expected Wins={:0.5f}, Observed Wins={}.'.format(
-                            validator_info.name,
-                            z_score,
-                            poet_config_view.ztest_maximum_win_deviation,
-                            expected_wins,
-                            observed_wins))
-
-                LOGGER.debug(
-                    'Validator %s: %f <= %f, Expected Wins=%f, Observed '
-                    'Wins=%d',
-                    validator_info.name,
-                    z_score,
-                    poet_config_view.ztest_maximum_win_deviation,
-                    expected_wins,
-                    observed_wins)
-
-        except ValueError as error:
-            LOGGER.error('Failed to verify block: %s', error)
+        # Reject the block if allowing this block to be claimed would result
+        # in the validator claiming blocks more frequently than statistically
+        # expected
+        wait_certificate = \
+            utils.deserialize_wait_certificate(
+                block=block_wrapper,
+                poet_enclave_module=poet_enclave_module)
+        if utils.validator_has_claimed_too_frequently(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                validator_state=validator_state,
+                poet_config_view=poet_config_view,
+                population_estimate=wait_certificate.population_estimate):
+            LOGGER.error(
+                'Block %s rejected: Validator is claiming blocks too '
+                'frequently',
+                block_wrapper.identifier[:8])
             return False
 
         return True

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -26,8 +26,9 @@ class PoetConfigView(object):
     or that are invalid, default values are returned.
     """
 
-    _DEFAULT_KEY_CLAIM_LIMIT_ = 25
-    _DEFAULT_BLOCK_CLAIM_DELAY_ = 1
+    _KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _BLOCK_CLAIM_DELAY_ = 1
+    _FIXED_DURATION_BLOCK_COUNT_ = 50
 
     def __init__(self, state_view):
         """Initialize a PoetConfigView object.
@@ -86,8 +87,8 @@ class PoetConfigView(object):
 
     @property
     def key_block_claim_limit(self):
-        """Return the key block claim limit if config setting exists or
-        default if not or value is invalid.
+        """Return the key block claim limit if config setting exists and
+        is valid, otherwise return the default.
 
         The key block claim limit is the maximum number of blocks that a
         validator may claim with a PoET key pair before it needs to refresh
@@ -97,13 +98,13 @@ class PoetConfigView(object):
             self._get_config_setting(
                 name='sawtooth.poet.key_block_claim_limit',
                 value_type=int,
-                default_value=PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_,
+                default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
 
     @property
     def block_claim_delay(self):
-        """Return the block claim delay if config setting exists or
-        default if not or value is invalid.
+        """Return the block claim delay if config setting exists and
+        is valid, otherwise return the default.
 
         The block claim delay is the number of blocks after a validator's
         signup information is committed to the validator registry before
@@ -113,5 +114,22 @@ class PoetConfigView(object):
             self._get_config_setting(
                 name='sawtooth.poet.block_claim_delay',
                 value_type=int,
-                default_value=PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_,
+                default_value=PoetConfigView._BLOCK_CLAIM_DELAY_,
                 validate_function=lambda value: value >= 0)
+
+    @property
+    def fixed_duration_block_count(self):
+        """Return the fixed duration block count if config setting exists and
+        is valid, otherwise return the default.
+
+        The fixed duration block count is the number of initial blocks in
+        the chain that, as a validator network starts up, will have their
+        local mean based on a ratio of the target and initial wait times
+        instead of the history of wait timer local means.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.fixed_duration_block_count',
+                value_type=int,
+                default_value=PoetConfigView._FIXED_DURATION_BLOCK_COUNT_,
+                validate_function=lambda value: value > 0)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -19,6 +19,7 @@ import logging
 
 from sawtooth_validator.state.config_view import ConfigView
 
+from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 from sawtooth_poet.poet_consensus import wait_timer
 
 LOGGER = logging.getLogger(__name__)
@@ -68,6 +69,8 @@ class PoetEnclaveFactory(object):
 
                 LOGGER.info('Load PoET enclave module: %s', module_name)
 
+                poet_config_view = PoetConfigView(state_view)
+
                 # For now, configure the wait timer settings based upon the
                 # values in the configuration if present.
                 target_wait_time = \
@@ -80,16 +83,12 @@ class PoetEnclaveFactory(object):
                         key='sawtooth.poet.initial_wait_time',
                         default_value=wait_timer.WaitTimer.initial_wait_time,
                         value_type=float)
+                fixed_duration_blocks = \
+                    poet_config_view.fixed_duration_block_count
                 certificate_sample_length = \
                     config_view.get_setting(
                         key='sawtooth.poet.certificate_sample_length',
-                        default_value=wait_timer.WaitTimer.
-                            certificate_sample_length,
-                        value_type=int)
-                fixed_duration_blocks = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.fixed_duration_blocks',
-                        default_value=certificate_sample_length,
+                        default_value=fixed_duration_blocks,
                         value_type=int)
                 minimum_wait_time = \
                     config_view.get_setting(
@@ -107,8 +106,8 @@ class PoetEnclaveFactory(object):
                     'sawtooth.poet.certificate_sample_length: %d',
                     certificate_sample_length)
                 LOGGER.info(
-                    'sawtooth.poet.fixed_duration_blocks: %d',
-                    fixed_duration_blocks)
+                    'sawtooth.poet.fixed_duration_block_count: %d',
+                    poet_config_view.fixed_duration_block_count)
                 LOGGER.info(
                     'sawtooth.poet.minimum_wait_time: %f',
                     minimum_wait_time)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -175,7 +175,8 @@ def get_current_validator_state(validator_info,
                 commit_block_number=enclosing_block.block_num,
                 key_block_claim_count=0,
                 poet_public_key=validator_info.signup_info.poet_public_key,
-                total_block_claim_count=0)
+                total_block_claim_count=0,
+                ztest_block_claim_count=0)
 
     return validator_state
 
@@ -231,7 +232,8 @@ def create_next_validator_state(validator_info,
             commit_block_number=commit_block_number,
             key_block_claim_count=key_block_claim_count,
             poet_public_key=validator_info.signup_info.poet_public_key,
-            total_block_claim_count=total_block_claim_count)
+            total_block_claim_count=total_block_claim_count,
+            ztest_block_claim_count=0)
 
 
 BlockInfo = \

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -42,11 +42,13 @@ class TestConsensusState(unittest.TestCase):
                     commit_block_number=0xdeadbeef,
                     key_block_claim_count=1,
                     poet_public_key='my key',
-                    total_block_claim_count=2))
+                    total_block_claim_count=2,
+                    ztest_block_claim_count=2))
         self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'my key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
+        self.assertEqual(validator_state.ztest_block_claim_count, 2)
 
     def test_set_validator_state(self):
         """Verify that trying to set validator state with invalid validator
@@ -64,7 +66,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=invalid_cbn,
                         key_block_claim_count=0,
                         poet_public_key='my key',
-                        total_block_claim_count=0))
+                        total_block_claim_count=0,
+                        ztest_block_claim_count=0))
 
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
@@ -75,7 +78,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='my key',
-                        total_block_claim_count=0))
+                        total_block_claim_count=0,
+                        ztest_block_claim_count=0))
 
         # Test invalid PoET public key in validator state
         for invalid_ppk in [None, (), [], {}, 1, 1.1, '']:
@@ -86,7 +90,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key=invalid_ppk,
-                        total_block_claim_count=0))
+                        total_block_claim_count=0,
+                        ztest_block_claim_count=0))
 
         # Test invalid total block claim count in validator state
         for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
@@ -97,7 +102,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='my key',
-                        total_block_claim_count=invalid_tbcc))
+                        total_block_claim_count=invalid_tbcc,
+                        ztest_block_claim_count=0))
 
         # Test with total block claim count < key block claim count
         with self.assertRaises(ValueError):
@@ -107,7 +113,31 @@ class TestConsensusState(unittest.TestCase):
                     commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='my key',
-                    total_block_claim_count=1))
+                    total_block_claim_count=1,
+                    ztest_block_claim_count=1))
+
+        # Test invalid zTest block claim counts in validator state
+        for invalid_zbcc in [None, (), [], {}, '1', 1.1, -1]:
+            with self.assertRaises(ValueError):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
+                        key_block_claim_count=0,
+                        poet_public_key='my key',
+                        total_block_claim_count=0,
+                        ztest_block_claim_count=invalid_zbcc))
+
+        # Test with total block claim count < zTest block claim count
+        with self.assertRaises(ValueError):
+            state.set_validator_state(
+                validator_id='Bond, James Bond',
+                validator_state=consensus_state.ValidatorState(
+                    commit_block_number=0xdeadbeef,
+                    key_block_claim_count=0,
+                    poet_public_key='my key',
+                    total_block_claim_count=1,
+                    ztest_block_claim_count=2))
 
         # Verify that can retrieve after set and validator state matches
         validator_state = \
@@ -115,7 +145,8 @@ class TestConsensusState(unittest.TestCase):
                 commit_block_number=0xdeadbeef,
                 key_block_claim_count=0,
                 poet_public_key='my key',
-                total_block_claim_count=0)
+                total_block_claim_count=1,
+                ztest_block_claim_count=1)
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=validator_state)
@@ -135,6 +166,9 @@ class TestConsensusState(unittest.TestCase):
         self.assertEqual(
             validator_state.total_block_claim_count,
             retrieved_validator_state.total_block_claim_count)
+        self.assertEqual(
+            validator_state.ztest_block_claim_count,
+            retrieved_validator_state.ztest_block_claim_count)
 
         # Verify that updating an existing validator state matches on get
         validator_state = \
@@ -142,7 +176,8 @@ class TestConsensusState(unittest.TestCase):
                 commit_block_number=0xfeedbeef,
                 key_block_claim_count=1,
                 poet_public_key='my new key',
-                total_block_claim_count=2)
+                total_block_claim_count=2,
+                ztest_block_claim_count=2)
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=validator_state)
@@ -162,6 +197,9 @@ class TestConsensusState(unittest.TestCase):
         self.assertEqual(
             validator_state.total_block_claim_count,
             retrieved_validator_state.total_block_claim_count)
+        self.assertEqual(
+            validator_state.ztest_block_claim_count,
+            retrieved_validator_state.ztest_block_claim_count)
 
     def test_serialize(self):
         """Verify that deserializing invalid data results in the appropriate
@@ -189,6 +227,23 @@ class TestConsensusState(unittest.TestCase):
             with self.assertRaises(ValueError):
                 state.parse_from_bytes(state.serialize_to_bytes())
 
+        # Invalid zTest block claim count
+        for invalid_zbcc in [None, 'not an int', (), [], {}, -1]:
+            state = consensus_state.ConsensusState()
+            state.ztest_block_claim_count = invalid_zbcc
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(state.serialize_to_bytes())
+
+        # zTest block claim count >= total block claim count
+        state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
+        state.ztest_block_claim_count = 1
+        with self.assertRaises(ValueError):
+            state.parse_from_bytes(state.serialize_to_bytes())
+        state.ztest_block_claim_count = 2
+        with self.assertRaises(ValueError):
+            state.parse_from_bytes(state.serialize_to_bytes())
+
         # Invalid validators
         for invalid_validators in [None, '', 1, 1.1, (), []]:
             state = consensus_state.ConsensusState()
@@ -198,13 +253,15 @@ class TestConsensusState(unittest.TestCase):
                 state.parse_from_bytes(state.serialize_to_bytes())
 
         state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
                 commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key',
-                total_block_claim_count=1))
+                total_block_claim_count=1,
+                ztest_block_claim_count=1))
         doppelganger_state = consensus_state.ConsensusState()
 
         # Truncate the serialized value on purpose
@@ -221,6 +278,7 @@ class TestConsensusState(unittest.TestCase):
         # Test invalid commit block number in validator state
         for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
@@ -230,7 +288,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=invalid_cbn,
                         key_block_claim_count=0,
                         poet_public_key='key 1',
-                        total_block_claim_count=1))
+                        total_block_claim_count=1,
+                        ztest_block_claim_count=1))
 
             serialized = state.serialize_to_bytes()
             with self.assertRaises(ValueError):
@@ -239,6 +298,7 @@ class TestConsensusState(unittest.TestCase):
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
@@ -248,7 +308,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='key 1',
-                        total_block_claim_count=1))
+                        total_block_claim_count=1,
+                        ztest_block_claim_count=1))
 
             serialized = state.serialize_to_bytes()
             with self.assertRaises(ValueError):
@@ -257,6 +318,7 @@ class TestConsensusState(unittest.TestCase):
         # Test invalid PoET public key in validator state
         for invalid_ppk in [None, (), [], {}, 1, 1.1, '']:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
@@ -266,7 +328,8 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key=invalid_ppk,
-                        total_block_claim_count=1))
+                        total_block_claim_count=1,
+                        ztest_block_claim_count=1))
 
             serialized = state.serialize_to_bytes()
             with self.assertRaises(ValueError):
@@ -275,6 +338,7 @@ class TestConsensusState(unittest.TestCase):
         # Test total block claim count in validator state
         for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
@@ -284,13 +348,16 @@ class TestConsensusState(unittest.TestCase):
                         commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key='key',
-                        total_block_claim_count=invalid_tbcc))
+                        total_block_claim_count=invalid_tbcc,
+                        ztest_block_claim_count=1))
 
             serialized = state.serialize_to_bytes()
             with self.assertRaises(ValueError):
                 state.parse_from_bytes(serialized)
 
         # Test with total block claim count < key block claim count
+        state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
         with mock.patch(
                 'sawtooth_poet.poet_consensus.consensus_state.'
                 'ConsensusState._check_validator_state'):
@@ -300,12 +367,56 @@ class TestConsensusState(unittest.TestCase):
                     commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='key',
-                    total_block_claim_count=1))
+                    total_block_claim_count=1,
+                    ztest_block_claim_count=1))
 
+        serialized = state.serialize_to_bytes()
+        with self.assertRaises(ValueError):
+            state.parse_from_bytes(serialized)
+
+        # Test invalid zTest block claim counts in validator state
+        for invalid_zbcc in [None, (), [], {}, '1', 1.1, -1]:
+            state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.'
+                    'ConsensusState._check_validator_state'):
+                state.set_validator_state(
+                    validator_id='Bond, James Bond',
+                    validator_state=consensus_state.ValidatorState(
+                        commit_block_number=0xdeadbeef,
+                        key_block_claim_count=0,
+                        poet_public_key='key 1',
+                        total_block_claim_count=1,
+                        ztest_block_claim_count=invalid_zbcc))
+
+            serialized = state.serialize_to_bytes()
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(serialized)
+
+        # Test with total block claim count < zTest block claim count
         state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
+        with mock.patch(
+                'sawtooth_poet.poet_consensus.consensus_state.'
+                'ConsensusState._check_validator_state'):
+            state.set_validator_state(
+                validator_id='Bond, James Bond',
+                validator_state=consensus_state.ValidatorState(
+                    commit_block_number=0xdeadbeef,
+                    key_block_claim_count=0,
+                    poet_public_key='key',
+                    total_block_claim_count=1,
+                    ztest_block_claim_count=2))
+
+        serialized = state.serialize_to_bytes()
+        with self.assertRaises(ValueError):
+            state.parse_from_bytes(serialized)
 
         # Simple serialization of new consensus state and then deserialize
         # and compare
+        state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
 
         doppelganger_state = consensus_state.ConsensusState()
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
@@ -324,13 +435,15 @@ class TestConsensusState(unittest.TestCase):
                 commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key 1',
-                total_block_claim_count=2)
+                total_block_claim_count=2,
+                ztest_block_claim_count=2)
         validator_state_2 = \
             consensus_state.ValidatorState(
                 commit_block_number=0xfeedbeef,
                 key_block_claim_count=3,
                 poet_public_key='key 2',
-                total_block_claim_count=4)
+                total_block_claim_count=4,
+                ztest_block_claim_count=4)
 
         state.set_validator_state(
             validator_id='Bond, James Bond',
@@ -340,6 +453,16 @@ class TestConsensusState(unittest.TestCase):
             validator_state=validator_state_2)
 
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
+
+        self.assertEqual(
+            state.expected_block_claim_count,
+            doppelganger_state.expected_block_claim_count)
+        self.assertEqual(
+            state.total_block_claim_count,
+            doppelganger_state.total_block_claim_count)
+        self.assertEqual(
+            state.ztest_block_claim_count,
+            doppelganger_state.ztest_block_claim_count)
 
         validator_state = \
             doppelganger_state.get_validator_state(
@@ -357,6 +480,9 @@ class TestConsensusState(unittest.TestCase):
         self.assertEqual(
             validator_state.total_block_claim_count,
             validator_state_1.total_block_claim_count)
+        self.assertEqual(
+            validator_state.ztest_block_claim_count,
+            validator_state_1.ztest_block_claim_count)
 
         validator_state = \
             doppelganger_state.get_validator_state(
@@ -374,3 +500,6 @@ class TestConsensusState(unittest.TestCase):
         self.assertEqual(
             validator_state.total_block_claim_count,
             validator_state_2.total_block_claim_count)
+        self.assertEqual(
+            validator_state.ztest_block_claim_count,
+            validator_state_2.ztest_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -39,12 +39,10 @@ class TestConsensusState(unittest.TestCase):
             state.get_validator_state(
                 validator_id='Bond, James Bond',
                 default=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=1,
                     poet_public_key='my key',
                     total_block_claim_count=2,
                     ztest_block_claim_count=2))
-        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'my key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
@@ -57,25 +55,12 @@ class TestConsensusState(unittest.TestCase):
         """
         state = consensus_state.ConsensusState()
 
-        # Test invalid commit block number in validator state
-        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
-            with self.assertRaises(ValueError):
-                state.set_validator_state(
-                    validator_id='Bond, James Bond',
-                    validator_state=consensus_state.ValidatorState(
-                        commit_block_number=invalid_cbn,
-                        key_block_claim_count=0,
-                        poet_public_key='my key',
-                        total_block_claim_count=0,
-                        ztest_block_claim_count=0))
-
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             with self.assertRaises(ValueError):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='my key',
                         total_block_claim_count=0,
@@ -87,7 +72,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=0,
@@ -99,7 +83,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='my key',
                         total_block_claim_count=invalid_tbcc,
@@ -110,7 +93,6 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='my key',
                     total_block_claim_count=1,
@@ -122,7 +104,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='my key',
                         total_block_claim_count=0,
@@ -133,7 +114,6 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=0,
                     poet_public_key='my key',
                     total_block_claim_count=1,
@@ -142,7 +122,6 @@ class TestConsensusState(unittest.TestCase):
         # Verify that can retrieve after set and validator state matches
         validator_state = \
             consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=0,
                 poet_public_key='my key',
                 total_block_claim_count=1,
@@ -154,9 +133,6 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -173,7 +149,6 @@ class TestConsensusState(unittest.TestCase):
         # Verify that updating an existing validator state matches on get
         validator_state = \
             consensus_state.ValidatorState(
-                commit_block_number=0xfeedbeef,
                 key_block_claim_count=1,
                 poet_public_key='my new key',
                 total_block_claim_count=2,
@@ -185,9 +160,6 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -257,7 +229,6 @@ class TestConsensusState(unittest.TestCase):
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key',
                 total_block_claim_count=1,
@@ -275,26 +246,6 @@ class TestConsensusState(unittest.TestCase):
         # Circumvent testing of validator state validity so that we can
         # serialize to invalid data to verify deserializing
 
-        # Test invalid commit block number in validator state
-        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
-            state = consensus_state.ConsensusState()
-            state.total_block_claim_count = 1
-            with mock.patch(
-                    'sawtooth_poet.poet_consensus.consensus_state.'
-                    'ConsensusState._check_validator_state'):
-                state.set_validator_state(
-                    validator_id='Bond, James Bond',
-                    validator_state=consensus_state.ValidatorState(
-                        commit_block_number=invalid_cbn,
-                        key_block_claim_count=0,
-                        poet_public_key='key 1',
-                        total_block_claim_count=1,
-                        ztest_block_claim_count=1))
-
-            serialized = state.serialize_to_bytes()
-            with self.assertRaises(ValueError):
-                state.parse_from_bytes(serialized)
-
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
@@ -305,7 +256,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='key 1',
                         total_block_claim_count=1,
@@ -325,7 +275,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=1,
@@ -345,7 +294,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key='key',
                         total_block_claim_count=invalid_tbcc,
@@ -364,7 +312,6 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='key',
                     total_block_claim_count=1,
@@ -384,7 +331,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='key 1',
                         total_block_claim_count=1,
@@ -403,7 +349,6 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=0,
                     poet_public_key='key',
                     total_block_claim_count=1,
@@ -432,14 +377,12 @@ class TestConsensusState(unittest.TestCase):
         # verify they are in deserialized
         validator_state_1 = \
             consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key 1',
                 total_block_claim_count=2,
                 ztest_block_claim_count=2)
         validator_state_2 = \
             consensus_state.ValidatorState(
-                commit_block_number=0xfeedbeef,
                 key_block_claim_count=3,
                 poet_public_key='key 2',
                 total_block_claim_count=4,
@@ -469,9 +412,6 @@ class TestConsensusState(unittest.TestCase):
                 validator_id='Bond, James Bond')
 
         self.assertEqual(
-            validator_state.commit_block_number,
-            validator_state_1.commit_block_number)
-        self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_1.key_block_claim_count)
         self.assertEqual(
@@ -488,9 +428,6 @@ class TestConsensusState(unittest.TestCase):
             doppelganger_state.get_validator_state(
                 validator_id='Smart, Maxwell Smart')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            validator_state_2.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_2.key_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -114,7 +114,6 @@ class TestConsensusStateStore(unittest.TestCase):
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='skeleton key',
                 total_block_claim_count=2,
@@ -139,7 +138,6 @@ class TestConsensusStateStore(unittest.TestCase):
             retrieved_state.get_validator_state(
                 validator_id='Bond, James Bond')
 
-        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'skeleton key')
         self.assertEqual(validator_state.total_block_claim_count, 2)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -109,13 +109,16 @@ class TestConsensusStateStore(unittest.TestCase):
         # Store consensus state
         state = consensus_state.ConsensusState()
         state.expected_block_claim_count = 3.14
+        state.total_block_claim_count = 2
+        state.ztest_block_claim_count = 1
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
                 commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='skeleton key',
-                total_block_claim_count=2))
+                total_block_claim_count=2,
+                ztest_block_claim_count=1))
 
         store['key'] = state
 
@@ -140,6 +143,7 @@ class TestConsensusStateStore(unittest.TestCase):
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'skeleton key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
+        self.assertEqual(validator_state.ztest_block_claim_count, 1)
 
         # Delete the key and then verify length and does not contain key
         del store['key']

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -36,7 +36,7 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_)
 
         _, kwargs = \
             mock_config_view.return_value.get_setting.call_args
@@ -45,7 +45,7 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             kwargs['default_value'],
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_)
         self.assertEqual(kwargs['value_type'], int)
 
         # Underlying config setting is not a valid value
@@ -54,13 +54,13 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_)
 
         mock_config_view.return_value.get_setting.return_value = 0
         # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
@@ -82,7 +82,7 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.block_claim_delay,
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            PoetConfigView._BLOCK_CLAIM_DELAY_)
 
         _, kwargs = \
             mock_config_view.return_value.get_setting.call_args
@@ -91,7 +91,7 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             kwargs['default_value'],
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            PoetConfigView._BLOCK_CLAIM_DELAY_)
         self.assertEqual(kwargs['value_type'], int)
 
         # Underlying config setting is not a valid value
@@ -100,7 +100,7 @@ class TestPoetConfigView(unittest.TestCase):
         # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.block_claim_delay,
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            PoetConfigView._BLOCK_CLAIM_DELAY_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 0
@@ -110,4 +110,52 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(
             poet_config_view.block_claim_delay,
+            1)
+
+    def test_fixed_duration_block_count(self, mock_config_view):
+        """Verify that retrieving fixed duration block count works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            PoetConfigView._FIXED_DURATION_BLOCK_COUNT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.fixed_duration_block_count')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            kwargs['default_value'],
+            PoetConfigView._FIXED_DURATION_BLOCK_COUNT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            PoetConfigView._FIXED_DURATION_BLOCK_COUNT_)
+
+        mock_config_view.return_value.get_setting.return_value = 0
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            PoetConfigView._FIXED_DURATION_BLOCK_COUNT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
             1)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -159,3 +159,113 @@ class TestPoetConfigView(unittest.TestCase):
         self.assertEqual(
             poet_config_view.fixed_duration_block_count,
             1)
+
+    def test_ztest_maximum_win_deviation(self, mock_config_view):
+        """Verify that retrieving zTest maximum win deviation works for
+        invalid cases (missing, invalid format, invalid value) as well as
+        valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.ztest_maximum_win_deviation')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            kwargs['default_value'],
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+        self.assertEqual(kwargs['value_type'], float)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1.0
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = 0.0
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('nan')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('inf')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('-inf')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 2.575
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            2.575)
+
+    def test_ztest_minimum_win_count(self, mock_config_view):
+        """Verify that retrieving zTest minimum win observations works for
+        invalid cases (missing, invalid format, invalid value) as well as
+        valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            PoetConfigView._ZTEST_MINIMUM_WIN_COUNT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.ztest_minimum_win_count')
+        # pylint: disable=protected-access
+        self.assertEqual(
+            kwargs['default_value'],
+            PoetConfigView._ZTEST_MINIMUM_WIN_COUNT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        # pylint: disable=protected-access
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            PoetConfigView._ZTEST_MINIMUM_WIN_COUNT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 0
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            0)


### PR DESCRIPTION
Per the PoET specification, validators are limited in how frequently they may claim blocks - i.e., the zTest.  If it is determined that allowing a validator to win an election (i.e., claim a block and have it added to the blockchain) would cause it to claim blocks more frequently than a configurable statistical rate, the block is rejected.

This PR updates:
* adds a fixed duration block count property to the PoET configuration view.  This value indicates the number of blocks which will have their local mean computed by using a simple ratio of target to initial wait times.  These blocks are not considered when performing the zTest.
* updates the PoET enclave factory to use the new PoET configuration view's fixed duration block count property.
* adds zTest block counts to both the consensus and validator state objects.  The zTest block count is the number of blocks claimed by all validators and a specific validator, respectively, that are covered by the zTest.  Additionally, code is added to properly maintain these values.
* adds minimum win count and maximum win deviation properties to the PoET configuration view.  These values are used when performing the zTest.  The minimum win count is that minimum number of blocks, after the fixed duration block count has been surpassed, a validator has to win before zTest will apply to any further blocks.  The maximum win deviation is used to determine if a validator has violated the zTest policy by comparing this against the deviation from the expected number of blocks a validator should have won.
* updates the PoET block verifier to ensure that when verifying blocks it checks to make sure a validator is throttled by the block claim frequency allowed 
* updates the PoET block publisher to refuse to initialize a block if the block frequency check fails, indicating that other validators would reject the block
* refactors all PoET policy tests (key block claim limit, block claim delay, and block claim frequency)
* adds a short-circuit for blocks upon which block publisher has already determined it would not be allowed to build on top of

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`sawtooth.consensus.algorithm=poet \`

Add:

```
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
sawtooth.poet.block_claim_delay=1 \
sawtooth.poet.fixed_duration_block_count=5 \
sawtooth.poet.ztest_maximum_win_deviation=1.645 \
sawtooth.poet.ztest_minimum_win_count=2 \
```

This should increase the chance of validators refusing the publish blocks because it would violate the block claim frequency test.  You can look at the logs for error log messages.

To reduce the likelihood of zTest failures, you can change `sawtooth.poet.ztest_maximum_win_deviation`.  The values are based upon the confidence interval (i.e., how confident we are that we have truly detected a validator winning at a frequency we consider too frequent):

```
3.075 => 99.9%
2.575 => 99.5%
2.321 => 99%
1.645 => 95%
```

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.