### PR TITLE
Enforce and abide by PoET block claim frequency policy (zTest)

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -15,7 +15,6 @@
 
 from collections import namedtuple
 
-import math
 import cbor
 
 ValidatorState = \
@@ -43,9 +42,6 @@ class ConsensusState(object):
     the block chain).
 
     Attributes:
-        expected_block_claim_count (float): The number of blocks that a
-            validator, based upon the population estimate, would be expected
-            to have claimed
         total_block_claim_count (int): The number of blocks that have been
             claimed by all validators
     """
@@ -55,7 +51,6 @@ class ConsensusState(object):
         Returns:
             None
         """
-        self.expected_block_claim_count = 0.0
         self.total_block_claim_count = 0
         self._validators = {}
 
@@ -172,18 +167,10 @@ class ConsensusState(object):
                         'buffer is not a valid serialization of a '
                         'ConsensusState object')
 
-            self.expected_block_claim_count = \
-                float(self_dict['expected_block_claim_count'])
             self.total_block_claim_count = \
                 int(self_dict['total_block_claim_count'])
             validators = self_dict['_validators']
 
-            if not math.isfinite(self.expected_block_claim_count) or \
-                    self.expected_block_claim_count < 0:
-                raise \
-                    ValueError(
-                        'expected_block_claim_count ({}) is invalid'.format(
-                            self.expected_block_claim_count))
             if self.total_block_claim_count < 0:
                 raise \
                     ValueError(
@@ -215,7 +202,7 @@ class ConsensusState(object):
 
     def __str__(self):
         validators = \
-            ['{}: {{KBCC: {}, PPK: {}, TBCC: {}, }}'.format(
+            ['{}: {{KBCC={}, PPK={}, TBCC={}, }}'.format(
                 key[:8],
                 value.key_block_claim_count,
                 value.poet_public_key[:8],
@@ -223,7 +210,6 @@ class ConsensusState(object):
              key, value in self._validators.items()]
 
         return \
-            'Expected: {}, Total: {}, V: {}'.format(
-                self.expected_block_claim_count,
+            'TBCC={}, V={}'.format(
                 self.total_block_claim_count,
                 validators)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -21,8 +21,7 @@ import cbor
 ValidatorState = \
     namedtuple(
         'ValidatorState',
-        ['commit_block_number',
-         'key_block_claim_count',
+        ['key_block_claim_count',
          'poet_public_key',
          'total_block_claim_count'
          ])
@@ -30,9 +29,6 @@ ValidatorState = \
 the validator state.  The validator state represents the state for a single
 validator at a point in time.  A validator state object contains:
 
-commit_block_number (int): The block number of the committed block that
-    contains the validator registry transaction which updated the validator's
-    PoET public key to the value found in poet_public_key
 key_block_claim_count (int): The number of blocks that the validator has
 claimed using the current PoET public key
 poet_public_key (str): The current PoET public key for the validator
@@ -50,7 +46,7 @@ class ConsensusState(object):
         expected_block_claim_count (float): The number of blocks that a
             validator, based upon the population estimate, would be expected
             to have claimed
-        total_bock_claim_count (int): The number of blocks that have been
+        total_block_claim_count (int): The number of blocks that have been
             claimed by all validators
     """
     def __init__(self):
@@ -65,13 +61,6 @@ class ConsensusState(object):
 
     @staticmethod
     def _check_validator_state(validator_state):
-        if not isinstance(validator_state.commit_block_number, int) \
-                or validator_state.commit_block_number < 0:
-            raise \
-                ValueError(
-                    'commit_block_number ({}) is invalid'.format(
-                        validator_state.commit_block_number))
-
         if not isinstance(
                 validator_state.key_block_claim_count, int) \
                 or validator_state.key_block_claim_count < 0:
@@ -226,13 +215,10 @@ class ConsensusState(object):
 
     def __str__(self):
         validators = \
-            ['{}...{}: {{CBN: {}, KBCC: {}, PPK: {}...{}, TBCC: {}}}'.format(
+            ['{}: {{KBCC: {}, PPK: {}, TBCC: {}, }}'.format(
                 key[:8],
-                key[-8:],
-                value.commit_block_number,
                 value.key_block_claim_count,
                 value.poet_public_key[:8],
-                value.poet_public_key[-8:],
                 value.total_block_claim_count) for
              key, value in self._validators.items()]
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -305,11 +305,10 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # with this PoET key.  If we have hit the key block claim limit, then
         # we need to check if the key has been refreshed.
         key_block_claim_limit = poet_config_view.key_block_claim_limit
-
-        if validator_state.poet_public_key == \
-                PoetBlockPublisher._poet_public_key and \
-                validator_state.key_block_claim_count >= \
-                key_block_claim_limit:
+        if utils.validator_has_claimed_maximum_number_of_blocks(
+                validator_info=validator_info,
+                validator_state=validator_state,
+                key_block_claim_limit=key_block_claim_limit):
             # Because we have hit the limit, check to see if we have already
             # submitted a validator registry transaction with new signup
             # information, and therefore a new PoET public key.  If not, then
@@ -323,7 +322,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     PoetBlockPublisher._poet_public_key]
             if not poet_key_state.has_been_refreshed:
                 LOGGER.info(
-                    'Reached block claim limit (%d) for key for key: %s...%s',
+                    'Reached block claim limit (%d) for key: %s...%s',
                     key_block_claim_limit,
                     PoetBlockPublisher._poet_public_key[:8],
                     PoetBlockPublisher._poet_public_key[-8:])
@@ -344,41 +343,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # Verify that we are abiding by the block claim delay (i.e., waiting a
         # certain number of blocks since our validator registry was added/
         # updated).
-
-        # While having a block claim delay is nice, it turns out that in
-        # practice the claim delay should not be more than one less than
-        # the number of validators.  It helps to imagine the scenario
-        # where each validator hits their block claim limit in sequential
-        # blocks and their new validator registry information is updated
-        # in the following block by another validator, assuming that there
-        # were no forks.  If there are N validators, once all N validators
-        # have updated their validator registry information, there will
-        # have been N-1 block commits and the Nth validator will only be
-        # able to get its updated validator registry information updated
-        # if the first validator that kicked this off is now able to claim
-        # a block.  If the block claim delay was greater than or equal to
-        # the number of validators, at this point no validators would be
-        # able to claim a block.
-        number_of_validators = \
-            len(validator_registry_view.get_validators())
-        block_claim_delay = \
-            min(
-                poet_config_view.block_claim_delay,
-                number_of_validators - 1)
-
-        # While a validator network is starting up, we need to be careful
-        # about applying the block claim delay because if we are too
-        # aggressive we will get ourselves into a situation where the
-        # block claim delay will prevent any validators from claiming
-        # blocks.  So, until we get at least block_claim_delay blocks
-        # we are going to choose not to enforce the delay.
-        if consensus_state.total_block_claim_count > block_claim_delay:
-            blocks_since_registration = \
-                block_header.block_num - \
-                validator_state.commit_block_number - 1
-
-            if block_claim_delay > blocks_since_registration:
-                return False
+        if utils.validator_has_claimed_too_early(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_number=block_header.block_num,
+                validator_registry_view=validator_registry_view,
+                poet_config_view=poet_config_view,
+                block_store=self._block_cache.block_store):
+            return False
 
         # Create a list of certificates for the wait timer.  This seems to
         # have a little too much knowledge of the WaitTimer implementation,
@@ -393,11 +365,17 @@ class PoetBlockPublisher(BlockPublisherInterface):
 
         # We need to create a wait timer for the block...this is what we
         # will check when we are asked if it is time to publish the block
-        self._wait_timer = \
+        wait_timer = \
             WaitTimer.create_wait_timer(
                 poet_enclave_module=poet_enclave_module,
                 validator_address=block_header.signer_pubkey,
                 certificates=list(certificates))
+
+        # At this point, we know that if we are able to claim the block we are
+        # initializing, we will not be prevented from doing so because of PoET
+        # policies.
+
+        self._wait_timer = wait_timer
 
         LOGGER.debug('Created wait timer: %s', self._wait_timer)
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -201,4 +201,20 @@ class PoetBlockVerifier(BlockVerifierInterface):
                 block_wrapper.identifier[:8])
             return False
 
+        # Reject the block if the validator is claiming blocks at a rate that
+        # is more frequent than is statistically allowed (i.e., zTest)
+        if utils.validator_has_claimed_too_frequently(
+                validator_info=validator_info,
+                previous_block_id=block_wrapper.previous_block_id,
+                consensus_state=consensus_state,
+                poet_config_view=poet_config_view,
+                population_estimate=wait_certificate.population_estimate,
+                block_cache=self._block_cache,
+                poet_enclave_module=poet_enclave_module):
+            LOGGER.error(
+                'Block %s rejected: Validator is claiming blocks too '
+                'frequently.',
+                block_wrapper.identifier[:8])
+            return False
+
         return True

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -99,152 +99,106 @@ class PoetBlockVerifier(BlockVerifierInterface):
             factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
 
         validator_registry_view = ValidatorRegistryView(state_view)
+        # Grab the validator info based upon the block signer's public
+        # key
         try:
-            # Grab the validator info based upon the block signer's public
-            # key
-            try:
-                validator_info = \
-                    validator_registry_view.get_validator_info(
-                        block_wrapper.header.signer_pubkey)
-            except KeyError:
-                raise \
-                    ValueError(
-                        'Received block from an unregistered validator '
-                        '{}...{}'.format(
-                            block_wrapper.header.signer_pubkey[:8],
-                            block_wrapper.header.signer_pubkey[-8:]))
+            validator_info = \
+                validator_registry_view.get_validator_info(
+                    block_wrapper.header.signer_pubkey)
+        except KeyError:
+            LOGGER.error(
+                'Block %s rejected: Received block from an unregistered '
+                'validator %s...%s',
+                block_wrapper.identifier[:8],
+                block_wrapper.header.signer_pubkey[:8],
+                block_wrapper.header.signer_pubkey[-8:])
+            return False
 
-            LOGGER.debug(
-                'Block Signer Name=%s, ID=%s...%s, PoET public key='
-                '%s...%s',
+        LOGGER.debug(
+            'Block Signer Name=%s, ID=%s...%s, PoET public key='
+            '%s...%s',
+            validator_info.name,
+            validator_info.id[:8],
+            validator_info.id[-8:],
+            validator_info.signup_info.poet_public_key[:8],
+            validator_info.signup_info.poet_public_key[-8:])
+
+        # Create a list of certificates leading up to this block.
+        # This seems to have a little too much knowledge of the
+        # WaitTimer implementation, but there is no use getting more
+        # than WaitTimer.certificate_sample_length wait certificates.
+        certificates = \
+            utils.build_certificate_list(
+                block_header=block_wrapper.header,
+                block_cache=self._block_cache,
+                poet_enclave_module=poet_enclave_module,
+                maximum_number=WaitTimer.certificate_sample_length)
+
+        # For the candidate block, reconstitute the wait certificate
+        # and verify that it is valid
+        wait_certificate = \
+            utils.deserialize_wait_certificate(
+                block=block_wrapper,
+                poet_enclave_module=poet_enclave_module)
+        if wait_certificate is None:
+            LOGGER.error(
+                'Block %s rejected: Block from validator %s (ID=%s...%s) was '
+                'not created by PoET consensus module',
+                block_wrapper.identifier[:8],
                 validator_info.name,
                 validator_info.id[:8],
-                validator_info.id[-8:],
-                validator_info.signup_info.poet_public_key[:8],
-                validator_info.signup_info.poet_public_key[-8:])
+                validator_info.id[-8:])
+            return False
 
-            # Create a list of certificates leading up to this block.
-            # This seems to have a little too much knowledge of the
-            # WaitTimer implementation, but there is no use getting more
-            # than WaitTimer.certificate_sample_length wait certificates.
-            certificates = \
-                utils.build_certificate_list(
-                    block_header=block_wrapper.header,
-                    block_cache=self._block_cache,
-                    poet_enclave_module=poet_enclave_module,
-                    maximum_number=WaitTimer.certificate_sample_length)
+        wait_certificate.check_valid(
+            poet_enclave_module=poet_enclave_module,
+            certificates=certificates,
+            poet_public_key=validator_info.signup_info.poet_public_key)
 
-            # For the candidate block, reconstitute the wait certificate
-            # and verify that it is valid
-            wait_certificate = \
-                utils.deserialize_wait_certificate(
-                    block=block_wrapper,
-                    poet_enclave_module=poet_enclave_module)
-            if wait_certificate is None:
-                raise \
-                    ValueError(
-                        'Being asked to verify a block that was not '
-                        'created by PoET consensus module')
+        # Get the consensus state for the block that is being built upon and
+        # then fetch the validator state for this validator
+        consensus_state = \
+            utils.get_consensus_state_for_block_id(
+                block_id=block_wrapper.previous_block_id,
+                block_cache=self._block_cache,
+                state_view_factory=self._state_view_factory,
+                consensus_state_store=self._consensus_state_store,
+                poet_enclave_module=poet_enclave_module)
+        validator_state = \
+            utils.get_current_validator_state(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_cache=self._block_cache)
+        poet_config_view = PoetConfigView(state_view=state_view)
 
-            poet_public_key = \
-                validator_info.signup_info.poet_public_key
-            wait_certificate.check_valid(
-                poet_enclave_module=poet_enclave_module,
-                certificates=certificates,
-                poet_public_key=poet_public_key)
+        # Reject the block if the validator has already claimed the key bock
+        # limit for its current PoET key pair.
+        key_block_claim_limit = poet_config_view.key_block_claim_limit
+        if utils.validator_has_claimed_maximum_number_of_blocks(
+                validator_info=validator_info,
+                validator_state=validator_state,
+                key_block_claim_limit=key_block_claim_limit):
+            LOGGER.error(
+                'Block %s rejected: Validator has reached maximum number of '
+                'blocks with key pair.',
+                block_wrapper.identifier[:8])
+            return False
 
-            # Get the consensus state for the block that is being built
-            # upon, fetch the validator state for this validator, and then
-            # see if that validator has already claimed the key bock limit
-            # for its current PoET key pair.  If so, then we reject the
-            # block.
-            consensus_state = \
-                utils.get_consensus_state_for_block_id(
-                    block_id=block_wrapper.previous_block_id,
-                    block_cache=self._block_cache,
-                    state_view_factory=self._state_view_factory,
-                    consensus_state_store=self._consensus_state_store,
-                    poet_enclave_module=poet_enclave_module)
-            validator_state = \
-                utils.get_current_validator_state(
-                    validator_info=validator_info,
-                    consensus_state=consensus_state,
-                    block_cache=self._block_cache)
-
-            poet_config_view = PoetConfigView(state_view=state_view)
-
-            if validator_state.poet_public_key == poet_public_key and \
-                    validator_state.key_block_claim_count >= \
-                    poet_config_view.key_block_claim_limit:
-                raise \
-                    ValueError(
-                        'Validator {} has already reached claim block limit '
-                        'for current PoET key pair: {} >= {}'.format(
-                            validator_info.name,
-                            validator_state.key_block_claim_count,
-                            poet_config_view.key_block_claim_limit))
-
-            # While having a block claim delay is nice, it turns out that in
-            # practice the claim delay should not be more than one less than
-            # the number of validators.  It helps to imagine the scenario
-            # where each validator hits their block claim limit in sequential
-            # blocks and their new validator registry information is updated
-            # in the following block by another validator, assuming that there
-            # were no forks.  If there are N validators, once all N validators
-            # have updated their validator registry information, there will
-            # have been N-1 block commits and the Nth validator will only be
-            # able to get its updated validator registry information updated
-            # if the first validator that kicked this off is now able to claim
-            # a block.  If the block claim delay was greater than or equal to
-            # the number of validators, at this point no validators would be
-            # able to claim a block.
-            number_of_validators = \
-                len(validator_registry_view.get_validators())
-            block_claim_delay = \
-                min(
-                    poet_config_view.block_claim_delay,
-                    number_of_validators - 1)
-
-            # While a validator network is starting up, we need to be careful
-            # about applying the block claim delay because if we are too
-            # aggressive we will get ourselves into a situation where the
-            # block claim delay will prevent any validators from claiming
-            # blocks.  So, until we get at least block_claim_delay blocks
-            # we are going to choose not to enforce the delay.
-            if consensus_state.total_block_claim_count <= block_claim_delay:
-                LOGGER.debug(
-                    'Skipping block claim delay check.  Only %d block(s) in '
-                    'the chain.  Claim delay is %d block(s). %d validator(s) '
-                    'registered.',
-                    consensus_state.total_block_claim_count,
-                    block_claim_delay,
-                    number_of_validators)
-                return True
-
-            blocks_since_registration = \
-                block_wrapper.block_num - \
-                validator_state.commit_block_number - 1
-
-            if block_claim_delay > blocks_since_registration:
-                raise \
-                    ValueError(
-                        'Validator {} claiming too early. Block: {}, '
-                        'registered in: {}, wait until after: {}.'.format(
-                            validator_info.name,
-                            block_wrapper.block_num,
-                            validator_state.commit_block_number,
-                            validator_state.commit_block_number +
-                            block_claim_delay))
-
-            LOGGER.debug(
-                '%d block(s) claimed since %s was registered and block '
-                'claim delay is %d block(s). Check passed.',
-                blocks_since_registration,
-                validator_info.name,
-                block_claim_delay)
-
-        except ValueError as error:
-            LOGGER.error('Failed to verify block: %s', error)
+        # Reject the block if the validator has not waited the required number
+        # of blocks between when the block containing its validator registry
+        # transaction was committed to the chain and trying to claim this
+        # block
+        if utils.validator_has_claimed_too_early(
+                validator_info=validator_info,
+                consensus_state=consensus_state,
+                block_number=block_wrapper.block_num,
+                validator_registry_view=validator_registry_view,
+                poet_config_view=poet_config_view,
+                block_store=self._block_cache.block_store):
+            LOGGER.error(
+                'Block %s rejected: Validator has not waited long enough '
+                'since registering validator information.',
+                block_wrapper.identifier[:8])
             return False
 
         return True

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -26,8 +26,9 @@ class PoetConfigView(object):
     or that are invalid, default values are returned.
     """
 
-    _DEFAULT_KEY_CLAIM_LIMIT_ = 25
-    _DEFAULT_BLOCK_CLAIM_DELAY_ = 1
+    _KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _BLOCK_CLAIM_DELAY_ = 1
+    _FIXED_DURATION_BLOCK_COUNT_ = 50
 
     def __init__(self, state_view):
         """Initialize a PoetConfigView object.
@@ -86,8 +87,8 @@ class PoetConfigView(object):
 
     @property
     def key_block_claim_limit(self):
-        """Return the key block claim limit if config setting exists or
-        default if not or value is invalid.
+        """Return the key block claim limit if config setting exists and
+        is valid, otherwise return the default.
 
         The key block claim limit is the maximum number of blocks that a
         validator may claim with a PoET key pair before it needs to refresh
@@ -97,13 +98,13 @@ class PoetConfigView(object):
             self._get_config_setting(
                 name='sawtooth.poet.key_block_claim_limit',
                 value_type=int,
-                default_value=PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_,
+                default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
 
     @property
     def block_claim_delay(self):
-        """Return the block claim delay if config setting exists or
-        default if not or value is invalid.
+        """Return the block claim delay if config setting exists and
+        is valid, otherwise return the default.
 
         The block claim delay is the number of blocks after a validator's
         signup information is committed to the validator registry before
@@ -113,5 +114,22 @@ class PoetConfigView(object):
             self._get_config_setting(
                 name='sawtooth.poet.block_claim_delay',
                 value_type=int,
-                default_value=PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_,
+                default_value=PoetConfigView._BLOCK_CLAIM_DELAY_,
                 validate_function=lambda value: value >= 0)
+
+    @property
+    def fixed_duration_block_count(self):
+        """Return the fixed duration block count if config setting exists and
+        is valid, otherwise return the default.
+
+        The fixed duration block count is the number of initial blocks in
+        the chain that, as a validator network starts up, will have their
+        local mean based on a ratio of the target and initial wait times
+        instead of the history of wait timer local means.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.fixed_duration_block_count',
+                value_type=int,
+                default_value=PoetConfigView._FIXED_DURATION_BLOCK_COUNT_,
+                validate_function=lambda value: value > 0)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -19,6 +19,7 @@ import logging
 
 from sawtooth_validator.state.config_view import ConfigView
 
+from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 from sawtooth_poet.poet_consensus import wait_timer
 
 LOGGER = logging.getLogger(__name__)
@@ -68,6 +69,8 @@ class PoetEnclaveFactory(object):
 
                 LOGGER.info('Load PoET enclave module: %s', module_name)
 
+                poet_config_view = PoetConfigView(state_view)
+
                 # For now, configure the wait timer settings based upon the
                 # values in the configuration if present.
                 target_wait_time = \
@@ -80,16 +83,12 @@ class PoetEnclaveFactory(object):
                         key='sawtooth.poet.initial_wait_time',
                         default_value=wait_timer.WaitTimer.initial_wait_time,
                         value_type=float)
+                fixed_duration_blocks = \
+                    poet_config_view.fixed_duration_block_count
                 certificate_sample_length = \
                     config_view.get_setting(
                         key='sawtooth.poet.certificate_sample_length',
-                        default_value=wait_timer.WaitTimer.
-                            certificate_sample_length,
-                        value_type=int)
-                fixed_duration_blocks = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.fixed_duration_blocks',
-                        default_value=certificate_sample_length,
+                        default_value=fixed_duration_blocks,
                         value_type=int)
                 minimum_wait_time = \
                     config_view.get_setting(
@@ -107,8 +106,8 @@ class PoetEnclaveFactory(object):
                     'sawtooth.poet.certificate_sample_length: %d',
                     certificate_sample_length)
                 LOGGER.info(
-                    'sawtooth.poet.fixed_duration_blocks: %d',
-                    fixed_duration_blocks)
+                    'sawtooth.poet.fixed_duration_block_count: %d',
+                    poet_config_view.fixed_duration_block_count)
                 LOGGER.info(
                     'sawtooth.poet.minimum_wait_time: %f',
                     minimum_wait_time)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -183,9 +183,8 @@ class PoetForkResolver(ForkResolverInterface):
                     consensus_state
 
                 LOGGER.debug(
-                    'Create consensus state: BID=%s, EBC=%f, TBCC=%d',
+                    'Create consensus state: BID=%s, TBCC=%d',
                     new_fork_head.identifier[:8],
-                    consensus_state.expected_block_claim_count,
                     consensus_state.total_block_claim_count)
             except KeyError:
                 # This _should_ never happen.  The new potential fork head

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -22,6 +22,7 @@ from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_poet_common.validator_registry_view.validator_registry_view \
     import ValidatorRegistryView
 
+from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 from sawtooth_poet.poet_consensus.wait_certificate import WaitCertificate
 from sawtooth_poet.poet_consensus.consensus_state import ConsensusState
 from sawtooth_poet.poet_consensus.consensus_state import ValidatorState
@@ -160,19 +161,14 @@ def get_current_validator_state(validator_info,
             point in time of the consensus state
     """
     # Fetch the validator state.  If it doesn't exist, then create an initial
-    # validator state object, including figuring out the block number in which
-    # the validator was most-recently registered.
+    # validator state object
     validator_state = \
         consensus_state.get_validator_state(
             validator_id=validator_info.id)
 
     if validator_state is None:
-        enclosing_block = \
-            block_cache.block_store.get_block_by_transaction_id(
-                validator_info.transaction_id)
         validator_state = \
             ValidatorState(
-                commit_block_number=enclosing_block.block_num,
                 key_block_claim_count=0,
                 poet_public_key=validator_info.signup_info.poet_public_key,
                 total_block_claim_count=0)
@@ -180,9 +176,7 @@ def get_current_validator_state(validator_info,
     return validator_state
 
 
-def create_next_validator_state(validator_info,
-                                current_validator_state,
-                                block_cache):
+def create_next_validator_state(validator_info, current_validator_state):
     """Starting with the current validator state, create the next validator
      validator state for the validator.
 
@@ -190,7 +184,6 @@ def create_next_validator_state(validator_info,
         validator_info (ValidatorInfo): Information about the validator
         current_validator_state (ValidatorState): The current validator
             state upon which we are going to base the next validator state
-        block_cache (BlockCache): The block store cache
 
     Returns:
         ValidatorState object representing new validator state
@@ -203,7 +196,6 @@ def create_next_validator_state(validator_info,
     # update
     if validator_info.signup_info.poet_public_key == \
             current_validator_state.poet_public_key:
-        commit_block_number = current_validator_state.commit_block_number
         key_block_claim_count = \
             current_validator_state.key_block_claim_count + 1
 
@@ -211,24 +203,18 @@ def create_next_validator_state(validator_info,
     # using the validator info's transaction ID to get the block number of the
     # block that committed the validator registry transaction
     else:
-        commit_block_number = \
-            block_cache.block_store.get_block_by_transaction_id(
-                validator_info.transaction_id).block_num
         key_block_claim_count = 1
 
     LOGGER.debug(
-        'Create validator state for %s: PPK=%s...%s, CBN=%d, KBCC=%d, '
-        'TBCC=%d',
+        'Create validator state for %s: PPK=%s...%s, KBCC=%d, TBCC=%d',
         validator_info.name,
         validator_info.signup_info.poet_public_key[:8],
         validator_info.signup_info.poet_public_key[-8:],
-        commit_block_number,
         key_block_claim_count,
         total_block_claim_count)
 
     return \
         ValidatorState(
-            commit_block_number=commit_block_number,
             key_block_claim_count=key_block_claim_count,
             poet_public_key=validator_info.signup_info.poet_public_key,
             total_block_claim_count=total_block_claim_count)
@@ -237,7 +223,7 @@ def create_next_validator_state(validator_info,
 BlockInfo = \
     collections.namedtuple(
         'BlockInfo',
-        ['wait_certificate', 'validator_info'])
+        ['wait_certificate', 'validator_info', 'poet_config_view'])
 
 """ Instead of creating a full-fledged class, let's use a named tuple for
 the block info.  The block info represents the information we need to
@@ -247,6 +233,8 @@ wait_certificate (WaitCertificate): The PoET wait certificate object for
     the block
 validator_info (ValidatorInfo): The validator registry information for the
     validator that claimed the block
+poet_config_view (PoetConfigView): The PoET cofiguration view associated with
+    the block
 """
 
 
@@ -320,7 +308,8 @@ def get_consensus_state_for_block_id(
             blocks[block_id] = \
                 BlockInfo(
                     wait_certificate=wait_certificate,
-                    validator_info=validator_info)
+                    validator_info=validator_info,
+                    poet_config_view=PoetConfigView(state_view))
 
         # Otherwise, this is a non-PoET block.  If we don't have any blocks
         # yet or the last block we processed was a PoET block, put a
@@ -330,7 +319,8 @@ def get_consensus_state_for_block_id(
             blocks[block_id] = \
                 BlockInfo(
                     wait_certificate=None,
-                    validator_info=None)
+                    validator_info=None,
+                    poet_config_view=None)
 
         previous_wait_certificate = wait_certificate
 
@@ -370,15 +360,155 @@ def get_consensus_state_for_block_id(
                 validator_id=block_info.validator_info.id,
                 validator_state=create_next_validator_state(
                     validator_info=block_info.validator_info,
-                    current_validator_state=validator_state,
-                    block_cache=block_cache))
-
-            LOGGER.debug(
-                'Store consensus state for block: %s...%s',
-                block_id[:8],
-                block_id[-8:])
+                    current_validator_state=validator_state))
 
             consensus_state.total_block_claim_count += 1
             consensus_state_store[block_id] = consensus_state
 
+            LOGGER.debug(
+                'Create consensus state: BID=%s, EBC=%f, TBCC=%d',
+                block_id[:8],
+                consensus_state.expected_block_claim_count,
+                consensus_state.total_block_claim_count)
+
     return consensus_state
+
+
+def validator_has_claimed_maximum_number_of_blocks(validator_info,
+                                                   validator_state,
+                                                   key_block_claim_limit):
+    """Determines if a validator has already claimed the maximum number of
+    blocks allowed with its PoET key pair.
+
+    Args:
+        validator_info (ValidatorInfo): The current validator information
+        validator_state (ValidatorState): The current state for the validator
+            for which the maximum block claim count is being tested
+        key_block_claim_limit (int): The limit of number of blocks that can be
+            claimed with a PoET key pair
+
+    Returns:
+        True if the validator has already claimed the maximum number of blocks
+        with its current PoET key pair, False otherwise
+    """
+
+    if validator_state.poet_public_key == \
+            validator_info.signup_info.poet_public_key:
+        if validator_state.key_block_claim_count >= key_block_claim_limit:
+            LOGGER.error(
+                'Validator %s (ID=%s...%s) has reached block claim limit for '
+                'current PoET keys %d >= %d',
+                validator_info.name,
+                validator_info.id[:8],
+                validator_info.id[-8:],
+                validator_state.key_block_claim_count,
+                key_block_claim_limit)
+            return True
+        else:
+            LOGGER.debug(
+                'Validator %s (ID=%s...%s): Claimed %d block(s) out of %d',
+                validator_info.name,
+                validator_info.id[:8],
+                validator_info.id[-8:],
+                validator_state.key_block_claim_count,
+                key_block_claim_limit)
+    else:
+        LOGGER.debug(
+            'Validator %s (ID=%s...%s): Claimed 0 block(s) out of %d',
+            validator_info.name,
+            validator_info.id[:8],
+            validator_info.id[-8:],
+            key_block_claim_limit)
+
+    return False
+
+
+def validator_has_claimed_too_early(validator_info,
+                                    consensus_state,
+                                    block_number,
+                                    validator_registry_view,
+                                    poet_config_view,
+                                    block_store):
+    """Determines if a validator has tried to claim a block too early (i.e,
+    has not waited the required number of blocks between when the block
+    containing its validator registry transaction was committed to the
+    chain and trying to claim a block).
+
+    Args:
+        validator_info (ValidatorInfo): The current validator information
+        consensus_state (ConsensusState): The current consensus state
+        block_number (int): The block number of the block that the validator
+            is attempting to claim
+        validator_registry_view (ValidatorRegistry): The current validator
+            registry view
+        poet_config_view (PoetConfigView): The current PoET configuration view
+        block_store (BlockStore): The block store
+
+    Returns:
+        True if the validator has not waited the required number of blocks
+        before attempting to claim a block, False otherwise
+    """
+
+    # While having a block claim delay is nice, it turns out that in
+    # practice the claim delay should not be more than one less than
+    # the number of validators.  It helps to imagine the scenario
+    # where each validator hits their block claim limit in sequential
+    # blocks and their new validator registry information is updated
+    # in the following block by another validator, assuming that there
+    # were no forks.  If there are N validators, once all N validators
+    # have updated their validator registry information, there will
+    # have been N-1 block commits and the Nth validator will only be
+    # able to get its updated validator registry information updated
+    # if the first validator that kicked this off is now able to claim
+    # a block.  If the block claim delay was greater than or equal to
+    # the number of validators, at this point no validators would be
+    # able to claim a block.
+    number_of_validators = len(validator_registry_view.get_validators())
+    block_claim_delay = \
+        min(poet_config_view.block_claim_delay, number_of_validators - 1)
+
+    # While a validator network is starting up, we need to be careful
+    # about applying the block claim delay because if we are too
+    # aggressive we will get ourselves into a situation where the
+    # block claim delay will prevent any validators from claiming
+    # blocks.  So, until we get at least block_claim_delay blocks
+    # we are going to choose not to enforce the delay.
+    if consensus_state.total_block_claim_count <= block_claim_delay:
+        LOGGER.debug(
+            'Skipping block claim delay check.  Only %d block(s) in '
+            'the chain.  Claim delay is %d block(s). %d validator(s) '
+            'registered.',
+            consensus_state.total_block_claim_count,
+            block_claim_delay,
+            number_of_validators)
+        return False
+
+    # Figure out the block in which the current validator information
+    # was committed.
+    commit_block = \
+        block_store.get_block_by_transaction_id(validator_info.transaction_id)
+    blocks_claimed_since_registration = \
+        block_number - commit_block.block_num - 1
+
+    if block_claim_delay > blocks_claimed_since_registration:
+        LOGGER.error(
+            'Validator %s (ID=%s...%s): Committed in block %d, trying to '
+            'claim block %d, must wait until block %d',
+            validator_info.name,
+            validator_info.id[:8],
+            validator_info.id[-8:],
+            commit_block.block_num,
+            block_number,
+            commit_block.block_num + block_claim_delay + 1)
+        return True
+
+    LOGGER.debug(
+        'Validator %s (ID=%s...%s): Committed in block %d, trying to '
+        'claim block %d',
+        validator_info.name,
+        validator_info.id[:8],
+        validator_info.id[-8:],
+        commit_block.block_num,
+        block_number)
+
+    return False

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -368,9 +368,8 @@ def get_consensus_state_for_block_id(
             consensus_state_store[block_id] = consensus_state
 
             LOGGER.debug(
-                'Create consensus state: BID=%s, EBC=%f, TBCC=%d',
+                'Create consensus state: BID=%s, TBCC=%d',
                 block_id[:8],
-                consensus_state.expected_block_claim_count,
                 consensus_state.total_block_claim_count)
 
     return consensus_state

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import math
 import collections
+import itertools
 import json
 import logging
 
@@ -220,9 +222,9 @@ def create_next_validator_state(validator_info, current_validator_state):
             total_block_claim_count=total_block_claim_count)
 
 
-BlockInfo = \
+_BlockInfo = \
     collections.namedtuple(
-        'BlockInfo',
+        '_BlockInfo',
         ['wait_certificate', 'validator_info', 'poet_config_view'])
 
 """ Instead of creating a full-fledged class, let's use a named tuple for
@@ -306,7 +308,7 @@ def get_consensus_state_for_block_id(
                 block_id[-8:])
 
             blocks[block_id] = \
-                BlockInfo(
+                _BlockInfo(
                     wait_certificate=wait_certificate,
                     validator_info=validator_info,
                     poet_config_view=PoetConfigView(state_view))
@@ -317,7 +319,7 @@ def get_consensus_state_for_block_id(
         # need to reset the statistics.
         elif len(blocks) == 0 or previous_wait_certificate is not None:
             blocks[block_id] = \
-                BlockInfo(
+                _BlockInfo(
                     wait_certificate=None,
                     validator_info=None,
                     poet_config_view=None)
@@ -510,5 +512,199 @@ def validator_has_claimed_too_early(validator_info,
         validator_info.id[-8:],
         commit_block.block_num,
         block_number)
+
+    return False
+
+_EstimateInfo = collections.namedtuple('_EstimateInfo',
+                                       ['population_estimate',
+                                        'previous_block_id',
+                                        'validator_id'])
+
+""" Instead of creating a full-fledged class, let's use a named tuple for
+the population estimates.  The population estimate represents what we need
+to help in computing zTest results.  A population estimate object contains:
+
+population_estimate (float): The population estimate for the corresponding
+    block
+previous_block_id (str): The ID of the block previous to the one that this
+    population estimate corresponds to
+validator_id (str): The ID of the validator that won the corresponding block
+"""
+
+# The population estimate cache is a mapping of block ID to its corresponding
+# _EstimateInfo object.  This is used so that when building the population
+# list, we don't have to always walk back the entire list
+# pylint: disable=invalid-name
+_population_estimate_cache = {}
+
+
+def _build_population_estimate_list(block_id,
+                                    consensus_state,
+                                    poet_config_view,
+                                    block_cache,
+                                    poet_enclave_module):
+    """Starting at the block provided, walk back the blocks and collect the
+    population estimates.
+
+    Args:
+        block_id (str): The ID of the block to start with
+        consensus_state (ConsensusState): The current consensus state
+        poet_config_view (PoetConfigView): The current PoET configuration view
+        block_cache (BlockCache): The block store cache
+        poet_enclave_module (module): The PoET enclave module
+
+    Returns:
+        deque: The list, in order of most-recent block to least-recent block,
+            of _PopulationEstimate objects.
+    """
+    population_estimate_list = collections.deque()
+
+    # Until we get to the first fixed-duration block (i.e., a block for which
+    # the local mean is simply a ratio of the target and initial wait times),
+    # first look in our population estimate cache for the population estimate
+    # information and if not there fetch the block.  Then add the value to the
+    # population estimate list.
+    #
+    # Note that since we know the total block claim count from the consensus
+    # state object, we don't have to worry about non-PoET blocks.  Using
+    # that value and the fixed duration block count from the PoET
+    # configuration view, we know now many blocks to get.
+    number_of_blocks = \
+        consensus_state.total_block_claim_count - \
+        poet_config_view.fixed_duration_block_count
+    for _ in range(number_of_blocks):
+        population_cache_entry = _population_estimate_cache.get(block_id)
+        if population_cache_entry is None:
+            block = block_cache[block_id]
+            wait_certificate = \
+                deserialize_wait_certificate(
+                    block=block,
+                    poet_enclave_module=poet_enclave_module)
+            population_cache_entry = \
+                _EstimateInfo(
+                    population_estimate=wait_certificate.population_estimate,
+                    previous_block_id=block.previous_block_id,
+                    validator_id=block.header.signer_pubkey)
+            _population_estimate_cache[block_id] = population_cache_entry
+
+        population_estimate_list.append(population_cache_entry)
+        block_id = population_cache_entry.previous_block_id
+
+    return population_estimate_list
+
+
+def validator_has_claimed_too_frequently(validator_info,
+                                         previous_block_id,
+                                         consensus_state,
+                                         poet_config_view,
+                                         population_estimate,
+                                         block_cache,
+                                         poet_enclave_module):
+    """Determine if allowing the validator to claim a block would allow it to
+    claim blocks more frequently that statistically expected (i.e, zTest).
+
+    Args:
+        validator_info (ValidatorInfo): The current validator information
+        previous_block_id (str): The ID of the block that is the immediate
+            predecessor of the block that the validator is attempting to claim
+        consensus_state (ConsensusState): The current consensus state
+        poet_config_view (PoetConfigView): The current PoET configuration view
+        population_estimate (float): The population estimate for the candidate
+            block
+        block_cache (BlockCache): The block store cache
+        poet_enclave_module (module): The PoET enclave module
+
+    Returns:
+        True if allowing the validator to claim the block would result in the
+        validator being allowed to claim more frequently than statistically
+        expected, False otherwise
+    """
+    # If there are note enough blocks in the block chain to apply the zTest
+    # (i.e., we have not progressed past the blocks for which the local mean
+    # is calculated as a fixed ratio of the target to initial wait), simply
+    # short-circuit the test an allow the block to be claimed.
+    if consensus_state.total_block_claim_count < \
+            poet_config_view.fixed_duration_block_count:
+        return False
+
+    # Build up the population estimate list for the block chain and then add
+    # the new information (i.e., the validator trying to claim as well as the
+    # population estimate) to the front to maintain the order of most-recent
+    # to least-recent.
+    population_estimate_list = \
+        _build_population_estimate_list(
+            block_id=previous_block_id,
+            consensus_state=consensus_state,
+            poet_config_view=poet_config_view,
+            block_cache=block_cache,
+            poet_enclave_module=poet_enclave_module)
+    population_estimate_list.appendleft(
+        _EstimateInfo(
+            population_estimate=population_estimate,
+            previous_block_id=previous_block_id,
+            validator_id=validator_info.id))
+
+    observed_wins = 0
+    expected_wins = 0
+    block_count = 0
+    minimum_win_count = poet_config_view.ztest_minimum_win_count
+    maximum_win_deviation = poet_config_view.ztest_maximum_win_deviation
+
+    # We are now going to compute a "1 sample Z test" for each
+    # progressive range of results in the history.  Test the
+    # hypothesis that validator won elections (i.e., was able to
+    # claim blocks) with higher mean than expected.
+    #
+    # See: http://www.cogsci.ucsd.edu/classes/SP07/COGS14/NOTES/
+    #             binomial_ztest.pdf
+
+    for estimate_info in population_estimate_list:
+        # Keep track of the number of blocks and the expected number of wins
+        # up to this point.
+        block_count += 1
+        expected_wins += 1.0 / estimate_info.population_estimate
+
+        # If the validator trying to claim the block also claimed this block,
+        # update the number of blocks won and if we have seen more than the
+        # number of wins necessary to trigger the zTest, then we are going to
+        # figure out if the validator is winning too frequently.
+        if estimate_info.validator_id == validator_info.id:
+            observed_wins += 1
+            if observed_wins > minimum_win_count and \
+                    observed_wins > expected_wins:
+                probability = expected_wins / block_count
+                standard_deviation = \
+                    math.sqrt(block_count * probability *
+                              (1.0 - probability))
+                z_score = \
+                    (observed_wins - expected_wins) / \
+                    standard_deviation
+                if z_score > maximum_win_deviation:
+                    LOGGER.error(
+                        'Validator %s (ID=%s...%s): zTest failed at depth %d '
+                        'z_score=%f, expected=%f, observed=%d',
+                        validator_info.name,
+                        validator_info.id[:8],
+                        validator_info.id[-8:],
+                        block_count,
+                        z_score,
+                        expected_wins,
+                        observed_wins)
+                    return True
+
+    LOGGER.debug(
+        'Validator %s (ID=%s...%s): zTest succeeded with depth %d, '
+        'expected=%f, observed=%d',
+        validator_info.name,
+        validator_info.id[:8],
+        validator_info.id[-8:],
+        block_count,
+        expected_wins,
+        observed_wins)
+
+    LOGGER.debug(
+        'zTest history: %s',
+        ['{:.4f}'.format(x.population_estimate) for x in
+         itertools.islice(population_estimate_list, 0, 3)])
 
     return False

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -149,14 +149,6 @@ class TestConsensusState(unittest.TestCase):
             with self.assertRaises(ValueError):
                 state.parse_from_bytes(cbor.dumps(invalid_state))
 
-        # Invalid expected block claim count
-        for invalid_ebcc in [None, 'not a float', (), [], {}, -1,
-                             float('nan'), float('inf'), float('-inf')]:
-            state = consensus_state.ConsensusState()
-            state.expected_block_claim_count = invalid_ebcc
-            with self.assertRaises(ValueError):
-                state.parse_from_bytes(state.serialize_to_bytes())
-
         # Invalid total block claim count
         for invalid_tbcc in [None, 'not an int', (), [], {}, -1]:
             state = consensus_state.ConsensusState()
@@ -273,9 +265,6 @@ class TestConsensusState(unittest.TestCase):
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
 
         self.assertEqual(
-            state.expected_block_claim_count,
-            doppelganger_state.expected_block_claim_count)
-        self.assertEqual(
             state.total_block_claim_count,
             doppelganger_state.total_block_claim_count)
 
@@ -301,9 +290,6 @@ class TestConsensusState(unittest.TestCase):
 
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
 
-        self.assertEqual(
-            state.expected_block_claim_count,
-            doppelganger_state.expected_block_claim_count)
         self.assertEqual(
             state.total_block_claim_count,
             doppelganger_state.total_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -39,11 +39,9 @@ class TestConsensusState(unittest.TestCase):
             state.get_validator_state(
                 validator_id='Bond, James Bond',
                 default=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=1,
                     poet_public_key='my key',
                     total_block_claim_count=2))
-        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'my key')
         self.assertEqual(validator_state.total_block_claim_count, 2)
@@ -55,24 +53,12 @@ class TestConsensusState(unittest.TestCase):
         """
         state = consensus_state.ConsensusState()
 
-        # Test invalid commit block number in validator state
-        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
-            with self.assertRaises(ValueError):
-                state.set_validator_state(
-                    validator_id='Bond, James Bond',
-                    validator_state=consensus_state.ValidatorState(
-                        commit_block_number=invalid_cbn,
-                        key_block_claim_count=0,
-                        poet_public_key='my key',
-                        total_block_claim_count=0))
-
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             with self.assertRaises(ValueError):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='my key',
                         total_block_claim_count=0))
@@ -83,7 +69,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=0))
@@ -94,7 +79,6 @@ class TestConsensusState(unittest.TestCase):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=0,
                         poet_public_key='my key',
                         total_block_claim_count=invalid_tbcc))
@@ -104,7 +88,6 @@ class TestConsensusState(unittest.TestCase):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='my key',
                     total_block_claim_count=1))
@@ -112,10 +95,9 @@ class TestConsensusState(unittest.TestCase):
         # Verify that can retrieve after set and validator state matches
         validator_state = \
             consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=0,
                 poet_public_key='my key',
-                total_block_claim_count=0)
+                total_block_claim_count=1)
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=validator_state)
@@ -123,9 +105,6 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -139,7 +118,6 @@ class TestConsensusState(unittest.TestCase):
         # Verify that updating an existing validator state matches on get
         validator_state = \
             consensus_state.ValidatorState(
-                commit_block_number=0xfeedbeef,
                 key_block_claim_count=1,
                 poet_public_key='my new key',
                 total_block_claim_count=2)
@@ -150,9 +128,6 @@ class TestConsensusState(unittest.TestCase):
         retrieved_validator_state = \
             state.get_validator_state(validator_id='Bond, James Bond')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            retrieved_validator_state.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             retrieved_validator_state.key_block_claim_count)
@@ -198,10 +173,10 @@ class TestConsensusState(unittest.TestCase):
                 state.parse_from_bytes(state.serialize_to_bytes())
 
         state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key',
                 total_block_claim_count=1))
@@ -218,34 +193,16 @@ class TestConsensusState(unittest.TestCase):
         # Circumvent testing of validator state validity so that we can
         # serialize to invalid data to verify deserializing
 
-        # Test invalid commit block number in validator state
-        for invalid_cbn in [None, (), [], {}, '1', 1.1, -1]:
-            state = consensus_state.ConsensusState()
-            with mock.patch(
-                    'sawtooth_poet.poet_consensus.consensus_state.'
-                    'ConsensusState._check_validator_state'):
-                state.set_validator_state(
-                    validator_id='Bond, James Bond',
-                    validator_state=consensus_state.ValidatorState(
-                        commit_block_number=invalid_cbn,
-                        key_block_claim_count=0,
-                        poet_public_key='key 1',
-                        total_block_claim_count=1))
-
-            serialized = state.serialize_to_bytes()
-            with self.assertRaises(ValueError):
-                state.parse_from_bytes(serialized)
-
         # Test invalid key block claim counts in validator state
         for invalid_kbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=invalid_kbcc,
                         poet_public_key='key 1',
                         total_block_claim_count=1))
@@ -257,13 +214,13 @@ class TestConsensusState(unittest.TestCase):
         # Test invalid PoET public key in validator state
         for invalid_ppk in [None, (), [], {}, 1, 1.1, '']:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key=invalid_ppk,
                         total_block_claim_count=1))
@@ -275,13 +232,13 @@ class TestConsensusState(unittest.TestCase):
         # Test total block claim count in validator state
         for invalid_tbcc in [None, (), [], {}, '1', 1.1, -1]:
             state = consensus_state.ConsensusState()
+            state.total_block_claim_count = 1
             with mock.patch(
                     'sawtooth_poet.poet_consensus.consensus_state.'
                     'ConsensusState._check_validator_state'):
                 state.set_validator_state(
                     validator_id='Bond, James Bond',
                     validator_state=consensus_state.ValidatorState(
-                        commit_block_number=0xdeadbeef,
                         key_block_claim_count=1,
                         poet_public_key='key',
                         total_block_claim_count=invalid_tbcc))
@@ -291,21 +248,26 @@ class TestConsensusState(unittest.TestCase):
                 state.parse_from_bytes(serialized)
 
         # Test with total block claim count < key block claim count
+        state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
         with mock.patch(
                 'sawtooth_poet.poet_consensus.consensus_state.'
                 'ConsensusState._check_validator_state'):
             state.set_validator_state(
                 validator_id='Bond, James Bond',
                 validator_state=consensus_state.ValidatorState(
-                    commit_block_number=0xdeadbeef,
                     key_block_claim_count=2,
                     poet_public_key='key',
                     total_block_claim_count=1))
 
-        state = consensus_state.ConsensusState()
+        serialized = state.serialize_to_bytes()
+        with self.assertRaises(ValueError):
+            state.parse_from_bytes(serialized)
 
         # Simple serialization of new consensus state and then deserialize
         # and compare
+        state = consensus_state.ConsensusState()
+        state.total_block_claim_count = 1
 
         doppelganger_state = consensus_state.ConsensusState()
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
@@ -321,13 +283,11 @@ class TestConsensusState(unittest.TestCase):
         # verify they are in deserialized
         validator_state_1 = \
             consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='key 1',
                 total_block_claim_count=2)
         validator_state_2 = \
             consensus_state.ValidatorState(
-                commit_block_number=0xfeedbeef,
                 key_block_claim_count=3,
                 poet_public_key='key 2',
                 total_block_claim_count=4)
@@ -341,13 +301,17 @@ class TestConsensusState(unittest.TestCase):
 
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
 
+        self.assertEqual(
+            state.expected_block_claim_count,
+            doppelganger_state.expected_block_claim_count)
+        self.assertEqual(
+            state.total_block_claim_count,
+            doppelganger_state.total_block_claim_count)
+
         validator_state = \
             doppelganger_state.get_validator_state(
                 validator_id='Bond, James Bond')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            validator_state_1.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_1.key_block_claim_count)
@@ -362,9 +326,6 @@ class TestConsensusState(unittest.TestCase):
             doppelganger_state.get_validator_state(
                 validator_id='Smart, Maxwell Smart')
 
-        self.assertEqual(
-            validator_state.commit_block_number,
-            validator_state_2.commit_block_number)
         self.assertEqual(
             validator_state.key_block_claim_count,
             validator_state_2.key_block_claim_count)

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -108,7 +108,6 @@ class TestConsensusStateStore(unittest.TestCase):
 
         # Store consensus state
         state = consensus_state.ConsensusState()
-        state.expected_block_claim_count = 3.14
         state.total_block_claim_count = 2
         state.set_validator_state(
             validator_id='Bond, James Bond',
@@ -127,10 +126,6 @@ class TestConsensusStateStore(unittest.TestCase):
 
         # Retrieve the state and verify equality
         retrieved_state = store['key']
-
-        self.assertEqual(
-            state.expected_block_claim_count,
-            retrieved_state.expected_block_claim_count)
 
         validator_state = \
             retrieved_state.get_validator_state(

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -109,10 +109,10 @@ class TestConsensusStateStore(unittest.TestCase):
         # Store consensus state
         state = consensus_state.ConsensusState()
         state.expected_block_claim_count = 3.14
+        state.total_block_claim_count = 2
         state.set_validator_state(
             validator_id='Bond, James Bond',
             validator_state=consensus_state.ValidatorState(
-                commit_block_number=0xdeadbeef,
                 key_block_claim_count=1,
                 poet_public_key='skeleton key',
                 total_block_claim_count=2))
@@ -136,7 +136,6 @@ class TestConsensusStateStore(unittest.TestCase):
             retrieved_state.get_validator_state(
                 validator_id='Bond, James Bond')
 
-        self.assertEqual(validator_state.commit_block_number, 0xdeadbeef)
         self.assertEqual(validator_state.key_block_claim_count, 1)
         self.assertEqual(validator_state.poet_public_key, 'skeleton key')
         self.assertEqual(validator_state.total_block_claim_count, 2)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -26,6 +26,8 @@ class TestPoetConfigView(unittest.TestCase):
     _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
     _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
+    _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
+    _EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_ = 3
 
     def test_key_block_claim_limit(self, mock_config_view):
         """Verify that retrieving key block claim limit works for invalid
@@ -153,3 +155,103 @@ class TestPoetConfigView(unittest.TestCase):
         self.assertEqual(
             poet_config_view.fixed_duration_block_count,
             1)
+
+    def test_ztest_maximum_win_deviation(self, mock_config_view):
+        """Verify that retrieving zTest maximum win deviation works for
+        invalid cases (missing, invalid format, invalid value) as well as
+        valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.ztest_maximum_win_deviation')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+        self.assertEqual(kwargs['value_type'], float)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1.0
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = 0.0
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('nan')
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('inf')
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        mock_config_view.return_value.get_setting.return_value = float('-inf')
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 2.575
+        self.assertEqual(
+            poet_config_view.ztest_maximum_win_deviation,
+            2.575)
+
+    def test_ztest_minimum_win_count(self, mock_config_view):
+        """Verify that retrieving zTest minimum win observations works for
+        invalid cases (missing, invalid format, invalid value) as well as
+        valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.ztest_minimum_win_count')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 0
+        self.assertEqual(
+            poet_config_view.ztest_minimum_win_count,
+            0)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -22,6 +22,11 @@ from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 @patch('sawtooth_poet.poet_consensus.poet_config_view.ConfigView')
 class TestPoetConfigView(unittest.TestCase):
 
+    # pylint: disable=invalid-name
+    _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
+    _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
+
     def test_key_block_claim_limit(self, mock_config_view):
         """Verify that retrieving key block claim limit works for invalid
         cases (missing, invalid format, invalid value) as well as valid case.
@@ -33,34 +38,30 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
-        # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
 
         _, kwargs = \
             mock_config_view.return_value.get_setting.call_args
 
         self.assertEqual(kwargs['key'], 'sawtooth.poet.key_block_claim_limit')
-        # pylint: disable=protected-access
         self.assertEqual(
             kwargs['default_value'],
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
         self.assertEqual(kwargs['value_type'], int)
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
         mock_config_view.return_value.get_setting.return_value = -1
-        # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
 
         mock_config_view.return_value.get_setting.return_value = 0
-        # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.key_block_claim_limit,
-            PoetConfigView._DEFAULT_KEY_CLAIM_LIMIT_)
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
@@ -79,28 +80,25 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
-        # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.block_claim_delay,
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
 
         _, kwargs = \
             mock_config_view.return_value.get_setting.call_args
 
         self.assertEqual(kwargs['key'], 'sawtooth.poet.block_claim_delay')
-        # pylint: disable=protected-access
         self.assertEqual(
             kwargs['default_value'],
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
         self.assertEqual(kwargs['value_type'], int)
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
         mock_config_view.return_value.get_setting.return_value = -1
-        # pylint: disable=protected-access
         self.assertEqual(
             poet_config_view.block_claim_delay,
-            PoetConfigView._DEFAULT_BLOCK_CLAIM_DELAY_)
+            TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 0
@@ -110,4 +108,48 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(
             poet_config_view.block_claim_delay,
+            1)
+
+    def test_fixed_duration_block_count(self, mock_config_view):
+        """Verify that retrieving fixed duration block count works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.fixed_duration_block_count')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
+
+        mock_config_view.return_value.get_setting.return_value = 0
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
+            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(
+            poet_config_view.fixed_duration_block_count,
             1)


### PR DESCRIPTION
Per the PoET specification, validators are limited in how frequently they may claim blocks - i.e., the zTest.  If it is determined that allowing a validator to win an election (i.e., claim a block and have it added to the blockchain) would cause it to claim blocks more frequently than a configurable statistical rate, the block is rejected.

This PR updates:
* adds a fixed duration block count property to the PoET configuration view.  This value indicates the number of blocks which will have their local mean computed by using a simple ratio of target to initial wait times.  These blocks are not considered when performing the zTest.
* updates the PoET enclave factory to use the new PoET configuration view's fixed duration block count property.
* refactors existing PoET policy tests (key block claim limit, block claim delay) to common utils
* adds minimum win count and maximum win deviation properties to the PoET configuration view.  These values are used when performing the zTest.  The minimum win count is that minimum number of blocks, after the fixed duration block count has been surpassed, a validator has to win before zTest will apply to any further blocks.  The maximum win deviation is used to determine if a validator has violated the zTest policy by comparing this against the deviation from the expected number of blocks a validator should have won.
* updates the PoET block verifier to ensure that when verifying blocks it checks to make sure a validator is throttled by the block claim frequency allowed 
* updates the PoET block publisher to refuse to initialize a block if the block frequency check fails, indicating that other validators would reject the block
* removes the expected block claim count from the per-block consensus state as it is not necessary
* adds a short-circuit for blocks upon which block publisher has already determined it would not be allowed to build on top of

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`sawtooth.consensus.algorithm=poet \`

Add:

```
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
sawtooth.poet.block_claim_delay=1 \
sawtooth.poet.fixed_duration_block_count=5 \
sawtooth.poet.ztest_maximum_win_deviation=2.321 \
sawtooth.poet.ztest_minimum_win_count=2 \
```

This should increase the chance of validators refusing the publish blocks because it would violate the block claim frequency test.  You can look at the logs for error log messages.

To reduce the likelihood of zTest failures, you can change `sawtooth.poet.ztest_maximum_win_deviation`.  The values are based upon the confidence interval (i.e., how confident we are that we have truly detected a validator winning at a frequency we consider too frequent):

```
3.075 => 99.9%
2.575 => 99.5%
2.321 => 99%
1.645 => 95%
```

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.