### PR TITLE
Nml 2165 - Add rate batch limit to block publisher. 

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -49,6 +49,9 @@ class SerialScheduler(Scheduler):
         self._last_in_batch = []
         self._last_state_hash = first_state_hash
 
+    def __del__(self):
+        self.cancel()
+
     def __iter__(self):
         return SchedulerIterator(self, self._condition)
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -32,8 +32,199 @@ from sawtooth_validator.journal.transaction_cache import TransactionCache
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 
+from sawtooth_validator.state.config_view import ConfigView
 
 LOGGER = logging.getLogger(__name__)
+
+
+class _CandidateBlock(object):
+    """This is a helper class for the BlockPublisher. The _CandidateBlock
+    tracks all the state associated with the Block that is being built.
+    This allows the BlockPublisher to focus on when to create and finalize
+    a block and not worry about how the block is built.
+    """
+    def __init__(self,
+                 block_store,
+                 consensus,
+                 scheduler,
+                 committed_txn_cache,
+                 block_builder,
+                 max_batches
+                 ):
+        self._pending_batches = []
+        self._pending_batch_ids = set()
+        self._block_store = block_store
+        self._consensus = consensus
+        self._scheduler = scheduler
+        self._committed_txn_cache = committed_txn_cache
+        # Look-up cache for transactions that are committed in the current
+        # chain and the state of the transactions already added to the
+        # candidate block.
+        self._block_builder = block_builder
+        self._max_batches = max_batches
+
+    def __del__(self):
+        # Cancel the scheduler if it is not complete
+        if not self._scheduler.complete(block=False):
+            self._scheduler.cancel()
+
+    @property
+    def previous_block_id(self):
+        return self._block_builder.previous_block_id
+
+    def _check_batch_dependencies(self, batch, committed_txn_cache):
+        """Check the dependencies for all transactions in this are present.
+        If all are present the committed_txn is updated with all txn in this
+        batch and True is returned. If they are not return failure and the
+        committed_txn is not updated.
+        :param batch: the batch to validate
+        :param committed_txn_cache: The cache holding the set of committed
+        transactions to check against, updated during processing.
+        :return: Boolean, True if dependencies checkout, False otherwise.
+        """
+        for txn in batch.transactions:
+            if not self._check_transaction_dependencies(
+                    txn,
+                    committed_txn_cache):
+                # if any transaction in this batch fails the whole batch
+                # fails.
+                committed_txn_cache.remove_batch(batch)
+                return False
+            # update so any subsequent txn in the same batch can be dependent
+            # on this transaction.
+            committed_txn_cache.add_txn(txn.header_signature)
+        return True
+
+    def _check_transaction_dependencies(self, txn, committed_txn_cache):
+        """Check that all this transactions dependencies are present.
+        :param txn: the transaction to check
+        :param committed_txn_cache: The cache holding the set of committed
+        transactions to check against.
+        :return: Boolean, True if dependencies checkout, False otherwise.
+        """
+        txn_hdr = TransactionHeader()
+        txn_hdr.ParseFromString(txn.header)
+        for dep in txn_hdr.dependencies:
+            if dep not in committed_txn_cache:
+                LOGGER.debug("Transaction rejected due " +
+                             "missing dependency, transaction " +
+                             "%s depends on %s", txn.header_signature, dep)
+                return False
+        return True
+
+    def _is_batch_already_committed(self, batch):
+        """ Test if a batch is already committed to the chain or
+        is already in the pending queue.
+        :param batch: the batch to check
+        """
+        return (self._block_store.has_batch(batch.header_signature) or
+                batch.header_signature in self._pending_batch_ids)
+
+    def add_batch(self, batch):
+        """Add a batch to the _CandidateBlock
+        :param batch: the batch to add to the block
+        """
+        # first we check if the transaction dependencies are satisfied
+        # The completer should have taken care of making sure all
+        # Batches containing dependent transactions were sent to the
+        # BlockPublisher prior to this Batch. So if there is a missing
+        # dependency this is an error condition and the batch will be
+        # dropped.
+        if self._is_batch_already_committed(batch):
+            # batch is already committed.
+            LOGGER.debug("Dropping previously committed batch: %s",
+                         batch.header_signature)
+            return
+        elif self._check_batch_dependencies(batch, self._committed_txn_cache):
+            self._pending_batches.append(batch)
+            self._pending_batch_ids.add(batch.header_signature)
+            try:
+                self._scheduler.add_batch(batch)
+            except SchedulerError as err:
+                LOGGER.debug("Scheduler error processing batch: %s", err)
+        else:
+            LOGGER.debug("Dropping batch due to missing dependencies: %s",
+                         batch.header_signature)
+
+    def check_publish_block(self):
+        """Check if it is okay to publish this candidate.
+        """
+        return self._consensus.check_publish_block(
+            self._block_builder.block_header)
+
+    def _sign_block(self, block, identity_signing_key):
+        """ The block should be complete and the final
+        signature from the publishing validator(this validator) needs to
+        be added.
+        :param block: the Block to sign.
+        :param identity_signing_key: the key to sign the block with.
+        """
+        header_bytes = block.block_header.SerializeToString()
+        signature = signing.sign(header_bytes, identity_signing_key)
+        block.set_signature(signature)
+
+    def finalize_block(self, identity_signing_key, pending_batches):
+        """Compose the final Block to publish. This involves flushing
+        the scheduler, having consensus bless the block, and signing
+        the block.
+        :param identity_signing_key: the key to sign the block with.
+        :param pending_batches: list to receive any batches that were
+        submitted to add to the block but were not validated before this
+        call.
+        """
+        self._scheduler.finalize()
+        self._scheduler.complete(block=True)
+
+        # this is a transaction cache to track the transactions committed
+        # up to this batch. Only valid transactions that were processed
+        # by the scheduler are added.
+        committed_txn_cache = TransactionCache(self._block_store)
+
+        builder = self._block_builder
+        state_hash = None
+        for batch in self._pending_batches:
+            result = self._scheduler.get_batch_execution_result(
+                batch.header_signature)
+            # if a result is None, this means that the executor never
+            # received the batch and it should be added to
+            # the pending_batches, to be added to the next
+            # block
+            if result is None:
+                pending_batches.append(batch)
+            elif result.is_valid:
+                # check if a dependent batch failed. This could be belt and
+                # suspenders action here but it is logically possible that
+                # a transaction has a dependency that fails it could
+                # still succeed validation. In which case we do not want
+                # to add it to the batch.
+                if not self._check_batch_dependencies(batch,
+                                                      committed_txn_cache):
+                    LOGGER.debug("Batch %s invalid, due to missing txn "
+                                 "dependency.", batch.header_signature)
+                    LOGGER.debug("Abandoning block %s:" +
+                                 "root state hash has invalid txn applied",
+                                 builder)
+                    return None
+                else:
+                    builder.add_batch(batch)
+                    committed_txn_cache.add_batch(batch)
+                state_hash = result.state_hash
+            else:
+                LOGGER.debug("Batch %s invalid, not added to block.",
+                             batch.header_signature)
+
+        if state_hash is None:
+            LOGGER.debug("Abandoning block %s no batches added", builder)
+            return None
+
+        if not self._consensus.finalize_block(builder.block_header):
+            LOGGER.debug("Abandoning block %s, consensus failed to finalize "
+                         "it", builder)
+            return False
+
+        builder.set_state_hash(state_hash)
+        self._sign_block(builder, identity_signing_key)
+        return builder.build_block()
 
 
 class BlockPublisher(object):
@@ -70,8 +261,8 @@ class BlockPublisher(object):
              consensus module can be stored.
         """
         self._lock = RLock()
-        self._candidate_block = None  # the next block in potential chain
-        self._consensus = None
+        self._candidate_block = None  # _CandidateBlock helper,
+        # the next block in potential chain
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._transaction_executor = transaction_executor
@@ -80,14 +271,7 @@ class BlockPublisher(object):
                                                batch_sender)
         self._pending_batches = []  # batches we are waiting for validation,
         # arranged in the order of batches received.
-        self._committed_txn_cache = TransactionCache(self._block_cache.
-                                                     block_store)
-        # Look-up cache for transactions that are committed in the current
-        # chain. Cache is used here so that we can support opportunistically
-        # building on top of a block we published. As well as hold the state
-        # of the transactions already added to the candidate block.
 
-        self._scheduler = None
         self._chain_head = chain_head  # block (BlockWrapper)
         self._squash_handler = squash_handler
         self._identity_signing_key = identity_signing_key
@@ -95,7 +279,7 @@ class BlockPublisher(object):
             signing.generate_pubkey(self._identity_signing_key)
         self._data_dir = data_dir
 
-    def _build_block(self, chain_head):
+    def _build_candidate_block(self, chain_head):
         """ Build a candidate block and construct the consensus object to
         validate it.
         :param chain_head: The block to build on top of.
@@ -109,7 +293,12 @@ class BlockPublisher(object):
             chain_head.header_signature,
             state_view)
 
-        self._consensus = consensus_module.\
+        config_view = ConfigView(state_view)
+        max_batches = config_view.get_setting(
+            'sawtooth.publisher.max_block_size',
+            default_value=0, value_type=int)
+
+        consensus = consensus_module.\
             BlockPublisher(block_cache=self._block_cache,
                            state_view_factory=self._state_view_factory,
                            batch_publisher=self._batch_publisher,
@@ -121,109 +310,25 @@ class BlockPublisher(object):
             previous_block_id=chain_head.header_signature,
             signer_pubkey=self._identity_public_key)
         block_builder = BlockBuilder(block_header)
-        if not self._consensus.initialize_block(block_builder.block_header):
+        if not consensus.initialize_block(block_builder.block_header):
             LOGGER.debug("Consensus not ready to build candidate block.")
             return None
 
-        # Cancel the previous scheduler if it did not complete.
-        if self._scheduler is not None \
-                and not self._scheduler.complete(block=False):
-            self._scheduler.cancel()
-
         # create a new scheduler
-        self._scheduler = self._transaction_executor.create_scheduler(
+        scheduler = self._transaction_executor.create_scheduler(
             self._squash_handler, chain_head.state_root_hash)
 
         # build the TransactionCache
-        self._committed_txn_cache = TransactionCache(self._block_cache.
-                                                     block_store)
-        if chain_head.header_signature not in self._block_cache.block_store:
-            # if we opportunistically building a block
-            # we need to check make sure we track that blocks transactions
-            # as recorded.
-            for batch in chain_head.block.batches:
-                for txn in batch.transactions:
-                    self._committed_txn_cache.add_txn(txn.header_signature)
+        committed_txn_cache = TransactionCache(self._block_cache.block_store)
 
-        self._transaction_executor.execute(self._scheduler)
+        self._transaction_executor.execute(scheduler)
+        self._candidate_block = _CandidateBlock(self._block_cache.block_store,
+                                                consensus, scheduler,
+                                                committed_txn_cache,
+                                                block_builder,
+                                                max_batches)
         for batch in self._pending_batches:
-            self._validate_batch(batch)
-
-        return block_builder
-
-    def _sign_block(self, block):
-        """ The block should be complete and the final
-        signature from the publishing validator(this validator) needs to
-        be added.
-        """
-        block_header = block.block_header
-        header_bytes = block_header.SerializeToString()
-        signature = signing.sign(
-            header_bytes,
-            self._identity_signing_key)
-        block.set_signature(signature)
-        return block
-
-    def _check_batch_dependencies(self, batch, committed_txn_cache):
-        """Check the dependencies for all transactions in this are present.
-        If all are present the committed_txn is updated with all txn in this
-        batch and True is returned. If they are not return failure and the
-        committed_txn is not updated.
-        :param batch: the batch to validate
-        :param committed_txn(TransactionCache): Current set of committed
-        transaction, updated during processing.
-        :return: Boolean, True if dependencies checkout, False otherwise.
-        """
-        for txn in batch.transactions:
-            if not self._check_transaction_dependencies(txn,
-                                                        committed_txn_cache):
-                # if any transaction in this batch fails the whole batch
-                # fails.
-                committed_txn_cache.remove_batch(batch)
-                return False
-            # update so any subsequent txn in the same batch can be dependent
-            # on this transaction.
-            committed_txn_cache.add_txn(txn.header_signature)
-        return True
-
-    def _check_transaction_dependencies(self, txn, committed_txn):
-        """Check that all this transactions dependencies are present.
-        :param tx: the transaction to check
-        :param committed_txn(TransactionCache): Current set of committed
-        :return: Boolean, True if dependencies checkout, False otherwise.
-        """
-        txn_hdr = TransactionHeader()
-        txn_hdr.ParseFromString(txn.header)
-        for dep in txn_hdr.dependencies:
-            if dep not in committed_txn:
-                LOGGER.debug("Transaction rejected due " +
-                             "missing dependency, transaction " +
-                             "%s depends on %s", txn.header_signature, dep)
-                return False
-        return True
-
-    def _validate_batch(self, batch):
-        """Schedule validation of a batch for inclusion in the new block
-        :param batch: the batch to validate
-        :return: None
-        """
-        if self._scheduler:
-            try:
-                self._scheduler.add_batch(batch)
-            except SchedulerError as err:
-                LOGGER.debug("Scheduler error processing batch: %s", err)
-
-    def is_batch_already_commited(self, batch):
-        """ Test if a batch is already committed to the chain or
-        is already in the pending queue.
-        """
-        if self._block_cache.block_store.has_batch(batch.header_signature):
-            return True
-        else:
-            for pending in self._pending_batches:
-                if batch.header_signature == pending.header_signature:
-                    return True
-        return False
+            self._candidate_block.add_batch(batch)
 
     def on_batch_received(self, batch):
         """
@@ -231,28 +336,11 @@ class BlockPublisher(object):
         :param batch: the new pending batch
         :return: None
         """
-        with self._lock:
-            # first we check if the transaction dependencies are satisfied
-            # The completer should have taken care of making sure all
-            # Batches containing dependent transactions were sent to the
-            # BlockPublisher prior to this Batch. So if there is a missing
-            # dependency this is an error condition and the batch will be
-            # dropped.
-            if self.is_batch_already_commited(batch):
-                # batch is already committed.
-                LOGGER.debug("Dropping previously committed batch: %s",
-                             batch.header_signature)
-                return
-            elif self._check_batch_dependencies(batch, self.
-                                                _committed_txn_cache):
-                self._pending_batches.append(batch)
-                # if we are building a block then send schedule it for
-                # execution.
-                if self._chain_head is not None:
-                    self._validate_batch(batch)
-            else:
-                LOGGER.debug("Dropping batch due to missing dependencies: %s",
-                             batch.header_signature)
+        self._pending_batches.append(batch)
+        # if we are building a block then send schedule it for
+        # execution.
+        if self._candidate_block:
+            self._candidate_block.add_batch(batch)
 
     def _rebuild_pending_batches(self, committed_batches, uncommitted_batches):
         """When the chain head is changed. This recomputes the list of pending
@@ -276,15 +364,11 @@ class BlockPublisher(object):
         # since batches can only be committed to a chain once.
         for batch in uncommitted_batches:
             if batch.header_signature not in committed_set:
-                if self._check_batch_dependencies(batch, self.
-                                                  _committed_txn_cache):
-                    self._pending_batches.append(batch)
+                self._pending_batches.append(batch)
 
         for batch in pending_batches:
             if batch.header_signature not in committed_set:
-                if self._check_batch_dependencies(batch, self.
-                                                  _committed_txn_cache):
-                    self._pending_batches.append(batch)
+                self._pending_batches.append(batch)
 
     def on_chain_updated(self, chain_head,
                          committed_batches=None,
@@ -306,96 +390,18 @@ class BlockPublisher(object):
 
                 self._chain_head = chain_head
 
-                if self._candidate_block is not None and \
-                        chain_head is not None and \
-                        chain_head.identifier == \
-                        self._candidate_block.previous_block_id:
-                    # nothing to do. We are building of the current head.
-                    # This can happen after we publish a block and
-                    # opportunistically create a new block.
-                    return
-                elif chain_head is None:
-                    # we don't have a chain head, we cannot build blocks
-                    self._candidate_block = None
-                    self._consensus = None
-
-                    for batch in self._pending_batches:
-                        self._committed_txn_cache.add_batch(batch)
-                else:
+                self._candidate_block = None  # we need to make a new
+                # _CandidateBlock (if we can) since the block chain has updated
+                # under us.
+                if chain_head is not None:
                     self._rebuild_pending_batches(committed_batches,
                                                   uncommitted_batches)
-                    self._candidate_block = self._build_block(chain_head)
+                    self._build_candidate_block(chain_head)
+
         # pylint: disable=broad-except
         except Exception as exc:
             LOGGER.critical("on_chain_updated exception.")
             LOGGER.exception(exc)
-
-    def _finalize_block(self, block):
-        if self._scheduler:
-            self._scheduler.finalize()
-            self._scheduler.complete(block=True)
-
-        # Read valid batches from self._scheduler
-        pending_batches = self._pending_batches
-        # this is a transaction cache to track the transactions committed
-        # upto this batch.
-        committed_txn_cache = TransactionCache(self._block_cache.block_store)
-        self._pending_batches = []
-        self._committed_txn_cache = TransactionCache(self._block_cache.
-                                                     block_store)
-
-        state_hash = None
-        for batch in pending_batches:
-            result = self._scheduler.get_batch_execution_result(
-                batch.header_signature)
-            # if a result is None, this means that the executor never
-            # received the batch and it should be added to
-            # the pending_batches
-            if result is None:
-                self._pending_batches.append(batch)
-                self._committed_txn_cache.add_batch(batch)
-            elif result.is_valid:
-                # check if a dependent batch failed. This could be belt and
-                # suspenders action here but it is logically possible that
-                # a transaction has a dependency that fails it could
-                # still succeed validation. In that case we do not want
-                # to add it to the batch.
-                if not self._check_batch_dependencies(batch,
-                                                      committed_txn_cache):
-                    LOGGER.debug("Batch %s invalid, due to missing txn "
-                                 "dependency.", batch.header_signature)
-                    LOGGER.debug("Abandoning block %s:" +
-                                 "root state hash has invalid txn applied",
-                                 block)
-                    pending_batches.remove(batch)
-                    self._pending_batches = pending_batches
-                    self._committed_txn_cache = \
-                        TransactionCache(self._block_cache.block_store)
-                    return False
-                else:
-                    block.add_batch(batch)
-                    self._committed_txn_cache.add_batch(batch)
-                state_hash = result.state_hash
-            else:
-                committed_txn_cache.uncommit_batch(batch)
-                LOGGER.debug("Batch %s invalid, not added to block.",
-                             batch.header_signature)
-
-        if state_hash is None:
-            LOGGER.debug("Abandoning block %s no batches added", block)
-            return False
-
-        if not self._consensus.finalize_block(block.block_header):
-            LOGGER.debug("Abandoning block %s, consensus failed to finalize "
-                         "it", block)
-            return False
-
-        self._consensus = None
-
-        block.set_state_hash(state_hash)
-        self._sign_block(block)
-
-        return True
 
     def on_check_publish_block(self, force=False):
         """Ask the consensus module if it is time to claim the candidate block
@@ -405,31 +411,38 @@ class BlockPublisher(object):
         """
         try:
             with self._lock:
+                pending_batch_count = len(self._pending_batches)
                 if self._chain_head is not None and\
                         self._candidate_block is None and\
-                        len(self._pending_batches) != 0:
-                    self._candidate_block = self._build_block(self._chain_head)
+                        pending_batch_count != 0:
+                    self._build_candidate_block(self._chain_head)
+
                 if self._candidate_block and \
-                        (force or len(self._pending_batches) != 0) and \
-                        self._consensus.check_publish_block(self.
-                                                            _candidate_block.
-                                                            block_header):
-                    candidate = self._candidate_block
+                        (force or pending_batch_count != 0) and \
+                        self._candidate_block.check_publish_block():
+
+                    pending_batches = []  # will receive the list of batches
+                    # that were not added to the block
+
+                    block = self._candidate_block.finalize_block(
+                        self._identity_signing_key,
+                        pending_batches)
                     self._candidate_block = None
 
-                    if not self._finalize_block(candidate):
-                        return
+                    if block:
+                        block = BlockWrapper(block)
+                        self._block_sender.send(block.block)
 
-                    block = BlockWrapper(candidate.build_block())
-                    self._block_cache[block.identifier] = block  # add the
-                    # block to the cache, so we can build on top of it.
-                    self._block_sender.send(block.block)
+                        self._pending_batches = pending_batches
+                        LOGGER.info("Claimed Block: %s", block)
 
-                    LOGGER.info("Claimed Block: %s", block)
+                        # We built our candidate, disable processing until
+                        # the chain head is updated. Only set this if
+                        # we succeeded. Otherwise try again, this
+                        # can happen in cases where txn dependencies
+                        # did not validate when building the block.
+                        self.on_chain_updated(None)
 
-                    # We built our candidate, disable processing until
-                    # the chain head is updated.
-                    self.on_chain_updated(None)
         # pylint: disable=broad-except
         except Exception as exc:
             LOGGER.critical("on_check_publish_block exception.")

--- a/validator/tests/unit3/test_journal/block_tree_manager.py
+++ b/validator/tests/unit3/test_journal/block_tree_manager.py
@@ -249,11 +249,13 @@ class BlockTreeManager(object):
         else:  # WTF try something crazy
             return self.block_cache[str(block)]
 
-    def generate_batch(self, txn_count=2, missing_deps=False):
-        txns = [
-            self.generate_transaction('txn_' + str(i))
-            for i in range(txn_count)
-        ]
+    def generate_batch(self, txn_count=2, missing_deps=False,
+                       txns=None):
+        if txns is None:
+            txns = [
+                self.generate_transaction('txn_' + str(i))
+                for i in range(txn_count)
+            ]
 
         if missing_deps:
             target_txn = txns[-1]

--- a/validator/tests/unit3/test_journal/mock.py
+++ b/validator/tests/unit3/test_journal/mock.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 from concurrent.futures import Executor
+
 from sawtooth_validator.execution.scheduler import Scheduler
 from sawtooth_validator.execution.scheduler import BatchExecutionResult
+
 from sawtooth_validator.journal.batch_sender import BatchSender
 from sawtooth_validator.journal.block_sender import BlockSender
+
 from sawtooth_validator.protobuf import batch_pb2
 from sawtooth_validator.protobuf import block_pb2
+from sawtooth_validator.protobuf.setting_pb2 import Setting
 
+from sawtooth_validator.state.config_view import ConfigView
 
 class SynchronousExecutor(Executor):
     def __init__(self):
@@ -226,3 +231,14 @@ class MockChainIdManager(object):
 
     def get_block_chain_id(self):
         return self._block_chain_id
+
+
+def CreateSetting(key, value):
+    """
+    Create a setting object to include in a MockStateFactory.
+    """
+    addr = ConfigView.setting_address(key)
+
+    setting = Setting()
+    setting.entries.add(key=key, value=repr(value))
+    return addr, setting.SerializeToString()


### PR DESCRIPTION
This PR contains 3 changes:
1) refactor the block publisher to move all of the logic managing a candidate block out of the BlockPublisher into a helper class. This also changed the policy for checking transaction dependencies to be done only in the context of a Candidate block that is being built. 

2) Update the block publisher to have a batch limit per block, to allow for block sizes to be controlled. 

3) Checks for duplicate transactions in batches. Look in the current chain and CandidateBlock to make sure that any transaction in a batch added has not been previously committed to the chain. 