### PR TITLE
Overhaul Rest Api error handling

### DIFF
--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -13,52 +13,207 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from aiohttp import web
+import json
+from aiohttp.web import HTTPError
 
 
-class WrongBodyType(web.HTTPBadRequest):
+class _ApiError(HTTPError):
+    """A parent class for all REST API errors. Extends aiohttp's HTTPError,
+    so instances will be caught automatically be the API, and turned into a
+    response to send back to clients. Children should not define any methods,
+    just four class variables which the parent __init__ will reference.
+
+    Attributes:
+        api_code (int): The fixed code to include in the JSON error response.
+            Once established, this code should never change.
+        status_code (int): HTTP status to use. Referenced withinin HTTPError's
+            __init__ method.
+        title (str): A short headline for the error.
+        message (str): The human-readable description of the error.
+
+    Raises:
+        AssertionError: If api_code, status_code, title, or message were
+            not set.
+    """
+    api_code = None
+    status_code = None
+    title = None
+    message = None
+
     def __init__(self):
-        message = 'Expected an octet-stream encoded Protobuf binary'
-        super().__init__(reason=message)
+        assert self.api_code is not None, 'Invalid ApiError, api_code not set'
+        assert self.status_code is not None, 'Invalid ApiError, status not set'
+        assert self.title is not None, 'Invalid ApiError, title not set'
+        assert self.message is not None, 'Invalid ApiError, message not set'
+
+        error = {
+            'code': self.api_code,
+            'title': self.title,
+            'message': self.message}
+
+        super().__init__(
+            content_type='application/json',
+            text=json.dumps(
+                {'error': error},
+                indent=2,
+                separators=(',', ': '),
+                sort_keys=True))
 
 
-class EmptyProtobuf(web.HTTPBadRequest):
-    def __init__(self):
-        message = 'Your submission contained no batches'
-        super().__init__(reason=message)
+class UnknownValidatorError(_ApiError):
+    api_code = 10
+    status_code = 500
+    title = 'Unknown Validator Error'
+    message = ('An unknown error occurred with the validator while '
+               'processing your request.')
 
 
-class BadProtobuf(web.HTTPBadRequest):
-    def __init__(self):
-        message = 'There was a problem decoding your Protobuf binary'
-        super().__init__(reason=message)
+class ValidatorNotReady(_ApiError):
+    api_code = 15
+    status_code = 503
+    title = 'Validator Not Ready'
+    message = ('The validator has no genesis block, and is not yet ready to '
+               'be queried. Try your request again later.')
 
 
-class BadStatusBody(web.HTTPBadRequest):
-    def __init__(self):
-        message = 'Expected a json formatted array of id strings'
-        super().__init__(reason=message)
+class ValidatorTimedOut(_ApiError):
+    api_code = 17
+    status_code = 503
+    title = 'Validator Timed Out'
+    message = ('The request timed out while waiting for a response from the '
+               'validator. Try your request again later.')
 
 
-class MissingStatusId(web.HTTPBadRequest):
-    def __init__(self):
-        message = 'At least one batch id must be specified to check status'
-        super().__init__(reason=message)
+class ValidatorDisconnected(_ApiError):
+    api_code = 18
+    status_code = 503
+    title = 'Validator Disconnected'
+    message = ('The validator disconnected before sending a response. '
+               'Try your request again later.')
 
 
-class BadCount(web.HTTPBadRequest):
-    def __init__(self):
-        message = 'The "count" parameter must be a non-zero integer'
-        super().__init__(reason=message)
+class StatusResponseMissing(_ApiError):
+    api_code = 27
+    status_code = 500
+    title = 'Unable to Fetch Statuses'
+    message = ('An unknown error occurred while attempting to fetch batch '
+               'statuses, and nothing was returned.')
 
 
-class ValidatorUnavailable(web.HTTPServiceUnavailable):
-    def __init__(self):
-        message = 'Could not reach validator, validator timed out'
-        super().__init__(reason=message)
+class SubmittedBatchesInvalid(_ApiError):
+    api_code = 30
+    status_code = 400
+    title = 'Submitted Batches Invalid'
+    message = ('The submitted BatchList is invalid. It was poorly formed, or '
+               'has an invalid signature.')
 
 
-class ValidatorDisconnect(web.HTTPServiceUnavailable):
-    def __init__(self):
-        message = 'The connection to the validator was lost'
-        super().__init__(reason=message)
+class NoBatchesSubmitted(_ApiError):
+    api_code = 34
+    status_code = 400
+    title = 'No Batches Submitted'
+    message = ('The protobuf BatchList you submitted was empty and contained '
+               'no Batches. You must submit at least one Batch.')
+
+
+class BadProtobufSubmitted(_ApiError):
+    api_code = 35
+    status_code = 400
+    title = 'Protobuf Not Decodable'
+    message = ('The protobuf BatchList you submitted was malformed and could '
+               'not be read.')
+
+
+class SubmissionWrongContentType(_ApiError):
+    api_code = 42
+    status_code = 400
+    title = 'Wrong Content Type'
+    message = ("Batches must be submitted in a BatchList protobuf binary, "
+               "with a 'Content-Type' header of 'application/octet-stream'.")
+
+
+class StatusWrongContentType(_ApiError):
+    api_code = 43
+    status_code = 400
+    title = 'Wrong Content Type'
+    message = ("Requests for batch statuses sent as a POST must have a "
+               "'Content-Type' header of 'application/json'.")
+
+
+class StatusBodyInvalid(_ApiError):
+    api_code = 46
+    status_code = 400
+    title = 'Bad Status Request'
+    message = ('Requests for batch statuses sent as a POST must have a JSON '
+               'formatted body with an array of at least one id string.')
+
+
+class HeadNotFound(_ApiError):
+    api_code = 50
+    status_code = 404
+    title = 'Head Not Found'
+    message = ("There is no block with the id specified in the 'head' "
+               "query parameter.")
+
+
+class CountInvalid(_ApiError):
+    api_code = 53
+    status_code = 400
+    title = 'Invalid Count Query'
+    message = ("The 'count' query parameter must be a positive, "
+               "non-zero integer.")
+
+
+class PagingInvalid(_ApiError):
+    api_code = 54
+    status_code = 400
+    title = 'Invalid Paging Query'
+    message = ("Paging request failed as written. One or more of the "
+               "'min', 'max', or 'count' query parameters were invalid or "
+               "out of range.")
+
+
+class InvalidStateAddress(_ApiError):
+    api_code = 62
+    status_code = 400
+    title = 'Invalid State Address'
+    message = ('The state address submitted was invalid. To fetch specific '
+               'state data, you must submit the full 70-character address.')
+
+
+class StatusIdQueryInvalid(_ApiError):
+    api_code = 66
+    status_code = 400
+    title = 'Id Query Invalid or Missing'
+    message = ("Requests for batch statuses sent as a GET request must have "
+               "an 'id' query parameter with a comma seperated list of "
+               "at least one batch id.")
+
+
+class BlockNotFound(_ApiError):
+    api_code = 70
+    status_code = 404
+    title = 'Block Not Found'
+    message = ('There is no block with the id specified in the blockchain.')
+
+
+class BatchNotFound(_ApiError):
+    api_code = 71
+    status_code = 404
+    title = 'Batch Not Found'
+    message = ('There is no batch with the id specified in the blockchain.')
+
+
+class TransactionNotFound(_ApiError):
+    api_code = 72
+    status_code = 404
+    title = 'Transaction Not Found'
+    message = ('There is no transaction with the id specified in the '
+               'blockchain.')
+
+
+class StateNotFound(_ApiError):
+    api_code = 75
+    status_code = 404
+    title = 'State Not Found'
+    message = ('There is no state data at the address specified.')

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -92,6 +92,14 @@ class ValidatorDisconnected(_ApiError):
                'Try your request again later.')
 
 
+class ResourceHeaderInvalid(_ApiError):
+    api_code = 21
+    status_code = 500
+    title = 'Invalid Resource Header'
+    message = ('The resource fetched from the validator had an invalid '
+               'header, and may be corrupted.')
+
+
 class StatusResponseMissing(_ApiError):
     api_code = 27
     status_code = 500

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -510,19 +510,19 @@ responses:
   400BadRequest:
     description: Request was malformed
     schema:
-      $ref: "#/definitions/ErrorList"
+      $ref: "#/definitions/Error"
   404NotFound:
-    description: Address, prefix, or root did not match any resource
+    description: Address or id did not match any resource
     schema:
-      $ref: "#/definitions/ErrorList"
+      $ref: "#/definitions/Error"
   500ServerError:
-    description: Something went wrong with the server
+    description: Something went wrong within the validator
     schema:
-      $ref: "#/definitions/ErrorList"
+      $ref: "#/definitions/Error"
   503ServiceUnavailable:
     description: API is unable to reach the validator
     schema:
-      $ref: "#/definitions/ErrorList"
+      $ref: "#/definitions/Error"
 
 parameters:
   address:
@@ -616,20 +616,17 @@ definitions:
 
   Error:
     properties:
-      message:
-        type: string
-        example: Batch failed signature validation
       code:
         type: integer
         example: 34
-      data:
-        type: object
-  ErrorList:
-    properties:
-      errors:
-        type: array
-        items:
-          $ref: "#/definitions/Error"
+      title:
+          type: string
+          example: No Batches Submitted
+      message:
+        type: string
+        example: >
+          The protobuf BatchList you submitted was empty and contained no
+          Batches. You must submit at least one Batch.
 
   BatchStatuses:
     properties:

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -617,14 +617,18 @@ class RouteHandler(object):
         return cls._parse_header(TransactionHeader, transaction)
 
     @classmethod
-    def _parse_header(cls, header_proto, obj):
-        """Deserializes a base64 encoded Protobuf header.
+    def _parse_header(cls, header_proto, resource):
+        """Deserializes a resource's base64 encoded Protobuf header.
         """
         header = header_proto()
-        header_bytes = base64.b64decode(obj['header'])
-        header.ParseFromString(header_bytes)
-        obj['header'] = cls.message_to_dict(header)
-        return obj
+        try:
+            header_bytes = base64.b64decode(resource['header'])
+            header.ParseFromString(header_bytes)
+        except (KeyError, TypeError, ValueError, DecodeError):
+            raise errors.ResourceHeaderInvalid()
+
+        resource['header'] = cls.message_to_dict(header)
+        return resource
 
     @staticmethod
     def _get_paging_controls(request):

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -191,7 +191,7 @@ class BaseApiTest(AioHTTPTestCase):
             data=batch_bytes,
             headers={'content-type': 'application/octet-stream'})
 
-    async def get_and_assert_status(self, endpoint, status):
+    async def get_assert_status(self, endpoint, status):
         """GETs from endpoint, asserts an HTTP status, returns parsed response
         """
         request = await self.client.get(endpoint)
@@ -202,26 +202,6 @@ class BaseApiTest(AioHTTPTestCase):
         """GETs from endpoint, asserts a 200 status, returns a parsed response
         """
         return await self.get_assert_status(endpoint, 200)
-
-    async def assert_400(self, endpoint):
-        """GETs from an endpoint, and asserts a 400 HTTP status
-        """
-        await self.get_and_assert_status(endpoint, 400)
-
-    async def assert_404(self, endpoint):
-        """GETs from an endpoint, and asserts a 404 HTTP status
-        """
-        await self.get_and_assert_status(endpoint, 404)
-
-    async def assert_500(self, endpoint):
-        """GETs from an endpoint, and asserts a 500 HTTP status
-        """
-        await self.get_and_assert_status(endpoint, 500)
-
-    async def assert_503(self, endpoint):
-        """GETs from an endpoint, and asserts a 503 HTTP status
-        """
-        await self.get_and_assert_status(endpoint, 503)
 
     def assert_all_instances(self, items, cls):
         """Asserts that all items in a collection are instances of a class
@@ -273,6 +253,20 @@ class BaseApiTest(AioHTTPTestCase):
             self.assert_valid_url(js_paging['previous'], previous_link)
         else:
             self.assertNotIn('previous', js_paging)
+
+    def assert_has_valid_error(self, response, expected_code):
+        """Asserts a response has only an error dict with an expected code
+        """
+        self.assertIn('error', response)
+        self.assertEqual(1, len(response))
+
+        error = response['error']
+        self.assertIn('code', error)
+        self.assertEqual(error['code'], expected_code)
+        self.assertIn('title', error)
+        self.assertIsInstance(error['title'], str)
+        self.assertIn('message', error)
+        self.assertIsInstance(error['message'], str)
 
     def assert_has_valid_data_list(self, response, expected_length):
         """Asserts a response has a data list of dicts of an expected length.

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -192,17 +192,16 @@ class BaseApiTest(AioHTTPTestCase):
             headers={'content-type': 'application/octet-stream'})
 
     async def get_and_assert_status(self, endpoint, status):
-        """GETs from an endpoint and asserts the HTTP status is as expected
+        """GETs from endpoint, asserts an HTTP status, returns parsed response
         """
         request = await self.client.get(endpoint)
         self.assertEqual(status, request.status)
-        return request
+        return await request.json()
 
-    async def get_json_assert_200(self, endpoint):
+    async def get_assert_200(self, endpoint):
         """GETs from endpoint, asserts a 200 status, returns a parsed response
         """
-        request = await self.get_and_assert_status(endpoint, 200)
-        return await request.json()
+        return await self.get_assert_status(endpoint, 200)
 
     async def assert_400(self, endpoint):
         """GETs from an endpoint, and asserts a 400 HTTP status

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -54,7 +54,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('2', '1', '0')
         self.stream.preset_response(head_id='2', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches')
+        response = await self.get_assert_200('/batches')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -115,7 +115,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('1', '0')
         self.stream.preset_response(head_id='1', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?head=1')
+        response = await self.get_assert_200('/batches?head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(head_id='1', paging=controls)
 
@@ -163,7 +163,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('0', '2')
         self.stream.preset_response(head_id='2', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?id=0,2')
+        response = await self.get_assert_200('/batches?id=0,2')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(batch_ids=['0', '2'], paging=controls)
 
@@ -193,7 +193,7 @@ class BatchListTests(BaseApiTest):
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
-        response = await self.get_json_assert_200('/batches?id=bad,notgood')
+        response = await self.get_assert_200('/batches?id=bad,notgood')
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/batches?head=2&id=bad,notgood')
@@ -226,7 +226,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('0')
         self.stream.preset_response(head_id='1', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?id=0&head=1')
+        response = await self.get_assert_200('/batches?id=0&head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(
             head_id='1',
@@ -263,7 +263,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('c')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?min=1&count=1')
+        response = await self.get_assert_200('/batches?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -321,7 +321,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('d', 'c')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?count=2')
+        response = await self.get_assert_200('/batches?count=2')
         controls = Mocks.make_paging_controls(2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -356,7 +356,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('b', 'a')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?min=2')
+        response = await self.get_assert_200('/batches?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -394,7 +394,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('c', 'b', 'a')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?min=c&count=5')
+        response = await self.get_assert_200('/batches?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -433,7 +433,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('c', 'b')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?max=b&count=2')
+        response = await self.get_assert_200('/batches?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -469,7 +469,7 @@ class BatchListTests(BaseApiTest):
         batches = Mocks.make_batches('d', 'c', 'b')
         self.stream.preset_response(head_id='d', paging=paging, batches=batches)
 
-        response = await self.get_json_assert_200('/batches?max=2&count=7')
+        response = await self.get_assert_200('/batches?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -510,7 +510,7 @@ class BatchGetTests(BaseApiTest):
         """
         self.stream.preset_response(batch=Mocks.make_batches('1')[0])
 
-        response = await self.get_json_assert_200('/batches/1')
+        response = await self.get_assert_200('/batches/1')
         self.stream.assert_valid_request_sent(batch_id='1')
 
         self.assertNotIn('head', response)

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -73,9 +73,12 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/batches')
+        response = await self.get_assert_status('/batches', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_batch_list_with_no_genesis(self):
@@ -86,9 +89,12 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 503
+            - an error property with a code of 15
         """
         self.stream.preset_response(self.status.NOT_READY)
-        await self.assert_503('/batches')
+        response = await self.get_assert_status('/batches', 503)
+
+        self.assert_has_valid_error(response, 15)
 
     @unittest_run_loop
     async def test_batch_list_with_head(self):
@@ -134,9 +140,12 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 50
         """
         self.stream.preset_response(self.status.NO_ROOT)
-        await self.assert_404('/batches?head=bad')
+        response = await self.get_assert_status('/batches?head=bad', 404)
+
+        self.assert_has_valid_error(response, 50)
 
     @unittest_run_loop
     async def test_batch_list_with_ids(self):
@@ -281,8 +290,11 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 53
         """
-        await self.assert_400('/batches?min=2&count=0')
+        response = await self.get_assert_status('/batches?min=2&count=0', 400)
+
+        self.assert_has_valid_error(response, 53)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_paging(self):
@@ -293,9 +305,12 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 54
         """
         self.stream.preset_response(self.status.INVALID_PAGING)
-        await self.assert_400('/batches?min=-1')
+        response = await self.get_assert_status('/batches?min=-1', 400)
+
+        self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
     async def test_batch_list_paginated_with_just_count(self):
@@ -527,9 +542,12 @@ class BatchGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/batches/1')
+        response = await self.get_assert_status('/batches/1', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_batch_get_with_bad_id(self):
@@ -540,6 +558,9 @@ class BatchGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 71
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/batches/bad')
+        response = await self.get_assert_status('/batches/bad', 404)
+
+        self.assert_has_valid_error(response, 71)

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -54,7 +54,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('2', '1', '0')
         self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks')
+        response = await self.get_assert_200('/blocks')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -115,7 +115,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('1', '0')
         self.stream.preset_response(head_id='1', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?head=1')
+        response = await self.get_assert_200('/blocks?head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(head_id='1', paging=controls)
 
@@ -163,7 +163,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('0', '2')
         self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?id=0,2')
+        response = await self.get_assert_200('/blocks?id=0,2')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(block_ids=['0', '2'], paging=controls)
 
@@ -193,7 +193,7 @@ class BlockListTests(BaseApiTest):
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
-        response = await self.get_json_assert_200('/blocks?id=bad,notgood')
+        response = await self.get_assert_200('/blocks?id=bad,notgood')
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/blocks?head=2&id=bad,notgood')
@@ -226,7 +226,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('0')
         self.stream.preset_response(head_id='1', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?id=0&head=1')
+        response = await self.get_assert_200('/blocks?id=0&head=1')
         self.stream.assert_valid_request_sent(
             head_id='1',
             block_ids=['0'],
@@ -262,7 +262,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('c')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?min=1&count=1')
+        response = await self.get_assert_200('/blocks?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -320,7 +320,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('d', 'c')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?count=2')
+        response = await self.get_assert_200('/blocks?count=2')
         controls = Mocks.make_paging_controls(2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -355,7 +355,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('b', 'a')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?min=2')
+        response = await self.get_assert_200('/blocks?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -393,7 +393,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('c', 'b', 'a')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?min=c&count=5')
+        response = await self.get_assert_200('/blocks?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -432,7 +432,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('c', 'b')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?max=b&count=2')
+        response = await self.get_assert_200('/blocks?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -468,7 +468,7 @@ class BlockListTests(BaseApiTest):
         blocks = Mocks.make_blocks('d', 'c', 'b')
         self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
 
-        response = await self.get_json_assert_200('/blocks?max=2&count=7')
+        response = await self.get_assert_200('/blocks?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -509,7 +509,7 @@ class BlockGetTests(BaseApiTest):
         """
         self.stream.preset_response(block=Mocks.make_blocks('1')[0])
 
-        response = await self.get_json_assert_200('/blocks/1')
+        response = await self.get_assert_200('/blocks/1')
         self.stream.assert_valid_request_sent(block_id='1')
 
         self.assertNotIn('head', response)

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -73,9 +73,12 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/blocks')
+        response = await self.get_assert_status('/blocks', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_block_list_with_no_genesis(self):
@@ -86,9 +89,12 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 503
+            - an error property with a code of 15
         """
         self.stream.preset_response(self.status.NOT_READY)
-        await self.assert_503('/blocks')
+        response = await self.get_assert_status('/blocks', 503)
+
+        self.assert_has_valid_error(response, 15)
 
     @unittest_run_loop
     async def test_block_list_with_head(self):
@@ -134,9 +140,12 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 404
+            - an error property with a code of 50
         """
         self.stream.preset_response(self.status.NO_ROOT)
-        await self.assert_404('/blocks?head=bad')
+        response = await self.get_assert_status('/blocks?head=bad', 404)
+
+        self.assert_has_valid_error(response, 50)
 
     @unittest_run_loop
     async def test_block_list_with_ids(self):
@@ -280,8 +289,11 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 53
         """
-        await self.assert_400('/blocks?min=2&count=0')
+        response = await self.get_assert_status('/blocks?min=2&count=0', 400)
+
+        self.assert_has_valid_error(response, 53)
 
     @unittest_run_loop
     async def test_block_list_with_bad_paging(self):
@@ -292,9 +304,13 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 54
         """
         self.stream.preset_response(self.status.INVALID_PAGING)
-        await self.assert_400('/blocks?min=-1')
+        response = await self.get_assert_status('/blocks?min=-1', 400)
+
+        self.assert_has_valid_error(response, 54)
+
 
     @unittest_run_loop
     async def test_block_list_paginated_with_just_count(self):
@@ -526,9 +542,12 @@ class BlockGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/blocks/1')
+        response = await self.get_assert_status('/blocks/1', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_block_get_with_bad_id(self):
@@ -539,6 +558,9 @@ class BlockGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 70
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/blocks/bad')
+        response = await self.get_assert_status('/blocks/bad', 404)
+
+        self.assert_has_valid_error(response, 70)

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -77,9 +77,12 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/state')
+        response = await self.get_assert_status('/state', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_state_list_with_no_genesis(self):
@@ -90,9 +93,12 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 503
+            - an error property with a code of 15
         """
         self.stream.preset_response(self.status.NOT_READY)
-        await self.assert_503('/state')
+        response = await self.get_assert_status('/state', 503)
+
+        self.assert_has_valid_error(response, 15)
 
     @unittest_run_loop
     async def test_state_list_with_head(self):
@@ -140,9 +146,12 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 50
         """
         self.stream.preset_response(self.status.NO_ROOT)
-        await self.assert_404('/state?head=bad')
+        response = await self.get_assert_status('/state?head=bad', 404)
+
+        self.assert_has_valid_error(response, 50)
 
     @unittest_run_loop
     async def test_state_list_with_address(self):
@@ -286,8 +295,11 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 53
         """
-        await self.assert_400('/state?min=2&count=0')
+        response = await self.get_assert_status('/state?min=2&count=0', 400)
+
+        self.assert_has_valid_error(response, 53)
 
     @unittest_run_loop
     async def test_state_list_with_bad_paging(self):
@@ -298,9 +310,12 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 54
         """
         self.stream.preset_response(self.status.INVALID_PAGING)
-        await self.assert_400('/state?min=-1')
+        response = await self.get_assert_status('/state?min=-1', 400)
+
+        self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
     async def test_state_list_paginated_with_just_count(self):
@@ -536,9 +551,12 @@ class StateGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/state/a')
+        response = await self.get_assert_status('/state/a', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_state_get_with_no_genesis(self):
@@ -549,9 +567,12 @@ class StateGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 503
+            - an error property with a code of 15
         """
         self.stream.preset_response(self.status.NOT_READY)
-        await self.assert_503('/state/a')
+        response = await self.get_assert_status('/state/a', 503)
+
+        self.assert_has_valid_error(response, 15)
 
     @unittest_run_loop
     async def test_state_get_with_bad_address(self):
@@ -562,9 +583,12 @@ class StateGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 75
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/state/bad')
+        response = await self.get_assert_status('/state/bad', 404)
+
+        self.assert_has_valid_error(response, 75)
 
     @unittest_run_loop
     async def test_state_get_with_head(self):
@@ -606,6 +630,9 @@ class StateGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 50
         """
         self.stream.preset_response(self.status.NO_ROOT)
-        await self.assert_404('/state/c?head=bad')
+        response = await self.get_assert_status('/state/b?head=bad', 404)
+
+        self.assert_has_valid_error(response, 50)

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -58,7 +58,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(a=b'3', b=b'5', c=b'7')
         self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state')
+        response = await self.get_assert_200('/state')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -121,7 +121,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(a=b'2', b=b'4')
         self.stream.preset_response(head_id='1', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?head=1')
+        response = await self.get_assert_200('/state?head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(head_id='1', paging=controls)
 
@@ -169,7 +169,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(c=b'7')
         self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?address=c')
+        response = await self.get_assert_200('/state?address=c')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(address='c', paging=controls)
 
@@ -199,7 +199,7 @@ class StateListTests(BaseApiTest):
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
-        response = await self.get_json_assert_200('/state?address=bad')
+        response = await self.get_assert_200('/state?address=bad')
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/state?head=2&address=bad')
@@ -232,7 +232,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(a=b'2')
         self.stream.preset_response(head_id='1', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?address=a&head=1')
+        response = await self.get_assert_200('/state?address=a&head=1')
         self.stream.assert_valid_request_sent(
             head_id='1',
             address='a',
@@ -268,7 +268,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(c=b'3')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?min=1&count=1')
+        response = await self.get_assert_200('/state?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -326,7 +326,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(d=b'4', c=b'3')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?count=2')
+        response = await self.get_assert_200('/state?count=2')
         controls = Mocks.make_paging_controls(2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -361,7 +361,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(b=b'2', a=b'1')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?min=2')
+        response = await self.get_assert_200('/state?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -399,7 +399,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(c=b'3', b=b'2', a=b'1')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?min=c&count=5')
+        response = await self.get_assert_200('/state?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -438,7 +438,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(c=b'3', b=b'2')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?max=b&count=2')
+        response = await self.get_assert_200('/state?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -474,7 +474,7 @@ class StateListTests(BaseApiTest):
         leaves = Mocks.make_leaves(d=b'4', c=b'3', b=b'2')
         self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
 
-        response = await self.get_json_assert_200('/state?max=2&count=7')
+        response = await self.get_assert_200('/state?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -516,7 +516,7 @@ class StateGetTests(BaseApiTest):
         """
         self.stream.preset_response(head_id='2', value=b'3')
 
-        response = await self.get_json_assert_200('/state/a')
+        response = await self.get_assert_200('/state/a')
         self.stream.assert_valid_request_sent(address='a')
 
         self.assert_has_valid_head(response, '2')
@@ -586,7 +586,7 @@ class StateGetTests(BaseApiTest):
         """
         self.stream.preset_response(head_id='1', value=b'4')
 
-        response = await self.get_json_assert_200('/state/b?head=1')
+        response = await self.get_assert_200('/state/b?head=1')
         self.stream.assert_valid_request_sent(head_id='1', address='b')
 
         self.assert_has_valid_head(response, '1')

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -232,7 +232,7 @@ class BatchStatusTests(BaseApiTest):
         statuses = {'pending': self.status.PENDING}
         self.stream.preset_response(batch_statuses=statuses)
 
-        response = await self.get_json_assert_200('/batch_status?id=pending')
+        response = await self.get_assert_200('/batch_status?id=pending')
         self.stream.assert_valid_request_sent(batch_ids=['pending'])
 
         self.assert_has_valid_link(response, '/batch_status?id=pending')
@@ -284,8 +284,7 @@ class BatchStatusTests(BaseApiTest):
         statuses = {'pending': self.status.COMMITTED}
         self.stream.preset_response(batch_statuses=statuses)
 
-        response = await self.get_json_assert_200(
-            '/batch_status?id=pending&wait')
+        response = await self.get_assert_200('/batch_status?id=pending&wait')
         self.stream.assert_valid_request_sent(
             batch_ids=['pending'],
             wait_for_commit=True,
@@ -318,7 +317,7 @@ class BatchStatusTests(BaseApiTest):
             'bad': self.status.UNKNOWN}
         self.stream.preset_response(batch_statuses=statuses)
 
-        response = await self.get_json_assert_200(
+        response = await self.get_assert_200(
             '/batch_status?id=committed,unknown,bad')
         self.stream.assert_valid_request_sent(
             batch_ids=['committed', 'unknown', 'bad'])

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -57,7 +57,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('2', '1', '0'))
 
-        response = await self.get_json_assert_200('/transactions')
+        response = await self.get_assert_200('/transactions')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -120,7 +120,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('1', '0'))
 
-        response = await self.get_json_assert_200('/transactions?head=1')
+        response = await self.get_assert_200('/transactions?head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(head_id='1', paging=controls)
 
@@ -168,7 +168,7 @@ class TransactionListTests(BaseApiTest):
         transactions = Mocks.make_txns('0', '2')
         self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
 
-        response = await self.get_json_assert_200('/transactions?id=0,2')
+        response = await self.get_assert_200('/transactions?id=0,2')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(transaction_ids=['0', '2'], paging=controls)
 
@@ -198,7 +198,7 @@ class TransactionListTests(BaseApiTest):
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
-        response = await self.get_json_assert_200('/transactions?id=bad,notgood')
+        response = await self.get_assert_200('/transactions?id=bad,notgood')
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/transactions?head=2&id=bad,notgood')
@@ -233,7 +233,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('0'))
 
-        response = await self.get_json_assert_200('/transactions?id=0&head=1')
+        response = await self.get_assert_200('/transactions?id=0&head=1')
         controls = Mocks.make_paging_controls()
         self.stream.assert_valid_request_sent(
             head_id='1',
@@ -272,7 +272,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('c'))
 
-        response = await self.get_json_assert_200('/transactions?min=1&count=1')
+        response = await self.get_assert_200('/transactions?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -332,7 +332,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('d', 'c'))
 
-        response = await self.get_json_assert_200('/transactions?count=2')
+        response = await self.get_assert_200('/transactions?count=2')
         controls = Mocks.make_paging_controls(2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -369,7 +369,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('b', 'a'))
 
-        response = await self.get_json_assert_200('/transactions?min=2')
+        response = await self.get_assert_200('/transactions?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -409,7 +409,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('c', 'b', 'a'))
 
-        response = await self.get_json_assert_200('/transactions?min=c&count=5')
+        response = await self.get_assert_200('/transactions?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -450,7 +450,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('c', 'b'))
 
-        response = await self.get_json_assert_200('/transactions?max=b&count=2')
+        response = await self.get_assert_200('/transactions?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -488,7 +488,7 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns('d', 'c', 'b'))
 
-        response = await self.get_json_assert_200('/transactions?max=2&count=7')
+        response = await self.get_assert_200('/transactions?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.stream.assert_valid_request_sent(paging=controls)
 
@@ -532,7 +532,7 @@ class TransactionGetTests(BaseApiTest):
         """
         self.stream.preset_response(transaction=Mocks.make_txns('1')[0])
 
-        response = await self.get_json_assert_200('/transactions/1')
+        response = await self.get_assert_200('/transactions/1')
         self.stream.assert_valid_request_sent(transaction_id='1')
 
         self.assertNotIn('head', response)

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -76,9 +76,12 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/transactions')
+        response = await self.get_assert_status('/transactions', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_txn_list_with_no_genesis(self):
@@ -89,9 +92,12 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 503
+            - an error property with a code of 15
         """
         self.stream.preset_response(self.status.NOT_READY)
-        await self.assert_503('/transactions')
+        response = await self.get_assert_status('/transactions', 503)
+
+        self.assert_has_valid_error(response, 15)
 
     @unittest_run_loop
     async def test_txn_list_with_head(self):
@@ -139,9 +145,12 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 50
         """
         self.stream.preset_response(self.status.NO_ROOT)
-        await self.assert_404('/transactions?head=bad')
+        response = await self.get_assert_status('/transactions?head=bad', 404)
+
+        self.assert_has_valid_error(response, 50)
 
     @unittest_run_loop
     async def test_txn_list_with_ids(self):
@@ -290,8 +299,11 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 53
         """
-        await self.assert_400('/transactions?min=2&count=0')
+        response = await self.get_assert_status('/transactions?count=0', 400)
+
+        self.assert_has_valid_error(response, 53)
 
     @unittest_run_loop
     async def test_txn_list_with_bad_paging(self):
@@ -302,9 +314,12 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 400
+            - an error property with a code of 54
         """
         self.stream.preset_response(self.status.INVALID_PAGING)
-        await self.assert_400('/transactions?min=-1')
+        response = await self.get_assert_status('/transactions?min=-1', 400)
+
+        self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
     async def test_txn_list_paginated_with_just_count(self):
@@ -549,9 +564,12 @@ class TransactionGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 500
+            - an error property with a code of 10
         """
         self.stream.preset_response(self.status.INTERNAL_ERROR)
-        await self.assert_500('/transactions/1')
+        response = await self.get_assert_status('/transactions/1', 500)
+
+        self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
     async def test_txn_get_with_bad_id(self):
@@ -562,6 +580,9 @@ class TransactionGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
+            - an error property with a code of 72
         """
         self.stream.preset_response(self.status.NO_RESOURCE)
-        await self.assert_404('/transactions/bad')
+        response = await self.get_assert_status('/transactions/bad', 404)
+
+        self.assert_has_valid_error(response, 72)

--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -216,10 +216,16 @@ class WorkloadGenerator(object):
                 status = list(json_result["data"].values())[0]
                 return status
             else:
-                LOGGER.debug("(%s): %s", code, json_result)
+                if 'error' in json_result:
+                    message = json_result['error']['message']
+                else:
+                    message = json_result
+
+                LOGGER.debug("(%s): %s", code, message)
                 return "UNKNOWN"
         except HTTPError as e:
-            if "The connection to the validator was lost" in str(e.msg):
+            error_code = json.loads(e.file.read().decode())['error']['code']
+            if error_code == 18:
                 self._remove_unresponsive_validator(url)
                 LOGGER.warning("The validator at %s is no longer connected. "
                                "Removing Validator.", url)

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -496,7 +496,7 @@ class StateGetRequest(_ClientRequestHandler):
             return self._status.NO_RESOURCE
         except ValueError:
             LOGGER.debug('Address %s is a nonleaf', request.address)
-            return self._status.MISSING_ADDRESS
+            return self._status.INVALID_ADDRESS
 
         return self._wrap_response(head_id=head_id, value=value)
 


### PR DESCRIPTION
Previously the Rest Api sent back errors which were simple text strings. New errors are a JSON envelope with an `"error"` property that is an object with three properties:
- `"code"`: A fixed integer code specific to the error
- `"title"`: A short headline describing the error
- `"message"`: A longer human readable description of what broke
    
Included in this PR:
- Overhaul in design of Api Errors and Error Traps to facilitate readable definitions
- Existing errors expanded and refactored with codes, titles, and messages
- Route handlers updated to support new errors
- Existing unit tests updated to check for new errors
- New bad header error to handle malformed resource headers from the validator
- Specs/documentation updated
- Small validator bug fix