### PR TITLE
Add Routed Batch and Block Response Handling to the Responder

### DIFF
--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -14,19 +14,28 @@
 # ------------------------------------------------------------------------------
 
 import logging
+import time
+from threading import RLock
 
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf import network_pb2
 from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.protobuf import block_pb2
+from sawtooth_validator.protobuf import batch_pb2
 
 LOGGER = logging.getLogger(__name__)
 
 
 class Responder(object):
-    def __init__(self, completer):
+    def __init__(self, completer, cache_purge_frequency=30):
         self.completer = completer
+        self.pending_requests = TimedCache(cache_purge_frequency)
+        self._cache_purge_frequency = cache_purge_frequency
+        self._purge_time = time.time() + self._cache_purge_frequency
+        self._lock = RLock()
 
     def check_for_block(self, block_id):
         # Ask Completer
@@ -44,6 +53,31 @@ class Responder(object):
         batch = self.completer.get_batch_by_transaction(transaction_id)
         return batch
 
+    def add_request(self, requested_id, connection_id):
+        with self._lock:
+            if requested_id in self.pending_requests:
+                if connection_id not in self.pending_requests[requested_id]:
+                    self.pending_requests[requested_id] += [connection_id]
+
+            else:
+                self.pending_requests[requested_id] = [connection_id]
+
+    def get_request(self, requested_id):
+        with self._lock:
+            return self.pending_requests.get(requested_id)
+
+    def remove_request(self, requested_id):
+        with self._lock:
+            if requested_id in self.pending_requests:
+                del self.pending_requests[requested_id]
+
+    def purge_requests(self):
+        with self._lock:
+            if self._purge_time < time.time():
+                LOGGER.debug("Purge pending_requests of expired entries.")
+                self.pending_requests.purge_expired()
+                self._purge_time = time.time() + self._cache_purge_frequency
+
 
 class BlockResponderHandler(Handler):
     def __init__(self, responder, gossip):
@@ -57,7 +91,9 @@ class BlockResponderHandler(Handler):
         node_id = block_request_message.node_id
         block = self._responder.check_for_block(block_id)
         if block is None:
-            # No block found, broadcast orignal message to other peers
+            # No block found, broadcast original message to other peers
+            # and add to pending requests
+            self._responder.add_request(block_id, connection_id)
             self._gossip.broadcast(block_request_message,
                                    validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
         else:
@@ -75,6 +111,34 @@ class BlockResponderHandler(Handler):
         return HandlerResult(status=HandlerStatus.PASS)
 
 
+class ResponderBlockResponseHandler(Handler):
+    def __init__(self, responder, gossip):
+        self._responder = responder
+        self._gossip = gossip
+
+    def handle(self, connection_id, message_content):
+        block_response = network_pb2.GossipBlockResponse()
+        block_response.ParseFromString(message_content)
+        block = block_pb2.Block()
+        block.ParseFromString(block_response.content)
+        open_request = self._responder.get_request(block.header_signature)
+
+        if open_request is None:
+            return HandlerResult(status=HandlerStatus.PASS)
+
+        for connection_id in open_request:
+            LOGGER.debug("Responding to block request: Send %s to %s",
+                         block.header_signature,
+                         connection_id)
+            self._gossip.send(validator_pb2.Message.GOSSIP_BLOCK_RESPONSE,
+                              message_content,
+                              connection_id)
+
+        self._responder.remove_request(block.header_signature)
+        self._responder.purge_requests()
+        return HandlerResult(status=HandlerStatus.PASS)
+
+
 class BatchByBatchIdResponderHandler(Handler):
     def __init__(self, responder, gossip):
         self._responder = responder
@@ -88,6 +152,10 @@ class BatchByBatchIdResponderHandler(Handler):
         node_id = batch_request_message.node_id
 
         if batch is None:
+            # No batch found, broadcast original message to other peers
+            # and add to pending requests
+            self._responder.add_request(batch_request_message.id,
+                                        connection_id)
             self._gossip.broadcast(
                 batch_request_message,
                 validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
@@ -133,6 +201,8 @@ class BatchByTransactionIdResponderHandler(Handler):
             batch = None
 
         if batches == []:
+            for txn_id in batch_request_message.ids:
+                self._responder.add_request(txn_id, connection_id)
             self._gossip.broadcast(
                 batch_request_message,
                 validator_pb2.Message.
@@ -142,6 +212,8 @@ class BatchByTransactionIdResponderHandler(Handler):
             new_request = network_pb2.GossipBatchByTransactionIdRequest()
             new_request.ids.extend(unfound_txn_ids)
             new_request.node_id = batch_request_message.node_id
+            for txn_id in unfound_txn_ids:
+                self._responder.add_request(txn_id, connection_id)
             self._gossip.broadcast(
                 new_request,
                 validator_pb2.Message.
@@ -160,4 +232,41 @@ class BatchByTransactionIdResponderHandler(Handler):
                                   batch_response.SerializeToString(),
                                   connection_id)
 
+        return HandlerResult(status=HandlerStatus.PASS)
+
+
+class ResponderBatchResponseHandler(Handler):
+    def __init__(self, responder, gossip):
+        self._responder = responder
+        self._gossip = gossip
+
+    def handle(self, connection_id, message_content):
+        batch_response = network_pb2.GossipBatchResponse()
+        batch_response.ParseFromString(message_content)
+        batch = batch_pb2.Batch()
+        batch.ParseFromString(batch_response.content)
+        open_request = self._responder.get_request(batch.header_signature)
+
+        if open_request is None:
+            open_request = []
+
+        requests_to_remove = [batch.header_signature]
+        for txn in batch.transactions:
+            requests_by_txn = self._responder.get_request(txn.header_signature)
+            if requests_by_txn is not None:
+                open_request += requests_by_txn
+                requests_to_remove += [txn.header_signature]
+
+        for connection_id in open_request:
+            LOGGER.debug("Responding to batch requests: Send %s to %s",
+                         batch.header_signature,
+                         connection_id)
+            self._gossip.send(validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
+                              message_content,
+                              connection_id)
+
+        for requested_id in requests_to_remove:
+            self._responder.remove_request(requested_id)
+
+        self._responder.purge_requests()
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -41,7 +41,9 @@ from sawtooth_validator.journal.completer import \
 from sawtooth_validator.journal.completer import Completer
 from sawtooth_validator.journal.responder import Responder
 from sawtooth_validator.journal.responder import BlockResponderHandler
+from sawtooth_validator.journal.responder import ResponderBlockResponseHandler
 from sawtooth_validator.journal.responder import BatchByBatchIdResponderHandler
+from sawtooth_validator.journal.responder import ResponderBatchResponseHandler
 from sawtooth_validator.journal.responder import \
     BatchByTransactionIdResponderHandler
 from sawtooth_validator.networking.dispatch import Dispatcher
@@ -328,6 +330,11 @@ class Validator(object):
             network_thread_pool)
 
         self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_BLOCK_RESPONSE,
+            ResponderBlockResponseHandler(responder, self._gossip),
+            network_thread_pool)
+
+        self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST,
             BatchByBatchIdResponderHandler(responder, self._gossip),
             network_thread_pool)
@@ -354,6 +361,11 @@ class Validator(object):
             validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
             CompleterGossipBatchResponseHandler(
                 completer),
+            network_thread_pool)
+
+        self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
+            ResponderBatchResponseHandler(responder, self._gossip),
             network_thread_pool)
 
         self._dispatcher.add_handler(

--- a/validator/tests/unit3/test_responder/__init__.py
+++ b/validator/tests/unit3/test_responder/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = []

--- a/validator/tests/unit3/test_responder/mock.py
+++ b/validator/tests/unit3/test_responder/mock.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
+
+
+class MockGossip():
+    def __init__(self):
+        self.broadcasted = {}
+        self.sent = {}
+
+    def broadcast(self, message, message_type):
+        if message_type in self.broadcasted:
+            self.broadcasted[message_type] += [message]
+        else:
+            self.broadcasted[message_type] = [message]
+
+    def send(self, message_type, message_data, connection_id):
+        if connection_id in self.sent:
+            self.sent[connection_id] += [(message_type, message_data)]
+        else:
+            self.sent[connection_id] = [(message_type, message_data)]
+
+
+class MockCompleter():
+    def __init__(self):
+        self.store = {}
+
+    def add_block(self, block):
+        self.store[block.header_signature] = BlockWrapper(block)
+
+    def add_batch(self, batch):
+        self.store[batch.header_signature] = batch
+        for txn in batch.transactions:
+            self.store[txn.header_signature] = batch
+
+    def get_chain_head(self):
+        pass
+
+    def get_block(self, block_id):
+        return self.store.get(block_id)
+
+    def get_batch(self, batch_id):
+        return self.store.get(batch_id)
+
+    def get_batch_by_transaction(self, transaction_id):
+        return self.store.get(transaction_id)

--- a/validator/tests/unit3/test_responder/tests.py
+++ b/validator/tests/unit3/test_responder/tests.py
@@ -1,0 +1,336 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from sawtooth_validator.protobuf import network_pb2
+from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.protobuf import block_pb2
+from sawtooth_validator.protobuf import batch_pb2
+from sawtooth_validator.protobuf import transaction_pb2
+from sawtooth_validator.journal.responder import Responder
+from sawtooth_validator.journal.responder import BlockResponderHandler
+from sawtooth_validator.journal.responder import BatchByBatchIdResponderHandler
+from sawtooth_validator.journal.responder import \
+    BatchByTransactionIdResponderHandler
+from sawtooth_validator.journal.responder import ResponderBlockResponseHandler
+from sawtooth_validator.journal.responder import ResponderBatchResponseHandler
+from test_responder.mock import MockGossip
+from test_responder.mock import MockCompleter
+
+
+class TestResponder(unittest.TestCase):
+    def setUp(self):
+        self.gossip = MockGossip()
+        self.completer = MockCompleter()
+        self.responder = Responder(self.completer)
+        self.block_request_handler = \
+            BlockResponderHandler(self.responder, self.gossip)
+        self.block_response_handler = \
+            ResponderBlockResponseHandler(self.responder, self.gossip)
+        self.batch_request_handler = \
+            BatchByBatchIdResponderHandler(self.responder, self.gossip)
+        self.batch_response_handler = \
+            ResponderBatchResponseHandler(self.responder, self.gossip)
+        self.batch_by_txn_request_handler = \
+            BatchByTransactionIdResponderHandler(self.responder, self.gossip)
+
+    # Tests
+    def test_block_responder_handler(self):
+        """
+        Test that the BlockResponderHandler correctly broadcasts a received
+        request that the Responder cannot respond to, or sends a
+        GossipBlockResponse back to the connection_id the handler received
+        the request from.
+        """
+        # The completer does not have the requested block
+        message = network_pb2.GossipBlockRequest(block_id="ABC", node_id=b"1")
+        self.block_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+        # If we cannot respond to the request, broadcast the block request
+        # and add to pending request
+        self.assert_message_was_broadcasted(
+            message, validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
+
+        self.assert_request_pending(
+            requested_id="ABC", connection_id="Connection_1")
+        self.assert_message_not_sent(connection_id="Connection_1")
+
+        # Add the block to the completer and resend the Block Request
+        block = block_pb2.Block(header_signature="ABC")
+        self.completer.add_block(block)
+        self.block_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+
+        # Check that the a Block Response was sent back to "Connection_1"
+        self.assert_message_sent(
+            connection_id="Connection_1",
+            message_type=validator_pb2.Message.GOSSIP_BLOCK_RESPONSE
+            )
+
+    def test_responder_block_response_handler(self):
+        """
+        Test that the ResponderBlockResponseHandler, after receiving a Block
+        Response, checks to see if the responder has any pending request for
+        that response and forwards the response on to the connection_id that
+        had requested it.
+        """
+        # The Responder does not have any pending requests for block "ABC"
+        block = block_pb2.Block(header_signature="ABC")
+        response_message = network_pb2.GossipBlockResponse(
+            content=block.SerializeToString(), node_id=b"1")
+
+        self.block_response_handler.handle(
+            "Connection_1", response_message.SerializeToString())
+
+        # ResponderBlockResponseHandler should not send any messages.
+        self.assert_message_not_sent("Connection_1")
+        self.assert_request_not_pending(requested_id="ABC")
+
+        # Handle a request message for block "ABC". This adds it to the pending
+        # request queue.
+        request_message = \
+            network_pb2.GossipBlockRequest(block_id="ABC", node_id=b"1")
+
+        self.block_request_handler.handle(
+            "Connection_2", request_message.SerializeToString())
+
+        self.assert_request_pending(
+            requested_id="ABC", connection_id="Connection_2")
+
+        # Handle the the BlockResponse Message. Since Connection_2 had
+        # requested the block but it could not be fulfilled at that time of the
+        # request the received BlockResponse is forwarded to Connection_2
+        self.block_response_handler.handle(
+            "Connection_1", response_message.SerializeToString())
+
+        self.assert_message_sent(
+            connection_id="Connection_2",
+            message_type=validator_pb2.Message.GOSSIP_BLOCK_RESPONSE
+            )
+        # The request for block "ABC" from "Connection_2" is no longer pending
+        # it should be removed from the pending request cache.
+        self.assert_request_not_pending(requested_id="ABC")
+
+    def test_batch_by_id_responder_handler(self):
+        """
+        Test that the BatchByBatchIdResponderHandler correctly broadcasts a
+        received request that the Responder cannot respond to, or sends a
+        GossipBatchResponse back to the connection_id the handler received
+        the request from.
+        """
+        # The completer does not have the requested batch
+        message = network_pb2.GossipBatchByBatchIdRequest(
+            id="abc", node_id=b"1")
+        self.batch_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+        # If we cannot respond to the request broadcast batch request and add
+        # to pending request
+        self.assert_message_was_broadcasted(
+            message, validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
+        self.assert_request_pending(
+            requested_id="abc", connection_id="Connection_1")
+        self.assert_message_not_sent(connection_id="Connection_1")
+
+        # Add the batch to the completer and resend the BatchByBatchIdRequest
+        batch = batch_pb2.Batch(header_signature="abc")
+        self.completer.add_batch(batch)
+        self.batch_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+
+        # Check that the a Batch Response was sent back to "Connection_1"
+        self.assert_message_sent(
+            connection_id="Connection_1",
+            message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
+            )
+
+    def test_batch_by_transaction_id_response_handler(self):
+        """
+        Test that the BatchByTransactionIdResponderHandler correctly broadcasts
+        a received request that the Responder cannot respond to, or sends a
+        GossipBatchResponse back to the connection_id the handler received
+        the request from.
+        """
+        # The completer does not have the requested batch with the transaction
+        message = network_pb2.GossipBatchByTransactionIdRequest(
+            ids=["123"], node_id=b"1")
+        self.batch_by_txn_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+
+        # If we cannot respond to the request, broadcast batch request and add
+        # to pending request
+        self.assert_message_was_broadcasted(
+            message,
+            validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST
+            )
+        self.assert_request_pending(
+            requested_id="123", connection_id="Connection_1")
+        self.assert_message_not_sent(connection_id="Connection_1")
+
+        # Add the batch to the completer and resend the
+        # BatchByTransactionIdRequest
+        transaction = transaction_pb2.Transaction(header_signature="123")
+        batch = batch_pb2.Batch(
+            header_signature="abc", transactions=[transaction])
+        self.completer.add_batch(batch)
+        self.batch_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+
+        # Check that the a Batch Response was sent back to "Connection_1"
+        self.assert_message_sent(
+            connection_id="Connection_1",
+            message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
+            )
+
+    def test_batch_by_transaction_id_multiple_txn_ids(self):
+        """
+        Test that the BatchByTransactionIdResponderHandler correctly broadcasts
+        a new request with only the transaction_ids that the Responder cannot
+        respond to, and sends a GossipBatchResponse for the transactions_id
+        requests that can be satisfied.
+        """
+        # Add batch that has txn 123
+        transaction = transaction_pb2.Transaction(header_signature="123")
+        batch = batch_pb2.Batch(
+            header_signature="abc", transactions=[transaction])
+        self.completer.add_batch(batch)
+        # Request transactions 123 and 456
+        message = network_pb2.GossipBatchByTransactionIdRequest(
+            ids=["123", "456"], node_id=b"1")
+        self.batch_by_txn_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+        self.batch_request_handler.handle(
+            "Connection_1", message.SerializeToString())
+
+        # Respond with a BatchResponse for transaction 123
+        self.assert_message_sent(
+            connection_id="Connection_1",
+            message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
+            )
+
+        # Broadcast a BatchByTransactionIdRequest for just 456
+        request_message = \
+            network_pb2.GossipBatchByTransactionIdRequest(
+                ids=["456"], node_id=b"1")
+        self.assert_message_was_broadcasted(
+            request_message,
+            validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST)
+
+        # And set a pending request for 456
+        self.assert_request_pending(
+            requested_id="456", connection_id="Connection_1")
+
+    def test_responder_batch_response_handler(self):
+        """
+        Test that the ResponderBatchResponseHandler, after receiving a Batch
+        Response, checks to see if the responder has any pending request for
+        that batch and forwards the response on to the connection_id that
+        had requested it.
+        """
+        # The Responder does not have any pending requests for block "ABC"
+        batch = batch_pb2.Batch(header_signature="abc")
+
+        response_message = network_pb2.GossipBatchResponse(
+            content=batch.SerializeToString(), node_id=b"1")
+
+        self.batch_response_handler.handle(
+            "Connection_1", response_message.SerializeToString())
+
+        # ResponderBlockResponseHandler should not send any messages.
+        self.assert_message_not_sent("Connection_1")
+        self.assert_request_not_pending(requested_id="abc")
+
+        # Handle a request message for batch "abc". This adds it to the pending
+        # request queue.
+        request_message = \
+            network_pb2.GossipBatchByBatchIdRequest(id="abc", node_id=b"1")
+
+        self.batch_request_handler.handle(
+            "Connection_2", request_message.SerializeToString())
+
+        self.assert_request_pending(
+            requested_id="abc", connection_id="Connection_2")
+
+        # Handle the the BatchResponse Message. Since Connection_2 had
+        # requested the batch but it could not be fulfilled at that time of the
+        # request the received BatchResponse is forwarded to Connection_2
+        self.batch_response_handler.handle(
+            "Connection_1", response_message.SerializeToString())
+
+        self.assert_message_sent(
+            connection_id="Connection_2",
+            message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
+            )
+        # The request for batch "abc" from "Connection_2" is no longer pending
+        # it should be removed from the pending request cache.
+        self.assert_request_not_pending(requested_id="abc")
+
+    def test_responder_batch_response_txn_handler(self):
+        """
+        Test that the ResponderBatchResponseHandler, after receiving a Batch
+        Response, checks to see if the responder has any pending request for
+        that transactions in the batch and forwards the response on to the
+        connection_id that had them.
+        """
+        transaction = transaction_pb2.Transaction(header_signature="123")
+        batch = batch_pb2.Batch(
+            header_signature="abc", transactions=[transaction])
+
+        response_message = network_pb2.GossipBatchResponse(
+            content=batch.SerializeToString(), node_id=b"1")
+
+        request_message = \
+            network_pb2.GossipBatchByTransactionIdRequest(
+                ids=["123"], node_id=b"1")
+
+        # Send BatchByTransaciontIdRequest for txn "123" and add it to the
+        # pending request cache
+        self.batch_request_handler.handle(
+            "Connection_2", request_message.SerializeToString())
+
+        self.assert_request_pending(
+            requested_id="123", connection_id="Connection_2")
+
+        # Send Batch Response that contains the batch that has txn "123"
+        self.batch_response_handler.handle(
+            "Connection_1", response_message.SerializeToString())
+
+        # Handle the the BatchResponse Message. Since Connection_2 had
+        # requested the txn_id in the batch but it could not be fulfilled at
+        # that time of the request the received BatchResponse is forwarded to
+        # Connection_2
+        self.assert_message_sent(
+            connection_id="Connection_2",
+            message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
+            )
+        # The request for transaction_id "123" from "Connection_2" is no
+        # longer pending it should be removed from the pending request cache.
+        self.assert_request_not_pending(requested_id="123")
+
+    # assertions
+    def assert_message_was_broadcasted(self, message, message_type):
+        self.assertIn(message, self.gossip.broadcasted[message_type])
+
+    def assert_message_not_sent(self, connection_id):
+        self.assertIsNone(self.gossip.sent.get(connection_id))
+
+    def assert_message_sent(self, connection_id, message_type):
+        self.assertIsNotNone(self.gossip.sent.get(connection_id))
+        self.assertTrue(self.gossip.sent.get(connection_id)[0][0] == \
+            message_type)
+
+    def assert_request_pending(self, requested_id, connection_id):
+        self.assertIn(connection_id, self.responder.get_request(requested_id))
+
+    def assert_request_not_pending(self, requested_id):
+        self.assertIsNone(self.responder.get_request(requested_id))


### PR DESCRIPTION
The Responder will keep track of received requests that it could not fulfill. When it receives a response to the broadcasted request message, it will send the message back to the  originally requester. This is done using a TimedCache to store the requests, and two new handlers.

For example:
A broadcasts a  request to B
B cannot fulfill the request so B broadcast the request to C
C can fulfill the request and send a Response to B
B receives the response and sends it to A 

This PR also adds Responder unit tests for the above expected behavior.