### PR TITLE
Compute Local Mean in Consensus State and More Refactoring Goodness

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -342,7 +342,7 @@ class ConsensusState(object):
         # configuration view, we know now many blocks to get.
         number_of_blocks = \
             self.total_block_claim_count - \
-            poet_config_view.fixed_duration_block_count
+            poet_config_view.population_estimate_sample_size
         with ConsensusState._population_estimate_cache_lock:
             for _ in range(number_of_blocks):
                 population_cache_entry = \
@@ -619,7 +619,7 @@ class ConsensusState(object):
         # mean is calculated as a fixed ratio of the target to initial wait),
         # simply short-circuit the test an allow the block to be claimed.
         if self.total_block_claim_count < \
-                poet_config_view.fixed_duration_block_count:
+                poet_config_view.population_estimate_sample_size:
             return False
 
         # Build up the population estimate list for the block chain and then

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -369,10 +369,12 @@ class ConsensusState(object):
                         utils.deserialize_wait_certificate(
                             block=block,
                             poet_enclave_module=poet_enclave_module)
+                    population_estimate = \
+                        wait_certificate.population_estimate(
+                            poet_config_view=poet_config_view)
                     population_cache_entry = \
                         ConsensusState._EstimateInfo(
-                            population_estimate=wait_certificate.
-                            population_estimate,
+                            population_estimate=population_estimate,
                             previous_block_id=block.previous_block_id,
                             validator_id=block.header.signer_pubkey)
                     ConsensusState._population_estimate_cache[block_id] = \

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -363,24 +363,20 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 block_header.previous_block_id[:8])
             return False
 
-        # Create a list of certificates for the wait timer.  This seems to
-        # have a little too much knowledge of the WaitTimer implementation,
-        # but there is no use getting more than
-        # WaitTimer.certificate_sample_length wait certificates.
-        certificates = \
-            utils.build_certificate_list(
-                block_header=block_header,
-                block_cache=self._block_cache,
-                poet_enclave_module=poet_enclave_module,
-                maximum_number=WaitTimer.certificate_sample_length)
-
         # We need to create a wait timer for the block...this is what we
         # will check when we are asked if it is time to publish the block
+        previous_certificate_id = \
+            utils.get_previous_certificate_id(
+                block_header=block_header,
+                block_cache=self._block_cache,
+                poet_enclave_module=poet_enclave_module)
         wait_timer = \
             WaitTimer.create_wait_timer(
                 poet_enclave_module=poet_enclave_module,
                 validator_address=block_header.signer_pubkey,
-                certificates=list(certificates))
+                previous_certificate_id=previous_certificate_id,
+                consensus_state=consensus_state,
+                poet_config_view=poet_config_view)
 
         # NOTE - we do the zTest after we create the wait timer because we
         # need its population estimate to see if this block would be accepted

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -390,7 +390,8 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 validator_info=validator_info,
                 previous_block_id=block_header.previous_block_id,
                 poet_config_view=poet_config_view,
-                population_estimate=wait_timer.population_estimate,
+                population_estimate=wait_timer.population_estimate(
+                    poet_config_view=poet_config_view),
                 block_cache=self._block_cache,
                 poet_enclave_module=poet_enclave_module):
             LOGGER.error(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -202,7 +202,8 @@ class PoetBlockVerifier(BlockVerifierInterface):
                 validator_info=validator_info,
                 previous_block_id=block_wrapper.previous_block_id,
                 poet_config_view=poet_config_view,
-                population_estimate=wait_certificate.population_estimate,
+                population_estimate=wait_certificate.population_estimate(
+                    poet_config_view=poet_config_view),
                 block_cache=self._block_cache,
                 poet_enclave_module=poet_enclave_module):
             LOGGER.error(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -31,6 +31,7 @@ class PoetConfigView(object):
     _FIXED_DURATION_BLOCK_COUNT_ = 50
     _INITIAL_WAIT_TIME_ = 3000.0
     _KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _MINIMUM_WAIT_TIME_ = 1.0
     _TARGET_WAIT_TIME_ = 20.0
     _ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _ZTEST_MINIMUM_WIN_COUNT_ = 3
@@ -155,6 +156,22 @@ class PoetConfigView(object):
                 value_type=int,
                 default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
+
+    @property
+    def minimum_wait_time(self):
+        """Return the minimum wait time if config setting exists and is valid,
+        otherwise return the default.
+
+        The minimum wait time is used as a lower bound for the minimum amount
+        of time a validator must want before attempting to claim a block.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.minimum_wait_time',
+                value_type=float,
+                default_value=PoetConfigView._MINIMUM_WAIT_TIME_,
+                validate_function=lambda value:
+                    math.isfinite(value) and value > 0)
 
     @property
     def target_wait_time(self):

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -29,6 +29,7 @@ class PoetConfigView(object):
 
     _BLOCK_CLAIM_DELAY_ = 1
     _FIXED_DURATION_BLOCK_COUNT_ = 50
+    _INITIAL_WAIT_TIME_ = 3000.0
     _KEY_BLOCK_CLAIM_LIMIT_ = 25
     _TARGET_WAIT_TIME_ = 20.0
     _ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
@@ -121,6 +122,23 @@ class PoetConfigView(object):
                 value_type=int,
                 default_value=PoetConfigView._FIXED_DURATION_BLOCK_COUNT_,
                 validate_function=lambda value: value > 0)
+
+    @property
+    def initial_wait_time(self):
+        """Return the initial wait time if config setting exists and is valid,
+        otherwise return the default.
+
+        The initial wait time is used during the bootstrapping of the block-
+        chain to compute the local mean for wait timers during the fixed
+        duration block count.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.initial_wait_time',
+                value_type=float,
+                default_value=PoetConfigView._INITIAL_WAIT_TIME_,
+                validate_function=lambda value:
+                    math.isfinite(value) and value >= 0)
 
     @property
     def key_block_claim_limit(self):

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -27,9 +27,9 @@ class PoetConfigView(object):
     or that are invalid, default values are returned.
     """
 
-    _KEY_BLOCK_CLAIM_LIMIT_ = 25
     _BLOCK_CLAIM_DELAY_ = 1
     _FIXED_DURATION_BLOCK_COUNT_ = 50
+    _KEY_BLOCK_CLAIM_LIMIT_ = 25
     _ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _ZTEST_MINIMUM_WIN_COUNT_ = 3
 
@@ -89,22 +89,6 @@ class PoetConfigView(object):
         return value
 
     @property
-    def key_block_claim_limit(self):
-        """Return the key block claim limit if config setting exists and
-        is valid, otherwise return the default.
-
-        The key block claim limit is the maximum number of blocks that a
-        validator may claim with a PoET key pair before it needs to refresh
-        its signup information.
-        """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.key_block_claim_limit',
-                value_type=int,
-                default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
-                validate_function=lambda value: value > 0)
-
-    @property
     def block_claim_delay(self):
         """Return the block claim delay if config setting exists and
         is valid, otherwise return the default.
@@ -135,6 +119,22 @@ class PoetConfigView(object):
                 name='sawtooth.poet.fixed_duration_block_count',
                 value_type=int,
                 default_value=PoetConfigView._FIXED_DURATION_BLOCK_COUNT_,
+                validate_function=lambda value: value > 0)
+
+    @property
+    def key_block_claim_limit(self):
+        """Return the key block claim limit if config setting exists and
+        is valid, otherwise return the default.
+
+        The key block claim limit is the maximum number of blocks that a
+        validator may claim with a PoET key pair before it needs to refresh
+        its signup information.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.key_block_claim_limit',
+                value_type=int,
+                default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
 
     @property

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -51,6 +51,16 @@ class PoetConfigView(object):
 
         self._config_view = ConfigView(state_view)
 
+        self._block_claim_delay = None
+        self._enclave_module_name = None
+        self._initial_wait_time = None
+        self._key_block_claim_limit = None
+        self._minimum_wait_time = None
+        self._population_estimate_sample_size = None
+        self._target_wait_time = None
+        self._ztest_maximum_win_deviation = None
+        self._ztest_minimum_win_count = None
+
     def _get_config_setting(self,
                             name,
                             value_type,
@@ -103,12 +113,15 @@ class PoetConfigView(object):
         signup information is committed to the validator registry before
         it can claim a block.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.block_claim_delay',
-                value_type=int,
-                default_value=PoetConfigView._BLOCK_CLAIM_DELAY_,
-                validate_function=lambda value: value >= 0)
+        if self._block_claim_delay is None:
+            self._block_claim_delay = \
+                self._get_config_setting(
+                    name='sawtooth.poet.block_claim_delay',
+                    value_type=int,
+                    default_value=PoetConfigView._BLOCK_CLAIM_DELAY_,
+                    validate_function=lambda value: value >= 0)
+
+        return self._block_claim_delay
 
     @property
     def enclave_module_name(self):
@@ -118,12 +131,15 @@ class PoetConfigView(object):
         The enclave module name is the name of the Python module containing the
         implementation of the underlying PoET enclave.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.enclave_module_name',
-                value_type=str,
-                default_value=PoetConfigView._ENCLAVE_MODULE_NAME_,
-                validate_function=lambda value: len(value) > 0)
+        if self._enclave_module_name is None:
+            self._enclave_module_name = \
+                self._get_config_setting(
+                    name='sawtooth.poet.enclave_module_name',
+                    value_type=str,
+                    default_value=PoetConfigView._ENCLAVE_MODULE_NAME_,
+                    validate_function=lambda value: len(value) > 0)
+
+        return self._enclave_module_name
 
     @property
     def initial_wait_time(self):
@@ -134,13 +150,16 @@ class PoetConfigView(object):
         chain to compute the local mean for wait timers until there are at
         least population_estimate_sample_size PoET blocks in the blockchain.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.initial_wait_time',
-                value_type=float,
-                default_value=PoetConfigView._INITIAL_WAIT_TIME_,
-                validate_function=lambda value:
-                    math.isfinite(value) and value >= 0)
+        if self._initial_wait_time is None:
+            self._initial_wait_time = \
+                self._get_config_setting(
+                    name='sawtooth.poet.initial_wait_time',
+                    value_type=float,
+                    default_value=PoetConfigView._INITIAL_WAIT_TIME_,
+                    validate_function=lambda value:
+                        math.isfinite(value) and value >= 0)
+
+        return self._initial_wait_time
 
     @property
     def key_block_claim_limit(self):
@@ -151,12 +170,15 @@ class PoetConfigView(object):
         validator may claim with a PoET key pair before it needs to refresh
         its signup information.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.key_block_claim_limit',
-                value_type=int,
-                default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
-                validate_function=lambda value: value > 0)
+        if self._key_block_claim_limit is None:
+            self._key_block_claim_limit = \
+                self._get_config_setting(
+                    name='sawtooth.poet.key_block_claim_limit',
+                    value_type=int,
+                    default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
+                    validate_function=lambda value: value > 0)
+
+        return self._key_block_claim_limit
 
     @property
     def minimum_wait_time(self):
@@ -166,13 +188,16 @@ class PoetConfigView(object):
         The minimum wait time is used as a lower bound for the minimum amount
         of time a validator must want before attempting to claim a block.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.minimum_wait_time',
-                value_type=float,
-                default_value=PoetConfigView._MINIMUM_WAIT_TIME_,
-                validate_function=lambda value:
-                    math.isfinite(value) and value > 0)
+        if self._minimum_wait_time is None:
+            self._minimum_wait_time = \
+                self._get_config_setting(
+                    name='sawtooth.poet.minimum_wait_time',
+                    value_type=float,
+                    default_value=PoetConfigView._MINIMUM_WAIT_TIME_,
+                    validate_function=lambda value:
+                        math.isfinite(value) and value > 0)
+
+        return self._minimum_wait_time
 
     @property
     def population_estimate_sample_size(self):
@@ -190,12 +215,16 @@ class PoetConfigView(object):
         blockchain, the local mean computed for a wait timer is based upon the
         ratio of the target and initial wait times.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.population_estimate_sample_size',
-                value_type=int,
-                default_value=PoetConfigView._POPULATION_ESTIMATE_SAMPLE_SIZE_,
-                validate_function=lambda value: value > 0)
+        if self._population_estimate_sample_size is None:
+            self._population_estimate_sample_size = \
+                self._get_config_setting(
+                    name='sawtooth.poet.population_estimate_sample_size',
+                    value_type=int,
+                    default_value=PoetConfigView.
+                    _POPULATION_ESTIMATE_SAMPLE_SIZE_,
+                    validate_function=lambda value: value > 0)
+
+        return self._population_estimate_sample_size
 
     @property
     def target_wait_time(self):
@@ -206,13 +235,16 @@ class PoetConfigView(object):
         validators in the network, a validator must wait before attempting to
         claim a block.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.target_wait_time',
-                value_type=float,
-                default_value=PoetConfigView._TARGET_WAIT_TIME_,
-                validate_function=lambda value:
-                    math.isfinite(value) and value > 0)
+        if self._target_wait_time is None:
+            self._target_wait_time = \
+                self._get_config_setting(
+                    name='sawtooth.poet.target_wait_time',
+                    value_type=float,
+                    default_value=PoetConfigView._TARGET_WAIT_TIME_,
+                    validate_function=lambda value:
+                        math.isfinite(value) and value > 0)
+
+        return self._target_wait_time
 
     @property
     def ztest_maximum_win_deviation(self):
@@ -231,13 +263,16 @@ class PoetConfigView(object):
         2.321 ==> 99%
         1.645 ==> 95%
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.ztest_maximum_win_deviation',
-                value_type=float,
-                default_value=PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_,
-                validate_function=lambda value:
-                    math.isfinite(value) and value > 0)
+        if self._ztest_maximum_win_deviation is None:
+            self._ztest_maximum_win_deviation = \
+                self._get_config_setting(
+                    name='sawtooth.poet.ztest_maximum_win_deviation',
+                    value_type=float,
+                    default_value=PoetConfigView._ZTEST_MAXIMUM_WIN_DEVIATION_,
+                    validate_function=lambda value:
+                        math.isfinite(value) and value > 0)
+
+        return self._ztest_maximum_win_deviation
 
     @property
     def ztest_minimum_win_count(self):
@@ -250,9 +285,12 @@ class PoetConfigView(object):
         the zTest will be applied to the validator's attempt to claim further
         blocks.
         """
-        return \
-            self._get_config_setting(
-                name='sawtooth.poet.ztest_minimum_win_count',
-                value_type=int,
-                default_value=PoetConfigView._ZTEST_MINIMUM_WIN_COUNT_,
-                validate_function=lambda value: value >= 0)
+        if self._ztest_minimum_win_count is None:
+            self._ztest_minimum_win_count = \
+                self._get_config_setting(
+                    name='sawtooth.poet.ztest_minimum_win_count',
+                    value_type=int,
+                    default_value=PoetConfigView._ZTEST_MINIMUM_WIN_COUNT_,
+                    validate_function=lambda value: value >= 0)
+
+        return self._ztest_minimum_win_count

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -28,6 +28,8 @@ class PoetConfigView(object):
     """
 
     _BLOCK_CLAIM_DELAY_ = 1
+    _ENCLAVE_MODULE_NAME_ = \
+        'sawtooth_poet_simulator.poet_enclave_simulator.poet_enclave_simulator'
     _INITIAL_WAIT_TIME_ = 3000.0
     _KEY_BLOCK_CLAIM_LIMIT_ = 25
     _MINIMUM_WAIT_TIME_ = 1.0
@@ -107,6 +109,21 @@ class PoetConfigView(object):
                 value_type=int,
                 default_value=PoetConfigView._BLOCK_CLAIM_DELAY_,
                 validate_function=lambda value: value >= 0)
+
+    @property
+    def enclave_module_name(self):
+        """Return the enclave module name if config setting exists and is
+        valid, otherwise return the default.
+
+        The enclave module name is the name of the Python module containing the
+        implementation of the underlying PoET enclave.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.enclave_module_name',
+                value_type=str,
+                default_value=PoetConfigView._ENCLAVE_MODULE_NAME_,
+                validate_function=lambda value: len(value) > 0)
 
     @property
     def initial_wait_time(self):

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -30,6 +30,7 @@ class PoetConfigView(object):
     _BLOCK_CLAIM_DELAY_ = 1
     _FIXED_DURATION_BLOCK_COUNT_ = 50
     _KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _TARGET_WAIT_TIME_ = 20.0
     _ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _ZTEST_MINIMUM_WIN_COUNT_ = 3
 
@@ -136,6 +137,23 @@ class PoetConfigView(object):
                 value_type=int,
                 default_value=PoetConfigView._KEY_BLOCK_CLAIM_LIMIT_,
                 validate_function=lambda value: value > 0)
+
+    @property
+    def target_wait_time(self):
+        """Return the target wait time if config setting exists and is valid,
+        otherwise return the default.
+
+        The target wait time is the desired average amount of time, across all
+        validators in the network, a validator must wait before attempting to
+        claim a block.
+        """
+        return \
+            self._get_config_setting(
+                name='sawtooth.poet.target_wait_time',
+                value_type=float,
+                default_value=PoetConfigView._TARGET_WAIT_TIME_,
+                validate_function=lambda value:
+                    math.isfinite(value) and value > 0)
 
     @property
     def ztest_maximum_win_deviation(self):

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -18,7 +18,6 @@ import importlib
 import logging
 
 from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
-from sawtooth_poet.poet_consensus import wait_timer
 
 LOGGER = logging.getLogger(__name__)
 
@@ -60,28 +59,18 @@ class PoetEnclaveFactory(object):
                 module_name = poet_config_view.enclave_module_name
 
                 LOGGER.info('Load PoET enclave module: %s', module_name)
-
-                # For now, configure the wait timer settings based upon the
-                # values in the PoET config view.
-                target_wait_time = poet_config_view.target_wait_time
-                initial_wait_time = poet_config_view.initial_wait_time
-                population_estimate_sample_size = \
-                    poet_config_view.population_estimate_sample_size
-                minimum_wait_time = poet_config_view.minimum_wait_time
-
-                LOGGER.info('Target wait time: %f', target_wait_time)
-                LOGGER.info('Initial wait time: %f', initial_wait_time)
+                LOGGER.info(
+                    'Target wait time: %f',
+                    poet_config_view.target_wait_time)
+                LOGGER.info(
+                    'Initial wait time: %f',
+                    poet_config_view.initial_wait_time)
                 LOGGER.info(
                     'Population estimate sample size: %d',
-                    population_estimate_sample_size)
-                LOGGER.info('Minimum wait time: %f', minimum_wait_time)
-
-                wait_timer.set_wait_timer_globals(
-                    target_wait_time=target_wait_time,
-                    initial_wait_time=initial_wait_time,
-                    certificate_sample_length=population_estimate_sample_size,
-                    fixed_duration_blocks=population_estimate_sample_size,
-                    minimum_wait_time=minimum_wait_time)
+                    poet_config_view.population_estimate_sample_size)
+                LOGGER.info(
+                    'Minimum wait time: %f',
+                    poet_config_view.minimum_wait_time)
 
                 # Load and initialize the module
                 module = importlib.import_module(module_name)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -17,8 +17,6 @@ import threading
 import importlib
 import logging
 
-from sawtooth_validator.state.config_view import ConfigView
-
 from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 from sawtooth_poet.poet_consensus import wait_timer
 
@@ -57,52 +55,26 @@ class PoetEnclaveFactory(object):
             # done so.  Otherwise, we are just going to return the previously-
             # loaded enclave module.
             if cls._poet_enclave_module is None:
-                # Get the configured PoET enclave module name, defaulting to
-                # the PoET enclave simulator module if not present.
-                config_view = ConfigView(state_view)
-                module_name = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.enclave_module',
-                        default_value='sawtooth_poet_simulator.'
-                                      'poet_enclave_simulator.'
-                                      'poet_enclave_simulator')
+                # Get the configured PoET enclave module name.
+                poet_config_view = PoetConfigView(state_view)
+                module_name = poet_config_view.enclave_module_name
 
                 LOGGER.info('Load PoET enclave module: %s', module_name)
 
-                poet_config_view = PoetConfigView(state_view)
-
                 # For now, configure the wait timer settings based upon the
-                # values in the configuration if present.
-                target_wait_time = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.target_wait_time',
-                        default_value=wait_timer.WaitTimer.target_wait_time,
-                        value_type=float)
-                initial_wait_time = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.initial_wait_time',
-                        default_value=wait_timer.WaitTimer.initial_wait_time,
-                        value_type=float)
+                # values in the PoET config view.
+                target_wait_time = poet_config_view.target_wait_time
+                initial_wait_time = poet_config_view.initial_wait_time
                 population_estimate_sample_size = \
                     poet_config_view.population_estimate_sample_size
-                minimum_wait_time = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.minimum_wait_time',
-                        default_value=wait_timer.WaitTimer.minimum_wait_time,
-                        value_type=float)
+                minimum_wait_time = poet_config_view.minimum_wait_time
 
+                LOGGER.info('Target wait time: %f', target_wait_time)
+                LOGGER.info('Initial wait time: %f', initial_wait_time)
                 LOGGER.info(
-                    'sawtooth.poet.target_wait_time: %f',
-                    target_wait_time)
-                LOGGER.info(
-                    'sawtooth.poet.initial_wait_time: %f',
-                    initial_wait_time)
-                LOGGER.info(
-                    'sawtooth.poet.population_estimate_sample_size: %d',
-                    poet_config_view.population_estimate_sample_size)
-                LOGGER.info(
-                    'sawtooth.poet.minimum_wait_time: %f',
-                    minimum_wait_time)
+                    'Population estimate sample size: %d',
+                    population_estimate_sample_size)
+                LOGGER.info('Minimum wait time: %f', minimum_wait_time)
 
                 wait_timer.set_wait_timer_globals(
                     target_wait_time=target_wait_time,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -83,13 +83,8 @@ class PoetEnclaveFactory(object):
                         key='sawtooth.poet.initial_wait_time',
                         default_value=wait_timer.WaitTimer.initial_wait_time,
                         value_type=float)
-                fixed_duration_blocks = \
-                    poet_config_view.fixed_duration_block_count
-                certificate_sample_length = \
-                    config_view.get_setting(
-                        key='sawtooth.poet.certificate_sample_length',
-                        default_value=fixed_duration_blocks,
-                        value_type=int)
+                population_estimate_sample_size = \
+                    poet_config_view.population_estimate_sample_size
                 minimum_wait_time = \
                     config_view.get_setting(
                         key='sawtooth.poet.minimum_wait_time',
@@ -103,11 +98,8 @@ class PoetEnclaveFactory(object):
                     'sawtooth.poet.initial_wait_time: %f',
                     initial_wait_time)
                 LOGGER.info(
-                    'sawtooth.poet.certificate_sample_length: %d',
-                    certificate_sample_length)
-                LOGGER.info(
-                    'sawtooth.poet.fixed_duration_block_count: %d',
-                    poet_config_view.fixed_duration_block_count)
+                    'sawtooth.poet.population_estimate_sample_size: %d',
+                    poet_config_view.population_estimate_sample_size)
                 LOGGER.info(
                     'sawtooth.poet.minimum_wait_time: %f',
                     minimum_wait_time)
@@ -115,8 +107,8 @@ class PoetEnclaveFactory(object):
                 wait_timer.set_wait_timer_globals(
                     target_wait_time=target_wait_time,
                     initial_wait_time=initial_wait_time,
-                    certificate_sample_length=certificate_sample_length,
-                    fixed_duration_blocks=fixed_duration_blocks,
+                    certificate_sample_length=population_estimate_sample_size,
+                    fixed_duration_blocks=population_estimate_sample_size,
                     minimum_wait_time=minimum_wait_time)
 
                 # Load and initialize the module

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -20,6 +20,8 @@ from sawtooth_poet.poet_consensus.consensus_state_store \
     import ConsensusStateStore
 from sawtooth_poet.poet_consensus import poet_enclave_factory as factory
 from sawtooth_poet.poet_consensus import utils
+from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
+
 from sawtooth_poet_common.validator_registry_view.validator_registry_view \
     import ValidatorRegistryView
 
@@ -260,7 +262,8 @@ class PoetForkResolver(ForkResolverInterface):
                     validator_info=validator_info,
                     wait_certificate=utils.deserialize_wait_certificate(
                         block=new_fork_head,
-                        poet_enclave_module=poet_enclave_module))
+                        poet_enclave_module=poet_enclave_module),
+                    poet_config_view=PoetConfigView(state_view))
                 self._consensus_state_store[new_fork_head.identifier] = \
                     consensus_state
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import collections
 import json
 import logging
 
@@ -94,53 +93,3 @@ def get_previous_certificate_id(block_header,
     return \
         NULL_BLOCK_IDENTIFIER if wait_certificate is None \
         else wait_certificate.identifier
-
-
-def build_certificate_list(block_header,
-                           block_cache,
-                           poet_enclave_module,
-                           maximum_number):
-    """Builds a list of up to maximum_length wait certificates for the blocks
-    immediately preceding the block represented by block_header.
-
-    Args:
-        block_header (BlockHeader): The header for the block
-        block_cache (BlockCache): The cache of blocks that are predecessors
-            to the block represented by block_header
-        poet_enclave_module (module): The PoET enclave module
-        maximum_number (int): The maximum number of certificates to return
-
-    Returns:
-        A list of wait certificates
-    """
-
-    # Create a list of certificates starting with the immediate predecessor
-    # to the block represented by block_header.  We will use a deque because
-    # we are walking the blocks in reverse order.
-    certificates = collections.deque()
-    block_id = block_header.previous_block_id
-
-    try:
-        while not block_id_is_genesis(block_id) and \
-                len(certificates) < maximum_number:
-            # Grab the block from the block store, use the consensus
-            # property to reconstitute the wait certificate, and add
-            # the wait certificate to the list.  If we get to a block
-            # that does not have a wait certificate, we stop.
-            block = block_cache[block_id]
-            wait_certificate = \
-                deserialize_wait_certificate(
-                    block=block,
-                    poet_enclave_module=poet_enclave_module)
-
-            if wait_certificate is None:
-                break
-
-            certificates.appendleft(wait_certificate)
-
-            # Move to the previous block
-            block_id = block.header.previous_block_id
-    except KeyError as ke:
-        LOGGER.error('Error getting block: %s', ke)
-
-    return list(certificates)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/utils.py
@@ -67,6 +67,35 @@ def deserialize_wait_certificate(block, poet_enclave_module):
     return wait_certificate
 
 
+def get_previous_certificate_id(block_header,
+                                block_cache,
+                                poet_enclave_module):
+    """Returns the wait certificate ID for the block immediately preceding the
+    block represented by block_header.
+
+    Args:
+        block_header (BlockHeader): The header for the block
+        block_cache (BlockCache): The cache of blocks that are predecessors
+            to the block represented by block_header
+        poet_enclave_module (module): The PoET enclave module
+
+    Returns:
+        str: The ID of the wait certificate for the block immediately
+        preceding the block represented by block_header
+    """
+    wait_certificate = None
+
+    if not block_id_is_genesis(block_header.previous_block_id):
+        wait_certificate = \
+            deserialize_wait_certificate(
+                block=block_cache[block_header.previous_block_id],
+                poet_enclave_module=poet_enclave_module)
+
+    return \
+        NULL_BLOCK_IDENTIFIER if wait_certificate is None \
+        else wait_certificate.identifier
+
+
 def build_certificate_list(block_header,
                            block_cache,
                            poet_enclave_module,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/wait_certificate.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/wait_certificate.py
@@ -19,8 +19,6 @@ from requests import Timeout
 
 from sawtooth_validator.exceptions import NotAvailableException
 
-from sawtooth_poet.poet_consensus.wait_timer import WaitTimer
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -122,10 +120,6 @@ class WaitCertificate(object):
 
         return cls(enclave_certificate)
 
-    @property
-    def population_estimate(self):
-        return self.local_mean / WaitTimer.target_wait_time
-
     def _enclave_wait_certificate(self, poet_enclave_module):
         return \
             poet_enclave_module.deserialize_wait_certificate(
@@ -160,6 +154,18 @@ class WaitCertificate(object):
                 self.duration,
                 self.identifier,
                 self.previous_certificate_id)
+
+    def population_estimate(self, poet_config_view):
+        """Return the population estimate for the block associated with this
+        wait certificate.
+
+        Args:
+            poet_config_view (PoetConfigView): The current PoEt config view
+
+        Returns:
+            float: The population estimate
+        """
+        return self.local_mean / poet_config_view.target_wait_time
 
     def check_valid(self,
                     poet_enclave_module,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/wait_certificate.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/wait_certificate.py
@@ -163,33 +163,39 @@ class WaitCertificate(object):
 
     def check_valid(self,
                     poet_enclave_module,
-                    certificates,
-                    poet_public_key):
+                    previous_certificate_id,
+                    poet_public_key,
+                    consensus_state,
+                    poet_config_view):
         """Determines whether the wait certificate is valid.
 
         Args:
             poet_enclave_module (module): The module that implements the
                 underlying PoET enclave.
-            certificates (list): A list of historical certs.
+            previous_certificate_id (str): The ID of the wait certificate for
+                the block attempting to build upon
             poet_public_key (str): The PoET public key that corresponds to
                 the private key used to sign the certificate.  This is
                 obtained from the signup information for the validator
                 that is the originator of the block for which the wait
                 certificate is associated.
-
+            consensus_state (ConsensusState): The current PoET consensus state
+            poet_config_view (PoetConfigView): The current PoET config view
         Returns:
             True if the wait certificate is valid, False otherwise.
         """
         enclave_certificate = \
             self._enclave_wait_certificate(poet_enclave_module)
-        expected_mean = WaitTimer.compute_local_mean(certificates)
+        expected_mean = \
+            consensus_state.compute_local_mean(
+                poet_config_view=poet_config_view)
 
-        if enclave_certificate.duration < WaitTimer.minimum_wait_time:
+        if enclave_certificate.duration < poet_config_view.minimum_wait_time:
             raise \
                 ValueError(
                     'Wait time less than minimum: {0} < {1}'.format(
                         enclave_certificate.duration,
-                        WaitTimer.minimum_wait_time))
+                        poet_config_view.minimum_wait_time))
 
         if not _is_close(
                 enclave_certificate.local_mean,
@@ -201,15 +207,14 @@ class WaitCertificate(object):
                         enclave_certificate.local_mean,
                         expected_mean))
 
-        if len(certificates) != 0 and \
-            enclave_certificate.previous_certificate_id != \
-                certificates[-1].identifier:
+        if enclave_certificate.previous_certificate_id != \
+                previous_certificate_id:
             raise \
                 ValueError(
                     'Previous certificate ID does not match: {0} != '
                     '{1}'.format(
                         enclave_certificate.previous_certificate_id,
-                        certificates[-1].identifier))
+                        previous_certificate_id))
 
         try:
             poet_enclave_module.verify_wait_certificate(

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -56,7 +56,11 @@ class TestConsensusState(unittest.TestCase):
         state = consensus_state.ConsensusState()
 
         wait_certificate = mock.Mock()
+        wait_certificate.duration = 3.1415
         wait_certificate.local_mean = 5.0
+
+        poet_config_view = mock.Mock()
+        poet_config_view.population_estimate_sample_size = 50
 
         validator_info = \
             ValidatorInfo(
@@ -68,7 +72,8 @@ class TestConsensusState(unittest.TestCase):
         # consensus state to add and set statistics appropriately.
         state.validator_did_claim_block(
             validator_info=validator_info,
-            wait_certificate=wait_certificate)
+            wait_certificate=wait_certificate,
+            poet_config_view=poet_config_view)
 
         self.assertEqual(
             state.aggregate_local_mean,
@@ -86,7 +91,8 @@ class TestConsensusState(unittest.TestCase):
         # the consensus and validator statistics are updated properly
         state.validator_did_claim_block(
             validator_info=validator_info,
-            wait_certificate=wait_certificate)
+            wait_certificate=wait_certificate,
+            poet_config_view=poet_config_view)
 
         self.assertEqual(
             state.aggregate_local_mean,
@@ -107,7 +113,8 @@ class TestConsensusState(unittest.TestCase):
 
         state.validator_did_claim_block(
             validator_info=validator_info,
-            wait_certificate=wait_certificate)
+            wait_certificate=wait_certificate,
+            poet_config_view=poet_config_view)
 
         self.assertEqual(
             state.aggregate_local_mean,
@@ -126,6 +133,9 @@ class TestConsensusState(unittest.TestCase):
         error.  Verify that serializing state and then deserializing results
         in the same state values.
         """
+        poet_config_view = mock.Mock()
+        poet_config_view.population_estimate_sample_size = 50
+
         # Simple deserialization check of buffer
         for invalid_state in [None, '', 1, 1.1, (), [], {}]:
             state = consensus_state.ConsensusState()
@@ -249,6 +259,7 @@ class TestConsensusState(unittest.TestCase):
 
         state = consensus_state.ConsensusState()
         wait_certificate = mock.Mock()
+        wait_certificate.duration = 3.14
         wait_certificate.local_mean = 5.0
 
         validator_info = \
@@ -259,7 +270,8 @@ class TestConsensusState(unittest.TestCase):
 
         state.validator_did_claim_block(
             validator_info=validator_info,
-            wait_certificate=wait_certificate)
+            wait_certificate=wait_certificate,
+            poet_config_view=poet_config_view)
         doppelganger_state = consensus_state.ConsensusState()
 
         # Truncate the serialized value on purpose
@@ -354,9 +366,11 @@ class TestConsensusState(unittest.TestCase):
         # Now put a couple of validators in, serialize, deserialize, and
         # verify they are in deserialized
         wait_certificate_1 = mock.Mock()
+        wait_certificate_1.duration = 3.14
         wait_certificate_1.local_mean = 5.0
         wait_certificate_2 = mock.Mock()
-        wait_certificate_2.local_mean = 5.0
+        wait_certificate_2.duration = 1.618
+        wait_certificate_2.local_mean = 2.718
 
         validator_info_1 = \
             ValidatorInfo(
@@ -371,10 +385,12 @@ class TestConsensusState(unittest.TestCase):
 
         state.validator_did_claim_block(
             validator_info=validator_info_1,
-            wait_certificate=wait_certificate_1)
+            wait_certificate=wait_certificate_1,
+            poet_config_view=poet_config_view)
         state.validator_did_claim_block(
             validator_info=validator_info_2,
-            wait_certificate=wait_certificate_2)
+            wait_certificate=wait_certificate_2,
+            poet_config_view=poet_config_view)
 
         doppelganger_state.parse_from_bytes(state.serialize_to_bytes())
 

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -137,6 +137,7 @@ class TestConsensusState(unittest.TestCase):
                 'sawtooth_poet.poet_consensus.consensus_state.cbor.loads') \
                 as mock_loads:
             mock_loads.return_value = {
+                '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                 '_total_block_claim_count': 0,
                 '_validators': {}
             }
@@ -153,6 +154,49 @@ class TestConsensusState(unittest.TestCase):
                     as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': invalid_alm,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
+                    '_total_block_claim_count': 0,
+                    '_validators': {}
+                }
+                with self.assertRaises(ValueError):
+                    state.parse_from_bytes(b'')
+
+        # Missing population samples
+        with mock.patch(
+                'sawtooth_poet.poet_consensus.consensus_state.cbor.loads') \
+                as mock_loads:
+            mock_loads.return_value = {
+                '_aggregate_local_mean': 0.0,
+                '_total_block_claim_count': 0,
+                '_validators': {}
+            }
+            with self.assertRaises(ValueError):
+                state.parse_from_bytes(b'')
+
+        # Invalid population samples
+        for invalid_ps in [None, 1, 1.0, 'str', (1,), [1],
+                           (1.0, None), (1.0, 'str'), (1.0, ()), (1.0, []),
+                           (1.0, {}),
+                           (1.0, float('nan')), (1.0, float('inf')),
+                           (1.0, float('-inf')), (float('nan'), 1.0),
+                           (float('inf'), 1.0), (float('-inf'), 1.0),
+                           (None, 1.0), ('str', 1.0), ((), 1.0), ([], 1.0),
+                           ({}, 1.0),
+                           [1.0, None], [1.0, 'str'], [1.0, ()], [1.0, []],
+                           [1.0, {}],
+                           [1.0, float('nan')], [1.0, float('inf')],
+                           [1.0, float('-inf')], [float('nan'), 1.0],
+                           [float('inf'), 1.0], [float('-inf'), 1.0],
+                           [None, 1.0], ['str', 1.0], [(), 1.0], [[], 1.0],
+                           [{}, 1.0]]:
+            state = consensus_state.ConsensusState()
+            with mock.patch(
+                    'sawtooth_poet.poet_consensus.consensus_state.cbor.'
+                    'loads') \
+                    as mock_loads:
+                mock_loads.return_value = {
+                    '_aggregate_local_mean': 0.0,
+                    '_population_samples': invalid_ps,
                     '_total_block_claim_count': 0,
                     '_validators': {}
                 }
@@ -165,6 +209,7 @@ class TestConsensusState(unittest.TestCase):
                 as mock_loads:
             mock_loads.return_value = {
                 '_aggregate_local_mean': 0.0,
+                '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                 '_validators': {}
             }
             with self.assertRaises(ValueError):
@@ -179,6 +224,7 @@ class TestConsensusState(unittest.TestCase):
                     as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': 0.0,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                     '_total_block_claim_count': invalid_tbcc,
                     '_validators': {}
                 }
@@ -194,6 +240,7 @@ class TestConsensusState(unittest.TestCase):
                     as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': 0.0,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                     '_total_block_claim_count': 0,
                     '_validators': invalid_validators
                 }
@@ -231,6 +278,7 @@ class TestConsensusState(unittest.TestCase):
                     'loads') as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': 0.0,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                     '_total_block_claim_count': 0,
                     '_validators': {
                         'validator_001': [invalid_kbcc, 'ppk_001', 0]
@@ -247,6 +295,7 @@ class TestConsensusState(unittest.TestCase):
                     'loads') as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': 0.0,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                     '_total_block_claim_count': 0,
                     '_validators': {
                         'validator_001': [0, invalid_ppk, 0]
@@ -263,6 +312,7 @@ class TestConsensusState(unittest.TestCase):
                     'loads') as mock_loads:
                 mock_loads.return_value = {
                     '_aggregate_local_mean': 0.0,
+                    '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                     '_total_block_claim_count': 0,
                     '_validators': {
                         'validator_001': [0, 'ppk_001', invalid_tbcc]
@@ -278,6 +328,7 @@ class TestConsensusState(unittest.TestCase):
                 'loads') as mock_loads:
             mock_loads.return_value = {
                 '_aggregate_local_mean': 0.0,
+                '_population_samples': [(2.718, 3.1415), (1.618, 0.618)],
                 '_total_block_claim_count': 0,
                 '_validators': {
                     'validator_001': [2, 'ppk_001', 1]

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state_store.py
@@ -102,6 +102,12 @@ class TestConsensusStateStore(unittest.TestCase):
         my_dict = {}
         mock_lmdb.return_value = my_dict
 
+        mock_poet_config_view = mock.Mock()
+        mock_poet_config_view.target_wait_time = 30.0
+        mock_poet_config_view.initial_wait_time = 3000.0
+        mock_poet_config_view.minimum_wait_time = 1.0
+        mock_poet_config_view.population_estimate_sample_size = 50
+
         store = \
             consensus_state_store.ConsensusStateStore(
                 data_dir=tempfile.gettempdir(),
@@ -133,6 +139,7 @@ class TestConsensusStateStore(unittest.TestCase):
 
         # Have a validator claim a block and update the store
         wait_certificate = mock.Mock()
+        wait_certificate.duration = 3.1415
         wait_certificate.local_mean = 5.0
         validator_info = \
             ValidatorInfo(
@@ -141,7 +148,8 @@ class TestConsensusStateStore(unittest.TestCase):
                     poet_public_key='key_001'))
         state.validator_did_claim_block(
             validator_info=validator_info,
-            wait_certificate=wait_certificate)
+            wait_certificate=wait_certificate,
+            poet_config_view=mock_poet_config_view)
         store['key'] = state
 
         # Verify the length and contains key

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -23,53 +23,11 @@ from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
 class TestPoetConfigView(unittest.TestCase):
 
     # pylint: disable=invalid-name
-    _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
     _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
+    _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_ = 3
-
-    def test_key_block_claim_limit(self, mock_config_view):
-        """Verify that retrieving key block claim limit works for invalid
-        cases (missing, invalid format, invalid value) as well as valid case.
-        """
-
-        poet_config_view = PoetConfigView(state_view=None)
-
-        # Underlying config setting does not parse to an integer
-        mock_config_view.return_value.get_setting.side_effect = \
-            ValueError('bad value')
-
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
-
-        _, kwargs = \
-            mock_config_view.return_value.get_setting.call_args
-
-        self.assertEqual(kwargs['key'], 'sawtooth.poet.key_block_claim_limit')
-        self.assertEqual(
-            kwargs['default_value'],
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
-        self.assertEqual(kwargs['value_type'], int)
-
-        # Underlying config setting is not a valid value
-        mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
-
-        mock_config_view.return_value.get_setting.return_value = 0
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
-
-        # Underlying config setting is a valid value
-        mock_config_view.return_value.get_setting.return_value = 1
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            1)
 
     def test_block_claim_delay(self, mock_config_view):
         """Verify that retrieving block claim delay works for invalid
@@ -154,6 +112,48 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(
             poet_config_view.fixed_duration_block_count,
+            1)
+
+    def test_key_block_claim_limit(self, mock_config_view):
+        """Verify that retrieving key block claim limit works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.key_block_claim_limit')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = -1
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
+
+        mock_config_view.return_value.get_setting.return_value = 0
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
+            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(
+            poet_config_view.key_block_claim_limit,
             1)
 
     def test_ztest_maximum_win_deviation(self, mock_config_view):

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -25,6 +25,7 @@ class TestPoetConfigView(unittest.TestCase):
     # pylint: disable=invalid-name
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
     _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
+    _EXPECTED_DEFAULT_INITIAL_WAIT_TIME_ = 3000.0
     _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_TARGET_WAIT_TIME_ = 20.0
     _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
@@ -106,6 +107,43 @@ class TestPoetConfigView(unittest.TestCase):
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(poet_config_view.fixed_duration_block_count, 1)
+
+    def test_initial_wait_time(self, mock_config_view):
+        """Verify that retrieving initial wait time works for invalid cases
+        (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.initial_wait_time,
+            TestPoetConfigView._EXPECTED_DEFAULT_INITIAL_WAIT_TIME_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.initial_wait_time')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_INITIAL_WAIT_TIME_)
+        self.assertEqual(kwargs['value_type'], float)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        for bad_value in \
+                [-100.0, -1.0, float('nan'), float('inf'), float('-inf')]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.initial_wait_time,
+                TestPoetConfigView._EXPECTED_DEFAULT_INITIAL_WAIT_TIME_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 3.1415
+        self.assertEqual(poet_config_view.initial_wait_time, 3.1415)
 
     def test_key_block_claim_limit(self, mock_config_view):
         """Verify that retrieving key block claim limit works for invalid

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -62,13 +62,16 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = None
         for bad_value in [-100, -1]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.block_claim_delay,
                 TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
 
         # Underlying config setting is a valid value
+        poet_config_view = PoetConfigView(state_view=None)
         mock_config_view.return_value.get_setting.return_value = 0
         self.assertEqual(poet_config_view.block_claim_delay, 0)
+        poet_config_view = PoetConfigView(state_view=None)
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(poet_config_view.block_claim_delay, 1)
 
@@ -99,12 +102,14 @@ class TestPoetConfigView(unittest.TestCase):
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
         mock_config_view.return_value.get_setting.return_value = ''
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(
             poet_config_view.enclave_module_name,
             TestPoetConfigView._EXPECTED_DEFAULT_ENCLAVE_MODULE_NAME_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 'valid value'
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.enclave_module_name, 'valid value')
 
     def test_initial_wait_time(self, mock_config_view):
@@ -136,12 +141,14 @@ class TestPoetConfigView(unittest.TestCase):
         for bad_value in \
                 [-100.0, -1.0, float('nan'), float('inf'), float('-inf')]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.initial_wait_time,
                 TestPoetConfigView._EXPECTED_DEFAULT_INITIAL_WAIT_TIME_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 3.1415
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.initial_wait_time, 3.1415)
 
     def test_key_block_claim_limit(self, mock_config_view):
@@ -172,12 +179,14 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = None
         for bad_value in [-100, -1, 0]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.key_block_claim_limit,
                 TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.key_block_claim_limit, 1)
 
     def test_minimum_wait_time(self, mock_config_view):
@@ -209,12 +218,14 @@ class TestPoetConfigView(unittest.TestCase):
         for bad_value in \
                 [-100.0, -1.0, 0.0, float('nan'), float('inf'), float('-inf')]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.minimum_wait_time,
                 TestPoetConfigView._EXPECTED_DEFAULT_MINIMUM_WAIT_TIME_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 3.1415
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.minimum_wait_time, 3.1415)
 
     def test_population_estimate_sample_size(self, mock_config_view):
@@ -250,6 +261,7 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = None
         for bad_value in [-100, -1, 0]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.population_estimate_sample_size,
                 TestPoetConfigView.
@@ -257,6 +269,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.population_estimate_sample_size, 1)
 
     def test_target_wait_time(self, mock_config_view):
@@ -288,12 +301,14 @@ class TestPoetConfigView(unittest.TestCase):
         for bad_value in \
                 [-100.0, -1.0, 0.0, float('nan'), float('inf'), float('-inf')]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.target_wait_time,
                 TestPoetConfigView._EXPECTED_DEFAULT_TARGET_WAIT_TIME_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 3.1415
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.target_wait_time, 3.1415)
 
     def test_ztest_maximum_win_deviation(self, mock_config_view):
@@ -328,6 +343,7 @@ class TestPoetConfigView(unittest.TestCase):
         for bad_value in \
                 [-100.0, -1.0, 0.0, float('nan'), float('inf'), float('-inf')]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.ztest_maximum_win_deviation,
                 TestPoetConfigView.
@@ -335,6 +351,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 2.575
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.ztest_maximum_win_deviation, 2.575)
 
     def test_ztest_minimum_win_count(self, mock_config_view):
@@ -368,10 +385,12 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.side_effect = None
         for bad_value in [-100, -1]:
             mock_config_view.return_value.get_setting.return_value = bad_value
+            poet_config_view = PoetConfigView(state_view=None)
             self.assertEqual(
                 poet_config_view.ztest_minimum_win_count,
                 TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 0
+        poet_config_view = PoetConfigView(state_view=None)
         self.assertEqual(poet_config_view.ztest_minimum_win_count, 0)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -24,6 +24,8 @@ class TestPoetConfigView(unittest.TestCase):
 
     # pylint: disable=invalid-name
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
+    _EXPECTED_DEFAULT_ENCLAVE_MODULE_NAME_ = \
+        'sawtooth_poet_simulator.poet_enclave_simulator.poet_enclave_simulator'
     _EXPECTED_DEFAULT_INITIAL_WAIT_TIME_ = 3000.0
     _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_MINIMUM_WAIT_TIME_ = 1.0
@@ -39,7 +41,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -70,6 +72,41 @@ class TestPoetConfigView(unittest.TestCase):
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(poet_config_view.block_claim_delay, 1)
 
+    def test_enclave_module_name(self, mock_config_view):
+        """Verify that retrieving enclave module name works for invalid
+        cases (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Simulate an underlying error parsing value
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.enclave_module_name,
+            TestPoetConfigView._EXPECTED_DEFAULT_ENCLAVE_MODULE_NAME_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.enclave_module_name')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_ENCLAVE_MODULE_NAME_)
+        self.assertEqual(kwargs['value_type'], str)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        mock_config_view.return_value.get_setting.return_value = ''
+        self.assertEqual(
+            poet_config_view.enclave_module_name,
+            TestPoetConfigView._EXPECTED_DEFAULT_ENCLAVE_MODULE_NAME_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 'valid value'
+        self.assertEqual(poet_config_view.enclave_module_name, 'valid value')
+
     def test_initial_wait_time(self, mock_config_view):
         """Verify that retrieving initial wait time works for invalid cases
         (missing, invalid format, invalid value) as well as valid case.
@@ -77,7 +114,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -114,7 +151,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -150,7 +187,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -188,7 +225,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -229,7 +266,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -267,7 +304,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 
@@ -308,7 +345,7 @@ class TestPoetConfigView(unittest.TestCase):
 
         poet_config_view = PoetConfigView(state_view=None)
 
-        # Underlying config setting does not parse to an integer
+        # Simulate an underlying error parsing value
         mock_config_view.return_value.get_setting.side_effect = \
             ValueError('bad value')
 

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -55,20 +55,17 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1
-        self.assertEqual(
-            poet_config_view.block_claim_delay,
-            TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
+        for bad_value in [-100, -1]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.block_claim_delay,
+                TestPoetConfigView._EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 0
-        self.assertEqual(
-            poet_config_view.block_claim_delay,
-            0)
+        self.assertEqual(poet_config_view.block_claim_delay, 0)
         mock_config_view.return_value.get_setting.return_value = 1
-        self.assertEqual(
-            poet_config_view.block_claim_delay,
-            1)
+        self.assertEqual(poet_config_view.block_claim_delay, 1)
 
     def test_fixed_duration_block_count(self, mock_config_view):
         """Verify that retrieving fixed duration block count works for invalid
@@ -98,21 +95,16 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1
-        self.assertEqual(
-            poet_config_view.fixed_duration_block_count,
-            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
-
-        mock_config_view.return_value.get_setting.return_value = 0
-        self.assertEqual(
-            poet_config_view.fixed_duration_block_count,
-            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
+        for bad_value in [-100, -1, 0]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.fixed_duration_block_count,
+                TestPoetConfigView.
+                _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
-        self.assertEqual(
-            poet_config_view.fixed_duration_block_count,
-            1)
+        self.assertEqual(poet_config_view.fixed_duration_block_count, 1)
 
     def test_key_block_claim_limit(self, mock_config_view):
         """Verify that retrieving key block claim limit works for invalid
@@ -140,21 +132,15 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
-
-        mock_config_view.return_value.get_setting.return_value = 0
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
+        for bad_value in [-100, -1, 0]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.key_block_claim_limit,
+                TestPoetConfigView._EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
-        self.assertEqual(
-            poet_config_view.key_block_claim_limit,
-            1)
+        self.assertEqual(poet_config_view.key_block_claim_limit, 1)
 
     def test_ztest_maximum_win_deviation(self, mock_config_view):
         """Verify that retrieving zTest maximum win deviation works for
@@ -185,36 +171,17 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1.0
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
-
-        mock_config_view.return_value.get_setting.return_value = 0.0
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
-
-        mock_config_view.return_value.get_setting.return_value = float('nan')
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
-
-        mock_config_view.return_value.get_setting.return_value = float('inf')
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
-
-        mock_config_view.return_value.get_setting.return_value = float('-inf')
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
+        for bad_value in \
+                [-100.0, -1.0, 0.0, float('nan'), float('inf'), float('-inf')]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.ztest_maximum_win_deviation,
+                TestPoetConfigView.
+                _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 2.575
-        self.assertEqual(
-            poet_config_view.ztest_maximum_win_deviation,
-            2.575)
+        self.assertEqual(poet_config_view.ztest_maximum_win_deviation, 2.575)
 
     def test_ztest_minimum_win_count(self, mock_config_view):
         """Verify that retrieving zTest minimum win observations works for
@@ -245,13 +212,12 @@ class TestPoetConfigView(unittest.TestCase):
 
         # Underlying config setting is not a valid value
         mock_config_view.return_value.get_setting.side_effect = None
-        mock_config_view.return_value.get_setting.return_value = -1
-        self.assertEqual(
-            poet_config_view.ztest_minimum_win_count,
-            TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
+        for bad_value in [-100, -1]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.ztest_minimum_win_count,
+                TestPoetConfigView._EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_)
 
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 0
-        self.assertEqual(
-            poet_config_view.ztest_minimum_win_count,
-            0)
+        self.assertEqual(poet_config_view.ztest_minimum_win_count, 0)

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -26,6 +26,7 @@ class TestPoetConfigView(unittest.TestCase):
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
     _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
     _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
+    _EXPECTED_DEFAULT_TARGET_WAIT_TIME_ = 20.0
     _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_ = 3
 
@@ -141,6 +142,43 @@ class TestPoetConfigView(unittest.TestCase):
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(poet_config_view.key_block_claim_limit, 1)
+
+    def test_target_wait_time(self, mock_config_view):
+        """Verify that retrieving target wait time works for invalid cases
+        (missing, invalid format, invalid value) as well as valid case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.target_wait_time,
+            TestPoetConfigView._EXPECTED_DEFAULT_TARGET_WAIT_TIME_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(kwargs['key'], 'sawtooth.poet.target_wait_time')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView._EXPECTED_DEFAULT_TARGET_WAIT_TIME_)
+        self.assertEqual(kwargs['value_type'], float)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        for bad_value in \
+                [-100.0, -1.0, 0.0, float('nan'), float('inf'), float('-inf')]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.target_wait_time,
+                TestPoetConfigView._EXPECTED_DEFAULT_TARGET_WAIT_TIME_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 3.1415
+        self.assertEqual(poet_config_view.target_wait_time, 3.1415)
 
     def test_ztest_maximum_win_deviation(self, mock_config_view):
         """Verify that retrieving zTest maximum win deviation works for

--- a/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_config_view.py
@@ -24,10 +24,10 @@ class TestPoetConfigView(unittest.TestCase):
 
     # pylint: disable=invalid-name
     _EXPECTED_DEFAULT_BLOCK_CLAIM_DELAY_ = 1
-    _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_ = 50
     _EXPECTED_DEFAULT_INITIAL_WAIT_TIME_ = 3000.0
     _EXPECTED_DEFAULT_KEY_BLOCK_CLAIM_LIMIT_ = 25
     _EXPECTED_DEFAULT_MINIMUM_WAIT_TIME_ = 1.0
+    _EXPECTED_DEFAULT_POPULATION_ESTIMATE_SAMPLE_SIZE_ = 50
     _EXPECTED_DEFAULT_TARGET_WAIT_TIME_ = 20.0
     _EXPECTED_DEFAULT_ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _EXPECTED_DEFAULT_ZTEST_MINIMUM_WIN_COUNT_ = 3
@@ -69,45 +69,6 @@ class TestPoetConfigView(unittest.TestCase):
         self.assertEqual(poet_config_view.block_claim_delay, 0)
         mock_config_view.return_value.get_setting.return_value = 1
         self.assertEqual(poet_config_view.block_claim_delay, 1)
-
-    def test_fixed_duration_block_count(self, mock_config_view):
-        """Verify that retrieving fixed duration block count works for invalid
-        cases (missing, invalid format, invalid value) as well as valid case.
-        """
-
-        poet_config_view = PoetConfigView(state_view=None)
-
-        # Underlying config setting does not parse to an integer
-        mock_config_view.return_value.get_setting.side_effect = \
-            ValueError('bad value')
-
-        self.assertEqual(
-            poet_config_view.fixed_duration_block_count,
-            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
-
-        _, kwargs = \
-            mock_config_view.return_value.get_setting.call_args
-
-        self.assertEqual(
-            kwargs['key'],
-            'sawtooth.poet.fixed_duration_block_count')
-        self.assertEqual(
-            kwargs['default_value'],
-            TestPoetConfigView._EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
-        self.assertEqual(kwargs['value_type'], int)
-
-        # Underlying config setting is not a valid value
-        mock_config_view.return_value.get_setting.side_effect = None
-        for bad_value in [-100, -1, 0]:
-            mock_config_view.return_value.get_setting.return_value = bad_value
-            self.assertEqual(
-                poet_config_view.fixed_duration_block_count,
-                TestPoetConfigView.
-                _EXPECTED_DEFAULT_FIXED_DURATION_BLOCK_COUNT_)
-
-        # Underlying config setting is a valid value
-        mock_config_view.return_value.get_setting.return_value = 1
-        self.assertEqual(poet_config_view.fixed_duration_block_count, 1)
 
     def test_initial_wait_time(self, mock_config_view):
         """Verify that retrieving initial wait time works for invalid cases
@@ -218,6 +179,48 @@ class TestPoetConfigView(unittest.TestCase):
         # Underlying config setting is a valid value
         mock_config_view.return_value.get_setting.return_value = 3.1415
         self.assertEqual(poet_config_view.minimum_wait_time, 3.1415)
+
+    def test_population_estimate_sample_size(self, mock_config_view):
+        """Verify that retrieving population estimate sample size works for
+        invalid cases (missing, invalid format, invalid value) as well as valid
+        case.
+        """
+
+        poet_config_view = PoetConfigView(state_view=None)
+
+        # Underlying config setting does not parse to an integer
+        mock_config_view.return_value.get_setting.side_effect = \
+            ValueError('bad value')
+
+        self.assertEqual(
+            poet_config_view.population_estimate_sample_size,
+            TestPoetConfigView.
+            _EXPECTED_DEFAULT_POPULATION_ESTIMATE_SAMPLE_SIZE_)
+
+        _, kwargs = \
+            mock_config_view.return_value.get_setting.call_args
+
+        self.assertEqual(
+            kwargs['key'],
+            'sawtooth.poet.population_estimate_sample_size')
+        self.assertEqual(
+            kwargs['default_value'],
+            TestPoetConfigView.
+            _EXPECTED_DEFAULT_POPULATION_ESTIMATE_SAMPLE_SIZE_)
+        self.assertEqual(kwargs['value_type'], int)
+
+        # Underlying config setting is not a valid value
+        mock_config_view.return_value.get_setting.side_effect = None
+        for bad_value in [-100, -1, 0]:
+            mock_config_view.return_value.get_setting.return_value = bad_value
+            self.assertEqual(
+                poet_config_view.population_estimate_sample_size,
+                TestPoetConfigView.
+                _EXPECTED_DEFAULT_POPULATION_ESTIMATE_SAMPLE_SIZE_)
+
+        # Underlying config setting is a valid value
+        mock_config_view.return_value.get_setting.return_value = 1
+        self.assertEqual(poet_config_view.population_estimate_sample_size, 1)
 
     def test_target_wait_time(self, mock_config_view):
         """Verify that retrieving target wait time works for invalid cases


### PR DESCRIPTION
This _should_ be the last big PoET-related PR (fingers crossed).  It completes the transition from the 0-7-based architecture/implementation to the new 0-8 architecture.  This PR:
* adds the remaining generic PoET configuration settings (target wait time, et al) to the PoET configuration view, updates the PoET configuration view to cache values so it doesn't have to re-fetch them (as the state view is read-only and they cannot change for the particular instantiation of the PoET configuration view), and adds unit tests for checking them
* removes the `sawtooth.poet.fixed_duration_count` setting as it is redundant because of `sawtooth.poet.population_estimate_sample_size` and also brings code closer to spec (spec does not define a separate fixed duration count and instead has defined the population estimate sample size as the fixed duration count)
* updates the PoET enclave factory to use the PoET configuration view instead of directlying using the more-generic configuration view
* pulls the computation of the local mean inside the consensus state object, which includes encapsulating the keeping and updating of population samples within the consensus object
* updates the wait timer (when creating) and wait certificate (when validating) to use the consensus state for computing the local mean as well as removing the prior implementation of this in the WaitTimer class
* because everything is now encapsulated inside the consensus state class, the previous PoET configuration class variables (target wait time, et al) have been removed from the WaitTimer class

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`sawtooth.consensus.algorithm=poet \`

Add:

```
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
sawtooth.poet.fixed_population_estimate_sample_size=10 \
```

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.