### PR TITLE
Update of Vagrant file and tutorial for proxy 

### DIFF
--- a/docs/source/app_developers_guide/getting_started.rst
+++ b/docs/source/app_developers_guide/getting_started.rst
@@ -157,17 +157,24 @@ If you are behind a network proxy, follow these steps before continuing:
 
 If you are using the Bash shell, run the following commands:
 
+.. warning::
+
+  The example URLs and port numbers used below are examples only.
+  Please substitute the actual URL, with actual port numbers, used
+  in your environment. Contact your network administrator for the
+  information if necessary.
+
 .. code-block:: console
 
-  % export http_proxy=http://example-proxy-server.com:911
-  % export https_proxy=https://example-proxy-server.com:912
+  % export http_proxy=http://example-proxy-server.com:3128
+  % export https_proxy=https://example-proxy-server.com:3129
 
 If you are using Windows, run the following commands:
 
 .. code-block:: console
 
-  % set http_proxy=http://example-proxy-server.com:911
-  % set https_proxy=https://example-proxy-server.com:912
+  % set http_proxy=http://example-proxy-server.com:3128
+  % set https_proxy=https://example-proxy-server.com:3129
 
 
 2. Install the vagrant-proxyconf plugin:

--- a/docs/source/app_developers_guide/getting_started.rst
+++ b/docs/source/app_developers_guide/getting_started.rst
@@ -144,6 +144,40 @@ The following tools are required:
 * `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ (5.1.16 r113841
   or later)
 
+
+Proxy Settings
+--------------
+
+If you are behind a network proxy, follow these steps before continuing:
+
+1. Set the following environment variables:
+
+  * http_proxy
+  * https_proxy
+
+If you are using the Bash shell, run the following commands:
+
+.. code-block:: console
+
+  % export http_proxy=http://example-proxy-server.com:911
+  % export https_proxy=https://example-proxy-server.com:912
+
+If you are using Windows, run the following commands:
+
+.. code-block:: console
+
+  % set http_proxy=http://example-proxy-server.com:911
+  % set https_proxy=https://example-proxy-server.com:912
+
+
+2. Install the vagrant-proxyconf plugin:
+
+.. code-block:: console
+
+  % cd sawtooth-core/tools
+  % vagrant plugin install vagrant-proxyconf
+
+
 Environment Startup
 -------------------
 

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   conf.each_pair {|key,value| puts "#{key} = #{value}"}
 
   if ARGV.include? "up"
-    if Vagrant.has_plugin?("vagrant-proxyconf")
+    if Vagrant.has_plugin?("vagrant-proxyconf") and (ENV["http_proxy"] or ENV["https_proxy"])
         puts "Configuring proxyconf plugin!"
         if ENV["http_proxy"]
             puts "http_proxy: " + ENV["http_proxy"]
@@ -86,7 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             puts "no_proxy: " + ENV["no_proxy"]
             config.proxy.no_proxy = ENV["no_proxy"]
         end
-    else
+    elsif ENV["http_proxy"] or ENV["https_proxy"]
         puts "Proxyconf plugin not found"
         puts "Install: vagrant plugin install vagrant-proxyconf"
     end


### PR DESCRIPTION
Update of Vagrant file and tutorial. 
Tutorial explains how to set env variables used by proxy.
Vagrant file does not notify about proxyconf unless http_proxy 
or https_proxy are set.