### PR TITLE
Remove non-ballot mode from sawtooth config

### DIFF
--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -505,7 +505,6 @@ def _config_inputs(key):
     setting key.
     """
     return [
-        _key_to_address('sawtooth.config.authorization_type'),
         _key_to_address('sawtooth.config.vote.proposals'),
         _key_to_address('sawtooth.config.vote.authorized_keys'),
         _key_to_address('sawtooth.config.vote.approval_threshold'),

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -53,6 +53,34 @@ def add_config_parser(subparsers, parent_parser):
                                            dest="subcommand")
     config_parsers.required = True
 
+    # The following parser is for the `genesis` subcommand.
+    # This command creates a batch that contains all of the initial
+    # transactions for on-chain settings
+    genesis_parser = config_parsers.add_parser('genesis')
+    genesis_parser.add_argument(
+        '-k', '--key',
+        type=str,
+        help='the signing key for the resulting batches '
+             'and initial authorized key')
+
+    genesis_parser.add_argument(
+        '-o', '--output',
+        type=str,
+        default='config-genesis.batch',
+        help='the name of the file to output the resulting batches')
+
+    genesis_parser.add_argument(
+        '-T', '--approval-threshold',
+        type=int,
+        help='the required number of votes to enable a setting change')
+
+    genesis_parser.add_argument(
+        '-A', '--authorized-key',
+        type=str,
+        action='append',
+        help='a public key for an user authorized to submit '
+             'config transactions')
+
     # The following parser is for the `proposal` subcommand group. These
     # commands allow the user to create proposals which may be applied
     # immediately or placed in ballot mode, depending on the current on-chain
@@ -189,6 +217,8 @@ def do_config(args):
         _do_config_proposal_vote(args)
     elif args.subcommand == 'settings' and args.settings_cmd == 'list':
         _do_config_list(args)
+    elif args.subcommand == 'genesis':
+        _do_config_genesis(args)
     else:
         raise AssertionError(
             '"{}" is not a valid subcommand of "config"'.format(
@@ -364,6 +394,46 @@ def _do_config_list(args):
             print(yaml.dump(settings_snapshot, default_flow_style=False)[0:-1])
     else:
         raise AssertionError('Unknown format {}'.format(args.format))
+
+
+def _do_config_genesis(args):
+    pubkey, signing_key = _read_signing_keys(args.key)
+
+    authorized_keys = args.authorized_key if args.authorized_key else [pubkey]
+    if pubkey not in authorized_keys:
+        authorized_keys.append(pubkey)
+
+    txns = []
+
+    txns.append(_create_propose_txn(
+        pubkey, signing_key,
+        ('sawtooth.config.vote.authorized_keys',
+         ','.join(authorized_keys))))
+
+    if args.approval_threshold is not None:
+        if args.approval_threshold < 1:
+            raise CliException('approval threshold must not be less than 1')
+
+        if args.approval_threshold > len(authorized_keys):
+            raise CliException(
+                'approval threshold must not be greater than the number of '
+                'authorized keys')
+
+        txns.append(_create_propose_txn(
+            pubkey, signing_key,
+            ('sawtooth.config.vote.approval_threshold',
+             str(args.approval_threshold))))
+
+    batch = _create_batch(pubkey, signing_key, txns)
+    batch_list = BatchList(batches=[batch])
+
+    try:
+        with open(args.output, 'wb') as batch_file:
+            batch_file.write(batch_list.SerializeToString())
+        print('Generated {}'.format(args.output))
+    except IOError as e:
+        raise CliException(
+            'Unable to write to batch file: {}'.format(str(e)))
 
 
 def _get_proposals(rest_client):

--- a/core_transactions/config/sawtooth_config/config_message_factory.py
+++ b/core_transactions/config/sawtooth_config/config_message_factory.py
@@ -48,7 +48,6 @@ class ConfigMessageFactory(object):
 
     def _create_tp_process_request(self, setting, payload):
         inputs = [
-            self._key_to_address('sawtooth.config.authorization_type'),
             self._key_to_address('sawtooth.config.vote.proposals'),
             self._key_to_address('sawtooth.config.vote.authorized_keys'),
             self._key_to_address('sawtooth.config.vote.approval_threshold'),

--- a/core_transactions/config/sawtooth_config/processor/handler.py
+++ b/core_transactions/config/sawtooth_config/processor/handler.py
@@ -219,10 +219,16 @@ def _validate_setting(auth_keys, setting, value):
             raise InvalidTransaction('authorized_keys must not be empty.')
 
     if setting == 'sawtooth.config.vote.approval_threshold':
+        threshold = None
         try:
-            int(value)
+            threshold = int(value)
         except ValueError:
             raise InvalidTransaction('approval_threshold must be an integer')
+
+        if threshold > len(auth_keys):
+            raise InvalidTransaction(
+                'approval_threshold must be less than or equal to number of '
+                'authorized_keys')
 
     if setting == 'sawtooth.config.vote.proposals':
         raise InvalidTransaction(

--- a/core_transactions/config/tests/test_tp_config.py
+++ b/core_transactions/config/tests/test_tp_config.py
@@ -89,6 +89,19 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_invalid_transaction()
 
+    def test_set_value_too_large_approval_threshold(self):
+        """
+        Tests setting an approval_threshold that is larger than the set of
+        authorized keys.  This should return an invalid transaction.
+        """
+        self._propose("sawtooth.config.vote.approval_threshold", "2")
+
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
+        self._expect_get('sawtooth.config.vote.approval_threshold')
+
+        self._expect_invalid_transaction()
+
     def test_set_value_empty_authorized_keys(self):
         """
         Tests setting an empty set of authorized keys.

--- a/core_transactions/config/tests/test_tp_config.py
+++ b/core_transactions/config/tests/test_tp_config.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import unittest
 import hashlib
 import base64
 
@@ -78,51 +77,54 @@ class TestConfig(TransactionProcessorTestCase):
     def _public_key(self):
         return self.factory.public_key
 
-    def test_set_value_no_auth(self):
-        """
-        Tests setting a value with no auth and no approvale type
-        """
-        self._propose("foo.bar.count", "1")
-
-        self._expect_get('sawtooth.config.authorization_type', 'None')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
-
-        # check the old value and set the new one
-        self._expect_get('foo.bar.count')
-        self._expect_set('foo.bar.count', '1')
-
-        self._expect_ok()
-
-    def test_set_value_bad_auth_type(self):
-        """
-        Tests setting an invalid authorization_type setting
-        """
-        self._propose("sawtooth.config.authorization_type", "foo")
-
-        self._expect_get('sawtooth.config.authorization_type', 'None')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
-
-        self._expect_invalid_transaction()
-
-    def test_error_on_bad_auth_type(self):
-        """
-        Sanity test that we get back an internal error for a bad auth type.
-        """
-        self._propose("foo.bar.count", "1")
-
-        self._expect_get('sawtooth.config.authorization_type', 'CrazyType')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
-
-        self._expect_internal_error()
-
     def test_set_value_bad_approval_threshold(self):
         """
         Tests setting an invalid approval_threshold.
         """
         self._propose("sawtooth.config.vote.approval_threshold", "foo")
 
-        self._expect_get('sawtooth.config.authorization_type', 'None')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
+        self._expect_get('sawtooth.config.vote.approval_threshold')
+
+        self._expect_invalid_transaction()
+
+    def test_set_value_empty_authorized_keys(self):
+        """
+        Tests setting an empty set of authorized keys.
+
+        Empty authorized keys should result in an invalid transaction.
+        """
+        self._propose("sawtooth.config.vote.authorized_keys", "")
+
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
+        self._expect_get('sawtooth.config.vote.approval_threshold')
+
+        self._expect_invalid_transaction()
+
+    def test_allow_set_authorized_keys_when_initially_empty(self):
+        """Tests that the authorized keys may be set if initially empty.
+        """
+        self._propose("sawtooth.config.vote.authorized_keys", self._public_key)
+
+        self._expect_get('sawtooth.config.vote.authorized_keys')
+        self._expect_get('sawtooth.config.vote.approval_threshold')
+
+        # Check that it is set
+        self._expect_get('sawtooth.config.vote.authorized_keys')
+        self._expect_set('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
+
+        self._expect_ok()
+
+    def test_reject_settings_when_auth_keys_is_empty(self):
+        """Tests that when auth keys is empty, only auth keys maybe set.
+        """
+        self._propose('my.config.setting', 'myvalue')
+
+        self._expect_get('sawtooth.config.vote.authorized_keys')
+        self._expect_get('sawtooth.config.vote.approval_threshold')
 
         self._expect_invalid_transaction()
 
@@ -133,19 +135,20 @@ class TestConfig(TransactionProcessorTestCase):
         """
         self._propose('sawtooth.config.vote.proposals', EMPTY_CANDIDATES)
 
-        self._expect_get('sawtooth.config.authorization_type', 'None')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
+        self._expect_get('sawtooth.config.vote.approval_threshold')
 
         self._expect_invalid_transaction()
 
-    def test_propose_in_ballot_mode(self):
+    def test_propose(self):
         """
         Tests proposing a value in ballot mode.
         """
         self._propose('my.config.setting', 'myvalue')
 
-        self._expect_get('sawtooth.config.authorization_type', 'Ballot')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key)
         self._expect_get('sawtooth.config.vote.approval_threshold', '2')
         self._expect_get('sawtooth.config.vote.proposals')
 
@@ -172,7 +175,7 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_ok()
 
-    def test_vote_in_ballot_mode_approved(self):
+    def test_vote_approved(self):
         """
         Tests voting on a given setting, where the setting is approved
         """
@@ -194,8 +197,8 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._vote(proposal_id, 'my.config.setting', ConfigVote.ACCEPT)
 
-        self._expect_get('sawtooth.config.authorization_type', 'Ballot')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key + ',some_other_pubkey')
         self._expect_get('sawtooth.config.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.config.vote.approval_threshold', '2')
@@ -212,7 +215,7 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_ok()
 
-    def test_vote_in_ballot_mode_counted(self):
+    def test_vote_counted(self):
         """
         Tests voting on a given setting, where the vote is counted only.
         """
@@ -234,8 +237,8 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._vote(proposal_id, 'my.config.setting', ConfigVote.ACCEPT)
 
-        self._expect_get('sawtooth.config.authorization_type', 'Ballot')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key + ',some_other_pubkey,third_pubkey')
         self._expect_get('sawtooth.config.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.config.vote.approval_threshold', '3')
@@ -262,7 +265,7 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_ok()
 
-    def test_vote_in_ballot_mode_rejected(self):
+    def test_vote_rejected(self):
         """
         Tests voting on a given setting, where the setting is rejected.
         """
@@ -288,8 +291,9 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._vote(proposal_id, 'my.config.setting', ConfigVote.REJECT)
 
-        self._expect_get('sawtooth.config.authorization_type', 'Ballot')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get(
+            'sawtooth.config.vote.authorized_keys',
+            self._public_key + ',some_other_pubkey,a_rejectors_pubkey')
         self._expect_get('sawtooth.config.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.config.vote.approval_threshold', '2')
@@ -302,8 +306,7 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_ok()
 
-    @unittest.expectedFailure  # delete unittest import when this is fixed
-    def test_vote_in_ballot_mode_rejects_a_tie(self):
+    def test_vote_rejects_a_tie(self):
         """
         Tests voting on a given setting, where there is a tie for accept and
         for reject, with no remaining auth keys.
@@ -327,8 +330,8 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._vote(proposal_id, 'my.config.setting', ConfigVote.REJECT)
 
-        self._expect_get('sawtooth.config.authorization_type', 'Ballot')
-        self._expect_get('sawtooth.config.vote.authorized_keys', '')
+        self._expect_get('sawtooth.config.vote.authorized_keys',
+                         self._public_key + ',some_other_pubkey')
         self._expect_get('sawtooth.config.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.config.vote.approval_threshold', '2')
@@ -341,15 +344,15 @@ class TestConfig(TransactionProcessorTestCase):
 
         self._expect_ok()
 
-    def test_authorized_keys_accept_no_approval(self):
+    def test_authorized_keys_accept_no_approval_threshhold(self):
         """
-        Tests setting a value with auth keys and no approval type
+        Tests setting a value with auth keys and no approval threshhold
         """
         self._propose("foo.bar.count", "1")
 
-        self._expect_get('sawtooth.config.authorization_type', 'None')
         self._expect_get('sawtooth.config.vote.authorized_keys',
                          'some_key,' + self._public_key)
+        self._expect_get('sawtooth.config.vote.approval_threshold')
 
         # check the old value and set the new one
         self._expect_get('foo.bar.count')
@@ -363,7 +366,6 @@ class TestConfig(TransactionProcessorTestCase):
         """
         self._propose("foo.bar.count", "1")
 
-        self._expect_get('sawtooth.config.authorization_type', 'None')
         self._expect_get('sawtooth.config.vote.authorized_keys',
                          'some_key,some_other_key')
 

--- a/integration/sawtooth_integration/docker/config-smoke.yaml
+++ b/integration/sawtooth_integration/docker/config-smoke.yaml
@@ -37,8 +37,10 @@ services:
       - 8800
     # start the validator with an empty genesis batch
     command: "bash -c \"\
+        echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis -k test.priv -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch  && \
         validator -v --public-uri tcp://validator:8800 \
             --component-endpoint tcp://eth0:40000 \
             --network-endpoint tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -26,12 +26,16 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen --force && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
         sawtooth config proposal create \
           -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm=poet \
           -o config.batch && \
         poet genesis -o poet.batch && \
-        sawtooth admin genesis config.batch poet.batch && \
+        sawtooth admin genesis \
+          config-genesis.batch config.batch poet.batch && \
         validator -v \
             --public-uri tcp://validator-0:8800 \
             --component-endpoint tcp://eth0:40000 \

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -29,6 +29,8 @@ LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.DEBUG)
 
 TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
+TEST_PUBKEY = \
+    '033775c26a68a3872f03314ccd080b8d8ec828572469737c7d3aa467f853a069d5'
 
 
 class TestConfigSmoke(unittest.TestCase):
@@ -92,6 +94,8 @@ class TestConfigSmoke(unittest.TestCase):
         args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
         settings = self._read_from_stdout(command, args)
 
-        _expected_setting_results = 'x: 1\ny: 1\n'
+        _expected_setting_results = \
+            'sawtooth.config.vote.authorized_keys: {}...\nx: 1\ny: 1\n'.format(
+                TEST_PUBKEY[:15])
         self.assertEqual(settings, _expected_setting_results,
                          'Setting results did not match.')

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -30,6 +30,7 @@ LOGGER.setLevel(logging.DEBUG)
 
 TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
 
+
 class TestConfigSmoke(unittest.TestCase):
 
     def setUp(self):
@@ -45,8 +46,10 @@ class TestConfigSmoke(unittest.TestCase):
     def _run(self, args):
         try:
             LOGGER.debug("Running %s", " ".join(args))
-            proc = subprocess.run(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+            proc = subprocess.run(args,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  check=True)
             LOGGER.debug(proc.stdout.decode())
         except subprocess.CalledProcessError as err:
             LOGGER.debug(err)
@@ -56,16 +59,15 @@ class TestConfigSmoke(unittest.TestCase):
 
     def _read_from_stdout(self, cmd, args):
         # Retrieve string of setting contents for comparison to input settings
-        backup = sys.stdout # backup the environment
-        sys.stdout = StringIO() # Capture the output of next statement
+        backup = sys.stdout  # backup the environment
+        sys.stdout = StringIO()  # Capture the output of next statement
 
         main(cmd, args)
-        settings = sys.stdout.getvalue() # release the output and store
+        settings = sys.stdout.getvalue()  # release the output and store
         sys.stdout.close()
         # Restore the environment
         sys.stdout = backup
         return settings
-
 
     def test_submit_then_list_settings(self):
         ''' Test ability to list settings after submission of a setting.
@@ -77,7 +79,7 @@ class TestConfigSmoke(unittest.TestCase):
 
         # Submit transaction, then list it using subprocess
         cmds = [
-            ['sawtooth','config', 'proposal', 'create', '-k', self._wif_file,
+            ['sawtooth', 'config', 'proposal', 'create', '-k', self._wif_file,
              '--url', 'http://rest_api:8080', 'x=1', 'y=1'],
             ['sawtooth', 'config', 'settings', 'list', '--url',
              'http://rest_api:8080']
@@ -91,4 +93,5 @@ class TestConfigSmoke(unittest.TestCase):
         settings = self._read_from_stdout(command, args)
 
         _expected_setting_results = 'x: 1\ny: 1\n'
-        self.assertEqual(settings, _expected_setting_results, 'Setting results did not match.' )
+        self.assertEqual(settings, _expected_setting_results,
+                         'Setting results did not match.')


### PR DESCRIPTION
Remove the non-ballot or non-voting mode from the sawtooth config transaction family reference implementation.  This change requires that there be at least on public key set in the authorized keys list before any setting can be changed.

The end result is a more secure model for handling configuration changes on-chain.

With the chain in the config transaction family requiring votes by authorized key, this PR introduces a new subcommand for `sawtooth config`: `genesis`.  Genesis provides a simple way to add authorized keys and set the vote threshold for accepting or rejecting a proposal.

Additionally:
 - config smoke adds the genesis step
 - poet smoke adds the genesis step