### PR TITLE
Update squash to return current state_root if there are no updates.

### DIFF
--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -331,6 +331,10 @@ class ContextManager(object):
                         effective_updates[k] = value
 
                 updates.update(effective_updates)
+
+            if len(updates) == 0:
+                return state_root
+
             virtual = not persist
             state_hash = tree.update(updates, virtual=virtual)
             if persist:

--- a/validator/tests/unit3/test_context_manager/tests.py
+++ b/validator/tests/unit3/test_context_manager/tests.py
@@ -87,6 +87,31 @@ class TestContextManager(unittest.TestCase):
         # 4)
         self.assertEqual(resulting_state_hash, test_resulting_state_hash)
 
+    def test_squash_no_updates(self):
+        """Tests that squashing a context that has no state updates will return
+           the starting state root hash.
+
+        Notes:
+            Set up the context
+
+            Test:
+                1) Squash the context.
+                2) Assert that the state hashe is the same as the starting
+                hash.
+        """
+        context_id = self.context_manager.create_context(
+            state_hash=self.first_state_hash,
+            base_contexts=[],
+            inputs=[],
+            outputs=[])
+        # 1)
+        squash = self.context_manager.get_squash_handler()
+        resulting_state_hash = squash(self.first_state_hash, [context_id],
+                                      persist=True)
+        # 2
+        self.assertIsNotNone(resulting_state_hash)
+        self.assertEquals(resulting_state_hash, self.first_state_hash)
+
     def _setup_context(self):
         # 1) Create transaction data
         first_transaction = {'inputs': ['aaaa', 'bbbb', 'cccc'],


### PR DESCRIPTION
Before, if there were no updates in the contexts being squash, a state_root_hash of None would be returned causing possible valid batches (No "InvalidTransactionErrors") to be found as invalid. This is a proposed fix for handling no-op transactions, assuming that we wish to allow such transactions. A consequence of this would be possible creation of "no-op" blocks, or a block that does not include a state change. As such that block would have the same state_root_hash as the previous block. 

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>