### PR TITLE
Implement Validator Signup Recent Block Test Plus Unit Test Goodness

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -123,8 +123,8 @@ def do_genesis(args):
             signup_info=vr_pb.SignUpInfo(
                 poet_public_key=signup_info.poet_public_key,
                 proof_data=signup_info.proof_data,
-                anti_sybil_id=signup_info.anti_sybil_id),
-        )
+                anti_sybil_id=signup_info.anti_sybil_id,
+                nonce=NULL_BLOCK_IDENTIFIER))
     serialized = payload.SerializeToString()
 
     # Create the address that will be used to look up this validator

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -96,7 +96,7 @@ def do_genesis(args):
         poet_enclave_module=poet_enclave_module,
         validator_address=pubkey,
         originator_public_key_hash=public_key_hash,
-        most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+        nonce=NULL_BLOCK_IDENTIFIER)
 
     print(
         'Writing key state for PoET public key: {}...{}'.format(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -20,7 +20,6 @@ import json
 
 import sawtooth_signing as signing
 
-from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus \
     import BlockPublisherInterface
@@ -113,19 +112,10 @@ class PoetBlockPublisher(BlockPublisherInterface):
         self._wait_timer = None
 
     def _register_signup_information(self, block_header, poet_enclave_module):
-        # Find the most-recent block in the block cache, if such a block
-        # exists, and get its wait certificate ID
-        wait_certificate_id = NULL_BLOCK_IDENTIFIER
-        most_recent_block = self._block_cache.block_store.chain_head
-        if most_recent_block is not None:
-            wait_certificate = \
-                utils.deserialize_wait_certificate(
-                    block=most_recent_block,
-                    poet_enclave_module=poet_enclave_module)
-            if wait_certificate is not None:
-                wait_certificate_id = wait_certificate.identifier
-
-        # Create signup information for this validator
+        # Create signup information for this validator, putting the block ID
+        # of the block previous to the block referenced by block_header in the
+        # nonce.  Block ID is better than wait certificate ID for testing
+        # freshness as we need to account for non-PoET blocks.
         public_key_hash = \
             hashlib.sha256(
                 block_header.signer_pubkey.encode()).hexdigest()
@@ -134,7 +124,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 poet_enclave_module=poet_enclave_module,
                 validator_address=block_header.signer_pubkey,
                 originator_public_key_hash=public_key_hash,
-                nonce=wait_certificate_id)
+                nonce=block_header.previous_block_id)
 
         # Create the validator registry payload
         payload = \
@@ -145,7 +135,8 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 signup_info=vr_pb.SignUpInfo(
                     poet_public_key=signup_info.poet_public_key,
                     proof_data=signup_info.proof_data,
-                    anti_sybil_id=signup_info.anti_sybil_id),
+                    anti_sybil_id=signup_info.anti_sybil_id,
+                    nonce=block_header.previous_block_id),
             )
         serialized = payload.SerializeToString()
 
@@ -184,12 +175,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 header_signature=signature)
 
         LOGGER.info(
-            'Register Validator Name=%s, ID=%s...%s, PoET public key=%s...%s',
+            'Register Validator Name=%s, ID=%s...%s, PoET public key=%s...%s, '
+            'Nonce=%s',
             payload.name,
             payload.id[:8],
             payload.id[-8:],
             payload.signup_info.poet_public_key[:8],
-            payload.signup_info.poet_public_key[-8:])
+            payload.signup_info.poet_public_key[-8:],
+            block_header.previous_block_id[:8])
 
         self._batch_publisher.send([transaction])
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -134,7 +134,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 poet_enclave_module=poet_enclave_module,
                 validator_address=block_header.signer_pubkey,
                 originator_public_key_hash=public_key_hash,
-                most_recent_wait_certificate_id=wait_certificate_id)
+                nonce=wait_certificate_id)
 
         # Create the validator registry payload
         payload = \

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -169,6 +169,18 @@ class PoetBlockVerifier(BlockVerifierInterface):
                 error)
             return False
 
+        # Reject the block if the validator signup information fails the
+        # freshness check.
+        if consensus_state.validator_signup_was_committed_too_late(
+                validator_info=validator_info,
+                poet_config_view=poet_config_view,
+                block_cache=self._block_cache):
+            LOGGER.error(
+                'Block %s rejected: Validator signup information not '
+                'committed in a timely manner.',
+                block_wrapper.identifier[:8])
+            return False
+
         # Reject the block if the validator has already claimed the key bock
         # limit for its current PoET key pair.
         if consensus_state.validator_has_claimed_block_limit(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_config_view.py
@@ -35,6 +35,7 @@ class PoetConfigView(object):
     _MINIMUM_WAIT_TIME_ = 1.0
     # pylint: disable=invalid-name
     _POPULATION_ESTIMATE_SAMPLE_SIZE_ = 50
+    _SIGNUP_COMMIT_MAXIMUM_DELAY_ = 0
     _TARGET_WAIT_TIME_ = 20.0
     _ZTEST_MAXIMUM_WIN_DEVIATION_ = 3.075
     _ZTEST_MINIMUM_WIN_COUNT_ = 3
@@ -58,6 +59,7 @@ class PoetConfigView(object):
         self._minimum_wait_time = None
         self._population_estimate_sample_size = None
         self._target_wait_time = None
+        self._signup_commit_maximum_delay = None
         self._ztest_maximum_win_deviation = None
         self._ztest_minimum_win_count = None
 
@@ -225,6 +227,32 @@ class PoetConfigView(object):
                     validate_function=lambda value: value > 0)
 
         return self._population_estimate_sample_size
+
+    @property
+    def signup_commit_maximum_delay(self):
+        """Return the signup commit maximum delay if config setting exists and
+        is valid, otherwise return the default.
+
+        The signup commit maximum delay is the maximum allowed number of blocks
+        between the head of the block chain when the signup information was
+        created and subsequent validator registry transaction was submitted and
+        when said transaction was committed to the blockchain.  For example, if
+        the signup commit maximum delay is one and the signup information's
+        containing validator registry transaction was created/submitted when
+        the blockchain head was block number 100, then the validator registry
+        transaction must have been committed either in block 101 (i.e., zero
+        blocks between 100 and 101) or block 102 (i.e., one block between 100
+        and 102).
+        """
+        if self._signup_commit_maximum_delay is None:
+            self._signup_commit_maximum_delay = \
+                self._get_config_setting(
+                    name='sawtooth.poet.signup_commit_maximum_delay',
+                    value_type=int,
+                    default_value=PoetConfigView._SIGNUP_COMMIT_MAXIMUM_DELAY_,
+                    validate_function=lambda value: value >= 0)
+
+        return self._signup_commit_maximum_delay
 
     @property
     def target_wait_time(self):

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
@@ -38,7 +38,7 @@ class SignupInfo(object):
                            poet_enclave_module,
                            validator_address,
                            originator_public_key_hash,
-                           most_recent_wait_certificate_id):
+                           nonce):
         """
         Creates signup information a PoET 1 validator uses to join the
         validator network.
@@ -51,8 +51,8 @@ class SignupInfo(object):
             originator_public_key_hash (str): A string representing SHA256
                 hash (i.e., hashlib.sha256(OPK).hexdigest()) of the
                 originator's public key
-            most_recent_wait_certificate_id (str): The ID of the
-                most-recently-created wait certificate.
+            nonce (str): A value that is to be stored in the nonce field of
+                the attestation verification report.
 
         Returns:
             SignupInfo: A signup info object.
@@ -62,7 +62,7 @@ class SignupInfo(object):
             poet_enclave_module.create_signup_info(
                 validator_address,
                 originator_public_key_hash,
-                most_recent_wait_certificate_id)
+                nonce)
         signup_info = cls(enclave_signup_info)
 
         return signup_info
@@ -136,8 +136,7 @@ class SignupInfo(object):
 
     def check_valid(self,
                     poet_enclave_module,
-                    originator_public_key_hash,
-                    most_recent_wait_certificate_id):
+                    originator_public_key_hash):
         """
         Checks the validity of the signup information.
 
@@ -147,16 +146,13 @@ class SignupInfo(object):
             originator_public_key_hash (str): A string representing SHA256
                 hash (i.e., hashlib.sha256(OPK).hexdigest()) of the
                 originator's public key
-            most_recent_wait_certificate_id (str): The ID of the
-                most-recently-created wait certificate.
 
         Returns:
             SignupInfo object
         """
         poet_enclave_module.verify_signup_info(
             self._enclave_signup_info(poet_enclave_module),
-            originator_public_key_hash,
-            most_recent_wait_certificate_id)
+            originator_public_key_hash)
 
     def serialize(self):
         # Simply return the serialized version of the enclave signup info

--- a/consensus/poet/core/tests/test_consensus/test_signup_info.py
+++ b/consensus/poet/core/tests/test_consensus/test_signup_info.py
@@ -41,7 +41,7 @@ class TestSignupInfo(unittest.TestCase):
                 poet_enclave_module=poet_enclave,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         self.assertIsNotNone(signup_info.poet_public_key)
         self.assertIsNotNone(signup_info.proof_data)
@@ -54,7 +54,7 @@ class TestSignupInfo(unittest.TestCase):
                 poet_enclave_module=poet_enclave,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
         serialized = signup_info.serialize()
         copy_signup_info = \
             SignupInfo.signup_info_from_serialized(
@@ -76,7 +76,7 @@ class TestSignupInfo(unittest.TestCase):
                 poet_enclave_module=poet_enclave,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
         poet_public_key = \
             SignupInfo.unseal_signup_data(
                 poet_enclave_module=poet_enclave,
@@ -94,13 +94,12 @@ class TestSignupInfo(unittest.TestCase):
                 poet_enclave_module=poet_enclave,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         try:
             signup_info.check_valid(
                 poet_enclave_module=poet_enclave,
-                originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                originator_public_key_hash=self._originator_public_key_hash)
         except ValueError as e:
             self.fail('Error with SignupInfo: {}'.format(e))
 
@@ -110,30 +109,9 @@ class TestSignupInfo(unittest.TestCase):
                 poet_enclave_module=poet_enclave,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         with self.assertRaises(ValueError):
             signup_info.check_valid(
                 poet_enclave_module=poet_enclave,
-                originator_public_key_hash=self._another_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
-
-    def test_non_matching_most_recent_wait_certificate_id(self):
-        signup_info = \
-            SignupInfo.create_signup_info(
-                poet_enclave_module=poet_enclave,
-                validator_address='1660 Pennsylvania Avenue NW',
-                originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
-
-        # NOTE - this requires that the signup information check for validity
-        #        actually make this check.  Currently the check is not done.
-        #        Once the check is added back, it should raise a
-        #        ValueError exception and this test will fail, alerting
-        #        you that you need to wrap the call in self.assertRaises
-        #
-        # with self.assertRaises(ValueError):
-        signup_info.check_valid(
-            poet_enclave_module=poet_enclave,
-            originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id='SomeFunkyCertificateID')
+                originator_public_key_hash=self._another_public_key_hash)

--- a/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
@@ -74,7 +74,7 @@ class TestWaitCertificate(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Make sure that trying to create a wait certificate before creating
         # a wait timer causes an error
@@ -90,7 +90,7 @@ class TestWaitCertificate(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Create a wait certificate for the genesis block so that we can
         # create another wait certificate that has to play by the rules.
@@ -128,7 +128,7 @@ class TestWaitCertificate(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Create a wait certificate for the genesis block so that we can
         # create another wait certificate that has to play by the rules.
@@ -168,7 +168,7 @@ class TestWaitCertificate(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Create two timers and try to create the wait certificate with the
         # first one, which should fail as it is not the current wait timer
@@ -206,7 +206,7 @@ class TestWaitCertificate(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Create a wait certificate for the genesis block so that we can
         # create another wait certificate that has to play by the rules.
@@ -263,7 +263,7 @@ class TestWaitCertificate(TestCase):
                 poet_enclave_module=self.poet_enclave_module,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         wt = \
             WaitTimer.create_wait_timer(
@@ -348,7 +348,7 @@ class TestWaitCertificate(TestCase):
                 poet_enclave_module=self.poet_enclave_module,
                 validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         wt = \
             WaitTimer.create_wait_timer(

--- a/consensus/poet/core/tests/test_consensus/test_wait_timer.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_timer.py
@@ -75,7 +75,7 @@ class TestWaitTimer(TestCase):
                 poet_enclave_module=self.poet_enclave_module,
                 validator_address='1060 W Addison Street',
                 originator_public_key_hash=self._originator_public_key_hash,
-                most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+                nonce=NULL_BLOCK_IDENTIFIER)
 
         stake_in_the_sand = time.time()
 
@@ -149,7 +149,7 @@ class TestWaitTimer(TestCase):
             poet_enclave_module=self.poet_enclave_module,
             validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
-            most_recent_wait_certificate_id=NULL_BLOCK_IDENTIFIER)
+            nonce=NULL_BLOCK_IDENTIFIER)
 
         # Verify that a timer doesn't expire before its creation time
         wt = wait_timer.WaitTimer.create_wait_timer(

--- a/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
+++ b/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
@@ -37,7 +37,6 @@ message ValidatorInfo {
     string transaction_id = 5;
 }
 
-
 message SignUpInfo {
     // Encoded public key corresponding to private key used by PoET to sign
     // wait certificates.
@@ -50,6 +49,10 @@ message SignUpInfo {
     // A string corresponding to the anti-Sybil ID for the enclave that
     // generated the signup information.
     string anti_sybil_id = 3;
+
+    // The nonce associated with the signup info.  Note that this must match
+    // the nonce provided when the signup info was created.
+    string nonce = 4;
 }
 
 message ValidatorMap {

--- a/consensus/poet/families/sawtooth_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_reg_message_factory.py
@@ -208,7 +208,8 @@ class ValidatorRegistryMessageFactory(object):
             SignUpInfo(
                 poet_public_key=signup_data['poet_public_key'],
                 proof_data=proof_data,
-                anti_sybil_id=originator_public_key_hash)
+                anti_sybil_id=originator_public_key_hash,
+                nonce=nonce)
 
     def create_tp_process_request(self, validator_id, payload):
         inputs = [
@@ -234,9 +235,9 @@ class ValidatorRegistryMessageFactory(object):
             name=validator_name,
             id=self.public_key,
             signup_info=signup_info,
-            transaction_id="7a79305e9734fd511386ae877da8770d66c22e4c7b18db8eb2"
-                           "ff6ec16f5a3452749ee49a04ea8a805ec5ec8b5d1fdfbcc6f3"
-                           "bf6374c99c9a906bc2837d0ad25a"
+            transaction_id="a48b383fe5c577471640f49e1e5341a9ed40a992125207e7c5"
+                           "dbecb21d6f5cc1002726c7ab6ab6e5bb1d13c4b2b65004156f"
+                           "6afaa573ab7aa3a0c41ed5c74b8f"
         ).SerializeToString()
 
         address = self._key_to_address(self.public_key)
@@ -249,9 +250,9 @@ class ValidatorRegistryMessageFactory(object):
             name=validator_name,
             id=self.public_key,
             signup_info=signup_info,
-            transaction_id="7a79305e9734fd511386ae877da8770d66c22e4c7b18db8eb2"
-                           "ff6ec16f5a3452749ee49a04ea8a805ec5ec8b5d1fdfbcc6f3"
-                           "bf6374c99c9a906bc2837d0ad25a"
+            transaction_id="a48b383fe5c577471640f49e1e5341a9ed40a992125207e7c5"
+                           "dbecb21d6f5cc1002726c7ab6ab6e5bb1d13c4b2b65004156f"
+                           "6afaa573ab7aa3a0c41ed5c74b8f"
         ).SerializeToString()
 
         address = self._key_to_address(self.public_key)

--- a/consensus/poet/families/sawtooth_validator_registry/validator_reg_message_factory.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_reg_message_factory.py
@@ -134,8 +134,7 @@ class ValidatorRegistryMessageFactory(object):
         return json.dumps(proof_data_dict)
 
     # Currently this is done in the enclave
-    def create_signup_info(self, originator_public_key_hash,
-                           most_recent_wait_certificate_id):
+    def create_signup_info(self, originator_public_key_hash, nonce):
         # currently not used
         # _active_wait_timer = None
 
@@ -194,7 +193,7 @@ class ValidatorRegistryMessageFactory(object):
                 base64.b64encode(
                     hashlib.sha256(
                         pse_manifest).hexdigest().encode()).decode()),
-            ('nonce', most_recent_wait_certificate_id),
+            ('nonce', nonce),
             ('timestamp', timestamp)
         ])
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -170,8 +170,7 @@ class ValidatorRegistryTransactionHandler(object):
 
     def verify_signup_info(self,
                            signup_info,
-                           originator_public_key_hash,
-                           most_recent_wait_certificate_id):
+                           originator_public_key_hash):
 
         # Verify the attestation verification report signature
         proof_data_dict = json.loads(signup_info.proof_data)
@@ -343,27 +342,6 @@ class ValidatorRegistryTransactionHandler(object):
                         sgx_quote.basename.name.hex(),
                         self.__VALID_BASENAME__.hex()))
 
-        # Verify that the wait certificate ID in the verification report
-        # matches the provided wait certificate ID.  The wait certificate ID
-        # is stored in the nonce field.
-        nonce = verification_report_dict.get('nonce')
-        if nonce is None:
-            raise \
-                ValueError(
-                    'Verification report does not have a nonce')
-
-        # NOTE - this check is currently not performed as a transaction
-        #        does not have a good way to obtaining the most recent
-        #        wait certificate ID.
-        #
-        # if nonce != most_recent_wait_certificate_id:
-        #     raise \
-        #         ValueError(
-        #             'Attestation evidence payload nonce {0} does not match '
-        #             'most-recently-committed wait certificate ID {1}'.format(
-        #                 nonce,
-        #                 most_recent_wait_certificate_id))
-
     def apply(self, transaction, state):
         txn_header = TransactionHeader()
         txn_header.ParseFromString(transaction.header)
@@ -391,8 +369,7 @@ class ValidatorRegistryTransactionHandler(object):
         try:
             self.verify_signup_info(
                 signup_info=signup_info,
-                originator_public_key_hash=public_key_hash,
-                most_recent_wait_certificate_id='0' * 16)
+                originator_public_key_hash=public_key_hash)
 
         except ValueError as error:
             raise InvalidTransaction(

--- a/consensus/poet/families/tests/test_tp_validator_registry.py
+++ b/consensus/poet/families/tests/test_tp_validator_registry.py
@@ -276,20 +276,6 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
         self._test_bad_signup_info(signup_info)
 
-        # ------------------------------------------------------
-        # No Nonce
-        proof_data_dict = json.loads(proof_data)
-        verification_report = \
-            json.loads(proof_data_dict["verification_report"])
-        del verification_report["nonce"]
-
-        signup_info.proof_data = \
-            self.factory.create_proof_data(
-                verification_report=verification_report,
-                evidence_payload=proof_data_dict.get('evidence_payload'))
-
-        self._test_bad_signup_info(signup_info)
-
     def test_invalid_pse_manifest(self):
         """
         Test that a transaction whose pse_manifast is invalid returns an

--- a/consensus/poet/families/tests/test_tp_validator_registry.py
+++ b/consensus/poet/families/tests/test_tp_validator_registry.py
@@ -276,6 +276,19 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
         self._test_bad_signup_info(signup_info)
 
+        # ------------------------------------------------------
+        # Nonce does not match the one in signup_info
+        proof_data_dict = json.loads(proof_data)
+        verification_report = \
+            json.loads(proof_data_dict["verification_report"])
+        signup_info.proof_data = \
+            self.factory.create_proof_data(
+                verification_report=verification_report,
+                evidence_payload=proof_data_dict.get('evidence_payload'))
+        signup_info.nonce = 'a non-matching nonce'
+
+        self._test_bad_signup_info(signup_info)
+
     def test_invalid_pse_manifest(self):
         """
         Test that a transaction whose pse_manifast is invalid returns an


### PR DESCRIPTION
This update adds an additional test in the PoET block verifier and publisher to check that the signup information for the validator was committed to the blockchain within a small number of blocks of it being created.  Specifically, when a validator generates its signup information it includes in the information a nonce, which is the block ID of the current head chain.  When validating the signup information is "fresh" other validators will look at the nonce and compare it to some number of previous blocks.  The number is configurable, but defaults to a delay of zero, meaning that the validator's signup information must be committed in the block immediately after the block referenced in the nonce.  This test can be relaxed by increasing the allowed delay.

Updates in this PR include:
* Adds some unit tests for the different PoET policies
* Updates the signup information in the valiator registry for the nonce, removing commented-out tests and code that no longer is necessary in the PoET simulator or validator registry transaction processor
* Updates the PoET config view to have a configuration setting to configure the maximum amount of signup commit delay allowed
* Updates the PoET consensus state to make the check of the signup information
* Updates the PoET block verifier to ensure signup information for a validator claiming a block passes the new check
* Updates the PoET block publisher to make the signup info check before initializing a block.  If the check fails, the PoET block publisher will attempt to sign up again

To test locally:
 `cd /project/sawtooth-core/integration/sawtooth_integration/docker` 

In `poet-smoke.yaml`, after the line:
`sawtooth.consensus.algorithm=poet \`

Add:

```
sawtooth.poet.target_wait_time=5 \
sawtooth.poet.initial_wait_time=0 \
```

Execute:
`run_docker_test poet-smoke.yaml`

Go get your beverage of choice and cross your fingers that the test passes.