### PR TITLE
Update keygen artifacts to produce .pub & .priv files

### DIFF
--- a/ansible/roles/sawtooth-genesis/tasks/main.yaml
+++ b/ansible/roles/sawtooth-genesis/tasks/main.yaml
@@ -3,7 +3,7 @@
 - name: Create keys if none exist
   command: sawtooth keygen validator --key-dir /etc/sawtooth-validator/keys
   args:
-    creates: /etc/sawtooth-validator/keys/*.wif
+    creates: /etc/sawtooth-validator/keys/*.priv
 
 - name: Create Genesis block
   shell: sawtooth admin poet1-genesis

--- a/ansible/roles/sawtooth-validator/defaults/main.yaml
+++ b/ansible/roles/sawtooth-validator/defaults/main.yaml
@@ -25,4 +25,4 @@ sawtooth_validator_transaction_families:
     - "ledger.transaction.integer_key"
 sawtooth_validator_ledger_type: "poet1"
 sawtooth_validator_administration_node: "NOT_SET"
-sawtooth_validator_key_file: "{key_dir}/{node}.wif"
+sawtooth_validator_key_file: "{key_dir}/{node}.priv"

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -65,12 +65,12 @@ def do_keygen(args):
         raise CliException(
             "Key directory does not exist: {}".format(key_dir))
 
-    wif_filename = os.path.join(key_dir, key_name + '.wif')
-    addr_filename = os.path.join(key_dir, key_name + '.addr')
+    wif_filename = os.path.join(key_dir, key_name + '.priv')
+    pub_filename = os.path.join(key_dir, key_name + '.pub')
 
     if not args.force:
         file_exists = False
-        for filename in [wif_filename, addr_filename]:
+        for filename in [wif_filename, pub_filename]:
             if os.path.exists(filename):
                 file_exists = True
                 print('file exists: {}'.format(filename), file=sys.stderr)
@@ -80,7 +80,6 @@ def do_keygen(args):
 
     privkey = signing.generate_privkey()
     pubkey = signing.generate_pubkey(privkey)
-    addr = signing.generate_identifier(pubkey)
 
     try:
         wif_exists = os.path.exists(wif_filename)
@@ -93,14 +92,15 @@ def do_keygen(args):
             wif_fd.write(privkey)
             wif_fd.write('\n')
 
-        addr_exists = os.path.exists(addr_filename)
-        with open(addr_filename, 'w') as addr_fd:
+        pub_exists = os.path.exists(pub_filename)
+        with open(pub_filename, 'w') as pub_fd:
             if not args.quiet:
-                if addr_exists:
-                    print('overwriting file: {}'.format(addr_filename))
+                if pub_exists:
+                    print('overwriting file: {}'.format(pub_filename))
                 else:
-                    print('writing file: {}'.format(addr_filename))
-            addr_fd.write(addr)
-            addr_fd.write('\n')
+                    print('writing file: {}'.format(pub_filename))
+            pub_fd.write(pubkey)
+            pub_fd.write('\n')
+
     except IOError as ioe:
         raise CliException('IOError: {}'.format(str(ioe)))

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -407,7 +407,7 @@ def _read_signing_keys(key_filename):
         filename = os.path.join(os.path.expanduser('~'),
                                 '.sawtooth',
                                 'keys',
-                                getpass.getuser() + '.wif')
+                                getpass.getuser() + '.priv')
 
     try:
         with open(filename, 'r') as key_file:

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -67,12 +67,12 @@ def do_keygen(args):
             except IOError as e:
                 raise CliException('IOError: {}'.format(str(e)))
 
-    wif_filename = os.path.join(key_dir, key_name + '.wif')
-    addr_filename = os.path.join(key_dir, key_name + '.addr')
+    wif_filename = os.path.join(key_dir, key_name + '.priv')
+    pub_filename = os.path.join(key_dir, key_name + '.pub')
 
     if not args.force:
         file_exists = False
-        for filename in [wif_filename, addr_filename]:
+        for filename in [wif_filename, pub_filename]:
             if os.path.exists(filename):
                 file_exists = True
                 print('file exists: {}'.format(filename), file=sys.stderr)
@@ -82,7 +82,6 @@ def do_keygen(args):
 
     privkey = signing.generate_privkey()
     pubkey = signing.generate_pubkey(privkey)
-    addr = signing.generate_identifier(pubkey)
 
     try:
         wif_exists = os.path.exists(wif_filename)
@@ -95,14 +94,15 @@ def do_keygen(args):
             wif_fd.write(privkey)
             wif_fd.write('\n')
 
-        addr_exists = os.path.exists(addr_filename)
-        with open(addr_filename, 'w') as addr_fd:
+        pub_exists = os.path.exists(pub_filename)
+        with open(pub_filename, 'w') as pub_fd:
             if not args.quiet:
-                if addr_exists:
-                    print('overwriting file: {}'.format(addr_filename))
+                if pub_exists:
+                    print('overwriting file: {}'.format(pub_filename))
                 else:
-                    print('writing file: {}'.format(addr_filename))
-            addr_fd.write(addr)
-            addr_fd.write('\n')
+                    print('writing file: {}'.format(pub_filename))
+            pub_fd.write(pubkey)
+            pub_fd.write('\n')
+
     except IOError as ioe:
         raise CliException('IOError: {}'.format(str(ioe)))

--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -32,9 +32,9 @@ class TestKeygen(unittest.TestCase):
         cls._key_dir = get_key_dir()
         cls._key_name = 'test_key'
         cls._wif_filename = os.path.join(cls._key_dir,
-                                         cls._key_name + '.wif')
-        cls._addr_filename = os.path.join(cls._key_dir,
-                                          cls._key_name + '.addr')
+                                         cls._key_name + '.priv')
+        cls._pub_filename = os.path.join(cls._key_dir,
+                                         cls._key_name + '.pub')
         if not os.path.exists(cls._key_dir):
             try:
                 os.makedirs(cls._key_dir, exist_ok=True)
@@ -95,7 +95,7 @@ class TestKeygen(unittest.TestCase):
         '''
         try:
             os.remove(self._wif_filename)
-            os.remove(self._addr_filename)
+            os.remove(self._pub_filename)
         except FileNotFoundError:
             pass
 

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -38,7 +38,7 @@ class TestConfigBatchlist(unittest.TestCase):
         self._temp_dir = tempfile.mkdtemp()
 
         # create a wif key for signing
-        self._wif_file = os.path.join(self._temp_dir, 'test.wif')
+        self._wif_file = os.path.join(self._temp_dir, 'test.priv')
         with open(self._wif_file, 'wb') as wif:
             wif.write(TEST_WIF.encode())
 

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -208,7 +208,7 @@ def _read_signing_keys(key_filename):
     """
     filename = key_filename
     if key_filename is None:
-        filename = os.path.join(config.get_key_dir(), 'validator.wif')
+        filename = os.path.join(config.get_key_dir(), 'validator.priv')
 
     try:
         with open(filename, 'r') as key_file:

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -99,7 +99,7 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         self.assertEqual(len(self._store), 1)
         self.assertTrue(poet_public_key in self._store)
 
-    def _create_key(self, key_name='validator.wif'):
+    def _create_key(self, key_name='validator.priv'):
         privkey = signing.generate_privkey()
         wif_file = os.path.join(self._temp_dir, key_name)
         with open(wif_file, 'w') as wif_fd:

--- a/core/sawtooth/cli/admin_sub/clean.py
+++ b/core/sawtooth/cli/admin_sub/clean.py
@@ -138,8 +138,8 @@ def do_clean_state(cfg, args):
 def do_delete_keys(cfg, args):
     # Use regex to specify which signing key files to remove
     key_directory = cfg.get("KeyDirectory")
-    files = get_purge_files(key_directory, r'\.addr')
-    files.extend(get_purge_files(key_directory, r'\.wif'))
+    files = get_purge_files(key_directory, r'\.pub')
+    files.extend(get_purge_files(key_directory, r'\.priv'))
 
     if args.dry_run is True:
         try:

--- a/core/sawtooth/cli/submit.py
+++ b/core/sawtooth/cli/submit.py
@@ -108,13 +108,13 @@ def do_submit(args):
     family_name = args.family
 
     # If we have a '/' in the key name, treat it as the full path to
-    # a wif file, without modification.  If it does not, then assume
+    # a priv file, without modification.  If it does not, then assume
     # it is in ~/.sawtooth/keys/.
     if '/' in key_name:
         key_file = key_name
     else:
         key_dir = os.path.join(os.path.expanduser('~'), '.sawtooth', 'keys')
-        key_file = os.path.join(key_dir, key_name + '.wif')
+        key_file = os.path.join(key_dir, key_name + '.priv')
 
     if not os.path.exists(key_file):
         raise ClientException('no such file: {}'.format(key_file))

--- a/docs/source/app_developers_guide/getting_started.rst
+++ b/docs/source/app_developers_guide/getting_started.rst
@@ -88,8 +88,8 @@ registering and creating intial blocks you can move on to the next step.
 .. code-block:: console
 
   Attaching to compose_validator_1, compose_tp_xo_python_1, compose_client_1, compose_tp_intkey_python_1, compose_tp_config_1, compose_rest_api_1
-  validator_1         | writing file: /etc/sawtooth/keys/validator.wif
-  validator_1         | writing file: /etc/sawtooth/keys/validator.addr
+  validator_1         | writing file: /etc/sawtooth/keys/validator.priv
+  validator_1         | writing file: /etc/sawtooth/keys/validator.pub
   validator_1         | Generating /var/lib/sawtooth/genesis.batch
   tp_xo_python_1      | [19:03:47 DEBUG   selector_events] Using selector: ZMQSelector
   validator_1         | [19:03:47.537 INFO     path] Skipping path loading from non-existent config file: /etc/sawtooth/path.toml
@@ -496,14 +496,14 @@ following commands from the Vagrant CLI:
 .. code-block:: console
 
   $ sawtooth keygen my_key
-  $ sawtooth config proposal create --key /home/ubuntu/.sawtooth/keys/my_key.wif sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_config", "version":"1.0", "encoding":"application/protobuf"}]'
+  $ sawtooth config proposal create --key /home/ubuntu/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_config", "version":"1.0", "encoding":"application/protobuf"}]'
   
 Or from the Docker CLI:
 
 .. code-block:: console
 
   $ sawtooth keygen my_key
-  $ sawtooth config proposal create --key /root/.sawtooth/keys/my_key.wif sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_config", "version":"1.0", "encoding":"application/protobuf"}]' --url http://rest_api:8080
+  $ sawtooth config proposal create --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_config", "version":"1.0", "encoding":"application/protobuf"}]' --url http://rest_api:8080
 
 A TP_PROCESS_REQUEST message appears in the logging output of the validator.
 

--- a/extensions/arcade/sawtooth_battleship/battleship_cli.py
+++ b/extensions/arcade/sawtooth_battleship/battleship_cli.py
@@ -228,8 +228,8 @@ def do_init(args, config):
     save_config(config)
 
     wif_filename = config.get('DEFAULT', 'key_file')
-    if wif_filename.endswith(".wif"):
-        addr_filename = wif_filename[0:-len(".wif")] + ".addr"
+    if wif_filename.endswith(".priv"):
+        addr_filename = wif_filename[0:-len(".priv")] + ".addr"
     else:
         addr_filename = wif_filename + ".addr"
 
@@ -404,8 +404,8 @@ def do_show(args, config):
 
     # figure out the proper user's target board, given the addr
     wif_filename = config.get('DEFAULT', 'key_file')
-    if wif_filename.endswith(".wif"):
-        addr_filename = wif_filename[0:-len(".wif")] + ".addr"
+    if wif_filename.endswith(".priv"):
+        addr_filename = wif_filename[0:-len(".priv")] + ".addr"
     else:
         addr_filename = wif_filename + ".addr"
     addr_file = file(addr_filename, mode='r')
@@ -546,7 +546,7 @@ def load_config():
     config = ConfigParser.SafeConfigParser()
     config.set('DEFAULT', 'url', 'http://localhost:8800')
     config.set('DEFAULT', 'key_dir', key_dir)
-    config.set('DEFAULT', 'key_file', '%(key_dir)s/%(username)s.wif')
+    config.set('DEFAULT', 'key_file', '%(key_dir)s/%(username)s.priv')
     config.set('DEFAULT', 'username', real_user)
     if os.path.exists(config_file):
         config.read(config_file)

--- a/extensions/arcade/tests/test_battleship.py
+++ b/extensions/arcade/tests/test_battleship.py
@@ -36,8 +36,8 @@ class TestBattleshipCommands(unittest.TestCase):
         data_dir = os.path.join(home_dir, ".sawtooth")
         user1_data = os.path.join(data_dir, "battleship-{}.data".format(user1))
         user2_data = os.path.join(data_dir, "battleship-{}.data".format(user2))
-        user1_key = os.path.join(key_dir, "{}.wif".format(user1))
-        user2_key = os.path.join(key_dir, "{}.wif".format(user2))
+        user1_key = os.path.join(key_dir, "{}.priv".format(user1))
+        user2_key = os.path.join(key_dir, "{}.priv".format(user2))
         user1_public_key = os.path.join(key_dir, "{}.addr".format(user1))
         user2_public_key = os.path.join(key_dir, "{}.addr".format(user2))
         files = [user1_data, user2_data, user1_key, user2_key,

--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -27,7 +27,7 @@ services:
     command: "bash -c \"\
         sawtooth admin keygen --force && \
         sawtooth config proposal create \
-          -k /etc/sawtooth/keys/validator.wif \
+          -k /etc/sawtooth/keys/validator.priv \
           sawtooth.consensus.algorithm=poet \
           -o config.batch && \
         poet genesis -o poet.batch && \

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -38,7 +38,7 @@ class TestConfigSmoke(unittest.TestCase):
         os.makedirs(self._data_dir)
 
         # create a wif key for signing
-        self._wif_file = os.path.join(self._temp_dir, 'test.wif')
+        self._wif_file = os.path.join(self._temp_dir, 'test.priv')
         with open(self._wif_file, 'wb') as wif:
             wif.write(TEST_WIF.encode())
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -177,8 +177,8 @@ def do_init(args, config):
     save_config(config)
 
     wif_filename = config.get('DEFAULT', 'key_file')
-    if wif_filename.endswith(".wif"):
-        addr_filename = wif_filename[0:-len(".wif")] + ".addr"
+    if wif_filename.endswith(".priv"):
+        addr_filename = wif_filename[0:-len(".priv")] + ".addr"
     else:
         addr_filename = wif_filename + ".addr"
 
@@ -299,7 +299,7 @@ def load_config():
     config = configparser.ConfigParser()
     config.set('DEFAULT', 'url', '127.0.0.1:8080')
     config.set('DEFAULT', 'key_dir', key_dir)
-    config.set('DEFAULT', 'key_file', '%(key_dir)s/%(username)s.wif')
+    config.set('DEFAULT', 'key_file', '%(key_dir)s/%(username)s.priv')
     config.set('DEFAULT', 'username', real_user)
     if os.path.exists(config_file):
         config.read(config_file)

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -32,7 +32,7 @@ def load_identity_signing_key(key_dir, key_name):
     Returns:
         str: the private signing key, in hex.
     """
-    key_path = os.path.join(key_dir, '{}.wif'.format(key_name))
+    key_path = os.path.join(key_dir, '{}.priv'.format(key_name))
 
     if not os.path.exists(key_path):
         raise LocalConfigurationError(


### PR DESCRIPTION
Commands 'sawtooth admin keygen' and 'sawtooth keygen'
updated to produce files with extensions .priv & .pub
instead of .wif & .addr

Files ending in .priv are equivalent to the files that
ended in .wif.

Signed-off-by: Todd Ojala <todd@bitwise.io>