### PR TITLE
Update DevMode consensus to handle non-DevMode blocks.

### DIFF
--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -16,6 +16,7 @@
 import time
 import random
 import hashlib
+import logging
 
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus\
@@ -26,6 +27,8 @@ from sawtooth_validator.journal.consensus.consensus\
     import ForkResolverInterface
 
 from sawtooth_validator.state.config_view import ConfigView
+
+LOGGER = logging.getLogger(__name__)
 
 
 class BlockPublisher(BlockPublisherInterface):
@@ -185,6 +188,34 @@ class ForkResolver(ForkResolverInterface):
             bool: True if choosing the new chain head, False if choosing
             the current chain head.
         """
+
+        # If the new fork head is not DevMode consensus, bail out.  This should
+        # never happen, but we need to protect against it.
+        if new_fork_head.consensus != b"Devmode":
+            raise \
+                TypeError(
+                    'New fork head {} is not a DevMode block'.format(
+                        new_fork_head.identifier[:8]))
+
+        # If the current fork head is not DevMode consensus, check the new fork
+        # head to see if its immediate predecessor is the current fork head. If
+        # so that means that consensus mode is changing.  If not, we are again
+        # in a situation that should never happen, but we need to guard
+        # against.
+        if cur_fork_head.consensus != b"Devmode":
+            if new_fork_head.previous_block_id == cur_fork_head.identifier:
+                LOGGER.info(
+                    'Choose new fork %s: New fork head switches consensus to '
+                    'DevMode',
+                    new_fork_head.identifier[:8])
+                return True
+
+            raise \
+                TypeError(
+                    'Trying to compare a DevMode block {} to a non-DevMode '
+                    'block {} that is not the direct predecessor'.format(
+                        new_fork_head.identifier[:8],
+                        cur_fork_head.identifier[:8]))
 
         if new_fork_head.block_num == cur_fork_head.block_num:
             cur_fork_hash = self.hash_signer_pubkey(


### PR DESCRIPTION
DevMode consensus is updated to, before looking at block header data:
* if the new fork head is not a DevMode block, raises an exception
* if the current fork head is not a DevMode block and is the immediate predecessor to the new fork, it immediately accepts the new fork head as that indicates that consensus mode is changing
* if the current fork head is not a DevMode block and also is not the immediate predecessor to the new fork head, it raises an exception

Easiest way I found to test was manually (fingers crossed these instructions work) in multiple xterms:

Start up a validator:
```
sawtooth admin keygen --force
sawtooth config proposal create -k /home/ubuntu/sawtooth/keys/validator.wif sawtooth.consensus.algorithm=poet -o config.batch
poet genesis -k /home/ubuntu/sawtooth/keys/validator.wif -o poet.batch
sawtooth admin genesis config.batch poet.batch
validator -v --public-uri tcp://0.0.0.0:8800
```
Start up a validator registry TP:
```
tp_validator_registry -v tcp://localhost:40000
```
Start up a config TP:
```
tp_config -v tcp://localhost:40000
```
Start up REST API:
```
rest_api
````
Propose a config setting for DevMode consensus:
```
/sawtooth config proposal create -k /home/ubuntu/sawtooth/keys/validator.wif sawtooth.consensus.algorithm=devmode
```
Ensure that after you create the config proposal that in the validator log you see that the blockchain is udpated (you should see a message about the new fork head being chosen).  Depending upon the wait timer chosen by the PoET consensus module, this may take a minute or so (it is random after all).

Propose a config setting for PoET consensus:
```
/sawtooth config proposal create -k /home/ubuntu/sawtooth/keys/validator.wif sawtooth.consensus.algorithm=poet
```
Monitor the log for the validator - you should see a message when you propose the config setting `sawtooth.consensus.algorithm=poet` that DevMode has chosen the new fork head and it should also log a message that it detected a switch to DevMode consensus.

Repeat the propose Poet/propose DevMode several times.  You should see DevMode detecting the switch.

Then propose a config setting that does not switch consensus modes:
```
/sawtooth config proposal create -k /home/ubuntu/sawtooth/keys/validator.wif sawtooth.poet.target_wait_time=5
```
You should see DevMode fork resolver choose the new fork, but no message about detecting a change as it should be building upon a DevMode block.