### PR TITLE
Create PoET block verifier unit tests for wait certificates.

### DIFF
--- a/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
@@ -1,0 +1,173 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import shutil
+import tempfile
+
+from unittest import TestCase
+from unittest import mock
+
+from sawtooth_poet.poet_consensus.poet_block_verifier import PoetBlockVerifier
+
+from sawtooth_poet_common.protobuf.validator_registry_pb2 \
+    import ValidatorInfo
+from sawtooth_poet_common.protobuf.validator_registry_pb2 \
+    import SignUpInfo
+
+
+@mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
+            'ConsensusStateStore')
+@mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.BlockWrapper')
+@mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.PoetConfigView')
+@mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.factory')
+class TestPoetBlockVerifier(TestCase):
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
+
+    @mock.patch(
+        'sawtooth_poet.poet_consensus.poet_block_verifier.ConsensusState')
+    @mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
+                'ValidatorRegistryView')
+    @mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.utils')
+    def test_non_poet_block(self,
+                            mock_utils,
+                            mock_validator_registry_view,
+                            mock_consensus_state,
+                            mock_poet_enclave_factory,
+                            mock_poet_config_view,
+                            mock_block_wrapper,
+                            mock_consensus_state_store):
+        """Verify that the PoET block verifier indicates failure if the block
+        is not a PoET block (i.e., the consensus field in the block header
+        is not a serialized wait certificate).
+        """
+
+        # Ensure that the consensus state does not generate failures that would
+        # allow this test to pass
+        mock_state = mock.Mock()
+        mock_state.validator_signup_was_committed_too_late.return_value = False
+        mock_state.validator_has_claimed_block_limit.return_value = False
+        mock_state.validator_is_claiming_too_early.return_value = False
+        mock_state.validator_is_claiming_too_frequently.return_value = False
+
+        mock_consensus_state.consensus_state_for_block_id.return_value = \
+            mock_state
+
+        # Make utils pretend it cannot deserialize the wait certificate
+        mock_utils.deserialize_wait_certificate.return_value = None
+
+        mock_block_cache = mock.MagicMock()
+        mock_state_view_factory = mock.Mock()
+        mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
+
+        mock_validator_registry_view.return_value.get_validator_info.\
+            return_value = \
+            ValidatorInfo(
+                name='validator_001',
+                id='validator_deadbeef',
+                signup_info=SignUpInfo(
+                    poet_public_key='00112233445566778899aabbccddeeff'))
+
+        with mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
+                        'LOGGER') as mock_logger:
+            block_verifier = \
+                PoetBlockVerifier(
+                    block_cache=mock_block_cache,
+                    state_view_factory=mock_state_view_factory,
+                    data_dir=self._temp_dir,
+                    validator_id='validator_deadbeef')
+            self.assertFalse(
+                block_verifier.verify_block(
+                    block_wrapper=mock_block))
+
+            # Could be a hack, but verify that the appropriate log message is
+            # generated - so we at least have some faith that the failure was
+            # because of what we are testing and not something else.  I know
+            # that this is fragile if the log message is changed, so would
+            # accept any suggestions on a better way to verify that the
+            # function fails for the reason we expect.
+            (message, *_), _ = mock_logger.error.call_args
+            self.assertTrue(
+                'was not created by PoET consensus module' in message)
+
+    @mock.patch(
+        'sawtooth_poet.poet_consensus.poet_block_verifier.ConsensusState')
+    @mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
+                'ValidatorRegistryView')
+    @mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.utils')
+    def test_invalid_wait_certificate(self,
+                                      mock_utils,
+                                      mock_validator_registry_view,
+                                      mock_consensus_state,
+                                      mock_poet_enclave_factory,
+                                      mock_poet_config_view,
+                                      mock_block_wrapper,
+                                      mock_consensus_state_store):
+
+        # Ensure that the consensus state does not generate failures that would
+        # allow this test to pass
+        mock_state = mock.Mock()
+        mock_state.validator_signup_was_committed_too_late.return_value = False
+        mock_state.validator_has_claimed_block_limit.return_value = False
+        mock_state.validator_is_claiming_too_early.return_value = False
+        mock_state.validator_is_claiming_too_frequently.return_value = False
+
+        mock_consensus_state.consensus_state_for_block_id.return_value = \
+            mock_state
+
+        # Make the certificate's check_valid pretend it failed
+        mock_wait_certificate = mock.Mock()
+        mock_wait_certificate.check_valid.side_effect = \
+            ValueError('Unit test fake failure')
+
+        mock_utils.deserialize_wait_certificate.return_value = \
+            mock_wait_certificate
+
+        mock_block_cache = mock.MagicMock()
+        mock_state_view_factory = mock.Mock()
+        mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
+
+        mock_validator_registry_view.return_value.get_validator_info.\
+            return_value = \
+            ValidatorInfo(
+                name='validator_001',
+                id='validator_deadbeef',
+                signup_info=SignUpInfo(
+                    poet_public_key='00112233445566778899aabbccddeeff'))
+
+        with mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
+                        'LOGGER') as mock_logger:
+            block_verifier = \
+                PoetBlockVerifier(
+                    block_cache=mock_block_cache,
+                    state_view_factory=mock_state_view_factory,
+                    data_dir=self._temp_dir,
+                    validator_id='validator_deadbeef')
+            self.assertFalse(
+                block_verifier.verify_block(
+                    block_wrapper=mock_block))
+
+            # Could be a hack, but verify that the appropriate log message is
+            # generated - so we at least have some faith that the failure was
+            # because of what we are testing and not something else.  I know
+            # that this is fragile if the log message is changed, so would
+            # accept any suggestions on a better way to verify that the
+            # function fails for the reason we expect.
+            (message, *_), _ = mock_logger.error.call_args
+            self.assertTrue('Wait certificate check failed' in message)


### PR DESCRIPTION
Adds unit test to verify proper PoET block verifier behavior when:
- the block is a non-PoET block (i.e., the block header consensus field does not contain a serialized wait certificate)
- the wait certificate is not valid

Signed-off-by: Jamie Jason <jamie.jason@intel.com>