### PR TITLE
Store State Deltas

### DIFF
--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -1,0 +1,38 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "state_delta_pb2";
+
+
+// A state change is an entry in a given delta set. StateChange objects 
+// have the type of SET, which is either an insert or update, or
+// DELETE.  Items marked as a DELETE will have no byte value.
+message StateChange {
+    enum Type {
+        SET = 0;
+        DELETE = 1;
+    }
+    string address = 1;
+    bytes value = 2;
+    Type type = 3;
+}
+
+// A collection of state changes.
+message StateDeltaSet {
+    repeated StateChange state_changes = 1;
+}

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -23,6 +23,7 @@ from threading import Thread
 from queue import Queue
 
 from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
 
 
 LOGGER = logging.getLogger(__name__)
@@ -166,14 +167,16 @@ class StateContext(object):
 
 class ContextManager(object):
 
-    def __init__(self, database):
+    def __init__(self, database, state_delta_store):
         """
 
         Args:
-            database database.Database subclass: the subclass/implementation of
-                                                the Database
+            database (database.Database subclass): the subclass/implementation
+                of the Database
+            state_delta_store (StateDeltaStore): the store for state deltas
         """
         self._database = database
+        self._state_delta_store = state_delta_store
         self._first_merkle_root = None
         self._contexts = _ThreadsafeContexts()
 
@@ -338,6 +341,13 @@ class ContextManager(object):
             virtual = not persist
             state_hash = tree.update(updates, virtual=virtual)
             if persist:
+                # save the state changes to the state_delta_store
+                changes = [StateChange(address=addr,
+                                       value=value,
+                                       type=StateChange.SET)
+                           for addr, value in updates.items()]
+                self._state_delta_store.save_state_deltas(state_hash, changes)
+
                 # clean up all contexts that are involved in being squashed.
                 base_c_ids = []
                 for c_id in context_ids:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -52,6 +52,7 @@ from sawtooth_validator.execution.executor import TransactionExecutor
 from sawtooth_validator.execution import processor_handlers
 from sawtooth_validator.state import client_handlers
 from sawtooth_validator.state.config_view import ConfigViewFactory
+from sawtooth_validator.state.state_delta_store import StateDeltaStore
 from sawtooth_validator.state.state_view import StateViewFactory
 from sawtooth_validator.gossip import signature_verifier
 from sawtooth_validator.networking.interconnect import Interconnect
@@ -108,7 +109,15 @@ class Validator(object):
 
         merkle_db = LMDBNoLockDatabase(db_filename, 'c')
 
-        context_manager = ContextManager(merkle_db)
+        delta_db_filename = os.path.join(data_dir,
+                                         'state-deltas-{}.lmdb'.format(
+                                             network_endpoint[-2:]))
+        LOGGER.debug('state delta store file is %s', delta_db_filename)
+        state_delta_db = LMDBNoLockDatabase(delta_db_filename, 'c')
+
+        state_delta_store = StateDeltaStore(state_delta_db)
+
+        context_manager = ContextManager(merkle_db, state_delta_store)
         self._context_manager = context_manager
 
         state_view_factory = StateViewFactory(merkle_db)

--- a/validator/sawtooth_validator/state/state_delta_store.py
+++ b/validator/sawtooth_validator/state/state_delta_store.py
@@ -1,0 +1,64 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+from sawtooth_validator.protobuf.state_delta_pb2 import StateDeltaSet
+
+
+class StateDeltaStore(object):
+    """A StateDeltaStore persists StateChange records to a provided database
+    implementation.
+    """
+
+    def __init__(self, delta_db):
+        """Constructs a StateDeltaStore, backed by a given database
+        implementation.
+
+        Args:
+            delta_db (:obj:sawtooth_validator.database.database.Database): A
+                database implementation that backs this store.
+        """
+        self._delta_db = delta_db
+
+    def save_state_deltas(self, state_root_hash, state_changes):
+        """Saves a list of state changes for the given state root hash to the
+        backing store.
+
+        Args:
+            state_root_hash (str): the state root hash that resulted in the
+                changes.
+            state_changes (list of StateChange objs): the list of StateChange
+                objects to be stored
+        """
+        delta_set = StateDeltaSet(state_changes=state_changes)
+
+        self._delta_db[state_root_hash] = delta_set.SerializeToString()
+
+    def get_state_deltas(self, state_root_hash):
+        """Returns the state deltas stored for a given state root hash.
+
+        Args:
+            state_root_hash (str): the state root hash associated with
+                the desired changes.
+
+        Raises:
+            KeyError: if the state_root_hash is unknown.
+        """
+        if state_root_hash not in self._delta_db:
+            raise KeyError(
+                'Unknown state_root_hash {}'.format(state_root_hash))
+
+        delta_set_bytes = self._delta_db[state_root_hash]
+        delta_set = StateDeltaSet()
+        delta_set.ParseFromString(delta_set_bytes)
+        return delta_set.state_changes

--- a/validator/tests/unit3/test_context_manager/tests.py
+++ b/validator/tests/unit3/test_context_manager/tests.py
@@ -18,6 +18,8 @@ import unittest
 from sawtooth_validator.database import dict_database
 from sawtooth_validator.execution import context_manager
 from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.state.state_delta_store import StateDeltaStore
+from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
 
 
 class TestContextManager(unittest.TestCase):
@@ -59,6 +61,7 @@ class TestContextManager(unittest.TestCase):
                 3) Apply all of the aggregate sets from all
                 of the contexts, to another database with a merkle tree.
                 4) Assert that the state hashes are the same.
+                5) Assert that the state deltas have been stored
         """
         # 1)
         context_id = self._setup_context()
@@ -86,6 +89,17 @@ class TestContextManager(unittest.TestCase):
             final_state_to_update, virtual=False)
         # 4)
         self.assertEqual(resulting_state_hash, test_resulting_state_hash)
+        state_changes = self.state_delta_store.get_state_deltas(
+            resulting_state_hash)
+
+        # 5)
+        for addr, value in final_state_to_update.items():
+            expected_state_change = StateChange(
+                address=addr,
+                value=value,
+                type=StateChange.SET)
+
+            self.assertTrue(expected_state_change in state_changes)
 
     def test_squash_no_updates(self):
         """Tests that squashing a context that has no state updates will return
@@ -96,9 +110,14 @@ class TestContextManager(unittest.TestCase):
 
             Test:
                 1) Squash the context.
-                2) Assert that the state hashe is the same as the starting
+                2) Assert that the state hash is the same as the starting
                 hash.
+                3) Assert that the state deltas have not been overwritten
         """
+        self.state_delta_store.save_state_deltas(
+            self.first_state_hash,
+            [StateChange(address='aaa', value=b'xyz', type=StateChange.SET)])
+
         context_id = self.context_manager.create_context(
             state_hash=self.first_state_hash,
             base_contexts=[],
@@ -111,6 +130,13 @@ class TestContextManager(unittest.TestCase):
         # 2
         self.assertIsNotNone(resulting_state_hash)
         self.assertEquals(resulting_state_hash, self.first_state_hash)
+
+        # 3
+        changes = self.state_delta_store.get_state_deltas(resulting_state_hash)
+
+        self.assertEqual(
+            [StateChange(address='aaa', value=b'xyz', type=StateChange.SET)],
+            [c for c in changes])
 
     def _setup_context(self):
         # 1) Create transaction data
@@ -165,8 +191,9 @@ class TestContextManager(unittest.TestCase):
 
     def setUp(self):
         self.database_of_record = dict_database.DictDatabase()
+        self.state_delta_store = StateDeltaStore(dict_database.DictDatabase())
         self.context_manager = context_manager.ContextManager(
-            self.database_of_record)
+            self.database_of_record, self.state_delta_store)
         self.first_state_hash = self.context_manager.get_first_root()
 
         # used for replicating state hash through direct merkle tree updates

--- a/validator/tests/unit3/test_scheduler/tests.py
+++ b/validator/tests/unit3/test_scheduler/tests.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import unittest
+from unittest.mock import Mock
 import logging
 import hashlib
 import threading
@@ -81,7 +82,8 @@ def create_batch(transactions, private_key, public_key):
 
 class TestSerialScheduler(unittest.TestCase):
     def setUp(self):
-        self.context_manager = ContextManager(dict_database.DictDatabase())
+        self.context_manager = ContextManager(dict_database.DictDatabase(),
+                                              state_delta_store=Mock())
         squash_handler = self.context_manager.get_squash_handler()
         self.first_state_root = self.context_manager.get_first_root()
         self.scheduler = SerialScheduler(squash_handler,

--- a/validator/tests/unit3/test_state_delta_store/tests.py
+++ b/validator/tests/unit3/test_state_delta_store/tests.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.state.state_delta_store import StateDeltaStore
+
+from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
+
+
+class StateDeltaStoreTest(unittest.TestCase):
+    def test_state_store_get_and_set(self):
+        """Tests that we correctly get and set state changes to a
+        StateDeltaStore.
+
+        This tests sets a list of state change values and then gets them back,
+        ensuring that the data is the same.
+        """
+
+        database = DictDatabase()
+
+        delta_store = StateDeltaStore(database)
+
+        changes = [StateChange(address='a100000' + str(i),
+                               value=str(i).encode(),
+                               type=StateChange.SET)
+                   for i in range(0, 10)]
+
+        delta_store.save_state_deltas('my_state_root_hash', changes)
+
+        stored_changes = delta_store.get_state_deltas('my_state_root_hash')
+        # This is a list-like repeated field, but to make it comparable we'll
+        # have to generate a new list
+        stored_changes = [c for c in stored_changes]
+
+        self.assertEqual(changes, stored_changes)
+
+    def test_raise_key_error_on_missing_root_hash(self):
+        """Tests that we correctly raise key error on a missing hash
+        """
+        database = DictDatabase()
+        delta_store = StateDeltaStore(database)
+
+        with self.assertRaises(KeyError):
+            delta_store.get_state_deltas('unknown_state_root_hash')


### PR DESCRIPTION
Creates a StateDeltaStore, where state changes can be stored.  These deltas are stored when the context manager performs the squash operation _and_ the state updates will be persisted.  

The purpose of storing these deltas is to support State Delta Subscriptions by external processes.