### PR TITLE
Fix periodic test failure in smoke tests

### DIFF
--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -221,9 +221,10 @@ services:
       - rest-api-0
       - rest-api-1
       - rest-api-2
-    command: nose2-3 -v -s
-        /project/sawtooth-core/integration/sawtooth_integration/tests
-        test_poet_smoke.TestPoetSmoke
+    command: nose2-3
+        -s /project/sawtooth-core/integration
+        -v
+        sawtooth_integration.tests.test_poet_smoke.TestPoetSmoke
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\

--- a/integration/sawtooth_integration/tests/integration_tools.py
+++ b/integration/sawtooth_integration/tests/integration_tools.py
@@ -1,0 +1,70 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import logging
+import time
+
+from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.error import URLError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_until_status(url, status_code=200, tries=5):
+    """Pause the program until the given url returns the required status.
+
+    Args:
+        url (str): The url to query.
+        status_code (int, optional): The required status code. Defaults to 200.
+        tries (int, optional): The number of attempts to request the url for
+            the given status. Defaults to 5.
+    Raises:
+        AssertionError: If the status is not recieved in the given number of
+            tries.
+    """
+    attempts = tries
+    while attempts > 0:
+        try:
+            response = urlopen(url)
+            if response.getcode() == status_code:
+                return
+
+        except HTTPError as e:
+            if e.code == status_code:
+                return
+
+            LOGGER.debug('failed to read url: %s', str(e))
+        except URLError as e:
+            LOGGER.debug('failed to read url: %s', str(e))
+
+        sleep_time = (tries - attempts + 1) * 2
+        LOGGER.debug('Retrying in %s secs', sleep_time)
+        time.sleep(sleep_time)
+
+        attempts -= 1
+
+    assert(False, "{} is not available within {} attempts".format(url, tries))
+
+
+def wait_for_rest_apis(endpoints, tries=5):
+    """Pause the program until all the given REST API endpoints are available.
+
+    Args:
+        endpoints (list of str): A list of host:port strings.
+        tries (int, optional): The number of attempts to request the url for
+            availability.
+    """
+    for endpoint in endpoints:
+        wait_until_status('http://{}/blocks', status_code=200, tries=tries)

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -22,12 +22,8 @@ import subprocess
 from sawtooth_cli.main import main
 import sys
 from io import StringIO
-import time
 
-from urllib.request import urlopen
-from urllib.error import HTTPError
-from urllib.error import URLError
-
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
@@ -39,6 +35,10 @@ TEST_PUBKEY = \
 
 
 class TestConfigSmoke(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis(['rest_api:8080'])
 
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
@@ -83,9 +83,6 @@ class TestConfigSmoke(unittest.TestCase):
             command 'sawtooth config settings list', and that the retrieved
             setting equals the input setting.
             '''
-
-        _wait_for('http://rest_api:8080/blocks')
-
         # Submit transaction, then list it using subprocess
         cmds = [
             ['sawtooth', 'config', 'proposal', 'create', '-k', self._wif_file,
@@ -106,25 +103,3 @@ class TestConfigSmoke(unittest.TestCase):
                 TEST_PUBKEY[:15])
         self.assertEqual(settings, _expected_setting_results,
                          'Setting results did not match.')
-
-
-def _wait_for(url, status_code=200, tries=5):
-    attempts = tries
-    while attempts > 0:
-        try:
-            response = urlopen(url)
-            if response.getcode() == status_code:
-                return
-
-        except HTTPError as e:
-            LOGGER.debug('failed to read url: %s', str(e))
-        except URLError as e:
-            LOGGER.debug('failed to read url: %s', str(e))
-
-        sleep_time = (tries - attempts + 1) * 2
-        LOGGER.debug('Retrying in %s secs', sleep_time)
-        time.sleep(sleep_time)
-
-        attempts -= 1
-
-    assert(False, "{} is not available within {} attempts".format(url, tries))

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -26,6 +26,7 @@ from base64 import b64decode
 import cbor
 
 from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 
 LOGGER = logging.getLogger(__name__)
@@ -33,6 +34,11 @@ LOGGER.setLevel(logging.INFO)
 
 
 class TestIntkeySmoke(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis(['rest_api:8080'])
+
     def test_intkey_smoke(self):
         '''
         After starting up a validator, intkey processor, and rest api,

--- a/integration/sawtooth_integration/tests/test_poet_smoke.py
+++ b/integration/sawtooth_integration/tests/test_poet_smoke.py
@@ -20,6 +20,7 @@ import time
 import logging
 
 from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 from sawtooth_cli.rest_client import RestClient
 
 
@@ -39,10 +40,13 @@ BATCH_COUNT = 20
 
 class TestPoetSmoke(unittest.TestCase):
     def setUp(self):
-        urls = ['http://rest-api-{}:8080'.format(i)
-                for i in range(VALIDATOR_COUNT)]
+        endpoints = ['rest-api-{}:8080'.format(i)
+                     for i in range(VALIDATOR_COUNT)]
 
-        self.clients = [IntkeyClient(url) for url in urls]
+        wait_for_rest_apis(endpoints)
+
+        self.clients = [IntkeyClient('http://' + endpoint)
+                        for endpoint in endpoints]
 
     def test_poet_smoke(self):
         '''

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -27,6 +27,7 @@ from base64 import b64decode
 import cbor
 
 from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 
 LOGGER = logging.getLogger(__name__)
@@ -37,6 +38,11 @@ INTKEY_PREFIX = '1cf126'
 XO_PREFIX = '5b7349'
 
 class TestTwoFamilies(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis(['rest_api:8080'])
+
     def test_two_families(self):
         '''
         After starting a validator with both intkey and xo

--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -19,12 +19,18 @@ import traceback
 import time
 import subprocess
 
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
+
 LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.DEBUG)
 
 
 class TestXoSmoke(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis(['rest_api:8080'])
 
     def test_xo_smoke(self):
 


### PR DESCRIPTION
In the smoke test, there is a periodic failure, based around the timing
in the system.  The rest api may or may not be ready, the validator may
not have a genesis block, and so forth, before the tests run.  This
commit takes the `_wait_for` from the test_config_smoke, and moves it to a
new package, `integration_tools` as `wait_for_status`.  This function
will give the system time to settle out, if needed, before running the
tests.

A convenience method `wait_for_rest_apis` takes a list of `"host:port"`
values and checks the `/blocks` endpoint for 200 responses.

Signed-off-by: Peter Schwarz <peterx.schwarz@intel.com>