### PR TITLE
Implement doc templating, and add templated txn making tutorials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /core_transactions/**/__pycache__/
 
 /docs/build/
+/docs/source/_autogen/
 
 /extensions/arcade/sawtooth_arcade.egg-info/
 

--- a/bin/make_templated_docs
+++ b/bin/make_templated_docs
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import re
+import yaml
+from jinja2 import Environment, FileSystemLoader
+
+# Directory paths
+abs_path = os.path.dirname(os.path.realpath(__file__))
+
+DOCS_ABS = abs_path + '/../docs/'
+OUTPUT_REL = 'source/_autogen'
+TEMPLATE_REL = 'source/_templates'
+
+output_abs = DOCS_ABS + OUTPUT_REL
+template_abs = DOCS_ABS + TEMPLATE_REL
+
+# Comment chars
+comments = {
+    '.rst': {'start': '.. /', 'line':' '},
+    '.html': {'start': '<!---', 'end': '--->'},
+    '.md': {'start': '<!---', 'end': '--->'},
+    '.py': {'line': '#'},
+    '.sh': {'line': '#'},
+    '.clj': {'line': ';'},
+    '.cljs': {'line': ';'},
+    'default': {'line': '//'}}
+
+# Build globals
+conf = yaml.load(open(template_abs + '/template_config.yaml', 'r'))
+env = Environment(
+    loader=FileSystemLoader(template_abs),
+    trim_blocks=True,
+    lstrip_blocks=True,
+    keep_trailing_newline=True)
+warning = env.get_template('partials/warning_header')
+
+# Render templates
+for name, target in conf['targets'].items():
+    template = env.get_template(target['template'])
+
+    extension = (re.findall('\.[^.]+$', target['template']) or [''])[0]
+    output_path = output_abs + '/' + name + extension
+    template_path = TEMPLATE_REL + '/' + target['template']
+
+    comment_chars = comments.get(extension, comments['default'])
+    warning.stream(
+        start_comment=comment_chars.get('start', ''),
+        end_comment=comment_chars.get('end', ''),
+        line_comment=comment_chars.get('line', ''),
+        template_path=template_path
+    ).dump(output_path)
+
+    output = open(output_path, 'a')
+    output.write(template.render(**target.get('args', {})))
+
+print('Templated docs generated. Files located in ' + OUTPUT_REL)
+print()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,7 +20,7 @@ ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) 
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean templates html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -52,39 +52,43 @@ help:
 clean:
 	rm -rf $(BUILDDIR)/*
 
-html:
+templates:
+	@mkdir -p source/_autogen
+	@../bin/make_templated_docs
+
+html: templates
 	@mkdir -p source/_static
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-dirhtml:
+dirhtml: templates
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-singlehtml:
+singlehtml: templates
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
-pickle:
+pickle: templates
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json:
+json: templates
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp:
+htmlhelp: templates
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-qthelp:
+qthelp: templates
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -93,7 +97,7 @@ qthelp:
 	@echo "To view the help file:"
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/IntelMaidenLane.qhc"
 
-applehelp:
+applehelp: templates
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
@@ -101,7 +105,7 @@ applehelp:
 	      "~/Library/Documentation/Help or install it in your application" \
 	      "bundle."
 
-devhelp:
+devhelp: templates
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -110,86 +114,86 @@ devhelp:
 	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/IntelMaidenLane"
 	@echo "# devhelp"
 
-epub:
+epub: templates
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-latex:
+latex: templates
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
 
-latexpdf:
+latexpdf: templates
 	@mkdir -p source/_static
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-latexpdfja:
+latexpdfja: templates
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-text:
+text: templates
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
-man:
+man: templates
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
-texinfo:
+texinfo: templates
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
 
-info:
+info: templates
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
-gettext:
+gettext: templates
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
-changes:
+changes: templates
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck:
+linkcheck: templates
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
-doctest:
+doctest: templates
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
-coverage:
+coverage: templates
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
-xml:
+xml: templates
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
-pseudoxml:
+pseudoxml: templates
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."

--- a/docs/source/_templates/partials/encoding_your_payload.rst
+++ b/docs/source/_templates/partials/encoding_your_payload.rst
@@ -1,0 +1,39 @@
+Encoding your Payload
+=====================
+
+Transaction payloads are composed of binary-encoded data that is opaque to the
+validator. The logic for encoding and decoding them rests entirely within the
+particular Transaction Processor itself. As a result, there are many possible
+formats, and you will have to look to the definition of the Transaction
+Processor itself for that information. As an example, the *IntKey*
+Transaction Processor uses a payload of three key/value pairs encoded as
+`CBOR <https://en.wikipedia.org/wiki/CBOR>`_. Creating one might look like this:
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const cbor = require('cbor')
+
+    const payload = {
+        Verb: 'set',
+        Name: 'foo',
+        Value: 42
+    }
+
+    const payloadBytes = cbor.encode(payload)
+
+{% else %}
+
+.. code-block:: python
+
+    import cbor
+
+    payload = {
+        'Verb': 'set',
+        'Name': 'foo',
+        'Value': 42}
+
+    payload_bytes = cbor.dumps(payload)
+
+{% endif %}

--- a/docs/source/_templates/partials/submitting_to_validator.rst
+++ b/docs/source/_templates/partials/submitting_to_validator.rst
@@ -1,0 +1,73 @@
+Submitting Batches to the Validator
+===================================
+
+The prescribed way to submit Batches to the validator is via the REST API.
+This is an independent process that runs alongside a validator, allowing clients
+to communicate using HTTP/JSON standards. Simply send a *POST* request to the
+*/batches* endpoint, with a *"Content-Type"* header of
+*"application/octet-stream"*, and the *body* as a serialized *BatchList*.
+
+There are a many ways to make an HTTP request, and hopefully the submission
+process is fairly straightforward from here, but as an example, this is what it
+might look if you sent the request from the same {{ language }} process that
+prepared the BatchList:
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const request = require('request')
+
+    request.post({
+        url: 'http://rest.api.domain/batches',
+        body: batchBytes,
+        headers: {'Content-Type': 'application/octet-stream'}
+    }, (err, response) => {
+        console.log(response)
+    })
+
+{% else %}
+
+.. code-block:: python
+
+    import urllib
+
+    request = urllib.Request(
+        'http://rest.api.domain/batches',
+        batch_bytes,
+        method='POST',
+        headers={'Content-Type': 'application/octet-stream'})
+
+    response = urllib.urlopen(request)
+
+{% endif %}
+
+
+And here is what it would look like if you saved the binary to a file, and then
+sent it with *curl*:
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const fs = require('fs')
+
+    const fileStream = fs.createWriteStream('intkey.batches')
+    fileStream.write(batchBytes)
+    fileStream.end()
+
+{% else %}
+
+.. code-block:: python
+
+    output = open('batches.intkey', 'wb')
+    output.write(batch_bytes)
+
+{% endif %}
+
+.. code-block:: bash
+
+    % curl --request POST \
+        --header "Content-Type: application/octet-stream" \
+        --data-binary "intkey.batches" \
+        "http://rest.api.domain/batches"

--- a/docs/source/_templates/partials/warning_header
+++ b/docs/source/_templates/partials/warning_header
@@ -1,0 +1,13 @@
+{{ start_comment }}
+{{ line_comment }}  **********************************************************
+{{ line_comment }}  *                        WARNING!!!                      *
+{{ line_comment }}  * ------------------------------------------------------ *
+{{ line_comment }}  * This is an auto-generated file.  Do NOT modify!        *
+{{ line_comment }}  *                                                        *
+{{ line_comment }}  * Modifications should be made to the original template, *
+{{ line_comment }}  * or to the config file:                                 *
+{{ line_comment }}  *     - {{ template_path }}
+{{ line_comment }}  *     - source/_templates/template_config.yaml           *
+{{ line_comment }}  **********************************************************
+{{ end_comment }}
+

--- a/docs/source/_templates/sdk_submit_tutorial.rst
+++ b/docs/source/_templates/sdk_submit_tutorial.rst
@@ -1,0 +1,259 @@
+{% set short_lang = 'python' %}
+{% if language == 'JavaScript' %}
+    {% set short_lang = 'js' %}
+{% endif -%}
+
+************************************
+Building and Submitting Transactions
+************************************
+
+The process of encoding information to be submitted to a distributed ledger is
+generally non-trivial. A series of cryptographic safeguards are used to
+confirm identity and data validity. *Hyperledger Sawtooth* is no different, but
+the {{ language }} SDK does provide client functionality that abstracts away
+most of these details, and greatly simplifies the process of making changes to
+the blockchain. If you are interested in getting into these details, you
+should check out the
+:doc:`txn_submit_tutorial_{{ short_lang }}` instead.
+
+
+Creating a Private Key
+======================
+
+In order to confirm your identity and sign the information you send to the
+validator, you will need a 256-bit key. Sawtooth uses the secp256k1 ECSDA
+standard for signing, which means that almost any set of 32 bytes is a valid
+key, and it is fairly simple to generate this using the SDK's *signer* module.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const {signer} = require('sawtooth-sdk')
+
+    const privateKey = signer.makePrivateKey()
+
+{% else %}
+{# Python is the default #}
+
+{% endif %}
+
+.. note::
+
+   This key is the **only** way to prove your identity on the blockchain. Any
+   person possessing it will be able to sign Transactions using your identity,
+   and there is no way to recover it if lost. It is very important that any
+   private key is kept secret and secure.
+
+
+{% include 'partials/encoding_your_payload.rst' %}
+
+.. note::
+
+   This process can be simplified somewhat by offloading some of the work to
+   the *payload encoder* of a *TransactionEncoder* (see below).
+
+
+Building the Transaction
+========================
+
+*Transactions* are the basis for individual changes of state to the Sawtooth
+blockchain. They are composed of a binary payload, a binary-encoded
+*TransactionHeader* with some cryptographic safeguards and metadata about how
+it should be handled, and a signature of that header. It would be worthwhile
+to familiarize yourself with the information in
+:doc:`/architecture/transactions_and_batches`, particularly the definition of
+TransactionHeaders.
+
+
+1. Create an Encoder
+--------------------
+
+A *TransactionEncoder* stores your private key, and (optionally) default
+TransactionHeader values and a function to encode each payload. Once
+instantiated, multiple Transactions can be created using these common elements,
+and without any explicit hashing or signing. You will never need to specify the
+*nonce*, *signer pubkey*, or *payload Sha512* properties of a TransactionHeader,
+as the SDK will generate these automatically. You will only need to set a
+*batcher pubkey* if a different private key will be used to sign Batches than
+Transactions (see below).
+
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const {TransactionEncoder} = require('sawtooth-sdk')
+
+    const encoder = new TransactionEncoder(privateKey, {
+        batcherPubkey: '02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758',
+        dependencies: ['540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a'],
+        familyName: 'intkey',
+        familyVersion: '1.0',
+        inputs: ['1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c'],
+        outputs: ['1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c'],
+        payloadEncoding: 'application/cbor'
+        payloadEncoder: cbor.encode
+    })
+
+{% else %}
+
+{% endif %}
+
+.. note::
+
+   Remember that *inputs* and *outputs* are state addresses that this
+   Transaction is allowed to read from or write to, and *dependencies* are the
+   *header signatures* of Transactions that must be committed before ours (see
+   TransactionHeaders in :doc:`/architecture/transactions_and_batches`). It would be unusual to set these properties when creating the *TransactionEncoder*, as they will usually vary on a Transaction by Transaction basis. They are set here simply to demonstrate the capability.
+
+
+2. Create the Transaction
+-------------------------
+
+If all of the necessary header defaults were set in the TransactionEncoder, a
+Transaction can be created simply by calling the *create* method and passing
+it a payload. If a *payload encoder* function was set, it will be run with the
+payload as its one argument. The payload encoder can do any work you like to
+format the payload, but in the end it what it returns *must* be binary
+encoded.
+
+Optionally, you may pass in header properties in order to override any defaults on for an individual Transaction.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const txn = encoder.create(payload, {
+        inputs: ['1cf12663ae9d398142a7d84c49b73ba2f667c8d377ceb7832db69b1a416133562ea496'],
+        outputs: ['1cf12663ae9d398142a7d84c49b73ba2f667c8d377ceb7832db69b1a416133562ea496']
+    })
+
+    const txn2 = encoder.create({
+        Verb: 'inc',
+        Name: 'foo',
+        Value: 1
+    })
+
+{% else %}
+
+{% endif %}
+
+
+3. (optional) Encode the Transaction(s)
+---------------------------------------
+
+If the same machine is creating Transactions and Batches there is no need to
+encode the Transaction instances. However, in the use case where Transactions
+are being batched externally, they must be serialized before being transmitted
+to the batcher. The {{ language }} SDK offers two options for this. One or more
+Transactions can be combined into a serialized *TransactionList* using the
+*encode* method, or if only serializing a single Transaction, creation and
+encoding can done in a single step with *createEncoded*.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const txnBytes = encoder.encode([txn1, txn2])
+
+    const txnBytes2 = encoder.createEncoded({
+        Verb: 'dec',
+        Name: 'foo',
+        Value: 3
+    })
+
+{% else %}
+
+{% endif %}
+
+
+Building the Batch
+==================
+
+Once you have one or more Transaction instances ready, they must be wrapped in a
+*Batch*. Batches are the atomic unit of change in Sawtooth's state. When a Batch
+is submitted to a validator each Transaction in it will be applied (in order),
+or *no* Transactions will be applied. Even if your Transactions are not
+dependent on any others, they cannot be submitted directly to the validator.
+They must all be wrapped in a Batch.
+
+
+1. Create an Encoder
+--------------------
+
+Similar to the TransactionEncoder, there is a *BatchEncoder* for making Batches.
+As Batches are much simpler than Transactions, the only argument to pass during
+instantiation is the private key to sign the Batches with.
+
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const {BatchEncoder} = require('sawtooth-sdk')
+
+    const batcher = new BatchEncoder(privateKey)
+
+{% else %}
+
+{% endif %}
+
+
+2. Create the Batch
+-------------------
+
+Using the SDK, creating a Batch is as simple as calling the *create* method and
+passing it one or more Transactions. If serialized, there is no need to
+decode them first. In addition to Transaction instances, the BatchEncoder can
+handle TransactionLists encoded as both raw binaries and url-safe base64
+strings.
+
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const batch = batcher.create(txn)
+
+    const batch2 = batcher.create([txn, txn2])
+
+    const batch3 = batcher.create(txnBytes)
+
+
+{% else %}
+
+{% endif %}
+
+
+3. Encode the Batch(es) in a BatchList
+--------------------------------------
+
+Like the TransactionEncoder, BatchEncoders have both *encode* and
+*createEncoded* methods for serializing Batches in a BatchList. If encoding
+multiple Batches in one BatchList, they must be created individually first, and
+then encoded. If only wrapping one Batch per BatchList, creating and encoding
+can happen in one step.
+
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const batchBytes = batcher.encode([batch, batch2, batch3])
+
+    const batchBytes2 = batcher.createEncoded(txn)
+
+{% else %}
+
+{% endif %}
+
+.. note::
+
+   Note, if the transaction creator is using a different private key than the
+   batcher, the *batcher pubkey* must have been specified for every Transaction,
+   and must have been generated from the private key being used to sign the
+   Batch, or validation will fail.
+
+
+{% include 'partials/submitting_to_validator.rst' %}

--- a/docs/source/_templates/template_config.yaml
+++ b/docs/source/_templates/template_config.yaml
@@ -7,3 +7,13 @@
 # -----------------------------------------------------------------------------
 
 targets:
+
+  txn_submit_tutorial_python:
+    template: txn_submit_tutorial.rst
+    args:
+      language: Python
+
+  txn_submit_tutorial_js:
+    template: txn_submit_tutorial.rst
+    args:
+      language: JavaScript

--- a/docs/source/_templates/template_config.yaml
+++ b/docs/source/_templates/template_config.yaml
@@ -17,3 +17,8 @@ targets:
     template: txn_submit_tutorial.rst
     args:
       language: JavaScript
+
+  sdk_submit_tutorial_js:
+    template: sdk_submit_tutorial.rst
+    args:
+      language: JavaScript

--- a/docs/source/_templates/template_config.yaml
+++ b/docs/source/_templates/template_config.yaml
@@ -1,0 +1,9 @@
+# This configuration file is used by the `make_templated_docs` script to
+# determine which files to generate.
+#
+# Add target files to generate to the `targets` property, with a `template`
+# property specifying the template to use, and any `args` to pass to the
+# template.
+# -----------------------------------------------------------------------------
+
+targets:

--- a/docs/source/_templates/txn_submit_tutorial.rst
+++ b/docs/source/_templates/txn_submit_tutorial.rst
@@ -1,0 +1,485 @@
+******************************************************
+Building and Submitting Transactions ({{ language }})
+******************************************************
+
+The process of encoding information to be submitted to a distributed ledger is
+generally non-trivial. A series of cryptographic safeguards are used to
+confirm identity and data validity, and *Hyperledger Sawtooth* is no different.
+SHA-512 hashes and secp256k1 signatures must be generated. Transaction and
+Batch Protobufs must be created and serialized. The process can be somewhat
+daunting, but this document will take Sawtooth client developers step by step
+through the process using copious {{ language }} examples.
+
+{% macro link_sdk(short_lang) %}
+
+.. note::
+
+   This document goes through building and submitting Transactions manually in
+   order to explain the complete process. If your goal is just to write a
+   functioning client, the {{ language }} SDK considerably simplifies the task.
+   Check out :doc:`sdk_submit_tutorial_{{short_lang}}`.
+
+{% endmacro %}
+
+{# Only include note if there is an SDK for the language #}
+{% if language == 'JavaScript' %}
+    {{ link_sdk('js') }}
+{% endif %}
+
+
+Creating Private and Public Keys
+================================
+
+In order to sign your Transactions, you will need a 256-bit private key.
+Sawtooth uses the secp256k1 ECSDA standard for signing, which means that almost
+any set of 32 bytes is a valid key.
+
+{% if language == 'JavaScript' %}
+
+A common way to generate one is to create a random set of bytes, and then use a
+secp256k1 library to ensure they are valid.
+
+.. code-block:: javascript
+
+    const crypto = require('crypto')
+    const secp256k1 = require('secp256k1')
+
+    let privateKeyBytes
+
+    do {
+        privateKeyBytes = crypto.randomBytes(32)
+    } while (!secp256k1.privateKeyVerify(privateKeyBytes))
+
+{% else %}
+{# Python code is the default #}
+
+The Python *secp256k1* module provides a *PrivateKey* handler class from which
+we can generate the actual bytes to use for a key.
+
+.. code-block:: python
+
+    import secp256k1
+
+    key_handler = secp256k1.PrivateKey()
+    private_key_bytes = key_handler.private_key
+
+{% endif %}
+
+.. note::
+
+   This key is the **only** way to prove your identity on the blockchain. Any
+   person possessing it will be able to sign Transactions using your identity,
+   and there is no way to recover it if lost. It is very important that any
+   private key is kept secret and secure.
+
+In addition to a private key, you will need a shareable public key generated
+from the private key. It should be encoded as a hexadecimal string, to
+distribute with the Transaction and confirm that its signature is valid.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const publicKeyBytes = secp256k1.publicKeyCreate(privateKeyBytes)
+
+    const publicKeyHex = publicKeyBytes.toString('hex')
+
+{% else %}
+
+.. code-block:: python
+
+    public_key_bytes = key_handler.pubkey.serialize()
+
+    public_key_hex = public_key_bytes.hex()
+
+{% endif %}
+
+
+{% include 'partials/encoding_your_payload.rst' %}
+
+
+Building the Transaction
+========================
+
+*Transactions* are the basis for individual changes of state to the Sawtooth
+blockchain. They are composed of a binary payload, a binary-encoded
+*TransactionHeader* with some cryptographic safeguards and metadata about how it
+should be handled, and a signature of that header. It would be worthwhile to
+familiarize yourself with the information in
+:doc:`/architecture/transactions_and_batches`, particularly the definition of
+TransactionHeaders.
+
+
+1. Create a SHA-512 Payload Hash
+--------------------------------
+
+However the payload was originally encoded, in order to confirm it has not been
+tampered with, a hash of it must be included within the Transaction's header.
+This hash should be created using the SHA-512 function, and then formatted as a
+hexadecimal string.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const sha512 = require('crypto').createHash('sha512')
+
+    const payloadSha512 = sha512.update(payloadBytes).digest('hex')
+
+{% else %}
+
+.. code-block:: python
+
+    from hashlib import sha512
+
+    payload_sha512 = sha512(payload_bytes).hexdigest()
+
+{% endif %}
+
+
+2. Build the TransactionHeader
+------------------------------
+
+Transactions and their headers are built using
+`Google Protocol Buffer <https://developers.google.com/protocol-buffers/>`_
+(or Protobuf) format. This allows data to be serialized and deserialzed
+consistently and efficiently across multiple platforms and multiple languages.
+The Protobuf definition files are located in the
+`/protos <https://github.com/hyperledger/sawtooth-core/tree/master/protos>`_
+directory at the root level of the sawtooth-core repo. These files will have to
+first be compiled into usable {{ language }} classes. Then, serializing a
+*TransactionHeader* is just a matter of plugging the right data into the right
+keys.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const protobuf = require('protobufjs')
+
+    const txnRoot = protobuf.loadSync('protos/transactions.proto')
+    const TransactionHeader = txnRoot.lookup('TransactionHeader')
+
+    const txnHeaderBytes = TransactionHeader.encode({
+        batcherPubkey: publicKeyHex,
+        dependencies: [],
+        familyName: 'intkey',
+        familyVersion: '1.0',
+        inputs: ['1cf126'],
+        nonce: Math.random().toString(36),
+        outputs: ['1cf126'],
+        payloadEncoding: 'application/cbor',
+        payloadSha512: payloadSha512,
+        signerPubkey: publicKeyHex
+    }).finish()
+
+{% else %}
+
+.. code-block:: bash
+
+    % protoc --python-out=compiled_protos/ protos/transactions.proto
+
+.. code-block:: python
+
+    from random import randint
+    from compiled_protos.transactions_pb2 import TransactionHeader
+
+    txn_header = TransactionHeader(
+        batcher_pubkey=public_key_hex,
+        dependencies=['540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a'],
+        family_name='intkey',
+        family_version='1.0',
+        inputs=['1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c'],
+        nonce=str(randint(0, 1000000000)),
+        outputs=['1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c'],
+        payload_encoding='application/cbor',
+        payload_sha512=payload_sha512,
+        signer_pubkey=public_key_hex)
+
+    txn_header_bytes = txn_header.SerializeToString()
+
+{% endif %}
+
+.. note::
+
+   Remember that *inputs* and *outputs* are state addresses that this
+   Transaction is allowed to read from or write to, and *dependencies* are the
+   *header signatures* of Transactions that must be committed before ours (see
+   TransactionHeaders in :doc:`/architecture/transactions_and_batches`). The
+   dependencies property will frequently be left empty, but generally at least
+   one input and output must always be set.
+
+
+3. Sign the Header
+------------------
+
+Once the TransactionHeader is created and serialized as a Protobuf binary, you
+can use your private key to create a secp256k1 signature. If not handled
+automatically by your signing library, you may need to generate a SHA-256 hash
+of the header bytes as well, as that is technically what gets signed. The
+signature itself should be formatted as a hexedecimal string for transmission.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const sha256 = require('crypto').createHash('sha256')
+    const txnHeaderHash = sha256.update(txnHeaderBytes).digest()
+
+    const txnSigBytes = secp256k1.sign(txnHeaderHash, privateKey).signature
+    const txnSignatureHex = txnSigBytes.toString('hex')
+
+{% else %}
+
+.. code-block:: python
+
+    key_handler = secp256k1.PrivateKey(private_key)
+
+    # No need to manually generate a SHA-256 hash in Python
+    txn_signature_bytes = key_handler.ecdsa_sign(txn_header_bytes)
+    txn_signature_hex = txn_signature_bytes.hex()
+
+{% endif %}
+
+
+4. Create the Transaction
+-------------------------
+
+With the other pieces in place, constructing the Transaction instance should be
+fairly straightforward. Create a *Transaction* class and use it to instantiate
+the Transaction.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const Transaction = txnRoot.lookup('Transaction')
+
+    const txn = Transaction.create({
+        header: txnHeaderBytes,
+        headerSignature: txnSignatureHex,
+        payload: payloadBytes
+    })
+
+{% else %}
+
+.. code-block:: python
+
+    from compiled_protos.transactions_pb2 import Transaction
+
+    txn = Transaction(
+        header=txn_header_bytes,
+        header_signature=txn_signature_hex,
+        payload=payload_bytes)
+
+{% endif %}
+
+
+5. (optional) Encode the Transaction(s)
+---------------------------------------
+
+If the same machine is creating Transactions and Batches there is no need to
+encode the Transaction instances. However, in the use case where Transactions
+are being batched externally, they must be serialized before being transmitted
+to the batcher. Technically any encoding scheme could be used so long as the
+batcher knows how to decode it, but Sawtooth does provide a *TransactionList*
+Protobuf for this purpose. Simply wrap a set of Transactions in the
+*transactions* property of a TransactionList and serialize it.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const TransactionList = txnRoot.lookup('TransactionList')
+
+    const txnBytes = TransactionList.encode({
+        transactions: [txn]
+    }).finish()
+
+{% else %}
+
+.. code-block:: python
+
+    from compiled_protos.transactions_pb2 import TransactionList
+
+    txnList = TransactionList(transactions=[txn])
+    txnBytes = txnList.SerializeToString()
+
+{% endif %}
+
+
+Building the Batch
+==================
+
+Once you have one or more Transaction instances ready, they must be wrapped in a
+*Batch*. Batches are the atomic unit of change in Sawtooth's state. When a Batch
+is submitted to a validator, each Transaction in it will be applied (in order)
+or *no* Transactions will be applied. Even if your Transactions are not
+dependent on any others, they cannot be submitted directly to the validator.
+They must all be wrapped in a Batch.
+
+
+1. (optional) Decode the Transaction(s)
+---------------------------------------
+
+If the batcher is on a separate machine than the Transaction creator, any
+Transactions will have been encoded as a binary and transmitted. If so, they
+must be decoded before being wrapped in a batch.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const txnList = TransactionList.decode(txnBytes)
+
+    const txn = txnList.transactions[0]
+
+{% else %}
+
+.. code-block:: python
+
+    txnList = TransactionList()
+    txnList.ParseFromString(txnBytes)
+
+    txn = txnList.transactions[0]
+
+{% endif %}
+
+
+2. Create the BatchHeader
+-------------------------
+
+The process for creating a *BatchHeader* is very similar to a TransactionHeader.
+Compile the *batches.proto* file, and then instantiate the appropriate
+{{ language }} class with the appropriate values. This time, there are just two
+properties: a *signer pubkey*, and a set of *Transaction ids*. Just like with a
+TransactionHeader, the signer pubkey must have been generated from the private
+key used to sign the Batch. The Transaction ids are a list of the
+*header signatures* from the Transactions to be batched. They must be in the
+same order as the Transactions themselves.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const batchRoot = protobuf.loadSync('protos/batches.proto')
+    const BatchHeader = batchRoot.lookup('BatchHeader')
+
+    const batchHeaderBytes = BatchHeader.encode({
+        signerPubkey: publicKey,
+        transactionIds: [txn.headerSignature]
+    }).finish()
+
+{% else %}
+
+.. code-block:: bash
+
+    % protoc --python-out=compiled_protos/ protos/batches.proto
+
+.. code-block:: python
+
+    from compiled_protos.batches_pb2 import BatchHeader
+
+    batch_header = BatchHeader(
+        signer_pubkey=public_key_hex,
+        transaction_ids=[txn.header_signature])
+
+    batch_header_bytes = batch_header.SerializeToString()
+
+{% endif %}
+
+
+3. Sign the Header
+------------------
+
+The process for signing a BatchHeader is identical to signing the
+TransactionHeader. Create a SHA-256 hash of the the header binary if necessary,
+and then use your private key to create a secp256k1 signature.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const batchHeaderHash = sha256.update(batchHeaderBytes).digest()
+
+    const batchSignature = secp256k1.sign(batchHeaderHash, privateKey)
+
+{% else %}
+
+.. code-block:: python
+
+    batch_signature_bytes = key_handler.ecdsa_sign(batch_header_bytes)
+
+    batch_signature_hex = batch_signature_bytes.hex()
+
+{% endif %}
+
+.. note::
+
+   The *batcher pubkey* specified in every TransactionHeader must have been
+   generated from the private key being used to sign the Batch, or validation
+   will fail.
+
+
+4. Create the Batch
+-------------------
+
+Creating a *Batch* also looks a lot like creating a Transaction. Just use the
+compiled class to instantiate a new Batch with the proper data.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const Batch = batchRoot.lookup('Batch')
+
+    const batch = Batch.create({
+        header: batchHeaderBytes,
+        headerSignature: batchSignature,
+        transactions: [txn]
+    })
+
+{% else %}
+
+.. code-block:: python
+
+    from compiled_protos.batches_pb2 import Batch
+
+    batch = Batch(
+        header=batch_header_bytes,
+        header_signature=batch_signature_hex,
+        transactions=[txn])
+
+{% endif %}
+
+
+5. Encode the Batch(es)
+-----------------------
+
+In order to submit one or more Batches to a validator, they must be serialized
+in a *BatchList* Protobuf. BatchLists have a single property, *batches*, which
+should be set to one or more Batches.
+
+{% if language == 'JavaScript' %}
+
+.. code-block:: javascript
+
+    const BatchList = batchRoot.lookup('BatchList')
+
+    const batchBytes = BatchList.encode({
+        batches: [batch]
+    }).finish()
+
+{% else %}
+
+.. code-block:: python
+
+    from compiled_protos.batches_pb2 import BatchList
+
+    batch_list = BatchList(batches=[batch])
+    batch_bytes = batch_list.SerializeToString()
+
+{% endif %}
+
+
+{% include 'partials/submitting_to_validator.rst' %}

--- a/docs/source/app_developers_guide.rst
+++ b/docs/source/app_developers_guide.rst
@@ -7,5 +7,6 @@ Application Developer's Guide
    :maxdepth: 2
 
    app_developers_guide/getting_started
+   app_developers_guide/writing_clients
    app_developers_guide/txn_family_tutorial
    app_developers_guide/testing

--- a/docs/source/app_developers_guide.rst
+++ b/docs/source/app_developers_guide.rst
@@ -10,3 +10,4 @@ Application Developer's Guide
    app_developers_guide/writing_clients
    app_developers_guide/txn_family_tutorial
    app_developers_guide/testing
+   app_developers_guide/javascript_sdk

--- a/docs/source/app_developers_guide/javascript_sdk.rst
+++ b/docs/source/app_developers_guide/javascript_sdk.rst
@@ -1,0 +1,8 @@
+**************
+JavaScript SDK
+**************
+
+.. toctree::
+   :maxdepth: 2
+
+   ../_autogen/sdk_submit_tutorial_js

--- a/docs/source/app_developers_guide/writing_clients.rst
+++ b/docs/source/app_developers_guide/writing_clients.rst
@@ -1,0 +1,9 @@
+*********************************
+Writing Clients with the REST API
+*********************************
+
+.. toctree::
+   :maxdepth: 2
+
+   ../_autogen/txn_submit_tutorial_python
+   ../_autogen/txn_submit_tutorial_js

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -551,7 +551,7 @@ definitions:
     properties:
       address:
         type: string
-        example: 1cf12632a292f6ddf757a0a59e9c2284c08cab235aa068b19f85c460f71485540368eec98c3f95af23b0c8cda4790c118238a3b97f2fba2bbff72f15987f00b41e7caf
+        example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
       data:
         type: string
         format: byte
@@ -561,7 +561,7 @@ definitions:
     properties:
       batcher_pubkey:
         type: string
-        example: 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM
+        example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
       dependencies:
         type: array
         items:
@@ -577,7 +577,7 @@ definitions:
         type: array
         items:
           type: string
-          example: 1cf12632a292f6ddf757a0a59e9c2284c08cab235aa068b19f85c460f71485540368eec98c3f95af23b0c8cda4790c118238a3b97f2fba2bbff72f15987f00b41e7caf
+          example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
       nonce:
         type: string
         example: QAApS4L
@@ -585,7 +585,7 @@ definitions:
         type: array
         items:
           type: string
-          example: 1cf12632a292f6ddf757a0a59e9c2284c08cab235aa068b19f85c460f71485540368eec98c3f95af23b0c8cda4790c118238a3b97f2fba2bbff72f15987f00b41e7caf
+          example: 1cf12650d858e0985ecc7f60418aaf0cc5ab587f42c2570a884095a9e8ccacd0f6545c
       payload_encoding:
         type: string
         example: application/cbor
@@ -644,7 +644,7 @@ definitions:
         example: 65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
       signer_pubkey:
         type: string
-        example: 16UwLL9Risc3QfPqBUvKofHmBQ7wMtjvM
+        example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
       batch_ids:
         type: array
         items:

--- a/tools/plugins/install_sphinx.sh
+++ b/tools/plugins/install_sphinx.sh
@@ -6,3 +6,6 @@ pip3 install sphinx
 pip3 install sphinx_rtd_theme
 pip3 install sphinxcontrib-httpdomain
 pip3 install sphinxcontrib-openapi
+
+# Used by make_templated_docs
+pip3 install Jinja2


### PR DESCRIPTION
Adds a new templating system to doc generation.
- Jinja2 templates can be added to the `docs/source/_templates/` directory, and output targets can be added to `template_config.yaml`.
- The `make` commands will build template targets into regular RST files before rendering them with sphinx.
- Generated files are stored in the `docs/source/_autogen/` directory.

Uses the new templating system to write three similar Transaction submission tutorials for Python, JavaScript, and the JavaScript SDK.