### PR TITLE
Fix poet smoke rest timeouts

### DIFF
--- a/integration/sawtooth_integration/tests/integration_tools.py
+++ b/integration/sawtooth_integration/tests/integration_tools.py
@@ -55,7 +55,8 @@ def wait_until_status(url, status_code=200, tries=5):
 
         attempts -= 1
 
-    assert(False, "{} is not available within {} attempts".format(url, tries))
+    raise AssertionError(
+        "{} is not available within {} attempts".format(url, tries))
 
 
 def wait_for_rest_apis(endpoints, tries=5):
@@ -67,4 +68,7 @@ def wait_for_rest_apis(endpoints, tries=5):
             availability.
     """
     for endpoint in endpoints:
-        wait_until_status('http://{}/blocks', status_code=200, tries=tries)
+        wait_until_status(
+            'http://{}/blocks'.format(endpoint),
+            status_code=200,
+            tries=tries)

--- a/integration/sawtooth_integration/tests/test_poet_smoke.py
+++ b/integration/sawtooth_integration/tests/test_poet_smoke.py
@@ -43,7 +43,7 @@ class TestPoetSmoke(unittest.TestCase):
         endpoints = ['rest-api-{}:8080'.format(i)
                      for i in range(VALIDATOR_COUNT)]
 
-        wait_for_rest_apis(endpoints)
+        wait_for_rest_apis(endpoints, tries=10)
 
         self.clients = [IntkeyClient('http://' + endpoint)
                         for endpoint in endpoints]


### PR DESCRIPTION
This fixes issues with both the assert on failure, and the incorrectly
formatted url for testing the rest api.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>