### PR TITLE
Delta subscription handlers

### DIFF
--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -36,3 +36,53 @@ message StateChange {
 message StateDeltaSet {
     repeated StateChange state_changes = 1;
 }
+
+// Registers a subscriber for StateDeltaEvent objects.  The
+// identity of the subscriber will be based on the ZMQ connection
+// id. This is an idempotent request.
+message RegisterStateDeltaSubscriberRequest {
+    // The block id (or ids, if trying to walk back a fork) the
+    // subscriber last received deltas on.  It can be set to empty
+    // if it has not yet received the genesis block.
+    repeated string last_known_block_ids = 1;
+    // The list of address prefixes of interest.  Only state changes
+    // that occur on values in the given prefixes will be sent to the
+    // subscriber.
+    repeated string address_prefixes = 2;
+}
+
+// The response to a RegisterStateDeltaSubscriberRequest
+message RegisterStateDeltaSubscriberResponse {
+    enum Status {
+        // returned on successful registration
+        OK = 0;
+        // returned on a failed registration, due to
+        // an internal validator error
+        INTERNAL_ERROR = 1;
+        // returned on a failed registration, due to all
+        // last_known_block_ids being unknown.  This could imply
+        // that a fork had occurred and been resolved since last
+        // unregistration.
+        UNKNOWN_BLOCK = 2;
+    }
+
+    Status status = 1;
+}
+
+// Unregisters a subscriber for StateDeltaEvent objects.  The
+// identity of the subscriber will be based on the ZMQ connection
+// id.  This is an idempotent request.
+message UnregisterStateDeltaSubscriberRequest {
+    // No data
+}
+
+message UnregisterStateDeltaSubscriberResponse {
+    enum Status {
+        // returned on successful registration
+        OK = 0;
+        // returned on a failed registration, due to
+        // an internal validator error
+        INTERNAL_ERROR = 1;
+    }
+    Status status = 1;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -109,6 +109,12 @@ message Message {
         NETWORK_ACK = 301;
         NETWORK_CONNECT = 302;
         NETWORK_DISCONNECT = 303;
+
+        // Message types for State Delta Exports
+        STATE_DELTA_SUBSCRIBE_REQUEST = 400;
+        STATE_DELTA_SUBSCRIBE_RESPONSE = 401;
+        STATE_DELTA_UNSUBSCRIBE_REQUEST = 402;
+        STATE_DELTA_UNSUBSCRIBE_RESPONSE = 403;
     }
     // The type of message, used to determine how to 'route' the message
     // to the appropriate handler as well as how to deserialize the

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -1,0 +1,171 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import logging
+from threading import Condition
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    RegisterStateDeltaSubscriberRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    RegisterStateDeltaSubscriberResponse
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    UnregisterStateDeltaSubscriberRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    UnregisterStateDeltaSubscriberResponse
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NoKnownBlockError(Exception):
+    pass
+
+
+class _DeltaSubscriber(object):
+    """Small holder for subscriber to prefix filters
+    """
+    def __init__(self, connection_id, address_prefix_filters):
+        self.connection_id = connection_id
+        self.address_prefixes = address_prefix_filters
+
+
+class StateDeltaProcessor(object):
+    """The StateDeltaProcessor manages subscribers for state deltas.
+    """
+
+    def __init__(self, service, state_delta_store, block_store):
+        """Constructs a new StateDeltaProcessor.
+
+        Args:
+            service (:obj:`Interconnect`): The zmq internal interface.
+            state_delta_store (:obj:`StateDeltaStore`): The source of state
+                delta values.
+            block_store (:obj:`BlockStore`): A BlockStore instance.
+        """
+        self._service = service
+        self._state_delta_store = state_delta_store
+        self._block_store = block_store
+
+        self._subscriber_cond = Condition()
+        self._subscribers = {}
+
+    @property
+    def subscriber_ids(self):
+        """Returns the connection ids of the current subscribers.
+        """
+        with self._subscriber_cond:
+            return list(self._subscribers.keys())
+
+    def add_subscriber(
+        self,
+        connection_id,
+        last_known_block_ids,
+        address_prefix_filters
+    ):
+        """Add a subscriber for deltas over specific address_prefixes.
+
+        Args:
+            connection_id (str): a connection id
+            last_known_block_ids (list of str): a list of block ids known to
+                to the subscriber, expected in order of newest to oldest
+            address_prefix_filters (list of str): a list of address prefixes
+                to filter
+
+        Raises:
+            NoKnownBlockError: if the list of last_known_block_ids does not
+                contain a block id contained in the block store.
+        """
+
+        if last_known_block_ids:
+            known_block_id = None
+            for block_id in last_known_block_ids:
+                if block_id in self._block_store:
+                    known_block_id = block_id
+                    break
+
+            if not known_block_id:
+                raise NoKnownBlockError()
+
+        with self._subscriber_cond:
+            self._subscribers[connection_id] = _DeltaSubscriber(
+                connection_id, address_prefix_filters)
+
+        LOGGER.debug('Added Subscriber %s for %s',
+                     connection_id, address_prefix_filters)
+
+    def remove_subscriber(self, connection_id):
+        """remove a subscriber with a given connection_id
+        """
+        with self._subscriber_cond:
+            if connection_id in self._subscribers:
+                subscriber = self._subscribers[connection_id]
+                del self._subscribers[connection_id]
+                LOGGER.debug('Removed Subscriber %s for %s',
+                             connection_id, subscriber.address_prefixes)
+
+
+class StateDeltaSubscriberHandler(Handler):
+    """Handles receiving messages for registering state delta subscribers.
+    """
+
+    _msg_type = validator_pb2.Message.STATE_DELTA_SUBSCRIBE_RESPONSE
+
+    def __init__(self, delta_processor):
+        self._delta_processor = delta_processor
+
+    def handle(self, connection_id, message_content):
+        request = RegisterStateDeltaSubscriberRequest()
+        request.ParseFromString(message_content)
+
+        ack = RegisterStateDeltaSubscriberResponse()
+        try:
+            self._delta_processor.add_subscriber(
+                connection_id,
+                request.last_known_block_ids,
+                request.address_prefixes)
+            ack.status = ack.OK
+        except NoKnownBlockError:
+            ack.status = ack.UNKNOWN_BLOCK
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=self._msg_type)
+
+
+class StateDeltaUnsubscriberHandler(Handler):
+    """Handles receiving messages for unregistering state delta subscribers.
+    """
+
+    _msg_type = validator_pb2.Message.STATE_DELTA_UNSUBSCRIBE_RESPONSE
+
+    def __init__(self, delta_processor):
+        self._delta_processor = delta_processor
+
+    def handle(self, connection_id, message_content):
+        request = UnregisterStateDeltaSubscriberRequest()
+        request.ParseFromString(message_content)
+
+        ack = UnregisterStateDeltaSubscriberResponse()
+        self._delta_processor.remove_subscriber(connection_id)
+        ack.status = ack.OK
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=self._msg_type)

--- a/validator/tests/unit3/test_state_delta_processor/tests.py
+++ b/validator/tests/unit3/test_state_delta_processor/tests.py
@@ -1,0 +1,199 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.state.state_delta_processor import \
+    StateDeltaProcessor
+from sawtooth_validator.state.state_delta_processor import \
+    NoKnownBlockError
+from sawtooth_validator.state.state_delta_processor import \
+    StateDeltaSubscriberHandler
+from sawtooth_validator.state.state_delta_processor import \
+    StateDeltaUnsubscriberHandler
+
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    RegisterStateDeltaSubscriberRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    RegisterStateDeltaSubscriberResponse
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    UnregisterStateDeltaSubscriberRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    UnregisterStateDeltaSubscriberResponse
+
+from test_journal.block_tree_manager import BlockTreeManager
+
+
+class StateDeltaProcessorHandlerTest(unittest.TestCase):
+
+    def test_register_subscriber(self):
+        """Tests that the handler will add a valid subscriber and return an OK
+        response.
+        """
+        mock_block_store = {'a': Mock()}
+        delta_processor = StateDeltaProcessor(
+            service=Mock(),
+            state_delta_store=Mock(),
+            block_store=mock_block_store)
+
+        handler = StateDeltaSubscriberHandler(delta_processor)
+
+        request = RegisterStateDeltaSubscriberRequest(
+            last_known_block_ids=['a'],
+            address_prefixes=['000000']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+
+        self.assertEqual(RegisterStateDeltaSubscriberResponse.OK,
+                         response.message_out.status)
+
+    def test_register_with_uknown_block_ids(self):
+        """Tests that the handler will respond with an UNKNOWN_BLOCK
+        when a subscriber does not supply a known block id in
+        last_known_block_ids
+        """
+        mock_block_store = {}
+
+        delta_processor = StateDeltaProcessor(
+            service=Mock(),
+            state_delta_store=Mock(),
+            block_store=mock_block_store)
+
+        handler = StateDeltaSubscriberHandler(delta_processor)
+
+        request = RegisterStateDeltaSubscriberRequest(
+            last_known_block_ids=['a'],
+            address_prefixes=['000000']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+
+        self.assertEqual(
+            RegisterStateDeltaSubscriberResponse.UNKNOWN_BLOCK,
+            response.message_out.status)
+
+
+class StateDeltaUnregisterSubscriberHandlerTest(unittest.TestCase):
+    def test_unregister_subscriber(self):
+        """Test that a handler will unregister a subscriber via a the requestor's
+        connection id.
+        """
+        mock_delta_processor = Mock()
+        handler = StateDeltaUnsubscriberHandler(mock_delta_processor)
+
+        request = UnregisterStateDeltaSubscriberRequest().SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+
+        mock_delta_processor.remove_subscriber.assert_called_with(
+            'test_conn_id')
+
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(UnregisterStateDeltaSubscriberResponse.OK,
+                         response.message_out.status)
+
+
+class StateDeltaProcessorTest(unittest.TestCase):
+
+    def test_add_subscriber(self):
+        """Test adding a subscriber, who has no known blocks.
+
+        This scenerio is valid for subscribers who have never connected and
+        would need to receive all deltas since the genesis block.
+        """
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=Mock(),
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'test_conn_id',
+            [],
+            ['deadbeef'])
+
+        self.assertEqual(['test_conn_id'], delta_processor.subscriber_ids)
+
+    def test_add_subscrber_known_block_id(self):
+        """Test adding a subscriber, whose known block id is the current
+        chainhead.
+        """
+
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=Mock(),
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'test_conn_id',
+            [block_tree_manager.chain_head.identifier],
+            ['deadbeef'])
+
+        self.assertEqual(['test_conn_id'], delta_processor.subscriber_ids)
+
+        self.assertTrue(not mock_service.send.called)
+
+    def test_add_subscriber_unknown_block_id(self):
+        """Test adding a subscriber, whose known block id is not in the
+        current chain.
+        """
+        block_tree_manager = BlockTreeManager()
+
+        delta_processor = StateDeltaProcessor(
+            service=Mock(),
+            state_delta_store=Mock(),
+            block_store=block_tree_manager.block_store)
+
+        with self.assertRaises(NoKnownBlockError):
+            delta_processor.add_subscriber(
+                'test_conn_id',
+                ['deadbeefb10c4'],
+                ['deadbeef'])
+
+    def test_remove_subscriber(self):
+        """Test adding a subscriber, whose known block id is the current
+        chainhead, followed by removing the subscriber.
+        """
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=Mock(),
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'test_conn_id',
+            [block_tree_manager.chain_head.identifier],
+            ['deadbeef' 'beefdead'])
+
+        self.assertEqual(['test_conn_id'], delta_processor.subscriber_ids)
+
+        delta_processor.remove_subscriber('test_conn_id')
+
+        self.assertEqual([], delta_processor.subscriber_ids)


### PR DESCRIPTION
Add the protobuf messages for State Delta Export subscribe and
unsubscribe.  This includes requests and responses, as well as the
message codes for the values.

Adds the `StateDeltaProcessor` to manage subscribers for state deltas.
Introduces a pair of handlers for registering and unregistering the
subscibers.

Subscribers are rejected if their registration request does not have a
block id that is in the current chain.