### PR TITLE
Publish State Change Deltas on Block Commit

### DIFF
--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -37,6 +37,22 @@ message StateDeltaSet {
     repeated StateChange state_changes = 1;
 }
 
+// A StateDeltaEvent contains the information about the start and
+// end of the delta (from a block perspective) and the list of
+// changes that have occurred in that time. The list of state
+// changes are limited to those in the namespaces specified at
+// subscriber registration time.
+message StateDeltaEvent {
+    // The block id associated with the changes.
+    string block_id = 1;
+    // The block number associated with the changes
+    int32 block_num = 2;
+    // The state root hash which resulted from the changes.
+    string state_root_hash = 3;
+    // The collection of StateChange objects
+    repeated StateChange state_changes = 4;
+}
+
 // Registers a subscriber for StateDeltaEvent objects.  The
 // identity of the subscriber will be based on the ZMQ connection
 // id. This is an idempotent request.

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -115,6 +115,7 @@ message Message {
         STATE_DELTA_SUBSCRIBE_RESPONSE = 401;
         STATE_DELTA_UNSUBSCRIBE_REQUEST = 402;
         STATE_DELTA_UNSUBSCRIBE_RESPONSE = 403;
+        STATE_DELTA_EVENT = 404;
     }
     // The type of message, used to determine how to 'route' the message
     // to the appropriate handler as well as how to deserialize the

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -121,6 +121,7 @@ class Journal(object):
                  squash_handler,
                  identity_signing_key,
                  chain_id_manager,
+                 state_delta_processor,
                  data_dir,
                  check_publish_block_frequency=0.1,
                  block_cache_purge_frequency=30,
@@ -142,6 +143,8 @@ class Journal(object):
             identity_signing_key (str): Private key for signing blocks
             chain_id_manager (:obj:`ChainIdManager`) The ChainIdManager
                 instance.
+            state_delta_processor (:obj:`StateDeltaProcessor`): The state
+                delta processor.
             data_dir (str): directory for data storage.
             check_publish_block_frequency(float): delay in seconds between
                 checks if a block should be claimed.
@@ -175,6 +178,7 @@ class Journal(object):
         self._block_queue = queue.Queue()
         self._chain_thread = None
         self._chain_id_manager = chain_id_manager
+        self._state_delta_processor = state_delta_processor
         self._data_dir = data_dir
 
     def _init_subprocesses(self):
@@ -203,6 +207,7 @@ class Journal(object):
             on_chain_updated=self._block_publisher.on_chain_updated,
             squash_handler=self._squash_handler,
             chain_id_manager=self._chain_id_manager,
+            state_delta_processor=self._state_delta_processor,
             identity_signing_key=self._identity_signing_key,
             data_dir=self._data_dir
         )

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -211,6 +211,7 @@ class Validator(object):
             squash_handler=context_manager.get_squash_handler(),
             identity_signing_key=identity_signing_key,
             chain_id_manager=chain_id_manager,
+            state_delta_processor=state_delta_processor,
             data_dir=data_dir,
             check_publish_block_frequency=0.1,
             block_cache_purge_frequency=30,

--- a/validator/tests/unit3/test_journal/mock.py
+++ b/validator/tests/unit3/test_journal/mock.py
@@ -242,3 +242,15 @@ def CreateSetting(key, value):
     setting = Setting()
     setting.entries.add(key=key, value=repr(value))
     return addr, setting.SerializeToString()
+
+
+class MockStateDeltaProcessor(object):
+    """Mock for the StateDeltaProcessor, which provides publishing of the state
+    changes on block publishing.
+    """
+
+    def __init__(self):
+        self.block = None
+
+    def publish_deltas(self, block):
+        self.block = block

--- a/validator/tests/unit3/test_state_delta_processor/tests.py
+++ b/validator/tests/unit3/test_state_delta_processor/tests.py
@@ -16,10 +16,12 @@
 import unittest
 from unittest.mock import Mock
 
+from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
 
+from sawtooth_validator.state.state_delta_store import StateDeltaStore
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaProcessor
 from sawtooth_validator.state.state_delta_processor import \
@@ -29,6 +31,8 @@ from sawtooth_validator.state.state_delta_processor import \
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
 
+from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
+from sawtooth_validator.protobuf.state_delta_pb2 import StateDeltaEvent
 from sawtooth_validator.protobuf.state_delta_pb2 import \
     RegisterStateDeltaSubscriberRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
@@ -37,6 +41,7 @@ from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberResponse
+from sawtooth_validator.protobuf import validator_pb2
 
 from test_journal.block_tree_manager import BlockTreeManager
 
@@ -197,3 +202,129 @@ class StateDeltaProcessorTest(unittest.TestCase):
         delta_processor.remove_subscriber('test_conn_id')
 
         self.assertEqual([], delta_processor.subscriber_ids)
+
+    def test_publish_deltas(self):
+        """Tests that a subscriber filtering on an address prefix receives only
+        the changes in an event that match.
+        """
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        database = DictDatabase()
+        delta_store = StateDeltaStore(database)
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=delta_store,
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'test_conn_id',
+            [block_tree_manager.chain_head.identifier],
+            ['deadbeef'])
+
+        next_block = block_tree_manager.generate_block()
+        # State added during context squash for our block
+        delta_store.save_state_deltas(
+            next_block.header.state_root_hash,
+            [StateChange(address='deadbeef01',
+                         value='my_state_Value'.encode(),
+                         type=StateChange.SET),
+             StateChange(address='a14ea01',
+                         value='some other state value'.encode(),
+                         type=StateChange.SET)])
+
+        # call to publish deltas for that block to the subscribers
+        delta_processor.publish_deltas(next_block)
+
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.STATE_DELTA_EVENT,
+            StateDeltaEvent(
+                block_id=next_block.identifier,
+                block_num=next_block.header.block_num,
+                state_root_hash=next_block.header.state_root_hash,
+                state_changes=[StateChange(address='deadbeef01',
+                               value='my_state_Value'.encode(),
+                               type=StateChange.SET)]
+            ).SerializeToString(),
+            connection_id='test_conn_id')
+
+    def test_publish_deltas_subscriber_matches_no_addresses(self):
+        """Given a subscriber whose prefix filters don't match any addresses
+        in the current state delta, it should still receive an event with the
+        block change information.
+        """
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        database = DictDatabase()
+        delta_store = StateDeltaStore(database)
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=delta_store,
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'settings_conn_id',
+            [block_tree_manager.chain_head.identifier],
+            ['000000'])
+
+        next_block = block_tree_manager.generate_block()
+        # State added during context squash for our block
+        delta_store.save_state_deltas(
+            next_block.header.state_root_hash,
+            [StateChange(address='deadbeef01',
+                         value='my_state_Value'.encode(),
+                         type=StateChange.SET),
+             StateChange(address='a14ea01',
+                         value='some other state value'.encode(),
+                         type=StateChange.SET)])
+
+        # call to publish deltas for that block to the subscribers
+        delta_processor.publish_deltas(next_block)
+
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.STATE_DELTA_EVENT,
+            StateDeltaEvent(
+                block_id=next_block.identifier,
+                block_num=next_block.header.block_num,
+                state_root_hash=next_block.header.state_root_hash,
+                state_changes=[]
+            ).SerializeToString(),
+            connection_id='settings_conn_id')
+
+    def test_publish_deltas_no_state_changes(self):
+        """Given a block transition, where no state changes happened (e.g. it
+        only had transactions which did not change state), the
+        StateDeltaProcessor should still publish an event with the block change
+        information.
+        """
+        mock_service = Mock()
+        block_tree_manager = BlockTreeManager()
+
+        database = DictDatabase()
+        delta_store = StateDeltaStore(database)
+
+        delta_processor = StateDeltaProcessor(
+            service=mock_service,
+            state_delta_store=delta_store,
+            block_store=block_tree_manager.block_store)
+
+        delta_processor.add_subscriber(
+            'subscriber_conn_id',
+            [block_tree_manager.chain_head.identifier],
+            ['000000'])
+
+        next_block = block_tree_manager.generate_block()
+        delta_processor.publish_deltas(next_block)
+
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.STATE_DELTA_EVENT,
+            StateDeltaEvent(
+                block_id=next_block.identifier,
+                block_num=next_block.header.block_num,
+                state_root_hash=next_block.header.state_root_hash,
+                state_changes=[]
+            ).SerializeToString(),
+            connection_id='subscriber_conn_id')


### PR DESCRIPTION
On block commit, the `ChainController` calls out to a `StateDeltaProcessor` instance to publish state changes to its subscribers.

