### PR TITLE
Fix python sdk stream class hiding errors

### DIFF
--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -26,7 +26,6 @@ from google.protobuf.message import Message as BaseMessage
 
 from sawtooth_sdk.messaging.exceptions import ValidatorConnectionError
 from sawtooth_sdk.messaging.future import FutureTimeoutError
-from sawtooth_sdk.messaging.stream import Stream
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
 import sawtooth_rest_api.exceptions as errors
@@ -53,14 +52,15 @@ class RouteHandler(object):
     instead.
 
     Args:
-        stream_url (str): The TCP url to communitcate with the validator
+        stream (:obj: messaging.stream.Stream): The object that communicates
+            with the validator.
         timeout (int, optional): The time in seconds before the Api should
             cancel a request and report that the validator is unavailable.
     """
-    def __init__(self, loop, stream_url, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, loop, stream, timeout=DEFAULT_TIMEOUT):
         loop.set_default_executor(ThreadPoolExecutor())
         self._loop = loop
-        self._stream = Stream(stream_url)
+        self._stream = stream
         self._timeout = timeout
 
     async def submit_batches(self, request):

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -157,8 +157,7 @@ class BaseApiTest(AioHTTPTestCase):
         Returns:
             RouteHandler: The route handlers to handle test queries
         """
-        handlers = RouteHandler(loop, 'tcp://0.0.0.0:40404', TEST_TIMEOUT)
-        handlers._stream = stream
+        handlers = RouteHandler(loop, stream, TEST_TIMEOUT)
         return handlers
 
     @staticmethod

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
@@ -43,30 +43,33 @@ def parse_args(args):
 
 def main(args=sys.argv[1:]):
     opts = parse_args(args)
-
-    processor = TransactionProcessor(url=opts.endpoint)
-    log_config = get_log_config(filename="intkey_log_config.toml")
-    if log_config is not None:
-        log_configuration(log_config=log_config)
-    else:
-        log_dir = get_log_dir()
-        # use the transaction processor zmq identity for filename
-        log_configuration(
-            log_dir=log_dir,
-            name="intkey-" + str(processor.zmq_id)[2:-1])
-
-    init_console_logging(verbose_level=opts.verbose)
-
-    # The prefix should eventually be looked up from the
-    # validator's namespace registry.
-    intkey_prefix = hashlib.sha512('intkey'.encode()).hexdigest()[0:6]
-    handler = IntkeyTransactionHandler(namespace_prefix=intkey_prefix)
-
-    processor.add_handler(handler)
-
+    processor = None
     try:
+        processor = TransactionProcessor(url=opts.endpoint)
+        log_config = get_log_config(filename="intkey_log_config.toml")
+        if log_config is not None:
+            log_configuration(log_config=log_config)
+        else:
+            log_dir = get_log_dir()
+            # use the transaction processor zmq identity for filename
+            log_configuration(
+                log_dir=log_dir,
+                name="intkey-" + str(processor.zmq_id)[2:-1])
+
+        init_console_logging(verbose_level=opts.verbose)
+
+        # The prefix should eventually be looked up from the
+        # validator's namespace registry.
+        intkey_prefix = hashlib.sha512('intkey'.encode()).hexdigest()[0:6]
+        handler = IntkeyTransactionHandler(namespace_prefix=intkey_prefix)
+
+        processor.add_handler(handler)
+
         processor.start()
     except KeyboardInterrupt:
         pass
+    except Exception as e:  # pylint: disable=broad-except
+        print("Error: {}".format(e), file=sys.stderr)
     finally:
-        processor.stop()
+        if processor is not None:
+            processor.stop()

--- a/sdk/examples/xo_python/sawtooth_xo/processor/main.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/main.py
@@ -43,30 +43,33 @@ def parse_args(args):
 
 def main(args=sys.argv[1:]):
     opts = parse_args(args)
-
-    processor = TransactionProcessor(url=opts.endpoint)
-    log_config = get_log_config(filename="xo_log_config.toml")
-    if log_config is not None:
-        log_configuration(log_config=log_config)
-    else:
-        log_dir = get_log_dir()
-        # use the transaction processor zmq identity for filename
-        log_configuration(
-            log_dir=log_dir,
-            name="xo-" + str(processor.zmq_id)[2:-1])
-
-    init_console_logging(verbose_level=opts.verbose)
-
-    # The prefix should eventually be looked up from the
-    # validator's namespace registry.
-    xo_prefix = hashlib.sha512('xo'.encode("utf-8")).hexdigest()[0:6]
-    handler = XoTransactionHandler(namespace_prefix=xo_prefix)
-
-    processor.add_handler(handler)
-
+    processor = None
     try:
+        processor = TransactionProcessor(url=opts.endpoint)
+        log_config = get_log_config(filename="xo_log_config.toml")
+        if log_config is not None:
+            log_configuration(log_config=log_config)
+        else:
+            log_dir = get_log_dir()
+            # use the transaction processor zmq identity for filename
+            log_configuration(
+                log_dir=log_dir,
+                name="xo-" + str(processor.zmq_id)[2:-1])
+
+        init_console_logging(verbose_level=opts.verbose)
+
+        # The prefix should eventually be looked up from the
+        # validator's namespace registry.
+        xo_prefix = hashlib.sha512('xo'.encode("utf-8")).hexdigest()[0:6]
+        handler = XoTransactionHandler(namespace_prefix=xo_prefix)
+
+        processor.add_handler(handler)
+
         processor.start()
     except KeyboardInterrupt:
         pass
+    except Exception as e:  # pylint: disable=broad-except
+        print("Error: {}".format(e))
     finally:
-        processor.stop()
+        if processor is not None:
+            processor.stop()


### PR DESCRIPTION
This PR causes the python sdk stream class to not hide errors, and exceptions on connecting to the validator will cause the class to raise an exception on instantiation. 