### PR TITLE
Implement Connection Maintenance 

### DIFF
--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -67,10 +67,12 @@ class DisconnectHandler(Handler):
 
         ack = NetworkAcknowledgement()
         ack.status = ack.OK
+        self._network.remove_connection(connection_id)
 
-        return HandlerResult(HandlerStatus.RETURN,
-                             message_out=ack,
-                             message_type=validator_pb2.Message.NETWORK_ACK)
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=validator_pb2.Message.NETWORK_ACK)
 
 
 class PingHandler(Handler):

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -499,6 +499,8 @@ class Validator(object):
 
     def stop(self):
         self._gossip.stop()
+        self._dispatcher.stop()
+        self._network_dispatcher.stop()
         self._network.stop()
 
         self._service.stop()
@@ -517,12 +519,6 @@ class Validator(object):
         # This will remove the MainThread, which will exit when we exit with
         # a sys.exit() or exit of main().
         threads.remove(threading.current_thread())
-
-        # Several Thread subclasses have a stop method not defined
-        # in superclass.
-        for t in threads:
-            if hasattr(t, 'stop'):
-                t.stop()
 
         while len(threads) > 0:
             if len(threads) < 4:


### PR DESCRIPTION
Connections that are used for getting candidate peers or an
unsuccessful peer request are removed. Also, send unregister
peer request to peers and disconnect messages to all connection
on validator shutdown.

Update gossip in core to have min and max peer connectivity set to 1:

self._gossip = Gossip(self._network,
                              public_uri=public_uri,
                              peering_mode=peering,
                              initial_join_endpoints=join_list,
                              initial_peer_endpoints=peer_list,
                              minimum_peer_connectivity=1,
                              maximum_peer_connectivity=1,
                              topology_check_frequency=1)

To test, start up the following validators one at a time (waiting for it to be completely started up) : 
validator -vvv --public-uri tcp://localhost:8800 --peering dynamic

validator --network-endpoint tcp://0.0.0.0:8801 --component-endpoint tcp://0.0.0.0:40001 --join tcp://localhost:8800 -vv --public-uri tcp://localhost:8801 --peering dynamic

validator --network-endpoint tcp://0.0.0.0:8802 --component-endpoint tcp://0.0.0.0:40002 --join tcp://localhost:8801 -vv --public-uri tcp://localhost:8802 --peering dynamic

The first two should be peered and the the third will be trying to peer unsuccessfully. You should see "Closing connection to .....". Control C one of the peered validators and you should see the other acknowledge an unregister peer request and a disconnect message. 
