### PR TITLE
Replace jackson-dataformat-cbor with co.nstant.in.cobr in Intkey Java

### DIFF
--- a/sdk/examples/intkey_java/pom.xml
+++ b/sdk/examples/intkey_java/pom.xml
@@ -69,14 +69,9 @@
             <version>3.0.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.8.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.8.3</version>
+          <groupId>co.nstant.in</groupId>
+          <artifactId>cbor</artifactId>
+          <version>0.7</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
This change allows us to encode the intkey state HashMap in
the correct format to work with the python intkey and javascript
intkey examples. Jackson was formatting it to be an indefinite
map instead of a definite map. This caused the state root hash
to be different on validation when running a mixed network.

To test:
build_all
start up a validator and connect both a tp_intkey_python -vv and a tp_intkey_java
run intkey workload

You should see both transaction processors receiving transactions and blocks being build. 