### PR TITLE
Add proper logger to REST API

### DIFF
--- a/integration/sawtooth_integration/docker/config-smoke.yaml
+++ b/integration/sawtooth_integration/docker/config-smoke.yaml
@@ -56,7 +56,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/intkey-go-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-go-smoke.yaml
@@ -65,7 +65,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/intkey-java-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-java-smoke.yaml
@@ -65,7 +65,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/intkey-javascript-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-javascript-smoke.yaml
@@ -65,7 +65,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/intkey-python-smoke.yaml
+++ b/integration/sawtooth_integration/docker/intkey-python-smoke.yaml
@@ -66,7 +66,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -101,7 +101,7 @@ services:
     expose:
       - 40000
       - 8080
-    command: rest_api --stream-url tcp://validator-0:40000 --host rest-api-0
+    command: rest_api -v --stream-url tcp://validator-0:40000 --host rest-api-0
     stop_signal: SIGKILL
 
   rest-api-1:
@@ -111,7 +111,7 @@ services:
     expose:
       - 40000
       - 8080
-    command: rest_api --stream-url tcp://validator-1:40000 --host rest-api-1
+    command: rest_api -v --stream-url tcp://validator-1:40000 --host rest-api-1
     stop_signal: SIGKILL
 
   rest-api-2:
@@ -121,7 +121,7 @@ services:
     expose:
       - 40000
       - 8080
-    command: rest_api --stream-url tcp://validator-2:40000 --host rest-api-2
+    command: rest_api -v --stream-url tcp://validator-2:40000 --host rest-api-2
     stop_signal: SIGKILL
 
   tp-intkey-0:

--- a/integration/sawtooth_integration/docker/two_families.yaml
+++ b/integration/sawtooth_integration/docker/two_families.yaml
@@ -76,7 +76,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/xo-javascript-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-javascript-smoke.yaml
@@ -64,7 +64,7 @@ services:
       - 8080
     depends_on:
      - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/docker/xo-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-smoke.yaml
@@ -64,7 +64,7 @@ services:
       - 8080
     depends_on:
      - validator
-    command: rest_api --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
     stop_signal: SIGKILL
 
   integration_test:

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -13,13 +13,21 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import sys
+import logging
 import asyncio
 import argparse
-import sys
 from aiohttp import web
-from sawtooth_rest_api.route_handlers import RouteHandler
 
 from sawtooth_sdk.messaging.stream import Stream
+from sawtooth_sdk.client.log import init_console_logging
+from sawtooth_sdk.client.log import log_configuration
+from sawtooth_sdk.client.config import get_log_config
+from sawtooth_sdk.client.config import get_log_dir
+from sawtooth_rest_api.route_handlers import RouteHandler
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def parse_args(args):
@@ -38,6 +46,10 @@ def parse_args(args):
     parser.add_argument('--timeout',
                         help='Seconds to wait for a validator response',
                         default=300)
+    parser.add_argument('-v', '--verbose',
+                        action='count',
+                        default=0,
+                        help='Increase level of output sent to stderr')
 
     return parser.parse_args(args)
 
@@ -46,7 +58,7 @@ async def logging_middleware(app, handler):
     """Simple logging middleware to report the method/route of all requests.
     """
     async def logging_handler(request):
-        print('Handling {} request for {}'.format(
+        LOGGER.info('Handling {} request for {}'.format(
             request.method,
             request.rel_url
         ))
@@ -82,7 +94,7 @@ def start_rest_api(host, port, stream, timeout):
         handler.fetch_transaction)
 
     # Start app
-    web.run_app(app, host=host, port=port)
+    web.run_app(app, host=host, port=port, access_log=None)
 
 
 def main():
@@ -90,6 +102,15 @@ def main():
     try:
         opts = parse_args(sys.argv[1:])
         stream = Stream(opts.stream_url)
+
+        log_config = get_log_config(filename="rest_api_log_config.toml")
+        if log_config is not None:
+            log_configuration(log_config=log_config)
+        else:
+            log_dir = get_log_dir()
+            log_configuration(log_dir=log_dir, name="sawtooth_rest_api")
+        init_console_logging(verbose_level=opts.verbose)
+
         start_rest_api(
             opts.host,
             int(opts.port),

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -47,6 +47,7 @@ setup(name='sawtooth-sdk',
       packages=find_packages(),
       data_files=data_files,
       install_requires=[
+          "colorlog",
           "sawtooth-signing",
           "protobuf",
           "pyzmq",


### PR DESCRIPTION
Adds a logger to the REST API, and replaces the existing access logger with an expanded access logger that no longer uses `print` statements.

This PR does not close STL-69 (https://jira.hyperledger.org/browse/STL-69), but establishes the groundwork for a more robust logger which will.