### PR TITLE
Send "catch-up" State Delta Events on Subscribe

### DIFF
--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -65,3 +65,10 @@ class PeeringException(Exception):
     Indicates that a request to peer with this validator should not be allowed.
     """
     pass
+
+
+class PossibleForkDetectedError(Exception):
+    """Exception thrown when a possible fork has occurred while iterating
+    through the block store.
+    """
+    pass

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -54,7 +54,9 @@ from sawtooth_validator.state import client_handlers
 from sawtooth_validator.state.config_view import ConfigViewFactory
 from sawtooth_validator.state.state_delta_processor import StateDeltaProcessor
 from sawtooth_validator.state.state_delta_processor import \
-    StateDeltaSubscriberHandler
+    StateDeltaAddSubscriberHandler
+from sawtooth_validator.state.state_delta_processor import \
+    StateDeltaSubscriberValidationHandler
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
 from sawtooth_validator.state.state_delta_store import StateDeltaStore
@@ -466,9 +468,15 @@ class Validator(object):
             client_handlers.StateCurrentRequest(
                 self._journal.get_current_root), thread_pool)
 
+        # State Delta Subscription Handlers
         self._dispatcher.add_handler(
             validator_pb2.Message.STATE_DELTA_SUBSCRIBE_REQUEST,
-            StateDeltaSubscriberHandler(state_delta_processor),
+            StateDeltaSubscriberValidationHandler(state_delta_processor),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.STATE_DELTA_SUBSCRIBE_REQUEST,
+            StateDeltaAddSubscriberHandler(state_delta_processor),
             thread_pool)
 
         self._dispatcher.add_handler(

--- a/validator/tests/unit3/test_block_store/tests.py
+++ b/validator/tests/unit3/test_block_store/tests.py
@@ -1,0 +1,113 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.exceptions import PossibleForkDetectedError
+from sawtooth_validator.journal.block_store import BlockStore
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
+
+from sawtooth_validator.protobuf.block_pb2 import Block
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+
+
+class BlockStorePredecessorIteratorTest(unittest.TestCase):
+
+    def test_iterate_chain(self):
+        """Given a block store, create an predecessor iterator.
+
+        1. Create a chain of length 5.
+        2. Iterate the chain using the get_predecessor_iter from the chain head
+        3. Verify that the block ids match the chain, in reverse order
+        """
+
+        block_store = BlockStore(DictDatabase())
+        chain = self._create_chain(5)
+        block_store.update_chain(chain)
+
+        ids = [b.identifier for b in block_store.get_predecessor_iter()]
+
+        self.assertEqual(
+            ['abcd4', 'abcd3', 'abcd2', 'abcd1', 'abcd0'],
+            ids)
+
+    def test_iterate_chain_from_starting_block(self):
+        """Given a block store, iterate if using an predecessor iterator from
+        a particular start point in the chain.
+
+        1. Create a chain of length 5.
+        2. Iterate the chain using the get_predecessor_iter from block 3
+        3. Verify that the block ids match the chain, in reverse order
+        """
+        block_store = BlockStore(DictDatabase())
+        chain = self._create_chain(5)
+        block_store.update_chain(chain)
+
+        block = block_store['abcd2']
+
+        ids = [b.identifier
+               for b in block_store.get_predecessor_iter(block)]
+
+        self.assertEqual(
+            ['abcd2', 'abcd1', 'abcd0'],
+            ids)
+
+    def test_iterate_chain_on_empty_block_store(self):
+        """Given a block store with no blocks, iterate using predecessor iterator
+        and verify that it results in an empty list.
+        """
+        block_store = BlockStore(DictDatabase())
+
+        self.assertEqual([], [b for b in block_store.get_predecessor_iter()])
+
+    def test_fork_detection_on_iteration(self):
+        """Given a block store where a fork occurred while using the predecessor
+        iterator, it should throw a PossibleForkDetectedError.
+
+        The fork occurrance will be simulated.
+        """
+        block_store = BlockStore(DictDatabase())
+        chain = self._create_chain(5)
+        block_store.update_chain(chain)
+
+        iterator = block_store.get_predecessor_iter()
+
+        self.assertEqual('abcd4', next(iterator).identifier)
+
+        del block_store['abcd3']
+
+        with self.assertRaises(PossibleForkDetectedError):
+            next(iterator)
+
+    def _create_chain(self, length):
+        chain = []
+        previous_block_id = NULL_BLOCK_IDENTIFIER
+        for i in range(length):
+            block = BlockWrapper(
+                Block(header_signature='abcd{}'.format(i),
+                      header=BlockHeader(
+                          block_num=i,
+                          previous_block_id=previous_block_id
+                      ).SerializeToString()))
+
+            previous_block_id = block.identifier
+
+            chain.append(block)
+
+        chain.reverse()
+
+        return chain

--- a/validator/tests/unit3/test_state_delta_processor/tests.py
+++ b/validator/tests/unit3/test_state_delta_processor/tests.py
@@ -52,16 +52,17 @@ class StateDeltaProcessorHandlerTest(unittest.TestCase):
         """Tests that the handler will add a valid subscriber and return an OK
         response.
         """
-        mock_block_store = {'a': Mock()}
+        block_tree_manager = BlockTreeManager()
+
         delta_processor = StateDeltaProcessor(
             service=Mock(),
             state_delta_store=Mock(),
-            block_store=mock_block_store)
+            block_store=block_tree_manager.block_store)
 
         handler = StateDeltaSubscriberHandler(delta_processor)
 
         request = RegisterStateDeltaSubscriberRequest(
-            last_known_block_ids=['a'],
+            last_known_block_ids=[block_tree_manager.chain_head.identifier],
             address_prefixes=['000000']).SerializeToString()
 
         response = handler.handle('test_conn_id', request)
@@ -76,12 +77,12 @@ class StateDeltaProcessorHandlerTest(unittest.TestCase):
         when a subscriber does not supply a known block id in
         last_known_block_ids
         """
-        mock_block_store = {}
+        block_tree_manager = BlockTreeManager()
 
         delta_processor = StateDeltaProcessor(
             service=Mock(),
             state_delta_store=Mock(),
-            block_store=mock_block_store)
+            block_store=block_tree_manager.block_store)
 
         handler = StateDeltaSubscriberHandler(delta_processor)
 
@@ -125,14 +126,28 @@ class StateDeltaProcessorTest(unittest.TestCase):
 
         This scenerio is valid for subscribers who have never connected and
         would need to receive all deltas since the genesis block.
+
+        On registration, the subscriber should receive one event, comprised
+        of the state changes for the genesis block.
         """
         mock_service = Mock()
         block_tree_manager = BlockTreeManager()
 
+        delta_store = StateDeltaStore(DictDatabase())
+
         delta_processor = StateDeltaProcessor(
             service=mock_service,
-            state_delta_store=Mock(),
+            state_delta_store=delta_store,
             block_store=block_tree_manager.block_store)
+
+        delta_store.save_state_deltas(
+            block_tree_manager.chain_head.state_root_hash,
+            [StateChange(address='deadbeef0000000',
+                         value='my_genesis_value'.encode(),
+                         type=StateChange.SET),
+             StateChange(address='a14ea01',
+                         value='some other state value'.encode(),
+                         type=StateChange.SET)])
 
         delta_processor.add_subscriber(
             'test_conn_id',
@@ -141,7 +156,22 @@ class StateDeltaProcessorTest(unittest.TestCase):
 
         self.assertEqual(['test_conn_id'], delta_processor.subscriber_ids)
 
-    def test_add_subscrber_known_block_id(self):
+        # test that it catches up, and receives the events from the chain head.
+        # In this case, it should just be once, as the chain head is the
+        # genesis block
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.STATE_DELTA_EVENT,
+            StateDeltaEvent(
+                block_id=block_tree_manager.chain_head.identifier,
+                block_num=block_tree_manager.chain_head.block_num,
+                state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                state_changes=[StateChange(address='deadbeef0000000',
+                               value='my_genesis_value'.encode(),
+                               type=StateChange.SET)]
+            ).SerializeToString(),
+            connection_id='test_conn_id')
+
+    def test_add_subscriber_known_block_id(self):
         """Test adding a subscriber, whose known block id is the current
         chainhead.
         """


### PR DESCRIPTION
When a state delta export subscriber registers with a known block id that is older than the current chain head, send the subscriber all the events that have occurred in the interim.   This allows the subscriber to behave as if it received all the correct events.

Additionally:

* Add a Predecessor Iterator on block store