### PR TITLE
Disable shutdown smoke tests

### DIFF
--- a/integration/sawtooth_integration/tests/test_shutdown_smoke.py
+++ b/integration/sawtooth_integration/tests/test_shutdown_smoke.py
@@ -35,6 +35,7 @@ class TestShutdownSmoke(unittest.TestCase):
             os.environ.get("VALIDATOR_IMAGE_NAME"),
             cls._id)
 
+    @unittest.skip("Skipping until STL-120 is complete: has periodic failures")
     def test_resting_shutdown_sigint(self):
         """Tests that SIGINT will cause validators with and without
         genesis to gracefully exit.
@@ -76,6 +77,7 @@ class TestShutdownSmoke(unittest.TestCase):
             self._log_and_clean_up(containers)
             self.fail(str(e))
 
+    @unittest.skip("Skipping until STL-120 is complete: has periodic failures")
     def test_resting_shutdown_sigterm(self):
         """Tests that SIGTERM will cause validators with and without
         genesis to gracefully exit.


### PR DESCRIPTION
Disable shutdown smoke tests until STL-120 is complete.  These test cause periodic failures due to the shutdown activities not being properly implemented.  While the argument could be made that we should keep things painful, so as to force ourselves to fix it, it makes the PR process (especially with external contributors) particularly painful.

See: https://jira.hyperledger.org/browse/STL-120

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>