### PR TITLE
If an InternalError is returned from a TP, resend TpProcessRequest.

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -85,6 +85,17 @@ class TransactionExecutorThread(object):
         if response.status == processor_pb2.TpProcessResponse.OK:
             self._scheduler.set_transaction_execution_result(
                 req.signature, True, req.context_id)
+        elif response.status == processor_pb2.TpProcessResponse.INTERNAL_ERROR:
+            header = transaction_pb2.TransactionHeader()
+            header.ParseFromString(req.header)
+
+            processor_type = processor_iterator.ProcessorType(
+                header.family_name,
+                header.family_version,
+                header.payload_encoding)
+
+            self._execute_or_wait_for_processor_type(processor_type, request)
+
         else:
             self._context_manager.delete_context(
                 context_id_list=[req.context_id])


### PR DESCRIPTION
Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>

This will cause TpProcessRequest to be re-sent if the response returned is an InternalError. If you only have on TP running against a validator, this will most likely cause the TpProcessRequest to be re-sent repeatedly forever. However, if you have two TPs running and one can handle the transaction, progress will still be made. 

To Test:
Add the following line to sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py:
49    def apply(self, transaction, state):
50 +      raise InternalError('Test InternalError')
51          content = cbor.loads(transaction.payload)

Start up a validator 
Start up  tp_intkey_python 
Run intkey workload.

You should see the Internal Error repeat forever. 

I created a Jira Task to write Unit Tests for the Executor (STL-186) to remove the need to do the above in the future. 