### PR TITLE
Remove batch signature check from the BlockValidator. This is a dupli…

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -126,25 +126,6 @@ class BlockValidator(object):
 
         return True
 
-    def _verify_block_signature(self, blkw):
-        """ Verify a block is properly signed.
-        :param blkw: the block to verify
-        :return: Boolean - True on success.
-        """
-        try:
-            return signing.verify(
-                blkw.block.header,
-                blkw.block.header_signature,
-                blkw.header.signer_pubkey)
-
-        # To be on the safe side, assume any exception thrown
-        # during signature validation means the signature
-        # is invalid.
-
-        # pylint: disable=broad-except
-        except Exception:
-            return False
-
     def _verify_batches_dependencies(self, batch, committed_txn):
         """Verify that all transactions dependencies in this batch have been
         satisfied, ie already committed by this block or prior block in the
@@ -223,9 +204,6 @@ class BlockValidator(object):
 
                 if valid:
                     valid = self._is_block_complete(blkw)
-
-                if valid:
-                    valid = self._verify_block_signature(blkw)
 
                 if valid:
                     valid = self._verify_block_batches(blkw, committed_txn)

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -522,24 +522,6 @@ class TestBlockValidator(unittest.TestCase):
         self.assert_invalid_block(head)
         self.assert_new_block_not_committed()
 
-    # block based tests
-    def test_block_bad_signature(self):
-        """
-        Test the case where the new block has a bad signature.
-        """
-        chain, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
-
-        new_block = self.block_tree_manager.generate_block(
-            previous_block=head,
-            add_to_cache=True,
-            invalid_signature=True)
-
-        self.validate_block(new_block)
-
-        self.assert_invalid_block(new_block)
-        self.assert_new_block_not_committed()
-
     def test_block_bad_consensus(self):
         """
         Test the case where the new block has a bad batch
@@ -731,15 +713,6 @@ class TestChainController(unittest.TestCase):
     def test_bad_blocks(self):
         '''Tests bad blocks extending current chain
         '''
-        # Bad due to signature
-        bad_sig = self.generate_block(
-            previous_block=self.init_head,
-            invalid_signature=True)
-
-        # chain head should be the same
-        self.receive_and_process_blocks(bad_sig)
-        self.assert_is_chain_head(self.init_head)
-
         # Bad due to consensus
         bad_consen = self.generate_block(
             previous_block=self.init_head,


### PR DESCRIPTION
…cate signature check of the validation done by the SignatureVerifier on block arrival.