### PR TITLE
Update PoET Enclave Simulator to not Use kwargs for Configuration

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/config.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/config.py
@@ -32,7 +32,7 @@ def _select_dir(sawtooth_home_dir, windows_dir, default_dir):
         return default_dir
 
 
-def _get_config_dir():
+def get_config_dir():
     """Returns the sawtooth configuration directory based on the
     SAWTOOTH_HOME environment variable (if set) or OS defaults.
     """
@@ -58,7 +58,7 @@ def _get_dir(toml_config_setting,
     Returns:
         directory (str): The path.
     """
-    conf_file = os.path.join(_get_config_dir(), 'path.toml')
+    conf_file = os.path.join(get_config_dir(), 'path.toml')
     if os.path.exists(conf_file):
         with open(conf_file) as fd:
             raw_config = fd.read()

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -87,7 +87,7 @@ def do_genesis(args):
     except ImportError as e:
         raise AssertionError(str(e))
 
-    poet_enclave_module.initialize(**{})
+    poet_enclave_module.initialize(config.get_config_dir())
 
     pubkey, signing_key = _read_signing_keys(args.key)
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -70,6 +70,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                  state_view_factory,
                  batch_publisher,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
@@ -85,6 +86,8 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     broadcast that batch to the network.
                 data_dir (str): path to location where persistent data for the
                     consensus module can be stored.
+                config_dir (str): path to location where configuration for the
+                    consensus module can be found.
                 validator_id (str): A unique ID for this validator
             Returns:
                 none.
@@ -94,12 +97,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
             state_view_factory,
             batch_publisher,
             data_dir,
+            config_dir,
             validator_id)
 
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._batch_publisher = batch_publisher
         self._data_dir = data_dir
+        self._config_dir = config_dir
         self._validator_id = validator_id
         self._consensus_state_store = \
             ConsensusStateStore(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -236,7 +236,9 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 state_view_factory=self._state_view_factory)
 
         poet_enclave_module = \
-            factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
+            factory.PoetEnclaveFactory.get_poet_enclave_module(
+                state_view=state_view,
+                config_dir=self._config_dir)
 
         # Get our validator registry entry to see what PoET public key
         # other validators think we are using.
@@ -466,7 +468,9 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 state_view_factory=self._state_view_factory)
 
         poet_enclave_module = \
-            factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
+            factory.PoetEnclaveFactory.get_poet_enclave_module(
+                state_view=state_view,
+                config_dir=self._config_dir)
 
         # We need to create a wait certificate for the block and then serialize
         # that into the block header consensus field.

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -42,6 +42,7 @@ class PoetBlockVerifier(BlockVerifierInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
@@ -54,6 +55,8 @@ class PoetBlockVerifier(BlockVerifierInterface):
                     particular block was the chain head.
                 data_dir (str): path to location where persistent data for the
                     consensus module can be stored.
+                config_dir (str): path to location where configuration for the
+                    consensus module can be found.
                 validator_id (str): A unique ID for this validator
             Returns:
                 none.
@@ -62,11 +65,13 @@ class PoetBlockVerifier(BlockVerifierInterface):
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._data_dir = data_dir
+        self._config_dir = config_dir
         self._validator_id = validator_id
         self._consensus_state_store = \
             ConsensusStateStore(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -101,7 +101,9 @@ class PoetBlockVerifier(BlockVerifierInterface):
                 state_view_factory=self._state_view_factory)
 
         poet_enclave_module = \
-            factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
+            factory.PoetEnclaveFactory.get_poet_enclave_module(
+                state_view=state_view,
+                config_dir=self._config_dir)
 
         validator_registry_view = ValidatorRegistryView(state_view)
         # Grab the validator info based upon the block signer's public

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_enclave_factory.py
@@ -31,7 +31,7 @@ class PoetEnclaveFactory(object):
     _poet_enclave_module = None
 
     @classmethod
-    def get_poet_enclave_module(cls, state_view):
+    def get_poet_enclave_module(cls, state_view, config_dir):
         """Returns the PoET enclave module based upon the corresponding value
         set by the sawtooth_config transaction family.  If no PoET enclave
         module has been set in the configuration, it defaults to the PoET
@@ -39,7 +39,8 @@ class PoetEnclaveFactory(object):
 
         Args:
             state_view (StateView): The current state view.
-
+            config_dir (str): path to location where configuration for the
+                poet enclave module can be found.
         Returns:
             module: The configured PoET enclave module, or the PoET enclave
                 simulator module if none configured.
@@ -74,7 +75,7 @@ class PoetEnclaveFactory(object):
 
                 # Load and initialize the module
                 module = importlib.import_module(module_name)
-                module.initialize(**{})
+                module.initialize(config_dir)
 
                 cls._poet_enclave_module = module
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -95,7 +95,9 @@ class PoetForkResolver(ForkResolverInterface):
                 block_wrapper=cur_fork_head,
                 state_view_factory=self._state_view_factory)
         poet_enclave_module = \
-            factory.PoetEnclaveFactory.get_poet_enclave_module(state_view)
+            factory.PoetEnclaveFactory.get_poet_enclave_module(
+                state_view=state_view,
+                config_dir=self._config_dir)
 
         current_fork_wait_certificate = \
             utils.deserialize_wait_certificate(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -39,6 +39,7 @@ class PoetForkResolver(ForkResolverInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
@@ -51,6 +52,8 @@ class PoetForkResolver(ForkResolverInterface):
                     particular block was the chain head.
                 data_dir (str): path to location where persistent data for the
                     consensus module can be stored.
+                config_dir (str): path to location where config data for the
+                    consensus module can be found.
                 validator_id (str): A unique ID for this validator
             Returns:
                 none.
@@ -59,11 +62,13 @@ class PoetForkResolver(ForkResolverInterface):
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
         self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._data_dir = data_dir
+        self._config_dir = config_dir
         self._validator_id = validator_id
         self._consensus_state_store = \
             ConsensusStateStore(

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
@@ -91,6 +91,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -158,6 +159,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -227,6 +229,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -303,6 +306,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -378,6 +382,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -453,6 +458,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -528,6 +534,7 @@ class TestPoetBlockVerifier(TestCase):
                     block_cache=mock_block_cache,
                     state_view_factory=mock_state_view_factory,
                     data_dir=self._temp_dir,
+                    config_dir=self._temp_dir,
                     validator_id='validator_deadbeef')
             self.assertFalse(
                 block_verifier.verify_block(
@@ -601,6 +608,7 @@ class TestPoetBlockVerifier(TestCase):
                 block_cache=mock_block_cache,
                 state_view_factory=mock_state_view_factory,
                 data_dir=self._temp_dir,
+                config_dir=self._temp_dir,
                 validator_id='validator_deadbeef')
         self.assertTrue(
             block_verifier.verify_block(

--- a/consensus/poet/core/tests/test_consensus/test_signup_info.py
+++ b/consensus/poet/core/tests/test_consensus/test_signup_info.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import unittest
+import os
 
 from sawtooth_poet_simulator.poet_enclave_simulator \
     import poet_enclave_simulator as poet_enclave
@@ -29,8 +30,7 @@ class TestSignupInfo(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        args = {"NodeName": "DasValidator"}
-        poet_enclave.initialize(**args)
+        poet_enclave.initialize(os.path.dirname(os.path.abspath(__file__)))
 
         cls._originator_public_key_hash = create_random_public_key_hash()
         cls._another_public_key_hash = create_random_public_key_hash()

--- a/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
@@ -15,6 +15,7 @@
 
 from importlib import reload
 import time
+import os
 from unittest import TestCase
 from unittest import mock
 from unittest import skip
@@ -47,9 +48,8 @@ class TestWaitCertificate(TestCase):
         # PoET enclave is set back to initial state at the start of every
         # test.
         self.poet_enclave_module = reload(poet_enclave)
-
-        args = {"NodeName": "DasValidator"}
-        self.poet_enclave_module.initialize(**args)
+        self.poet_enclave_module.initialize(
+            os.path.dirname(os.path.abspath(__file__)))
 
         self.mock_poet_config_view = mock.Mock()
         self.mock_poet_config_view.target_wait_time = 5.0

--- a/consensus/poet/core/tests/test_consensus/test_wait_timer.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_timer.py
@@ -15,6 +15,7 @@
 
 from importlib import reload
 import time
+import os
 from unittest import TestCase
 from unittest import mock
 from unittest import skip
@@ -45,9 +46,8 @@ class TestWaitTimer(TestCase):
         # PoET enclave is set back to initial state at the start of every
         # test.
         self.poet_enclave_module = reload(poet_enclave)
-
-        args = {"NodeName": "DasValidator"}
-        self.poet_enclave_module.initialize(**args)
+        self.poet_enclave_module.initialize(
+            os.path.dirname(os.path.abspath(__file__)))
 
         self.mock_poet_config_view = mock.Mock()
         self.mock_poet_config_view.target_wait_time = 5.0

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -301,6 +301,7 @@ class BlockValidator(object):
             ForkResolver(block_cache=self._block_cache,
                          state_view_factory=self._state_view_factory,
                          data_dir=self._data_dir,
+                         config_dir=self._config_dir,
                          validator_id=self._identity_public_key)
 
         return fork_resolver.compare_forks(self._chain_head, self._new_block)

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -57,7 +57,8 @@ class BlockValidator(object):
                  executor,
                  squash_handler,
                  identity_signing_key,
-                 data_dir):
+                 data_dir,
+                 config_dir):
         """Initialize the BlockValidator
         Args:
              consensus_module: The consensus module that contains
@@ -75,6 +76,8 @@ class BlockValidator(object):
              identity_signing_key: Private key for signing blocks.
              data_dir: Path to location where persistent data for the
              consensus module can be stored.
+             config_dir: Path to location where config data for the
+             consensus module can be found.
         Returns:
             None
         """
@@ -90,6 +93,7 @@ class BlockValidator(object):
         self._identity_public_key = \
             signing.generate_pubkey(self._identity_signing_key)
         self._data_dir = data_dir
+        self._config_dir = config_dir
         self._result = {
             'new_block': new_block,
             'chain_head': chain_head,
@@ -200,6 +204,7 @@ class BlockValidator(object):
                     BlockVerifier(block_cache=self._block_cache,
                                   state_view_factory=self._state_view_factory,
                                   data_dir=self._data_dir,
+                                  config_dir=self._config_dir,
                                   validator_id=self._identity_public_key)
 
                 if valid:
@@ -405,7 +410,8 @@ class ChainController(object):
                  chain_id_manager,
                  state_delta_processor,
                  identity_signing_key,
-                 data_dir):
+                 data_dir,
+                 config_dir):
         """Initialize the ChainController
         Args:
              block_cache: The cache of all recent blocks and the processing
@@ -426,6 +432,8 @@ class ChainController(object):
              identity_signing_key: Private key for signing blocks.
              data_dir: path to location where persistent data for the
              consensus module can be stored.
+             config_dir: path to location where config data for the
+             consensus module can be found.
         Returns:
             None
         """
@@ -442,6 +450,7 @@ class ChainController(object):
         self._identity_public_key = \
             signing.generate_pubkey(self._identity_signing_key)
         self._data_dir = data_dir
+        self._config_dir = config_dir
 
         self._blocks_processing = {}  # a set of blocks that are
         # currently being processed.
@@ -488,7 +497,8 @@ class ChainController(object):
                 executor=self._transaction_executor,
                 squash_handler=self._squash_handler,
                 identity_signing_key=self._identity_signing_key,
-                data_dir=self._data_dir)
+                data_dir=self._data_dir,
+                config_dir=self._config_dir)
             self._blocks_processing[blkw.block.header_signature] = validator
             self._executor.submit(validator.run)
 
@@ -670,7 +680,8 @@ class ChainController(object):
                     executor=self._transaction_executor,
                     squash_handler=self._squash_handler,
                     identity_signing_key=self._identity_signing_key,
-                    data_dir=self._data_dir)
+                    data_dir=self._data_dir,
+                    config_dir=self._config_dir)
 
                 valid = validator.validate_block(block, committed_txn)
                 if valid:

--- a/validator/sawtooth_validator/journal/consensus/consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus.py
@@ -112,6 +112,7 @@ class BlockVerifierInterface(metaclass=ABCMeta):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
@@ -124,6 +125,8 @@ class BlockVerifierInterface(metaclass=ABCMeta):
                 was the chain head.
                 data_dir: path to location where persistent data for the
                 consensus module can be stored.
+                config_dir (str): path to location where configuration for the
+                consensus module can be found.
                 validator_id: A unique ID for this validator
             Returns:
                 none.

--- a/validator/sawtooth_validator/journal/consensus/consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus.py
@@ -153,6 +153,7 @@ class ForkResolverInterface(metaclass=ABCMeta):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
         StateView is not passed to this object as it is ambiguous as to which
@@ -169,6 +170,8 @@ class ForkResolverInterface(metaclass=ABCMeta):
                 was the chain head.
                 data_dir: path to location where persistent data for the
                 consensus module can be stored.
+                data_dir: path to location where config data for the
+                consensus module can be found.
                 validator_id: A unique ID for this validator
             Returns:
                 none.

--- a/validator/sawtooth_validator/journal/consensus/consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus.py
@@ -31,6 +31,7 @@ class BlockPublisherInterface(metaclass=ABCMeta):
                  state_view_factory,
                  batch_publisher,
                  data_dir,
+                 config_dir,
                  validator_id):
         """Initialize the object, is passed (read-only) state access objects.
             Args:
@@ -46,6 +47,8 @@ class BlockPublisherInterface(metaclass=ABCMeta):
                 batch to the network.
                 data_dir: path to location where persistent data for the
                 consensus module can be stored.
+                config_dir (str): path to location where configuration for the
+                consensus module can be found.
                 validator_id: A unique ID for this validator
             Returns:
                 none.

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -165,11 +165,13 @@ class ForkResolver(ForkResolverInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     @staticmethod

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -44,12 +44,14 @@ class BlockPublisher(BlockPublisherInterface):
                  state_view_factory,
                  batch_publisher,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             batch_publisher,
             data_dir,
+            config_dir,
             validator_id)
 
         self._block_cache = block_cache

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -144,11 +144,13 @@ class BlockVerifier(BlockVerifierInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     def verify_block(self, block_wrapper):

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -95,11 +95,13 @@ class ForkResolver(ForkResolverInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     def compare_forks(self, cur_fork_head, new_fork_head):

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -30,12 +30,14 @@ class BlockPublisher(BlockPublisherInterface):
                  block_cache,
                  state_view_factory,
                  batch_publisher,
+                 config_dir,
                  data_dir,
                  validator_id):
         super().__init__(block_cache,
                          state_view_factory,
                          batch_publisher,
                          data_dir,
+                         config_dir,
                          validator_id)
 
     def initialize_block(self, block_header):

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -73,11 +73,13 @@ class BlockVerifier(BlockVerifierInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     def verify_block(self, block_wrapper):

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -48,6 +48,7 @@ class GenesisController(object):
                  state_view_factory,
                  identity_key,
                  data_dir,
+                 config_dir,
                  chain_id_manager,
                  batch_sender):
         """Creates a GenesisController.
@@ -63,6 +64,7 @@ class GenesisController(object):
                 factory for creating state views during processing.
             identity_key (str): A private key used for signing blocks, in hex.
             data_dir (str): The directory for data files.
+            config_dir (str): The directory for config files.
             chain_id_manager (ChainIdManager): utility class to manage the
             chain id file.
             batch_sender: interface to broadcast batches to the network.
@@ -76,6 +78,7 @@ class GenesisController(object):
         self._identity_public_key = \
             signing.generate_pubkey(self._identity_priv_key)
         self._data_dir = data_dir
+        self._config_dir = config_dir
         self._chain_id_manager = chain_id_manager
         self._batch_sender = batch_sender
 
@@ -241,6 +244,7 @@ class GenesisController(object):
                 state_view_factory=self._state_view_factory,
                 batch_publisher=BatchPublisher(),
                 data_dir=self._data_dir,
+                config_dir=self._config_dir,
                 validator_id=self._identity_public_key)
         except UnknownConsensusModuleError as e:
             raise InvalidGenesisStateError(e)

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -123,6 +123,7 @@ class Journal(object):
                  chain_id_manager,
                  state_delta_processor,
                  data_dir,
+                 config_dir,
                  check_publish_block_frequency=0.1,
                  block_cache_purge_frequency=30,
                  block_cache_keep_time=300,
@@ -146,6 +147,7 @@ class Journal(object):
             state_delta_processor (:obj:`StateDeltaProcessor`): The state
                 delta processor.
             data_dir (str): directory for data storage.
+            config_dir (str): directory for configuration.
             check_publish_block_frequency(float): delay in seconds between
                 checks if a block should be claimed.
             block_cache_purge_frequency (float): delay in seconds between
@@ -180,6 +182,7 @@ class Journal(object):
         self._chain_id_manager = chain_id_manager
         self._state_delta_processor = state_delta_processor
         self._data_dir = data_dir
+        self._config_dir = config_dir
 
     def _init_subprocesses(self):
         self._block_publisher = BlockPublisher(
@@ -191,7 +194,8 @@ class Journal(object):
             squash_handler=self._squash_handler,
             chain_head=self._block_store.chain_head,
             identity_signing_key=self._identity_signing_key,
-            data_dir=self._data_dir
+            data_dir=self._data_dir,
+            config_dir=self._config_dir
         )
         self._publisher_thread = self._PublisherThread(
             block_publisher=self._block_publisher,

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -213,7 +213,8 @@ class Journal(object):
             chain_id_manager=self._chain_id_manager,
             state_delta_processor=self._state_delta_processor,
             identity_signing_key=self._identity_signing_key,
-            data_dir=self._data_dir
+            data_dir=self._data_dir,
+            config_dir=self._config_dir
         )
         self._chain_thread = self._ChainThread(
             chain_controller=self._chain_controller,

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -265,7 +265,8 @@ class BlockPublisher(object):
                  squash_handler,
                  chain_head,
                  identity_signing_key,
-                 data_dir):
+                 data_dir,
+                 config_dir):
         """
         Initialize the BlockPublisher object
 
@@ -282,7 +283,9 @@ class BlockPublisher(object):
             chain_head (:obj:`BlockWrapper`): The initial chain head.
             identity_signing_key (str): Private key for signing blocks
             data_dir (str): path to location where persistent data for the
-             consensus module can be stored.
+                consensus module can be stored.
+            config_dir (str): path to location where configuration can be
+                found.
         """
         self._lock = RLock()
         self._candidate_block = None  # _CandidateBlock helper,
@@ -302,6 +305,7 @@ class BlockPublisher(object):
         self._identity_public_key = \
             signing.generate_pubkey(self._identity_signing_key)
         self._data_dir = data_dir
+        self._config_dir = config_dir
 
     def _build_candidate_block(self, chain_head):
         """ Build a candidate block and construct the consensus object to
@@ -327,6 +331,7 @@ class BlockPublisher(object):
                            state_view_factory=self._state_view_factory,
                            batch_publisher=self._batch_publisher,
                            data_dir=self._data_dir,
+                           config_dir=self._config_dir,
                            validator_id=self._identity_public_key)
 
         block_header = BlockHeader(

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -206,6 +206,7 @@ def main(args=sys.argv[1:]):
                           opts.join,
                           opts.peers,
                           path_config.data_dir,
+                          path_config.config_dir,
                           identity_signing_key)
 
     # pylint: disable=broad-except

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -105,7 +105,7 @@ class Validator(object):
                 to in order to perform the initial topology buildout
             peer_list (list of str): a list of peer addresses
             data_dir (str): path to the data directory
-            key_dir (str): path to the key directory
+            identity_signing_key (str): key validator uses for signing
         """
         db_filename = os.path.join(data_dir,
                                    'merkle-{}.lmdb'.format(

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -82,7 +82,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Validator(object):
     def __init__(self, network_endpoint, component_endpoint, public_uri,
-                 peering, join_list, peer_list, data_dir,
+                 peering, join_list, peer_list, data_dir, config_dir,
                  identity_signing_key):
         """Constructs a validator instance.
 
@@ -105,6 +105,7 @@ class Validator(object):
                 to in order to perform the initial topology buildout
             peer_list (list of str): a list of peer addresses
             data_dir (str): path to the data directory
+            config_dir (str): path to the config directory
             identity_signing_key (str): key validator uses for signing
         """
         db_filename = os.path.join(data_dir,
@@ -213,6 +214,7 @@ class Validator(object):
             chain_id_manager=chain_id_manager,
             state_delta_processor=state_delta_processor,
             data_dir=data_dir,
+            config_dir=config_dir,
             check_publish_block_frequency=0.1,
             block_cache_purge_frequency=30,
             block_cache_keep_time=300
@@ -226,6 +228,7 @@ class Validator(object):
             state_view_factory=state_view_factory,
             identity_key=identity_signing_key,
             data_dir=data_dir,
+            config_dir=config_dir,
             chain_id_manager=chain_id_manager,
             batch_sender=batch_sender
         )

--- a/validator/tests/unit3/test_devmode_consensus/tests.py
+++ b/validator/tests/unit3/test_devmode_consensus/tests.py
@@ -54,6 +54,7 @@ class TestCheckPublishBlock(unittest.TestCase):
                 state_view_factory=factory,
                 batch_publisher=None,
                 data_dir=None,
+                config_dir=None,
                 validator_id='Validator_001')
 
         block_header = self.create_block_header()
@@ -71,6 +72,7 @@ class TestCheckPublishBlock(unittest.TestCase):
                 state_view_factory=factory,
                 batch_publisher=None,
                 data_dir=None,
+                config_dir=None,
                 validator_id='Validator_001')
         block_header = self.create_block_header()
 
@@ -97,6 +99,7 @@ class TestCheckPublishBlock(unittest.TestCase):
                 state_view_factory=factory,
                 batch_publisher=None,
                 data_dir=None,
+                config_dir=None,
                 validator_id='Validator_001')
         block_header = self.create_block_header("name")
         self.assertTrue(dev_mode.check_publish_block(block_header))
@@ -109,6 +112,7 @@ class TestCheckPublishBlock(unittest.TestCase):
                 state_view_factory=factory,
                 batch_publisher=None,
                 data_dir=None,
+                config_dir=None,
                 validator_id='Validator_001')
         block_header = self.create_block_header("name")
         self.assertTrue(dev_mode.check_publish_block(block_header))

--- a/validator/tests/unit3/test_genesis/tests.py
+++ b/validator/tests/unit3/test_genesis/tests.py
@@ -59,6 +59,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -78,6 +79,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -97,6 +99,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -121,6 +124,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -150,6 +154,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -178,6 +183,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(DictDatabase()),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )
@@ -219,6 +225,7 @@ class TestGenesisController(unittest.TestCase):
             StateViewFactory(state_database),
             self._identity_key,
             data_dir=self._temp_dir,
+            config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
             batch_sender=Mock('batch_sender')
         )

--- a/validator/tests/unit3/test_genesis_consensus/tests.py
+++ b/validator/tests/unit3/test_genesis_consensus/tests.py
@@ -43,11 +43,13 @@ class TestGenesisBlockPublisher(unittest.TestCase):
         state_view_factory = Mock()
         batch_publisher = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_publisher = BlockPublisher(block_cache,
                                          state_view_factory,
                                          batch_publisher,
                                          data_dir,
+                                         config_dir,
                                          validator_id)
 
         block_header = BlockHeader(
@@ -70,11 +72,13 @@ class TestGenesisBlockPublisher(unittest.TestCase):
         state_view_factory = Mock()
         batch_publisher = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_publisher = BlockPublisher(block_cache,
                                          state_view_factory,
                                          batch_publisher,
                                          data_dir,
+                                         config_dir,
                                          validator_id)
 
         block_header = BlockHeader(
@@ -97,11 +101,13 @@ class TestGenesisBlockPublisher(unittest.TestCase):
         state_view_factory = Mock()
         batch_publisher = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_publisher = BlockPublisher(block_cache,
                                          state_view_factory,
                                          batch_publisher,
                                          data_dir,
+                                         config_dir,
                                          validator_id)
 
         block_header = BlockHeader(
@@ -124,11 +130,13 @@ class TestGenesisBlockPublisher(unittest.TestCase):
         state_view_factory = Mock()
         batch_publisher = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_publisher = BlockPublisher(block_cache,
                                          state_view_factory,
                                          batch_publisher,
                                          data_dir,
+                                         config_dir,
                                          validator_id)
 
         block_header = BlockHeader(
@@ -151,11 +159,13 @@ class TestGenesisBlockPublisher(unittest.TestCase):
         state_view_factory = Mock()
         batch_publisher = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_publisher = BlockPublisher(block_cache,
                                          state_view_factory,
                                          batch_publisher,
                                          data_dir,
+                                         config_dir,
                                          validator_id)
 
         block_header = BlockHeader(

--- a/validator/tests/unit3/test_genesis_consensus/tests.py
+++ b/validator/tests/unit3/test_genesis_consensus/tests.py
@@ -188,10 +188,12 @@ class TestGenesisBlockVerifier(unittest.TestCase):
         block_cache = Mock()
         state_view_factory = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_verifier = BlockVerifier(block_cache,
                                        state_view_factory,
                                        data_dir,
+                                       config_dir,
                                        validator_id)
 
         block = Block(header=BlockHeader(
@@ -208,10 +210,12 @@ class TestGenesisBlockVerifier(unittest.TestCase):
         block_cache = Mock()
         state_view_factory = Mock()
         data_dir = 'mock_dir'
+        config_dir = 'mock_dir'
         validator_id = 'validator_001'
         block_verifier = BlockVerifier(block_cache,
                                        state_view_factory,
                                        data_dir,
+                                       config_dir,
                                        validator_id)
 
         block = Block(header=BlockHeader(

--- a/validator/tests/unit3/test_journal/block_tree_manager.py
+++ b/validator/tests/unit3/test_journal/block_tree_manager.py
@@ -101,7 +101,8 @@ class BlockTreeManager(object):
             squash_handler=None,
             chain_head=chain_head,
             identity_signing_key=self.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
     @property
     def chain_head(self):

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -75,11 +75,13 @@ class BlockVerifier(BlockVerifierInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     def verify_block(self, block_wrapper):

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -28,12 +28,14 @@ class BlockPublisher(BlockPublisherInterface):
                  state_view_factory,
                  batch_publisher,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             batch_publisher,
             data_dir,
+            config_dir,
             validator_id)
 
     def initialize_block(self, block_header):

--- a/validator/tests/unit3/test_journal/mock_consensus.py
+++ b/validator/tests/unit3/test_journal/mock_consensus.py
@@ -95,11 +95,13 @@ class ForkResolver(ForkResolverInterface):
                  block_cache,
                  state_view_factory,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(
             block_cache,
             state_view_factory,
             data_dir,
+            config_dir,
             validator_id)
 
     def compare_forks(self, cur_fork_head, new_fork_head):

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -104,7 +104,8 @@ class TestBlockPublisher(unittest.TestCase):
             squash_handler=None,
             chain_head=self.block_tree_manager.chain_head,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
         self.init_chain_head = self.block_tree_manager.chain_head
 
@@ -256,7 +257,8 @@ class TestBlockPublisher(unittest.TestCase):
             squash_handler=None,
             chain_head=self.block_tree_manager.chain_head,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
         self.receive_batches()
 
@@ -285,7 +287,8 @@ class TestBlockPublisher(unittest.TestCase):
             squash_handler=None,
             chain_head=self.block_tree_manager.chain_head,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
         self.assert_no_block_published()
 
@@ -1075,7 +1078,8 @@ class TestJournal(unittest.TestCase):
                 identity_signing_key=btm.identity_signing_key,
                 chain_id_manager=None,
                 state_delta_processor=self.state_delta_processor,
-                data_dir=None
+                data_dir=None,
+                config_dir=None
             )
 
             self.gossip.on_batch_received = journal.on_batch_received

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -633,7 +633,8 @@ class TestBlockValidator(unittest.TestCase):
             executor=MockTransactionExecutor(),
             squash_handler=None,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
     class BlockValidationHandler(object):
         def __init__(self):
@@ -683,7 +684,8 @@ class TestChainController(unittest.TestCase):
             chain_id_manager=self.chain_id_manager,
             state_delta_processor=self.state_delta_processor,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
         init_root = self.chain_ctrl.chain_head
         self.assert_is_chain_head(init_root)
@@ -991,7 +993,8 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
             chain_id_manager=self.chain_id_manager,
             state_delta_processor=self.state_delta_processor,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
-            data_dir=None)
+            data_dir=None,
+            config_dir=None)
 
         self.assertIsNone(self.chain_ctrl.chain_head)
 


### PR DESCRIPTION
The legacy way in which the PoET enclave simulator determined configuration was by having a dictionary (aka, kwargs) passed in to its initialize function.  This PR replaces the kwargs with the location of the validator's configuration directory.  The enclave should use a `toml` file for any configuration and the file should be found in the configuration directory.

Changes:
* The consensus module block publisher, block verifier, and fork resolver interfaces has been updated to take a configuration directory parameter
* All code that touches these interfaces have been updated
* The PoET enclave simulator has been updated to use the config directory to locate its `toml` file (if it exists) and use it for configuration