### PR TITLE
Add synchronization lock between the BlockPublisher and ChainControlle…

### DIFF
--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -204,6 +204,7 @@ class Journal(object):
             state_view_factory=self._state_view_factory,
             executor=ThreadPoolExecutor(1),
             transaction_executor=self._transaction_executor,
+            chain_head_lock=self._block_publisher.chain_head_lock,
             on_chain_updated=self._block_publisher.on_chain_updated,
             squash_handler=self._squash_handler,
             chain_id_manager=self._chain_id_manager,

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -303,6 +303,10 @@ class BlockPublisher(object):
             signing.generate_pubkey(self._identity_signing_key)
         self._data_dir = data_dir
 
+    @property
+    def chain_head_lock(self):
+        return self._lock
+
     def _build_candidate_block(self, chain_head):
         """ Build a candidate block and construct the consensus object to
         validate it.
@@ -404,7 +408,8 @@ class BlockPublisher(object):
         The existing chain has been updated, the current head block has
         changed.
 
-        :param chain_head: the new head of block_chain
+        :param chain_head: the new head of block_chain, can be None if
+        no block publishing is desired.
         :param committed_batches: the set of batches that were committed
          as part of the new chain.
         :param uncommitted_batches: the list of transactions if any that are

--- a/validator/tests/unit3/test_journal/tests.py
+++ b/validator/tests/unit3/test_journal/tests.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import logging
+from threading import RLock
 import unittest
 from unittest.mock import patch
 
@@ -680,6 +681,7 @@ class TestChainController(unittest.TestCase):
         self.txn_executor = MockTransactionExecutor()
         self.block_sender = MockBlockSender()
         self.chain_id_manager = MockChainIdManager()
+        self._chain_head_lock = RLock()
         self.state_delta_processor = MockStateDeltaProcessor()
 
         def chain_updated(head, committed_batches=None,
@@ -693,6 +695,7 @@ class TestChainController(unittest.TestCase):
             block_sender=self.block_sender,
             executor=self.executor,
             transaction_executor=MockTransactionExecutor(),
+            chain_head_lock=self._chain_head_lock,
             on_chain_updated=chain_updated,
             squash_handler=None,
             chain_id_manager=self.chain_id_manager,
@@ -998,6 +1001,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
         self.block_sender = MockBlockSender()
         self.chain_id_manager = MockChainIdManager()
         self.state_delta_processor = MockStateDeltaProcessor()
+        self.chain_head_lock = RLock()
 
         def chain_updated(head, committed_batches=None,
                           uncommitted_batches=None):
@@ -1010,6 +1014,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
             block_sender=self.block_sender,
             executor=self.executor,
             transaction_executor=MockTransactionExecutor(),
+            chain_head_lock=self.chain_head_lock,
             on_chain_updated=chain_updated,
             squash_handler=None,
             chain_id_manager=self.chain_id_manager,


### PR DESCRIPTION
…r to prevent ChainController(and encapsulaed Consensus algos) accessesing an updated blockstore.

Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>