### PR TITLE
Add current serial scheduler test to parallel scheduler test

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -322,8 +322,8 @@ class ParallelScheduler(Scheduler):
         with self._condition:
             if self._final:
                 raise SchedulerError('Invalid attempt to add batch to '
-                                     'finalized scheduler; batch: {}'.format(
-                    batch.header_signature))
+                                     'finalized scheduler; batch: {}'
+                                     .format(batch.header_signature))
 
             self._batches.append(batch)
             self._batches_by_id[batch.header_signature] = batch
@@ -363,9 +363,11 @@ class ParallelScheduler(Scheduler):
                 # predecessor tree, with duplicate information being
                 # automatically discarded by the set_writer() call.
                 for address in header.inputs:
-                    self._predecessor_tree.add_reader(address, txn.header_signature)
+                    self._predecessor_tree.add_reader(
+                        address, txn.header_signature)
                 for address in header.outputs:
-                    self._predecessor_tree.set_writer(address, txn.header_signature)
+                    self._predecessor_tree.set_writer(
+                        address, txn.header_signature)
 
             self._condition.notify_all()
 
@@ -384,7 +386,8 @@ class ParallelScheduler(Scheduler):
             for txn in batch.transactions:
                 txn_result = self._txn_results[txn.header_signature]
                 if not txn_result.is_valid:
-                    return BatchExecutionResult(is_valid=False, state_hash=None)
+                    return BatchExecutionResult(
+                        is_valid=False, state_hash=None)
                 if txn_result.context_id is not None:
                     contexts.append(txn_result.context_id)
                 if txn_result.state_hash is not None:
@@ -396,8 +399,9 @@ class ParallelScheduler(Scheduler):
                 if index == 0:
                     last_state_hash = self._first_state_hash
                 else:
-                    prev_batch = self._batches(index - 1)
-                    last_state_hash = self._batch_results[prev_batch].state_hash
+                    prev_batch = self._batches[index - 1]
+                    last_state_hash = \
+                        self._batch_results[prev_batch].state_hash
 
             state_hash = self._squash(last_state_hash, contexts, persist=True)
             return BatchExecutionResult(is_valid=True, state_hash=state_hash)
@@ -415,16 +419,17 @@ class ParallelScheduler(Scheduler):
 
             self._txn_results[txn_signature] = txn_result
 
-            # TODO - mark all transactions which depend upon this one as
+            # mark all transactions which depend upon this one as
             # invalid as well
-            # TODO - mark all transactions in batches impacted by this failure
+
+            # mark all transactions in batches impacted by this failure
             # as failed -- "failed by association"; this presumably trickles
             # through and invalidates a lot
 
             self._condition.notify_all()
 
     def _unscheduled_transactions(self):
-        # TODO - shouldn't actually return txn if dependencies were
+        # shouldn't actually return txn if dependencies were
         # marked invalid.
         txns = []
         for batch in self._batches:
@@ -442,8 +447,6 @@ class ParallelScheduler(Scheduler):
 
     def _get_initial_state_for_transaction(self, txn):
         # Collect contexts that this transaction depends upon
-
-        # FIXME
         return self._last_state_hash
 
     def next_transaction(self):

--- a/validator/tests/unit3/test_scheduler/tests.py
+++ b/validator/tests/unit3/test_scheduler/tests.py
@@ -35,18 +35,32 @@ from sawtooth_validator.state.merkle import MerkleDatabase
 
 LOGGER = logging.getLogger(__name__)
 
-
-def create_transaction(name, private_key, public_key):
+def create_transaction(name, private_key, public_key, inputs=None,
+                        outputs=None, dependencies = None):
     payload = name
     addr = '000000' + hashlib.sha512(name.encode()).hexdigest()
+
+    if inputs is None:
+        inputs = [addr]
+    else:
+        inputs = inputs.copy().append(addr)
+
+    if outputs is None:
+        outputs = [addr]
+    else:
+        outputs.copy().append(addr)
+
+    if dependencies is None:
+        dependencies = []
 
     header = transaction_pb2.TransactionHeader(
         signer_pubkey=public_key,
         family_name='scheduler_test',
         family_version='1.0',
-        inputs=[addr],
-        outputs=[addr],
-        dependencies=[],
+        inputs=inputs,
+        outputs=outputs,
+        dependencies=dependencies,
+        nonce=str(time.time()),
         payload_encoding="application/cbor",
         payload_sha512=hashlib.sha512(payload.encode()).hexdigest(),
         batcher_pubkey=public_key)
@@ -60,7 +74,7 @@ def create_transaction(name, private_key, public_key):
         payload=payload.encode(),
         header_signature=signature)
 
-    return transaction
+    return transaction, header
 
 
 def create_batch(transactions, private_key, public_key):
@@ -82,6 +96,14 @@ def create_batch(transactions, private_key, public_key):
     return batch
 
 
+def _get_address_from_txn(txn_info):
+    txn_header = transaction_pb2.TransactionHeader()
+    txn_header.ParseFromString(txn_info.txn.header)
+    inputs_or_outputs = list(txn_header.inputs)
+    address_b = inputs_or_outputs[0]
+    return address_b
+
+
 class TestSerialScheduler(unittest.TestCase):
     def setUp(self):
         self.context_manager = ContextManager(dict_database.DictDatabase(),
@@ -94,13 +116,6 @@ class TestSerialScheduler(unittest.TestCase):
 
     def tearDown(self):
         self.context_manager.stop()
-
-    def _get_address_from_txn(self, txn_info):
-        txn_header = transaction_pb2.TransactionHeader()
-        txn_header.ParseFromString(txn_info.txn.header)
-        inputs_or_outputs = list(txn_header.inputs)
-        address_b = inputs_or_outputs[0]
-        return address_b
 
     def test_transaction_order(self):
         """Tests the that transactions are returned in order added.
@@ -122,7 +137,7 @@ class TestSerialScheduler(unittest.TestCase):
         for names in [['a', 'b', 'c'], ['d', 'e'], ['f', 'g', 'h', 'i']]:
             batch_txns = []
             for name in names:
-                txn = create_transaction(
+                txn, _ = create_transaction(
                     name=name,
                     private_key=private_key,
                     public_key=public_key)
@@ -130,7 +145,7 @@ class TestSerialScheduler(unittest.TestCase):
                 batch_txns.append(txn)
                 txns.append(txn)
 
-            batch = create_batch(
+            batch =  create_batch(
                 transactions=batch_txns,
                 private_key=private_key,
                 public_key=public_key)
@@ -169,7 +184,7 @@ class TestSerialScheduler(unittest.TestCase):
         private_key = signing.generate_privkey()
         public_key = signing.generate_pubkey(private_key)
 
-        txn = create_transaction(
+        txn, _ =  create_transaction(
             name='a',
             private_key=private_key,
             public_key=public_key)
@@ -210,7 +225,7 @@ class TestSerialScheduler(unittest.TestCase):
         private_key = signing.generate_privkey()
         public_key = signing.generate_pubkey(private_key)
 
-        txn = create_transaction(
+        txn, _ = create_transaction(
             name='a',
             private_key=private_key,
             public_key=public_key)
@@ -255,7 +270,7 @@ class TestSerialScheduler(unittest.TestCase):
         for names in [['a', 'b', 'c'], ['d', 'e'], ['f', 'g', 'h', 'i']]:
             batch_txns = []
             for name in names:
-                txn = create_transaction(
+                txn, _ = create_transaction(
                     name=name,
                     private_key=private_key,
                     public_key=public_key)
@@ -302,7 +317,7 @@ class TestSerialScheduler(unittest.TestCase):
         public_key = signing.generate_pubkey(private_key)
 
         # Create a basic transaction and batch.
-        txn = create_transaction(
+        txn, _ = create_transaction(
             name='a',
             private_key=private_key,
             public_key=public_key)
@@ -400,7 +415,7 @@ class TestSerialScheduler(unittest.TestCase):
         txns = []
 
         for name in ['a', 'b']:
-            txn = create_transaction(
+            txn, _ = create_transaction(
                 name=name,
                 private_key=private_key,
                 public_key=public_key)
@@ -450,7 +465,7 @@ class TestSerialScheduler(unittest.TestCase):
         for names in [['a', 'b'], ['invalid', 'c'], ['d', 'e']]:
             batch_txns = []
             for name in names:
-                txn = create_transaction(
+                txn, _ = create_transaction(
                     name=name,
                     private_key=private_key,
                     public_key=public_key)
@@ -495,16 +510,16 @@ class TestSerialScheduler(unittest.TestCase):
         address_a = inputs_or_outputs[0]
 
         txn_info_b = next(sched2)
-        address_b = self._get_address_from_txn(txn_info_b)
+        address_b = _get_address_from_txn(txn_info_b)
 
         txn_infoInvalid = next(sched2)
         txn_info_c = next(sched2)
 
         txn_info_d = next(sched2)
-        address_d = self._get_address_from_txn(txn_info_d)
+        address_d = _get_address_from_txn(txn_info_d)
 
         txn_info_e = next(sched2)
-        address_e = self._get_address_from_txn(txn_info_e)
+        address_e = _get_address_from_txn(txn_info_e)
 
         merkle_database = MerkleDatabase(dict_database.DictDatabase())
         state_root_end = merkle_database.update(


### PR DESCRIPTION
This includes consolidating the use of create_transaction and
create_batch, adding setUp and tearDown to TestParallelScheduler,
adding test to TestParallelScheduler that should also work from
TestSerialScheduler, and adding the previous context_id to
create_context in test_transaction_order_with_dependencies.

Two tests are currently failing.