### PR TITLE
Remove active key state class variable in PoET block publisher

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
@@ -64,6 +64,23 @@ class PoetKeyStateStore(MutableMapping):
         """
         return self._store_db.keys()
 
+    @property
+    def active_key(self):
+        return self._store_db.get('active_key')
+
+    @active_key.setter
+    def active_key(self, value):
+        # If the value is not None, then we are not going to allow an active
+        # key that is not in the key state store.  Setting to None is allowed
+        # as that is basically clearing out the active key.
+        if value is not None and value not in self._store_db:
+            raise \
+                ValueError(
+                    'Cannot make non-existent key [{}...{}] active'.format(
+                        value[:8],
+                        value[-8:]))
+        self._store_db['active_key'] = value
+
     def __init__(self, data_dir, validator_id):
         """Initialize the store
 
@@ -170,6 +187,10 @@ class PoetKeyStateStore(MutableMapping):
         """
         try:
             del self._store_db[poet_public_key]
+
+            # If the key is the active key, then also clear the active key
+            if self.active_key == poet_public_key:
+                self.active_key = None
         except KeyError:
             pass
 

--- a/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
@@ -54,6 +54,102 @@ class TestPoetKeyStateStore(unittest.TestCase):
 
     @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
            'LMDBNoLockDatabase')
+    def test_active_key_new_store(self, mock_lmdb):
+        """Verify that a brand new key state store does not have an active key
+        """
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        self.assertIsNone(store.active_key)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_active_key_not_present(self, mock_lmdb):
+        """Verify that trying to set a non-existent key as active fails
+        """
+        mock_lmdb.return_value = {}
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        with self.assertRaises(ValueError):
+            store.active_key = 'ppk_1'
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_active_key_present(self, mock_lmdb):
+        """Verify that setting a present key active succeeds
+        """
+        mock_lmdb.return_value = {
+            'ppk_1':
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(b'sealed_1'),
+                    has_been_refreshed=False)
+        }
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        store.active_key = 'ppk_1'
+        self.assertEqual(store.active_key, 'ppk_1')
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_active_key_clear(self, mock_lmdb):
+        """Verify that clearing the active succeeds
+        """
+        mock_lmdb.return_value = {
+            'ppk_1':
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(b'sealed_1'),
+                    has_been_refreshed=False)
+        }
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        store.active_key = 'ppk_1'
+        self.assertEqual(store.active_key, 'ppk_1')
+
+        store.active_key = None
+        self.assertIsNone(store.active_key)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
+    def test_active_key_delete(self, mock_lmdb):
+        """Verify that deleting the key state for the active key also clears
+        the active key
+        """
+        mock_lmdb.return_value = {
+            'ppk_1':
+                poet_key_state_store.PoetKeyState(
+                    sealed_signup_data=base64.b64encode(b'sealed_1'),
+                    has_been_refreshed=False)
+        }
+
+        store = \
+            poet_key_state_store.PoetKeyStateStore(
+                data_dir=tempfile.gettempdir(),
+                validator_id='0123456789abcdef')
+
+        store.active_key = 'ppk_1'
+        self.assertEqual(store.active_key, 'ppk_1')
+
+        del store['ppk_1']
+        self.assertIsNone(store.active_key)
+
+    @patch('sawtooth_poet.poet_consensus.poet_key_state_store.'
+           'LMDBNoLockDatabase')
     def test_store_nonexistent_key(self, mock_lmdb):
         """Verify that retrieval of a non-existent key raises the appropriate
         exception.


### PR DESCRIPTION
The PoET block publisher keeps track of its active PoET public key by storing it in a class variable so that it is persisted across creation of PoET block publisher objects.  While this works, it leads to headaches when running tests.  This update removes the class variable and puts it in the PoET key state store.