### PR TITLE
Responder should not broadcast if it there is no chain head

### DIFF
--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -93,9 +93,15 @@ class BlockResponderHandler(Handler):
         if block is None:
             # No block found, broadcast original message to other peers
             # and add to pending requests
-            self._responder.add_request(block_id, connection_id)
-            self._gossip.broadcast(block_request_message,
-                                   validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
+            if block_id == "HEAD":
+                LOGGER.debug("No chain head available. Cannot respond to block"
+                             " requests.")
+            else:
+                self._responder.add_request(block_id, connection_id)
+                self._gossip.broadcast(
+                    block_request_message,
+                    validator_pb2.Message.GOSSIP_BLOCK_REQUEST,
+                    exclude=[connection_id])
         else:
             LOGGER.debug("Responding to block requests: %s",
                          block.get_block().header_signature)
@@ -158,7 +164,8 @@ class BatchByBatchIdResponderHandler(Handler):
                                         connection_id)
             self._gossip.broadcast(
                 batch_request_message,
-                validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
+                validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST,
+                exclude=[connection_id])
         else:
             LOGGER.debug("Responding to batch requests %s",
                          batch.header_signature)
@@ -206,7 +213,8 @@ class BatchByTransactionIdResponderHandler(Handler):
             self._gossip.broadcast(
                 batch_request_message,
                 validator_pb2.Message.
-                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST)
+                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST,
+                exclude=[connection_id])
 
         elif unfound_txn_ids != []:
             new_request = network_pb2.GossipBatchByTransactionIdRequest()
@@ -217,7 +225,8 @@ class BatchByTransactionIdResponderHandler(Handler):
             self._gossip.broadcast(
                 new_request,
                 validator_pb2.Message.
-                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST)
+                GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST,
+                exclude=[connection_id])
 
         if batches != []:
             for batch in batches:

--- a/validator/tests/unit3/test_responder/mock.py
+++ b/validator/tests/unit3/test_responder/mock.py
@@ -20,7 +20,7 @@ class MockGossip():
         self.broadcasted = {}
         self.sent = {}
 
-    def broadcast(self, message, message_type):
+    def broadcast(self, message, message_type, exclude):
         if message_type in self.broadcasted:
             self.broadcasted[message_type] += [message]
         else:


### PR DESCRIPTION
Logs a statement saying that there is no chain head and that
the responder cannot respond to block requests. Also
adds the requester to the exclude list on broadcast.
This reduces the amount of duplicate requests in the system.


This should ~~remove~~ reduce the periodic failure in poet-smoke because of the following error.  "AssertionError:RestApi/blocks is not available within 10 attempts" 
The AssertionError was being caused by two validators peering when neither of them had the genesis block, causing the network to be flooded with block requests.

There is another issue within the dispatcher/signature verifier that is also throwing causes the same assertion error. A new Jira story has been created to investigate further. 