### PR TITLE
App Dev Guide should not use git or repo

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -64,6 +64,7 @@ html: templates cli
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@cp ../docker/compose/sawtooth-default.yaml $(BUILDDIR)/html/app_developers_guide/sawtooth-default.yaml
 
 dirhtml: templates cli
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/source/app_developers_guide/environment_setup.rst
+++ b/docs/source/app_developers_guide/environment_setup.rst
@@ -30,54 +30,32 @@ The following tools are required:
 * `Docker Compose <https://docs.docker.com/compose/install/>`_ (Linux only)
 
 
-Step One: Clone Repository
---------------------------
+Get the Docker Compose File
+---------------------------
 
-You'll need to have git installed in order to clone the Sawtooth source
-code repository. You can find up-to-date installation instructions here:
+A docker compose file is provided which defines the process for constructing
+a sawtooth environment, including the container images to download and the
+network settings.
 
-* `Git install instructions <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_
+This docker compose file can serve as the basis for your own multi-container
+sawtooth development environment or application.
 
-.. note:: 
-
-  When checking out Sawtooth on Windows for use with vagrant, you should
-  take steps to ensure that Windows-style CRLF line endings are not added to
-  the code. The bash scripts used by your vagrant VM will not run correctly 
-  with CRLF line endings. Git uses a configuration setting, *core.autocrlf*,
-  to control whether or not LF-style line endings are automatically converted
-  to CRLF-style line endings. `This setting should be set in such a way that 
-  CRLFs are not introduced into your repository 
-  <https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration>`_.
-
-Open up a terminal and run the following:
-
-.. code-block:: console
-
-   % cd $HOME
-   % mkdir project
-   % cd project
-   % git clone https://github.com/hyperledger/sawtooth-core.git
-
-.. note::
-
-  On a Windows environment, the suggested version of the last command
-  above is:
-
-  .. code-block:: console
-
-      C:\> git clone https://github.com/hyperledger/sawtooth-core.git
-      --config core.autocrlf=false
+Download the docker compose file `here <./sawtooth-default.yaml>`_.
 
 
 Environment Startup
 -------------------
 
-To start up the environment, run:
+To start up the environment, perform the following tasks:
+
+1. Open a terminal window.
+2. Change your working directory to the same directory where you saved the
+   docker compose file. *Example command on a Linux system:* '$ cd ~/Downloads'
+3. Run the following command:
 
 .. code-block:: console
 
-  % cd sawtooth-core
-  % docker-compose -f docker/compose/sawtooth-default.yaml up
+  % docker-compose -f sawtooth-default.yaml up
 
 Downloading the docker images that comprise the Sawtooth demo
 environment can take serveral minutes. Once you see the containers
@@ -118,8 +96,7 @@ Resetting The Environment
 If the environment needs to be reset for any reason, it can be returned to
 the default state by logging out of the client container, then pressing
 CTRL-c from the window where you originally ran docker-compose. Once the
-containers have all shut down run 'docker-compose -f sawtooth-default.yaml
-down'.
+containers have all shut down run 'docker-compose -f sawtooth-default.yaml down'.
 
 .. code-block:: console
 
@@ -136,7 +113,7 @@ down'.
   Stopping compose_tp_intkey_python_1 ... done
   Stopping compose_validator_1 ... done
 
-  % docker-compose -f docker/compose/sawtooth-default.yaml down
+  % docker-compose -f sawtooth-default.yaml down
 
 Next Steps
 ----------


### PR DESCRIPTION
Removed use of git clone in the App Dev Guide,
Environment setup section.

Signed-off-by: Todd Ojala <todd@bitwise.io>