### PR TITLE
Add configuration option to select between schedulers 

### DIFF
--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -87,6 +87,9 @@ def parse_args(args):
                         action='count',
                         default=0,
                         help='Increase output sent to stderr')
+    parser.add_argument('--scheduler',
+                        choices=['serial', 'parallel'],
+                        help='The type of scheduler to be used.')
 
     return parser.parse_args(args)
 
@@ -207,7 +210,8 @@ def main(args=sys.argv[1:]):
                           opts.peers,
                           path_config.data_dir,
                           path_config.config_dir,
-                          identity_signing_key)
+                          identity_signing_key,
+                          opts.scheduler)
 
     # pylint: disable=broad-except
     try:


### PR DESCRIPTION
Defaults to SerialScheduler. If you want to use the ParallelScheduler create a validator.toml file in
the config directory. In the file, add the following line: 

scheduler = "parallel"

This PR also adds a command line option to ./bin validator 
--scheduler {serial,parallel}
                        The type of scheduler to be used.

Built on top of #451 for the lint fixes.