### PR TITLE
Add Get State Deltas Handler

### DIFF
--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -102,3 +102,35 @@ message UnregisterStateDeltaSubscriberResponse {
     }
     Status status = 1;
 }
+
+// Request message for a set of StateDeltaEvent objects, based on a given list
+// of block_ids and a known filter.  The result will include a set of
+// StateDeltaEvent objects.
+message GetStateDeltaEventsRequest {
+    // The block ids to query
+    repeated string block_ids = 1;
+
+    // The list of address prefixes of interest.  Only state changes
+    // that occur on values in the given prefixes will be sent to the
+    // subscriber.
+    repeated string address_prefixes = 2;
+}
+
+// Response message for a GetStateDeltasRequest.  Returns a list of
+// StateDeltaEvent objects for the block_ids requested.  Only block_ids known
+// to the validator will result in events.
+message GetStateDeltaEventsResponse {
+    enum Status {
+        // returned on a successful request
+        OK = 0;
+        // returned on a failed request, due to an internal validator error.
+        INTERNAL_ERROR = 1;
+        // return on a bad request, where no block id was provided in the
+        // request.
+        NO_VALID_BLOCKS_SPECIFIED = 2;
+    }
+    Status status = 1;
+    // the events returned for the request.  This may contain only a subset of
+    // events matching the given block ids, as unknown blocks are ignored.
+    repeated StateDeltaEvent events = 2;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -116,6 +116,8 @@ message Message {
         STATE_DELTA_UNSUBSCRIBE_REQUEST = 402;
         STATE_DELTA_UNSUBSCRIBE_RESPONSE = 403;
         STATE_DELTA_EVENT = 404;
+        STATE_DELTA_GET_EVENTS_REQUEST = 405;
+        STATE_DELTA_GET_EVENTS_RESPONSE = 406;
     }
     // The type of message, used to determine how to 'route' the message
     // to the appropriate handler as well as how to deserialize the

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -58,6 +58,8 @@ from sawtooth_validator.state.state_delta_processor import \
     StateDeltaSubscriberValidationHandler
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
+from sawtooth_validator.state.state_delta_processor import \
+    GetStateDeltaEventsHandler
 from sawtooth_validator.state.state_delta_store import StateDeltaStore
 from sawtooth_validator.state.state_view import StateViewFactory
 from sawtooth_validator.gossip import signature_verifier
@@ -481,6 +483,11 @@ class Validator(object):
         self._dispatcher.add_handler(
             validator_pb2.Message.STATE_DELTA_UNSUBSCRIBE_REQUEST,
             StateDeltaUnsubscriberHandler(state_delta_processor),
+            thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.STATE_DELTA_GET_EVENTS_REQUEST,
+            GetStateDeltaEventsHandler(block_store, state_delta_store),
             thread_pool)
 
     def start(self):

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -173,7 +173,7 @@ class StateDeltaProcessor(object):
             block (:obj:`BlockWrapper`): The block whose state delta will
                 be published.
         """
-        LOGGER.debug('Publishing state delta fro %s', block)
+        LOGGER.debug('Publishing state delta from %s', block)
         state_root_hash = block.header.state_root_hash
 
         deltas = self._get_delta(state_root_hash)

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -30,6 +30,10 @@ from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberResponse
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    GetStateDeltaEventsRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    GetStateDeltaEventsResponse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -289,6 +293,57 @@ class StateDeltaUnsubscriberHandler(Handler):
         ack = UnregisterStateDeltaSubscriberResponse()
         self._delta_processor.remove_subscriber(connection_id)
         ack.status = ack.OK
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=self._msg_type)
+
+
+class GetStateDeltaEventsHandler(Handler):
+    """Handles receiving messages for getting state delta events based on block
+    ids.
+    """
+    _msg_type = validator_pb2.Message.STATE_DELTA_GET_EVENTS_RESPONSE
+
+    def __init__(self, block_store, state_delta_store):
+        self._block_store = block_store
+        self._state_delta_store = state_delta_store
+
+    def handle(self, connection_id, message_content):
+        request = GetStateDeltaEventsRequest()
+        request.ParseFromString(message_content)
+
+        # Create a temporary subscriber for this response
+        temp_subscriber = _DeltaSubscriber(connection_id,
+                                           request.address_prefixes)
+        events = []
+        for block_id in request.block_ids:
+            try:
+                block = self._block_store[block_id]
+            except KeyError:
+                LOGGER.debug('Ignoring state delete event request for %s...',
+                             block_id[:8])
+                continue
+
+            try:
+                deltas = self._state_delta_store.get_state_deltas(
+                    block.header.state_root_hash)
+            except KeyError:
+                deltas = []
+
+            event = StateDeltaEvent(
+                block_id=block_id,
+                block_num=block.header.block_num,
+                state_root_hash=block.header.state_root_hash,
+                state_changes=temp_subscriber.deltas_of_interest(deltas))
+
+            events.append(event)
+
+        status = GetStateDeltaEventsResponse.OK if len(events) > 0 else \
+            GetStateDeltaEventsResponse.NO_VALID_BLOCKS_SPECIFIED
+
+        ack = GetStateDeltaEventsResponse(status=status, events=events)
 
         return HandlerResult(
             HandlerStatus.RETURN,

--- a/validator/tests/unit3/test_state_delta_processor/tests.py
+++ b/validator/tests/unit3/test_state_delta_processor/tests.py
@@ -32,6 +32,8 @@ from sawtooth_validator.state.state_delta_processor import \
     StateDeltaAddSubscriberHandler
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
+from sawtooth_validator.state.state_delta_processor import \
+    GetStateDeltaEventsHandler
 
 from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
 from sawtooth_validator.protobuf.state_delta_pb2 import StateDeltaEvent
@@ -43,6 +45,10 @@ from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
     UnregisterStateDeltaSubscriberResponse
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    GetStateDeltaEventsRequest
+from sawtooth_validator.protobuf.state_delta_pb2 import \
+    GetStateDeltaEventsResponse
 from sawtooth_validator.protobuf import validator_pb2
 
 from test_journal.block_tree_manager import BlockTreeManager
@@ -166,6 +172,109 @@ class StateDeltaUnregisterSubscriberHandlerTest(unittest.TestCase):
 
         self.assertEqual(HandlerStatus.RETURN, response.status)
         self.assertEqual(UnregisterStateDeltaSubscriberResponse.OK,
+                         response.message_out.status)
+
+
+class GetStateDeltaEventsHandlerTest(unittest.TestCase):
+    def test_get_events(self):
+        """Tests that the GetStateDeltaEventsHandler will return a response
+        with the state event for the block requested.
+        """
+        block_tree_manager = BlockTreeManager()
+
+        delta_store = StateDeltaStore(DictDatabase())
+
+        delta_store.save_state_deltas(
+            block_tree_manager.chain_head.state_root_hash,
+            [StateChange(address='deadbeef0000000',
+                         value='my_genesis_value'.encode(),
+                         type=StateChange.SET),
+             StateChange(address='a14ea01',
+                         value='some other state value'.encode(),
+                         type=StateChange.SET)])
+
+        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+                                             delta_store)
+
+        request = GetStateDeltaEventsRequest(
+            block_ids=[block_tree_manager.chain_head.identifier],
+            address_prefixes=['deadbeef']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(GetStateDeltaEventsResponse.OK,
+                         response.message_out.status)
+
+        self.assertEqual(
+            [StateDeltaEvent(
+                 block_id=block_tree_manager.chain_head.identifier,
+                 block_num=block_tree_manager.chain_head.block_num,
+                 state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                 state_changes=[StateChange(address='deadbeef0000000',
+                                value='my_genesis_value'.encode(),
+                                type=StateChange.SET)])],
+            [event for event in response.message_out.events])
+
+    def test_get_events_ignore_bad_blocks(self):
+        """Tests that the GetStateDeltaEventsHandler will return a response
+        containing only the events for blocks that exists.
+        """
+        block_tree_manager = BlockTreeManager()
+
+        delta_store = StateDeltaStore(DictDatabase())
+
+        delta_store.save_state_deltas(
+            block_tree_manager.chain_head.state_root_hash,
+            [StateChange(address='deadbeef0000000',
+                         value='my_genesis_value'.encode(),
+                         type=StateChange.SET),
+             StateChange(address='a14ea01',
+                         value='some other state value'.encode(),
+                         type=StateChange.SET)])
+
+        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+                                             delta_store)
+
+        request = GetStateDeltaEventsRequest(
+            block_ids=[block_tree_manager.chain_head.identifier,
+                       'somebadblockid'],
+            address_prefixes=['deadbeef']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(GetStateDeltaEventsResponse.OK,
+                         response.message_out.status)
+
+        self.assertEqual(
+            [StateDeltaEvent(
+                 block_id=block_tree_manager.chain_head.identifier,
+                 block_num=block_tree_manager.chain_head.block_num,
+                 state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                 state_changes=[StateChange(address='deadbeef0000000',
+                                value='my_genesis_value'.encode(),
+                                type=StateChange.SET)])],
+            [event for event in response.message_out.events])
+
+    def test_get_events_no_valid_block_ids(self):
+        """Tests that the GetStateDeltaEventsHandler will return a response
+        with NO_VALID_BLOCKS_SPECIFIED error when no valid blocks are
+        specified in the request.
+        """
+        block_tree_manager = BlockTreeManager()
+
+        delta_store = StateDeltaStore(DictDatabase())
+
+        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+                                             delta_store)
+
+        request = GetStateDeltaEventsRequest(
+            block_ids=['somebadblockid'],
+            address_prefixes=['deadbeef']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(GetStateDeltaEventsResponse.NO_VALID_BLOCKS_SPECIFIED,
                          response.message_out.status)
 
 


### PR DESCRIPTION
Add Get State Delta handler to request state delta events by block ID.

This is useful for pre-catching up a client, in the case where they don't want to flood the network with many event messages.

Adds tests to verify that the subscriber sending a list of known block ids will return true if the request contains some known ids.