### PR TITLE
Remove stacktraces on 404 from sawtooth show command

### DIFF
--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -95,7 +95,8 @@ class RestClient(object):
         if code == 200:
             return json_result
         elif code == 404:
-            return None
+            raise CliException('There is no resource with the identifier "{}"'.
+                               format(path.split('/')[-1]))
         else:
             raise CliException("({}): {}".format(code, json_result))
 


### PR DESCRIPTION
Previously, the Sawtooth CLI mishandled 404 errors when fetching
resources, causing a stack trace to be be printed to the console
when running a 'sawtooth show' command with a bad id.
This replaces the stack trace with a more sensible error message.

Signed-off-by: Todd Ojala <todd@bitwise.io>