### PR TITLE
Add no-op transaction processor and workload client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@
 /sdk/examples/intkey_javascript/node_modules/
 /sdk/examples/intkey_java/dependency-reduced-pom.xml
 /sdk/examples/intkey_java/target/
+/sdk/examples/noop_python/**/__pycache__/
 /sdk/java/target/
 /sdk/go/src/sawtooth_sdk/protobuf/
 /sdk/go/src/github.com/

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@
 /sdk/go/src/github.com/
 /sdk/go/bin/
 /sdk/examples/intkey_go/bin/
+/sdk/examples/noop_go/bin/
 /sdk/go/pkg/
 
 /signing/build/

--- a/bin/noop
+++ b/bin/noop
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+import sysconfig
+
+build_str = "lib.{}-{}.{}".format(
+    sysconfig.get_platform(),
+    sys.version_info.major, sys.version_info.minor)
+
+sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+            'signing'))
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'examples', 'noop_python'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
+
+from sawtooth_noop.client_cli.main import main_wrapper
+
+if __name__ == '__main__':
+    main_wrapper()

--- a/bin/tp_noop_go
+++ b/bin/tp_noop_go
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2017 Intel Corporation
 #
@@ -15,19 +15,12 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-set -e
-
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+bin=$top_dir/sdk/examples/noop_go/bin/tp_noop_go
 
-echo -e "\033[0;32m--- Running protogen go ---\n\033[0m"
-$top_dir/bin/protogen go
-
-echo -e "\033[0;32m--- Building tp_intkey_go ---\n\033[0m"
-cd $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey
-mkdir -p $top_dir/sdk/examples/intkey_go/bin
-go build -o $top_dir/sdk/examples/intkey_go/bin/tp_intkey_go
-
-echo -e "\033[0;32m--- Building tp_noop_go ---\n\033[0m"
-cd $top_dir/sdk/examples/noop_go/src/sawtooth_noop
-mkdir -p $top_dir/sdk/examples/noop_go/bin
-go build -o $top_dir/sdk/examples/noop_go/bin/tp_noop_go
+if [ -e $bin ]
+then
+    $bin $*
+else
+    echo "Please build Noop Go first with 'build_all -l go' or 'build_go'"
+fi

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -40,7 +40,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
-ENV GOPATH=/go:/project/sawtooth-core/sdk/go:/project/sawtooth-core/sdk/examples/intkey_go
+ENV GOPATH=/go:/project/sawtooth-core/sdk/go:/project/sawtooth-core/sdk/examples/intkey_go:/project/sawtooth-core/sdk/examples/noop_go
 
 RUN mkdir /go \
  && go get -u \

--- a/docker/sawtooth-int-tp_noop_go
+++ b/docker/sawtooth-int-tp_noop_go
@@ -1,5 +1,3 @@
-#!/bin/bash
-#
 # Copyright 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,19 +13,27 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-set -e
+# Description:
+#   Builds an image with Sawtooth TP Noop Go installed.
+#
+# Build:
+#   This image should be built using `build_all installed`.
+#
+# Run:
+#   $ docker run sawtooth-tp_noop_go
 
-top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+FROM ubuntu:xenial
 
-echo -e "\033[0;32m--- Running protogen go ---\n\033[0m"
-$top_dir/bin/protogen go
+LABEL "install-type"="copied-bin"
 
-echo -e "\033[0;32m--- Building tp_intkey_go ---\n\033[0m"
-cd $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey
-mkdir -p $top_dir/sdk/examples/intkey_go/bin
-go build -o $top_dir/sdk/examples/intkey_go/bin/tp_intkey_go
+RUN apt-get update \
+ && apt-get install -y -q \
+    libzmq3-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-echo -e "\033[0;32m--- Building tp_noop_go ---\n\033[0m"
-cd $top_dir/sdk/examples/noop_go/src/sawtooth_noop
-mkdir -p $top_dir/sdk/examples/noop_go/bin
-go build -o $top_dir/sdk/examples/noop_go/bin/tp_noop_go
+COPY tp_noop_go /usr/bin/tp_noop_go
+
+EXPOSE 40000/tcp
+
+CMD ["tp_noop_go", "tcp://validator:40000"]

--- a/sdk/examples/noop_go/src/sawtooth_noop/handler/handler.go
+++ b/sdk/examples/noop_go/src/sawtooth_noop/handler/handler.go
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+package handler
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"sawtooth_sdk/logging"
+	"sawtooth_sdk/processor"
+	"sawtooth_sdk/protobuf/processor_pb2"
+	"strings"
+)
+
+var logger *logging.Logger = logging.Get()
+
+type NoopHandler struct {
+	namespace string
+}
+
+func NewNoopHandler(namespace string) *NoopHandler {
+	return &NoopHandler{
+		namespace: namespace,
+	}
+}
+
+const FAMILY_NAME = "noop"
+
+func (self *NoopHandler) FamilyName() string {
+	return FAMILY_NAME
+}
+func (self *NoopHandler) FamilyVersion() string {
+	return "1.0"
+}
+func (self *NoopHandler) Encoding() string {
+	return "none"
+}
+func (self *NoopHandler) Namespaces() []string {
+	return []string{self.namespace}
+}
+
+func (self *NoopHandler) Apply(request *processor_pb2.TpProcessRequest, state *processor.State) error {
+	return nil
+}
+
+func Hexdigest(str string) string {
+	hash := sha512.New()
+	hash.Write([]byte(str))
+	hashBytes := hash.Sum(nil)
+	return strings.ToLower(hex.EncodeToString(hashBytes))
+}

--- a/sdk/examples/noop_go/src/sawtooth_noop/main.go
+++ b/sdk/examples/noop_go/src/sawtooth_noop/main.go
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+package main
+
+import (
+	"flag"
+	noop "sawtooth_noop/handler"
+	"sawtooth_sdk/logging"
+	"sawtooth_sdk/processor"
+	"syscall"
+)
+
+func main() {
+	v := flag.Bool("v", false, "Info level logging")
+	vv := flag.Bool("vv", false, "Debug level logging")
+	endpoint := "tcp://localhost:40000"
+
+	flag.Parse()
+	args := flag.Args()
+	if len(args) > 0 {
+		// Overwrite the default endpoint if specified
+		endpoint = args[0]
+	}
+
+	level := logging.WARN
+	if *v {
+		level = logging.INFO
+	}
+	if *vv {
+		level = logging.DEBUG
+	}
+
+	logger := logging.Get()
+	logger.SetLevel(level)
+
+	prefix := noop.Hexdigest("noop")[:6]
+	handler := noop.NewNoopHandler(prefix)
+	processor := processor.NewTransactionProcessor(endpoint)
+	processor.AddHandler(handler)
+	processor.ShutdownOnSignal(syscall.SIGINT, syscall.SIGTERM)
+	err := processor.Start()
+	if err != nil {
+		logger.Error("Processor stopped: ", err)
+	}
+}

--- a/sdk/examples/noop_python/sawtooth_noop/__init__.py
+++ b/sdk/examples/noop_python/sawtooth_noop/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = [
+    'client_cli'
+]

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/__init__.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import argparse
+import hashlib
+import os
+import logging
+import binascii
+import random
+import string
+import time
+import cbor
+import sawtooth_signing as signing
+
+import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
+import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NoopPayload(object):
+    def __init__(self):
+        self.nonce = binascii.b2a_hex(random.getrandbits(8*8).to_bytes(8, byteorder='little'))
+        self._sha512 = None
+
+    def sha512(self):
+        if self._sha512 is None:
+            self._sha512 = hashlib.sha512(self.nonce).hexdigest()
+        return self._sha512
+
+
+def create_noop_transaction(private_key, public_key):
+    payload = NoopPayload()
+
+    header = transaction_pb2.TransactionHeader(
+        signer_pubkey=public_key,
+        family_name='noop',
+        family_version='1.0',
+        inputs=[],
+        outputs=[],
+        dependencies=[],
+        payload_encoding="none",
+        payload_sha512=payload.sha512(),
+        batcher_pubkey=public_key,
+        nonce=time.time().hex().encode())
+
+    header_bytes = header.SerializeToString()
+
+    signature = signing.sign(header_bytes, private_key)
+
+    transaction = transaction_pb2.Transaction(
+        header=header_bytes,
+        payload=payload.nonce,
+        header_signature=signature)
+
+    return transaction
+
+
+def create_batch(transactions, private_key, public_key):
+    transaction_signatures = [t.header_signature for t in transactions]
+
+    header = batch_pb2.BatchHeader(
+        signer_pubkey=public_key,
+        transaction_ids=transaction_signatures)
+
+    header_bytes = header.SerializeToString()
+
+    signature = signing.sign(header_bytes, private_key)
+
+    batch = batch_pb2.Batch(
+        header=header_bytes,
+        transactions=transactions,
+        header_signature=signature)
+
+    return batch

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/exceptions.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/exceptions.py
@@ -1,0 +1,18 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+class NoopCliException(Exception):
+    pass

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
@@ -1,0 +1,116 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import argparse
+import logging
+import os
+import sys
+import traceback
+
+from colorlog import ColoredFormatter
+
+from sawtooth_noop.client_cli.workload import add_workload_parser
+from sawtooth_noop.client_cli.workload import do_workload
+
+from sawtooth_noop.client_cli.exceptions import NoopCliException
+
+
+def create_console_handler(verbose_level):
+    clog = logging.StreamHandler()
+    formatter = ColoredFormatter(
+        "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
+        "%(white)s%(message)s",
+        datefmt="%H:%M:%S",
+        reset=True,
+        log_colors={
+            'DEBUG': 'cyan',
+            'INFO': 'green',
+            'WARNING': 'yellow',
+            'ERROR': 'red',
+            'CRITICAL': 'red',
+        })
+
+    clog.setFormatter(formatter)
+
+    if verbose_level == 0:
+        clog.setLevel(logging.WARN)
+    elif verbose_level == 1:
+        clog.setLevel(logging.INFO)
+    else:
+        clog.setLevel(logging.DEBUG)
+
+    return clog
+
+
+def setup_loggers(verbose_level):
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(create_console_handler(verbose_level))
+
+
+def create_parent_parser(prog_name):
+    parent_parser = argparse.ArgumentParser(prog=prog_name, add_help=False)
+    parent_parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        help='enable more verbose output')
+
+    return parent_parser
+
+
+def create_parser(prog_name):
+    parent_parser = create_parent_parser(prog_name)
+
+    parser = argparse.ArgumentParser(
+        parents=[parent_parser],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    subparsers = parser.add_subparsers(title='subcommands', dest='command')
+
+    add_workload_parser(subparsers, parent_parser)
+
+    return parser
+
+
+def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+    parser = create_parser(prog_name)
+    args = parser.parse_args(args)
+
+    if args.verbose is None:
+        verbose_level = 0
+    else:
+        verbose_level = args.verbose
+    setup_loggers(verbose_level=verbose_level)
+
+    if args.command == 'workload':
+        do_workload(args)
+    else:
+        raise NoopCliException("invalid command: {}".format(args.command))
+
+
+def main_wrapper():
+    # pylint: disable=bare-except
+    try:
+        main()
+    except NoopCliException as e:
+        print(sys.stderr, "Error: {}".format(e))
+        sys.exit(1)
+    except KeyboardInterrupt:
+        pass
+    except SystemExit as e:
+        raise e
+    except:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -1,0 +1,151 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import argparse
+import logging
+import random
+import threading
+from collections import namedtuple
+from datetime import datetime
+from http.client import RemoteDisconnected
+
+import requests
+import sawtooth_signing as signing
+from sawtooth_sdk.workload.workload_generator import WorkloadGenerator
+from sawtooth_sdk.workload.sawtooth_workload import Workload
+from sawtooth_sdk.protobuf import batch_pb2
+from sawtooth_noop.client_cli.create_batch import create_noop_transaction
+from sawtooth_noop.client_cli.create_batch import create_batch
+
+LOGGER = logging.getLogger(__name__)
+
+def post_batches(url, batches):
+    data = batches.SerializeToString()
+    headers = {'Content-Type': 'application/octet-stream'}
+    headers['Content-Length'] = str(len(data))
+
+    try:
+        result = requests.post(url + "/batches", data, headers=headers)
+        result.raise_for_status()
+        code, json_result = (result.status_code, result.json())
+        if not (code == 200 or code == 201 or code == 202):
+            LOGGER.warning("(%s): %s", code, json_result)
+        return(code, json_result)
+    except requests.exceptions.HTTPError as e:
+        LOGGER.warning("(%s): %s", e.response.status_code, e.response.reason)
+        return (e.response.status_code, e.response.reason)
+    except RemoteDisconnected as e:
+        LOGGER.warning(e)
+    except requests.exceptions.ConnectionError as e:
+        LOGGER.warning(
+            'Unable to connect to "%s": make sure URL is correct', url
+        )
+
+
+class NoopWorkload(Workload):
+    """
+    This workload is for the Sawtooth Noop transaction family.
+    """
+    def __init__(self, delegate, args):
+        super(NoopWorkload, self).__init__(delegate, args)
+        self._urls = []
+        self._lock = threading.Lock()
+        self._delegate = delegate
+        self._private_key = signing.generate_privkey()
+        self._public_key = signing.generate_pubkey(self._private_key)
+
+    def on_will_start(self):
+        pass
+
+    def on_will_stop(self):
+        pass
+
+    def on_validator_discovered(self, url):
+        self._urls.append(url)
+
+    def on_validator_removed(self, url):
+        with self._lock:
+            if url in self._urls:
+                self._urls.remove(url)
+
+    def on_all_batches_committed(self):
+        self._send_batch()
+
+    def on_batch_committed(self, batch_id):
+        self._send_batch()
+
+    def on_batch_not_yet_committed(self):
+        self._send_batch()
+
+    def _send_batch(self):
+        with self._lock:
+            url = random.choice(self._urls) if \
+                len(self._urls) > 0 else None
+
+        batch_id = None
+        if url is not None:
+            txns = []
+            for _ in range(0, 1):
+                txns.append(create_noop_transaction(
+                    private_key=self._private_key,
+                    public_key=self._public_key))
+
+            batch = create_batch(
+                transactions=txns,
+                private_key=self._private_key,
+                public_key=self._public_key)
+
+            batch_id = batch.header_signature
+
+            batch_list = batch_pb2.BatchList(batches=[batch])
+            post_batches(url, batch_list)
+
+            self.delegate.on_new_batch(batch_id, url)
+
+
+def do_workload(args):
+    """
+    Create WorkloadGenerator and IntKeyWorkload. Set IntKey workload in
+    generator and run.
+    """
+    try:
+        generator = WorkloadGenerator(args)
+        workload = NoopWorkload(generator, args)
+        generator.set_workload(workload)
+        generator.run()
+    except KeyboardInterrupt:
+        generator.stop()
+
+
+def add_workload_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser(
+        'workload',
+        parents=[parent_parser],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('--rate',
+                        type=int,
+                        help='Batch rate in batches per second. '
+                             'Should be greater then 0.',
+                        default=1)
+    parser.add_argument('-d', '--display-frequency',
+                        type=int,
+                        help='time in seconds between display of batches '
+                             'rate updates.',
+                        default=30)
+    parser.add_argument('-u', '--urls',
+                        help='comma separated urls of the REST API to connect '
+                        'to.',
+                        default="http://127.0.0.1:8080")


### PR DESCRIPTION
These commits add a Go noop transaction processor which immediately returns when invoked without parsing payload or accessing state. Also included is a python client which includes a workload generator to submit noop transactions. The transaction payload consist of an 8 byte random nonce to give the transactions unique signatures.

Submission of solely noop transactions results in moving the block chain forward without changes to the state root hash.

This is intended for use in performance/integration testing.