### PR TITLE
Run sawtooth keygen in client compose container

### DIFF
--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -75,4 +75,7 @@ services:
       - 40000
     depends_on:
       - rest_api
-    entrypoint: tail -f /dev/null
+    entrypoint: "bash -c \"\
+        sawtooth keygen && \
+        tail -f /dev/null \
+        \""


### PR DESCRIPTION
This removes the need for the app developer to manually create the key
themselves before using the CLI commands.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>