### PR TITLE
Add sort query to REST API

### DIFF
--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -146,6 +146,10 @@ Error Codes and Descriptions
      - Invalid Paging Query
      - The validator rejected the paging request submitted. One or more of the
        'min', 'max', or 'count' query parameters were invalid or out of range.
+   * - 57
+     - Invalid Sort Query
+     - The validator rejected the sort request submitted. Most likely one of
+       the keys specified was not found in the resources sorted.
    * - 62
      - Invalid State Address
      - The state address submitted was invalid. Returned when attempting to

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -58,6 +58,18 @@ message PagingResponse {
     int32 total_resources = 4;
 }
 
+// Sorting controls to be sent with List requests. More than one can be sent.
+// If so, the first is used, and additional controls are tie-breakers.
+// Attributes:
+//     keys: Nested set of keys to sort by (i.e. ['header', 'signer_pubkey'])
+//     reverse: Whether or not to reverse the sort (i.e. descending order)
+//     compare_length: Sorts by value length, rather than the property itself
+message SortControls {
+    repeated string keys = 1;
+    bool reverse = 2;
+    bool compare_length = 3;
+}
+
 // Submits a list of Batches to be added to the blockchain.
 // If `wait_for_commit` is set to true, the validator will wait to respond
 // until all batches are committed, or until the specified `timeout`
@@ -165,6 +177,7 @@ message ClientStateListRequest {
     }
     string address = 3;
     PagingControls paging = 4;
+    repeated SortControls sorting = 5;
 }
 
 // A response that lists the data Entries from the state's merkle tree,
@@ -178,6 +191,7 @@ message ClientStateListRequest {
 //   * NO_ROOT - the head block or merkle_root specified was not found
 //   * NO_RESOURCE - the head/root specified is valid, but contains no data
 //   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
 
 message ClientStateListResponse {
     enum Status {
@@ -187,6 +201,7 @@ message ClientStateListResponse {
         NO_ROOT = 3;
         NO_RESOURCE = 4;
         INVALID_PAGING = 5;
+        INVALID_SORT = 6;
     }
     Status status = 1;
     repeated Leaf leaves = 2;
@@ -240,6 +255,7 @@ message ClientBlockListRequest {
     string head_id = 1;
     repeated string block_ids = 2;
     PagingControls paging = 3;
+    repeated SortControls sorting = 4;
 }
 
 // A response that lists a chain of blocks with the newest at the beginning,
@@ -252,6 +268,7 @@ message ClientBlockListRequest {
 //   * NO_ROOT - the head block specified was not found
 //   * NO_RESOURCE - no blocks were found with the parameters specified
 //   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientBlockListResponse {
     enum Status {
         OK = 0;
@@ -260,6 +277,7 @@ message ClientBlockListResponse {
         NO_ROOT = 3;
         NO_RESOURCE = 4;
         INVALID_PAGING = 5;
+        INVALID_SORT = 6;
     }
     Status status = 1;
     repeated Block blocks = 2;
@@ -297,6 +315,7 @@ message ClientBatchListRequest {
     string head_id = 1;
     repeated string batch_ids = 2;
     PagingControls paging = 3;
+    repeated SortControls sorting = 4;
 }
 
 // A response that lists batches from newest to oldest.
@@ -308,6 +327,7 @@ message ClientBatchListRequest {
 //   * NO_ROOT - the head block specified was not found
 //   * NO_RESOURCE - no batches were found with the parameters specified
 //   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientBatchListResponse {
     enum Status {
         OK = 0;
@@ -316,6 +336,7 @@ message ClientBatchListResponse {
         NO_ROOT = 3;
         NO_RESOURCE = 4;
         INVALID_PAGING = 5;
+        INVALID_SORT = 6;
     }
     Status status = 1;
     repeated Batch batches = 2;
@@ -352,6 +373,7 @@ message ClientTransactionListRequest {
     string head_id = 1;
     repeated string transaction_ids = 2;
     PagingControls paging = 3;
+    repeated SortControls sorting = 4;
 }
 
 // A response that lists transactions from newest to oldest.
@@ -363,6 +385,7 @@ message ClientTransactionListRequest {
 //   * NO_ROOT - the head block specified was not found
 //   * NO_RESOURCE - no txns were found with the parameters specified
 //   * INVALID_PAGING - the paging controls were malformed or out of range
+//   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientTransactionListResponse {
     enum Status {
         OK = 0;
@@ -371,6 +394,7 @@ message ClientTransactionListResponse {
         NO_ROOT = 3;
         NO_RESOURCE = 4;
         INVALID_PAGING = 5;
+        INVALID_SORT = 6;
     }
     Status status = 1;
     repeated Transaction transactions = 2;

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -189,6 +189,14 @@ class PagingInvalid(_ApiError):
                "out of range.")
 
 
+class SortInvalid(_ApiError):
+    api_code = 57
+    status_code = 400
+    title = 'Invalid Sort Query'
+    message = ("The sort request failed as written. Some of the keys "
+               "specified were not valid.")
+
+
 class InvalidStateAddress(_ApiError):
     api_code = 62
     status_code = 400

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -73,6 +73,7 @@ paths:
         - $ref: "#/parameters/count"
         - $ref: "#/parameters/min"
         - $ref: "#/parameters/max"
+        - $ref: "#/parameters/sort"
       responses:
         200:
           description: Successfully retrieved batches
@@ -214,6 +215,7 @@ paths:
         - $ref: "#/parameters/count"
         - $ref: "#/parameters/min"
         - $ref: "#/parameters/max"
+        - $ref: "#/parameters/sort"
       responses:
         200:
           description: Successfully retrieved state data
@@ -275,6 +277,7 @@ paths:
         - $ref: "#/parameters/count"
         - $ref: "#/parameters/min"
         - $ref: "#/parameters/max"
+        - $ref: "#/parameters/sort"
       responses:
         200:
           description: Successfully retrieved blocks
@@ -333,6 +336,7 @@ paths:
         - $ref: "#/parameters/count"
         - $ref: "#/parameters/min"
         - $ref: "#/parameters/max"
+        - $ref: "#/parameters/sort"
       responses:
         200:
           description: Successfully retrieved transactions
@@ -451,6 +455,17 @@ parameters:
     in: query
     type: string
     description: Id or index to end paging (inclusive)
+  sort:
+    name: sort
+    in: query
+    type: string
+    description: |
+      Comma-separated keys to sort a list by:
+        - can reference header keys explicitly or implicitly
+        - dot-notation indicates nested keys
+        - starting a key with a minus-sign indicates descending order
+        - ending a key with `.length` sorts by the length
+        - example: `sort=header.signer_pubkey,-transaction_ids.length`
 
 definitions:
   Head:

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -206,6 +206,7 @@ class RouteHandler(object):
         validator_query = client_pb2.ClientStateListRequest(
             head_id=request.url.query.get('head', None),
             address=request.url.query.get('address', None),
+            sorting=self._get_sorting_message(request),
             paging=self._make_paging_message(paging_controls))
 
         response = await self._query_validator(
@@ -267,6 +268,7 @@ class RouteHandler(object):
         validator_query = client_pb2.ClientBlockListRequest(
             head_id=request.url.query.get('head', None),
             block_ids=self._get_filter_ids(request),
+            sorting=self._get_sorting_message(request),
             paging=self._make_paging_message(paging_controls))
 
         response = await self._query_validator(
@@ -322,6 +324,7 @@ class RouteHandler(object):
         validator_query = client_pb2.ClientBatchListRequest(
             head_id=request.url.query.get('head', None),
             batch_ids=self._get_filter_ids(request),
+            sorting=self._get_sorting_message(request),
             paging=self._make_paging_message(paging_controls))
 
         response = await self._query_validator(
@@ -378,6 +381,7 @@ class RouteHandler(object):
         validator_query = client_pb2.ClientTransactionListRequest(
             head_id=request.url.query.get('head', None),
             transaction_ids=self._get_filter_ids(request),
+            sorting=self._get_sorting_message(request),
             paging=self._make_paging_message(paging_controls))
 
         response = await self._query_validator(
@@ -496,6 +500,12 @@ class RouteHandler(object):
         try:
             if content.status == proto.INVALID_PAGING:
                 raise errors.PagingInvalid()
+        except AttributeError:
+            pass
+
+        try:
+            if content.status == proto.INVALID_SORT:
+                raise errors.SortInvalid()
         except AttributeError:
             pass
 
@@ -718,6 +728,37 @@ class RouteHandler(object):
             end_id=controls.get('end_id', None),
             start_index=start_index,
             count=count)
+
+    @staticmethod
+    def _get_sorting_message(request):
+        """Parses the sort query into a list of SortControls protobuf messages.
+        """
+        control_list = []
+        sort_query = request.url.query.get('sort', None)
+        if sort_query is None:
+            return control_list
+
+        for key_string in sort_query.split(','):
+            if key_string[0] == '-':
+                reverse = True
+                key_string = key_string[1:]
+            else:
+                reverse = False
+
+            keys = key_string.split('.')
+
+            if keys[-1] == 'length':
+                compare_length = True
+                keys.pop()
+            else:
+                compare_length = False
+
+            control_list.append(client_pb2.SortControls(
+                keys=keys,
+                reverse=reverse,
+                compare_length=compare_length))
+
+        return control_list
 
     def _set_wait(self, request, validator_query):
         """Parses the `wait` query parameter, and sets the corresponding

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -22,6 +22,7 @@ from sawtooth_rest_api.route_handlers import RouteHandler
 from sawtooth_rest_api.protobuf.client_pb2 import Leaf
 from sawtooth_rest_api.protobuf.client_pb2 import PagingControls
 from sawtooth_rest_api.protobuf.client_pb2 import PagingResponse
+from sawtooth_rest_api.protobuf.client_pb2 import SortControls
 from sawtooth_rest_api.protobuf.block_pb2 import Block
 from sawtooth_rest_api.protobuf.block_pb2 import BlockHeader
 from sawtooth_rest_api.protobuf.batch_pb2 import BatchList
@@ -384,6 +385,16 @@ class Mocks(object):
             total_resources=total,
             next_id=next_id,
             previous_id=previous_id)
+
+    @staticmethod
+    def make_sort_controls(*keys, reverse=False, compare_length=False):
+        """Returns a SortControls Protobuf in a list. Use concatenation to
+        combine multiple sort controls.
+        """
+        return [SortControls(
+            keys=keys,
+            reverse=reverse,
+            compare_length=compare_length)]
 
     @staticmethod
     def make_leaves(**leaf_data):

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -495,6 +495,223 @@ class BlockListTests(BaseApiTest):
         self.assert_has_valid_data_list(response, 3)
         self.assert_blocks_well_formed(response['data'], 'd', 'c', 'b')
 
+    @unittest_run_loop
+    async def test_block_list_sorted(self):
+        """Verifies GET /blocks can send proper sort controls.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three blocks with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'header_signature'
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/blocks?head=2&sort=header_signature'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full blocks with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        blocks = Mocks.make_blocks('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+
+        response = await self.get_assert_200('/blocks?sort=header_signature')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('header_signature')
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/blocks?head=2&sort=header_signature')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_batch_list_with_bad_sort(self):
+        """Verifies a GET /blocks with a bad sort breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of INVALID_PAGING
+
+        It should send back a JSON response with:
+            - a response status of 400
+            - an error property with a code of 57
+        """
+        self.stream.preset_response(self.status.INVALID_SORT)
+        response = await self.get_assert_status('/blocks?sort=bad', 400)
+
+        self.assert_has_valid_error(response, 57)
+
+    @unittest_run_loop
+    async def test_block_list_sorted_with_nested_keys(self):
+        """Verifies GET /blocks can send proper sort controls with nested keys.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three blocks with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with keys of 'header' and 'signer_pubkey'
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link ending in '/blocks?head=2&sort=header.signer_pubkey'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full blocks with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        blocks = Mocks.make_blocks('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+
+        response = await self.get_assert_200(
+            '/blocks?sort=header.signer_pubkey')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/blocks?head=2&sort=header.signer_pubkey')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_block_list_sorted_in_reverse(self):
+        """Verifies a GET /blocks can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three blocks with ids '2', '1', and '0'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'header_signature' that is reversed
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/blocks?head=2&sort=-header_signature'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full blocks with ids '2', '1', and '0'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        blocks = Mocks.make_blocks('2', '1', '0')
+        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+
+        response = await self.get_assert_200('/blocks?sort=-header_signature')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls(
+            'header_signature', reverse=True)
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/blocks?head=2&sort=-header_signature')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_blocks_well_formed(response['data'], '2', '1', '0')
+
+    @unittest_run_loop
+    async def test_block_list_sorted_by_length(self):
+        """Verifies a GET /blocks can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three blocks with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'batches' sorted by length
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/blocks?head=2&sort=batches.length'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full blocks with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        blocks = Mocks.make_blocks('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+
+        response = await self.get_assert_200('/blocks?sort=batches.length')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('batches', compare_length=True)
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/blocks?head=2&sort=batches.length')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_block_list_sorted_by_many_keys(self):
+        """Verifies a GET /blocks can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three blocks with ids '2', '1', and '0'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - multiple sort controls with:
+                * a key of 'header_signature' that is reversed
+                * a key of 'batches' that is sorted by length
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - link with '/blocks?head=2&sort=-header_signature,batches.length'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full blocks with ids '2', '1', and '0'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        blocks = Mocks.make_blocks('2', '1', '0')
+        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+
+        response = await self.get_assert_200(
+            '/blocks?sort=-header_signature,batches.length')
+        page_controls = Mocks.make_paging_controls()
+        sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
+                   Mocks.make_sort_controls('batches', compare_length=True))
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/blocks?head=2&sort=-header_signature,batches.length')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_blocks_well_formed(response['data'], '2', '1', '0')
+
 
 class BlockGetTests(BaseApiTest):
 

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -514,6 +514,223 @@ class TransactionListTests(BaseApiTest):
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], 'd', 'c', 'b')
 
+    @unittest_run_loop
+    async def test_txn_list_sorted(self):
+        """Verifies GET /transactions can send proper sort controls.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'header_signature'
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/transactions?head=2&sort=header_signature'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full transactions with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        transactions = Mocks.make_txns('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_assert_200('/transactions?sort=header_signature')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('header_signature')
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/transactions?head=2&sort=header_signature')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_batch_list_with_bad_sort(self):
+        """Verifies a GET /transactions with a bad sort breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of INVALID_PAGING
+
+        It should send back a JSON response with:
+            - a response status of 400
+            - an error property with a code of 57
+        """
+        self.stream.preset_response(self.status.INVALID_SORT)
+        response = await self.get_assert_status('/transactions?sort=bad', 400)
+
+        self.assert_has_valid_error(response, 57)
+
+    @unittest_run_loop
+    async def test_txn_list_sorted_with_nested_keys(self):
+        """Verifies GET /transactions can send proper sort controls with nested keys.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with keys of 'header' and 'signer_pubkey'
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link ending in '/transactions?head=2&sort=header.signer_pubkey'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full transactions with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        transactions = Mocks.make_txns('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_assert_200(
+            '/transactions?sort=header.signer_pubkey')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/transactions?head=2&sort=header.signer_pubkey')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_txn_list_sorted_in_reverse(self):
+        """Verifies a GET /transactions can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids '2', '1', and '0'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'header_signature' that is reversed
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/transactions?head=2&sort=-header_signature'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full transactions with ids '2', '1', and '0'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        transactions = Mocks.make_txns('2', '1', '0')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_assert_200('/transactions?sort=-header_signature')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls(
+            'header_signature', reverse=True)
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/transactions?head=2&sort=-header_signature')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+
+    @unittest_run_loop
+    async def test_txn_list_sorted_by_length(self):
+        """Verifies a GET /transactions can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids '0', '1', and '2'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - sort controls with a key of 'payload' sorted by length
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - a link property ending in '/transactions?head=2&sort=payload.length'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full transactions with ids '0', '1', and '2'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        transactions = Mocks.make_txns('0', '1', '2')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_assert_200('/transactions?sort=payload.length')
+        page_controls = Mocks.make_paging_controls()
+        sorting = Mocks.make_sort_controls('payload', compare_length=True)
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/transactions?head=2&sort=payload.length')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+
+    @unittest_run_loop
+    async def test_txn_list_sorted_by_many_keys(self):
+        """Verifies a GET /transactions can send proper sort parameters.
+
+        It will receive a Protobuf response with:
+            - a head id of '2'
+            - a paging response with a start of 0, and 3 total resources
+            - three transactions with ids '2', '1', and '0'
+
+        It should send a Protobuf request with:
+            - empty paging controls
+            - multiple sort controls with:
+                * a key of 'header_signature' that is reversed
+                * a key of 'payload' that is sorted by length
+
+        It should send back a JSON response with:
+            - a status of 200
+            - a head property of '2'
+            - link with '/transactions?head=2&sort=-header_signature,payload.length'
+            - a paging property that matches the paging response
+            - a data property that is a list of 3 dicts
+            - and those dicts are full transactions with ids '2', '1', and '0'
+        """
+        paging = Mocks.make_paging_response(0, 3)
+        transactions = Mocks.make_txns('2', '1', '0')
+        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+
+        response = await self.get_assert_200(
+            '/transactions?sort=-header_signature,payload.length')
+        page_controls = Mocks.make_paging_controls()
+        sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
+                   Mocks.make_sort_controls('payload', compare_length=True))
+        self.stream.assert_valid_request_sent(
+            paging=page_controls,
+            sorting=sorting)
+
+        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_link(response,
+            '/transactions?head=2&sort=-header_signature,payload.length')
+        self.assert_has_valid_paging(response, paging)
+        self.assert_has_valid_data_list(response, 3)
+        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+
 
 class TransactionGetTests(BaseApiTest):
 

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -15,6 +15,7 @@
 
 import abc
 import logging
+from functools import cmp_to_key
 # pylint: disable=import-error,no-name-in-module
 # needed for google.protobuf import
 from google.protobuf.message import DecodeError
@@ -26,6 +27,8 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 
 from sawtooth_validator.protobuf import client_pb2
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf import validator_pb2
 
 
@@ -382,6 +385,118 @@ class _Pager(object):
             return resources[index].address
 
 
+class _Sorter(object):
+    """A static class containing a method to sort lists of resources based on
+    SortControls sent with the request.
+    """
+    @classmethod
+    def sort_resources(cls, request, resources, fail_enum, header_proto=None):
+        """Sorts a list of resources based on a list of sort controls
+
+        Args:
+            request (object): The parsed protobuf request object
+            resources (list of objects): The resources to be sorted
+            fail_enum (int, enum): The enum status to raise with invalid keys
+            header_proto(class): Class to decode a resources header
+
+        Returns:
+            list: The sorted list of resources
+        """
+        if not request.sorting:
+            return resources
+
+        value_handlers = cls._get_handler_set(request, fail_enum, header_proto)
+
+        def sorter(resource_a, resource_b):
+            for handler in value_handlers:
+                val_a, val_b = handler.get_sort_values(resource_a, resource_b)
+
+                if val_a < val_b:
+                    return handler.xform_result(-1)
+                if val_a > val_b:
+                    return handler.xform_result(1)
+
+            return 0
+
+        return sorted(resources, key=cmp_to_key(sorter))
+
+    @classmethod
+    def _get_handler_set(cls, request, fail_enum, header_proto=None):
+        """Goes through the list of SortControls and returns a list of
+        unique _ValueHandlers. Maintains order, but drops SortControls that
+        have already appeared to help prevent spamming.
+        """
+        added = set()
+        handlers = []
+
+        for controls in request.sorting:
+            control_bytes = controls.SerializeToString()
+            if control_bytes not in added:
+                added.add(control_bytes)
+                handlers.append(
+                    cls._ValueHandler(controls, fail_enum, header_proto))
+
+        return handlers
+
+    class _ValueHandler(object):
+        """Handles fetching proper compare values for one SortControls.
+
+        Args:
+            controls (object): Individual SortControl object
+            fail_status (integer, enum): Status to send when controls are bad
+            header_proto (class): Class to decode the resource header
+        """
+        def __init__(self, controls, fail_status, header_proto=None):
+            self._keys = controls.keys
+            self._compare_length = controls.compare_length
+            self._fail_status = fail_status
+            self._header_proto = header_proto
+
+            if controls.reverse:
+                self.xform_result = lambda x: -x
+            else:
+                self.xform_result = lambda x: x
+
+            if header_proto and self._keys[0] == 'header':
+                self._had_explicit_header = True
+                self._keys = self._keys[1:]
+            else:
+                self._had_explicit_header = False
+
+        def get_sort_values(self, resource_a, resource_b):
+            """Applies sort control logic to fetch from two resources the
+            values that should actually be compared.
+            """
+            if (self._had_explicit_header or
+                    self._header_proto and
+                    not hasattr(resource_a, self._keys[0])):
+                resource_a = self._get_header(resource_a)
+                resource_b = self._get_header(resource_b)
+
+            for key in self._keys:
+                try:
+                    resource_a = getattr(resource_a, key)
+                    resource_b = getattr(resource_b, key)
+                except AttributeError:
+                    raise _ResponseFailed(self._fail_status)
+
+            if self._compare_length:
+                try:
+                    resource_a = len(resource_a)
+                    resource_b = len(resource_b)
+                except TypeError:
+                    raise _ResponseFailed(self._fail_status)
+
+            return resource_a, resource_b
+
+        def _get_header(self, resource):
+            """Fetches a header from a resource.
+            """
+            header = self._header_proto()
+            header.ParseFromString(resource.header)
+            return header
+
+
 class BatchSubmitFinisher(_ClientRequestHandler):
     def __init__(self, block_store, batch_cache):
         super().__init__(
@@ -459,6 +574,11 @@ class StateListRequest(_ClientRequestHandler):
         # Order leaves, remove if tree.leaves refactored to be ordered
         leaves.sort(key=lambda l: l.address)
 
+        leaves = _Sorter.sort_resources(
+            request,
+            leaves,
+            self._status.INVALID_SORT)
+
         leaves, paging = _Pager.paginate_resources(
             request,
             leaves,
@@ -518,6 +638,12 @@ class BlockListRequest(_ClientRequestHandler):
             lambda filter_id: self._block_store[filter_id].block,
             lambda block: [block])
 
+        blocks = _Sorter.sort_resources(
+            request,
+            blocks,
+            self._status.INVALID_SORT,
+            BlockHeader)
+
         blocks, paging = _Pager.paginate_resources(
             request,
             blocks,
@@ -569,6 +695,12 @@ class BatchListRequest(_ClientRequestHandler):
             self._block_store.get_batch,
             lambda block: [a for a in block.batches])
 
+        batches = _Sorter.sort_resources(
+            request,
+            batches,
+            self._status.INVALID_SORT,
+            BatchHeader)
+
         batches, paging = _Pager.paginate_resources(
             request,
             batches,
@@ -619,6 +751,12 @@ class TransactionListRequest(_ClientRequestHandler):
             request.transaction_ids,
             self._block_store.get_transaction,
             lambda block: [t for a in block.batches for t in a.transactions])
+
+        transactions = _Sorter.sort_resources(
+            request,
+            transactions,
+            self._status.INVALID_SORT,
+            TransactionHeader)
 
         transactions, paging = _Pager.paginate_resources(
             request,

--- a/validator/tests/unit3/test_client_request_handlers/base_case.py
+++ b/validator/tests/unit3/test_client_request_handlers/base_case.py
@@ -44,6 +44,15 @@ class ClientHandlerTestCase(unittest.TestCase):
         paging_request = client_pb2.PagingControls(**paging_args)
         return self.make_request(paging=paging_request, **kwargs)
 
+    def make_sort_controls(self, *keys, reverse=False, compare_length=False):
+        """Creates a SortControls object and returns it in a list. Use
+        concatenation to combine multiple SortControls.
+        """
+        return [client_pb2.SortControls(
+            keys=keys,
+            reverse=reverse,
+            compare_length=compare_length)]
+
     def _serialize(self, **kwargs):
         request = self._request_proto(**kwargs)
         return request.SerializeToString()
@@ -63,6 +72,12 @@ class ClientHandlerTestCase(unittest.TestCase):
         Simulates what block store would look like if genesis had not been run.
         """
         del self._store.store['chain_head_id']
+
+    def add_blocks(self, *base_ids):
+        """Adds new blocks to a test case's block store with specified base_ids.
+        """
+        for base_id in base_ids:
+            self._store.add_block(base_id)
 
     def assert_all_instances(self, items, cls):
         """Checks that all items in a collection are instances of a class

--- a/validator/tests/unit3/test_client_request_handlers/mocks.py
+++ b/validator/tests/unit3/test_client_request_handlers/mocks.py
@@ -36,11 +36,11 @@ def _increment_key(key, offset=1):
 def _make_mock_transaction(base_id='id', payload='payload'):
     txn_id = 't-' + base_id
     header = TransactionHeader(
-        batcher_pubkey='pubkey',
+        batcher_pubkey='pubkey-' + base_id,
         family_name='family',
         family_version='0.0',
         nonce=txn_id,
-        signer_pubkey='pubkey')
+        signer_pubkey='pubkey-' + base_id)
 
     return Transaction(
         header=header.SerializeToString(),
@@ -52,7 +52,7 @@ def make_mock_batch(base_id='id'):
     txn = _make_mock_transaction(base_id)
 
     header = BatchHeader(
-        signer_pubkey='pubkey',
+        signer_pubkey='pubkey-' + base_id,
         transaction_ids=[txn.header_signature])
 
     return Batch(
@@ -88,7 +88,7 @@ class MockBlockStore(BlockStore):
         header = BlockHeader(
             block_num=num,
             previous_block_id=previous_id,
-            signer_pubkey='pubkey',
+            signer_pubkey='pubkey-' + base_id,
             batch_ids=[block_id],
             consensus=b'consensus',
             state_root_hash=root)

--- a/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
@@ -402,7 +402,7 @@ class TestStateListRequests(ClientHandlerTestCase):
                 * a total resource count of 2
             - a list of leaves with 1 item
             - that item is an instance of Leaf
-            - that has a header_signature of 'b-0'
+            - that Leaf has an address of 'b' and data of b'4'
         """
         response = self.make_paged_request(count=1, start_index=1, head_id='B-1')
 
@@ -426,7 +426,7 @@ class TestStateListRequests(ClientHandlerTestCase):
             - a paging response with a total resource count of 1
             - a list of leaves with 1 item
             - that item is an instance of Leaf
-            - that has a header_signature of 'b-0'
+            - that Leaf has an address of 'b' and data of b'5'
         """
         response = self.make_paged_request(count=1, start_index=0, address='b')
 

--- a/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/unit3/test_client_request_handlers/test_state_handlers.py
@@ -438,6 +438,81 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual('b', response.leaves[0].address)
         self.assertEqual(b'5', response.leaves[0].data)
 
+    def test_state_list_sorted_by_key(self):
+        """Verifies data list requests work sorted by header_signature.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response showing all 3 resources returned
+            - a list of leaves with 3 items
+            - the items are instances of Leaf
+            - the first Leaf has an address of 'a' and data of b'3'
+            - the last Leaf has an address of 'c' and data of b'7'
+        """
+        controls = self.make_sort_controls('address')
+        response = self.make_request(sorting=controls)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response)
+        self.assertEqual(3, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+
+        self.assertEqual('a', response.leaves[0].address)
+        self.assertEqual(b'3', response.leaves[0].data)
+        self.assertEqual('c', response.leaves[2].address)
+        self.assertEqual(b'7', response.leaves[2].data)
+
+    def test_state_list_sorted_by_bad_key(self):
+        """Verifies data list requests break properly sorted by a bad key.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of INVALID_SORT
+            - that head_id, paging, and leaves are missing
+        """
+        controls = self.make_sort_controls('bad')
+        response = self.make_request(sorting=controls)
+
+        self.assertEqual(self.status.INVALID_SORT, response.status)
+        self.assertFalse(response.head_id)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.leaves)
+
+    def test_state_list_sorted_in_reverse(self):
+        """Verifies data list requests work sorted by a key in reverse.
+
+        Queries the latest state in the default mock db:
+            {'a': b'3', 'b': b'5', 'c': b'7'}
+
+        Expects to find:
+            - a status of OK
+            - a head_id of 'B-2', the latest
+            - a paging response showing all 3 resources returned
+            - a list of leaves with 3 items
+            - the items are instances of Leaf
+            - the first Leaf has an address of 'c' and data of b'7'
+            - the last Leaf has an address of 'a' and data of b'3'
+        """
+        controls = self.make_sort_controls('data', reverse=True)
+        response = self.make_request(sorting=controls)
+
+        self.assertEqual(self.status.OK, response.status)
+        self.assertEqual('B-2', response.head_id)
+        self.assert_valid_paging(response)
+        self.assertEqual(3, len(response.leaves))
+        self.assert_all_instances(response.leaves, client_pb2.Leaf)
+        self.assertEqual('c', response.leaves[0].address)
+        self.assertEqual(b'7', response.leaves[0].data)
+        self.assertEqual('a', response.leaves[2].address)
+        self.assertEqual(b'3', response.leaves[2].data)
+
 
 class TestStateGetRequests(ClientHandlerTestCase):
     def setUp(self):


### PR DESCRIPTION
Results to endpoints that list resources can now be sorted validator-side (pre-pagination) using the `sort` query parameter. It accepts a comma-separated list of keys which can be modified with some useful syntax:

- dot-notation indicates nested keys
- the header can be explicitly or implicity referenced
- starting with a minus sign indicates descending order
- ending with ".length" indicates the lengths should be compared
- additional key strings are tie-breakers for earlier ones
- example: `sort=-header.transaction_ids.length,signer_pubkey`

Includes a full set of unit tests.