### PR TITLE
Xo update

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -174,6 +174,9 @@ main() {
                 deployment)
                     test_deployment
                     ;;
+                xo)
+                    test_xo
+                    ;;
                 *)
                     echo "Module '$MODULE' not found."
                     ;;
@@ -286,6 +289,19 @@ test_integration() {
 
 test_deployment() {
     run_docker_test systemd_services -s integration_test
+}
+
+test_xo() {
+    # xo python
+    run_docker_test ./sdk/examples/xo_python/tests/tp-xo-python.yaml -s validator
+    copy_coverage .coverage.tp-xo-python
+    run_docker_test xo-python-smoke -s integration_test
+    copy_coverage .coverage.xo-smoke
+    # xo js
+    run_docker_test ./sdk/examples/xo_python/tests/tp-xo-javascript.yaml -s validator
+    copy_coverage .coverage.tp-xo-javascript
+    run_docker_test xo-javascript-smoke -s integration_test
+    copy_coverage .coverage.xo-javascript-smoke
 }
 
 copy_coverage() {

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -276,8 +276,8 @@ test_python_sdk() {
     copy_coverage .coverage.workload
     run_docker_test xo-python-smoke -s integration_test
     copy_coverage .coverage.xo-python-smoke
-    run_docker_test two_families -s integration_test
-    copy_coverage .coverage.two_families
+    run_docker_test two-families -s integration_test
+    copy_coverage .coverage.two-families
 }
 
 test_integration() {

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -271,8 +271,8 @@ test_python_sdk() {
     copy_coverage .coverage.intkey-python-smoke
     run_docker_test workload -s integration_test
     copy_coverage .coverage.workload
-    run_docker_test xo-smoke -s integration_test
-    copy_coverage .coverage.xo-smoke
+    run_docker_test xo-python-smoke -s integration_test
+    copy_coverage .coverage.xo-python-smoke
     run_docker_test two_families -s integration_test
     copy_coverage .coverage.two_families
 }

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -302,6 +302,9 @@ test_xo() {
     copy_coverage .coverage.tp-xo-javascript
     run_docker_test xo-javascript-smoke -s integration_test
     copy_coverage .coverage.xo-javascript-smoke
+    # all languages
+    run_docker_test xo-all-lang-smoke
+    copy_coverage .coverage.xo-all-lang-smoke
 }
 
 copy_coverage() {

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -14,7 +14,9 @@
 # ------------------------------------------------------------------------------
 
 import json
+from base64 import b64decode
 from http.client import RemoteDisconnected
+
 import requests
 # pylint: disable=no-name-in-module,import-error
 # needed for the google.protobuf imports to pass pylint
@@ -24,8 +26,8 @@ from sawtooth_cli.exceptions import CliException
 
 
 class RestClient(object):
-    def __init__(self, base_url=None):
-        self._base_url = base_url or 'http://localhost:8080'
+    def __init__(self, url=None):
+        self.url = url or 'http://localhost:8080'
 
     def list_blocks(self):
         return self._get('/blocks')['data']
@@ -47,6 +49,14 @@ class RestClient(object):
 
     def list_state(self, subtree=None, head=None):
         return self._get('/state', address=subtree, head=head)
+
+    def get_data(self, subtree=None, head=None):
+        return [
+            b64decode(entry['data'])
+            for entry in self.list_state(
+                subtree=subtree,
+                head=head)['data']
+        ]
 
     def get_leaf(self, address, head=None):
         return self._get('/state/' + address, head=head)
@@ -81,7 +91,7 @@ class RestClient(object):
 
     def _get(self, path, **queries):
         code, json_result = self._submit_request(
-            self._base_url + path,
+            self.url + path,
             params=self._format_queries(queries),
         )
 
@@ -109,7 +119,7 @@ class RestClient(object):
         headers['Content-Length'] = '%d' % len(data)
 
         code, json_result = self._submit_request(
-            self._base_url + path,
+            self.url + path,
             params=self._format_queries(queries),
             data=data,
             headers=headers,
@@ -154,7 +164,7 @@ class RestClient(object):
         except requests.exceptions.ConnectionError as e:
             raise CliException(
                 ('Unable to connect to "{}": '
-                 'make sure URL is correct').format(self._base_url))
+                 'make sure URL is correct').format(self.url))
 
     @staticmethod
     def _format_queries(queries):

--- a/integration/sawtooth_integration/docker/two-families.yaml
+++ b/integration/sawtooth_integration/docker/two-families.yaml
@@ -99,4 +99,5 @@ services:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/intkey_python:\
         /project/sawtooth-core/integration:\
+        /project/sawtooth-core/cli:\
         /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/docker/xo-all-lang-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-all-lang-smoke.yaml
@@ -1,0 +1,101 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  tp_config:
+    image: sawtooth-tp_config:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    depends_on:
+      - validator
+    command: tp_config -vv tcp://validator:40000
+    stop_signal: SIGKILL
+
+  tp_xo_python:
+    image: sawtooth-tp_xo_python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    depends_on:
+      - validator
+    command: tp_xo_python -v tcp://validator:40000
+    stop_signal: SIGKILL
+
+  tp_xo_javascript:
+    image: sawtooth-tp_xo_javascript:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    depends_on:
+      - validator
+    command: tp_xo_javascript tcp://validator:40000
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8800
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        validator --public-uri tcp://validator:8800 -v \
+            --component-endpoint tcp://eth0:40000 \
+            --network-endpoint tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest_api:
+    image: sawtooth-rest_api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8080
+    depends_on:
+     - validator
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
+    stop_signal: SIGKILL
+
+  integration_test:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    depends_on:
+      - validator
+      - rest_api
+    # Wait for rest_api
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_xo_smoke.TestXoSmoke
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"

--- a/integration/sawtooth_integration/docker/xo-javascript-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-javascript-smoke.yaml
@@ -86,4 +86,5 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/integration:\
-        /project/sawtooth-core/signing"
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"

--- a/integration/sawtooth_integration/docker/xo-python-smoke.yaml
+++ b/integration/sawtooth_integration/docker/xo-python-smoke.yaml
@@ -86,4 +86,5 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/integration:\
-        /project/sawtooth-core/signing"
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -90,8 +90,17 @@ class XOHandler extends TransactionHandler {
       .then((update) => {
         let header = TransactionHeader.decode(transactionProcessRequest.header)
         let player = header.signerPubkey
-        if (!update.name) {
+
+        let name = update.name
+        if (!name) {
           throw new InvalidTransaction('Name is required')
+        }
+
+        console.log(`${name.indexOf('|')}`)
+
+        if (name.indexOf(',') !== -1 || name.indexOf('|') !== -1) {
+          throw new InvalidTransaction(
+            'Name cannot contain "," or "|"')
         }
 
         if (!update.action) {

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -33,9 +33,10 @@ const _decodeRequest = (payload) =>
   new Promise((resolve, reject) => {
     payload = payload.toString().split(",")
     if (payload.length == 3){
-      resolve({name: payload[0],
-              action: payload[1],
-              space: payload[2]});
+      resolve({
+        action: payload[0],
+        name: payload[1],
+        space: payload[2]});
     }
     else {
       let reason = new InvalidTransaction("Invalid payload serialization")

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -211,13 +211,13 @@ const _handleTake = (state, address, update, player) => (possibleAddressValues) 
   stateValue.board = boardList.join("")
 
   if (_isWin(stateValue.board, "X")) {
-    stateValue.GameState = "P1-WIN"
+    stateValue.gameState = "P1-WIN"
   }
   else if (_isWin(stateValue.board, "O")) {
-    stateValue.GameState = "P2-WIN"
+    stateValue.gameState = "P2-WIN"
   }
   else if (stateValue.board.search('-') == -1) {
-    stateValue.GameState = "TIE"
+    stateValue.gameState = "TIE"
   }
 
   let setValue = Buffer.from([stateValue.board, stateValue.gameState, stateValue.player1,

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -31,7 +31,7 @@ const XO_NAMESPACE = _hash(XO_FAMILY).substring(0, 6)
 
 const _decodeRequest = (payload) =>
   new Promise((resolve, reject) => {
-    payload = payload.toString().split(",")
+    payload = payload.toString().split(',')
     if (payload.length == 3){
       resolve({
         action: payload[0],
@@ -39,29 +39,37 @@ const _decodeRequest = (payload) =>
         space: payload[2]});
     }
     else {
-      let reason = new InvalidTransaction("Invalid payload serialization")
+      let reason = new InvalidTransaction('Invalid payload serialization')
       reject(reason)
     }
   })
 
-const _decodeState = (data) => {
-  // Set "" to any missing data
-  data = data.toString().split(",")
-  if (data.length < 5){
-    while (data.length < 5){
-      data.push("")
+const _decodeStateData = (data, name) => {
+  let stringData = data.toString()
+
+  if (!stringData) {
+    return {
+      board: '',
+      gameState: '',
+      player1: '',
+      player2: '',
+      addressData: [],
     }
   }
-  return {board: data[0],
-          gameState: data[1],
-          player1: data[2],
-          player2: data[3],
-          storedName: data[4]}
-}
 
-const _toInternalError = (err) => {
-  let message = (err.message) ? err.message : err
-  throw new InternalError(message)
+  let addressData = stringData.split('|').map((x) => x.split(','))
+
+  let gameInfo = addressData.filter((x) => (x[0] === name))[0]
+
+  addressData = addressData.filter((x) => (x[0] !== name))
+
+  return {
+    board: gameInfo[1],
+    gameState: gameInfo[2],
+    player1: gameInfo[3],
+    player2: gameInfo[4],
+    addressData: addressData,
+  }
 }
 
 const _setEntry = (state, address, data) => {
@@ -71,76 +79,54 @@ const _setEntry = (state, address, data) => {
   return state.set(entries)
 }
 
-const _gameToStr = (board, state, player1, player2, name) => {
-    board = board.replace(/-/g, " ")
-    board = board.split("")
-    let out = ""
-    out += `GAME: ${name}\n`
-    out += `PLAYER 1: ${player1.substring(0,6)}\n`
-    out += `PLAYER 2: ${player2.substring(0,6)}\n`
-    out += `STATE: ${state}\n`
-    out += `\n`
-    out += `${board[0]} | ${board[1]} | ${board[2]} \n`
-    out += `---|---|--- \n`
-    out += `${board[3]} | ${board[4]} | ${board[5]} \n`
-    out += `---|---|--- \n`
-    out += `${board[6]} | ${board[7]} | ${board[8]} \n`
-    return out
-}
+class XOHandler extends TransactionHandler {
+  constructor () {
+    super(XO_FAMILY, '1.0', 'csv-utf8', [XO_NAMESPACE])
+  }
 
-const _display = (msg) => {
-    let n = msg.search(`\n`)
-    let length = 0
-    let line_lengths = []
-    if (n != -1) {
-        msg = msg.split("\n")
-        for (let i=0; i < msg.length; i++){
-          if (msg[i].length > length) {
-            length = msg[i].length
-          }
+  apply (transactionProcessRequest, state) {
+    return _decodeRequest(transactionProcessRequest.payload)
+      .catch(_toInternalError)
+      .then((update) => {
+        let header = TransactionHeader.decode(transactionProcessRequest.header)
+        let player = header.signerPubkey
+        if (!update.name) {
+          throw new InvalidTransaction('Name is required')
         }
-      }
-    else {
-        length = msg.length
-        msg = [msg]
-      }
 
-    console.log("+" + "-".repeat(length + 2) + "+")
-    for (let i=0; i < msg.length; i++){
-        let len = length - msg[i].length
-
-        if ((len%2) == 1){
-          console.log("+ " + " ".repeat(Math.floor(len/2)) + msg[i] +
-                      " ".repeat(Math.floor(len/2+1))+ " +")
+        if (!update.action) {
+          throw new InvalidTransaction('Action is required')
         }
-        else{
-          console.log("+ " + " ".repeat(Math.floor(len/2)) + msg[i] +
-                      " ".repeat(Math.floor(len/2))+ " +")
-          }
-      }
-    console.log("+" + "-".repeat(length + 2) + "+")
-}
 
-const _isWin = (board, letter) => {
-    let wins = [[1, 2, 3], [4, 5, 6], [7, 8, 9],
-            [1, 4, 7], [2, 5, 8], [3, 6, 9],
-            [1, 5, 9], [3, 5, 7]]
-    let win
-    for (let i=0; i < wins.length; i++) {
-        win = wins[i]
-        if (board[win[0] - 1] === letter
-            && board[win[1] - 1] === letter
-            && board[win[2] - 1] === letter) {
-              return true
+        // Perform the action
+        let handlerFn
+        if (update.action === 'create') {
+          handlerFn = _handleCreate
+        } else if (update.action === 'take') {
+          handlerFn = _handleTake
+        } else {
+          throw new InvalidTransaction(`Action must be create or take not ${update.action}`)
+        }
+
+        let address = XO_NAMESPACE + _hash(update.name).slice(-64)
+
+        return state.get([address]).then(handlerFn(state, address, update, player))
+          .then((addresses) => {
+            if (addresses.length === 0) {
+              throw new InternalError('State Error!')
             }
-        }
-    return false
+          })
+      })
+  }
+
 }
 
 const _handleCreate = (state, address, update, player) => (possibleAddressValues) => {
   let stateValueRep = possibleAddressValues[address]
 
-  let stateValue = _decodeState(stateValueRep)
+  let name = update.name
+
+  let stateValue = _decodeStateData(stateValueRep, name)
   if (stateValue.board != "") {
     throw new InvalidTransaction("Invalid Action: Game already exists.")
   }
@@ -149,19 +135,28 @@ const _handleCreate = (state, address, update, player) => (possibleAddressValues
   let gameState = "P1-NEXT"
   let player1 = ""
   let player2 = ""
-  let setValue = Buffer.from([board, gameState, player1, player2, update.name].join())
+
+  let gameString = [name, board, gameState, player1, player2].join(',')
+
+  let addressData = stateValue.addressData.concat([gameString])
+
+  addressData.sort()
+
+  let setValue = Buffer.from(
+    addressData.join('|'))
+
   _display(`Player ${player.toString().substring(0, 6)} created a game.`)
+
   return _setEntry(state, address, setValue)
 }
 
 const _handleTake = (state, address, update, player) => (possibleAddressValues) => {
   let stateValueRep = possibleAddressValues[address]
-  let stateValue
-  stateValue = _decodeState(stateValueRep)
 
-  if (stateValue.storedName != update.name) {
-    throw new InternalError("Hash collision")
-  }
+  let name = update.name
+
+  let stateValue = _decodeStateData(stateValueRep, name)
+
   try{
     let space = parseInt(update.space)
   }
@@ -221,8 +216,20 @@ const _handleTake = (state, address, update, player) => (possibleAddressValues) 
     stateValue.gameState = "TIE"
   }
 
-  let setValue = Buffer.from([stateValue.board, stateValue.gameState, stateValue.player1,
-      stateValue.player2, update.name].join())
+  let board = stateValue.board
+  let gameState = stateValue.gameState
+  let player1 = stateValue.player1
+  let player2 = stateValue.player2
+
+  let gameString = [name, board, gameState, player1, player2].join(',')
+
+  let addressData = stateValue.addressData.concat([gameString])
+
+  addressData.sort()
+
+  let setValue = Buffer.from(
+    addressData.join('|'))
+
   _display(`Player ${player.toString().substring(0, 6)} takes space: ${update.space}\n\n` +
            _gameToStr(stateValue.board, stateValue.gameState, stateValue.player1
              , stateValue.player2, update.name))
@@ -230,46 +237,75 @@ const _handleTake = (state, address, update, player) => (possibleAddressValues) 
   return _setEntry(state, address, setValue)
 }
 
-class XOHandler extends TransactionHandler {
-  constructor () {
-    super(XO_FAMILY, '1.0', 'csv-utf8', [XO_NAMESPACE])
-  }
+const _toInternalError = (err) => {
+  let message = (err.message) ? err.message : err
+  throw new InternalError(message)
+}
 
-  apply (transactionProcessRequest, state) {
-    return _decodeRequest(transactionProcessRequest.payload)
-      .catch(_toInternalError)
-      .then((update) => {
-        let header = TransactionHeader.decode(transactionProcessRequest.header)
-        let player = header.signerPubkey
-        if (!update.name) {
-          throw new InvalidTransaction('Name is required')
-        }
-
-        if (!update.action) {
-          throw new InvalidTransaction('Action is required')
-        }
-
-        // Perform the action
-        let handlerFn
-        if (update.action === 'create') {
-          handlerFn = _handleCreate
-        } else if (update.action === 'take') {
-          handlerFn = _handleTake
-        } else {
-          throw new InvalidTransaction(`Action must be create or take not ${update.action}`)
-        }
-
-        let address = XO_NAMESPACE + _hash(update.name).slice(-64)
-
-        return state.get([address]).then(handlerFn(state, address, update, player))
-          .then((addresses) => {
-            if (addresses.length === 0) {
-              throw new InternalError('State Error!')
+const _isWin = (board, letter) => {
+    let wins = [[1, 2, 3], [4, 5, 6], [7, 8, 9],
+            [1, 4, 7], [2, 5, 8], [3, 6, 9],
+            [1, 5, 9], [3, 5, 7]]
+    let win
+    for (let i=0; i < wins.length; i++) {
+        win = wins[i]
+        if (board[win[0] - 1] === letter
+            && board[win[1] - 1] === letter
+            && board[win[2] - 1] === letter) {
+              return true
             }
-          })
-      })
-  }
+        }
+    return false
+}
 
+const _gameToStr = (board, state, player1, player2, name) => {
+    board = board.replace(/-/g, " ")
+    board = board.split("")
+    let out = ""
+    out += `GAME: ${name}\n`
+    out += `PLAYER 1: ${player1.substring(0,6)}\n`
+    out += `PLAYER 2: ${player2.substring(0,6)}\n`
+    out += `STATE: ${state}\n`
+    out += `\n`
+    out += `${board[0]} | ${board[1]} | ${board[2]} \n`
+    out += `---|---|--- \n`
+    out += `${board[3]} | ${board[4]} | ${board[5]} \n`
+    out += `---|---|--- \n`
+    out += `${board[6]} | ${board[7]} | ${board[8]} \n`
+    return out
+}
+
+const _display = (msg) => {
+    let n = msg.search(`\n`)
+    let length = 0
+    let line_lengths = []
+    if (n != -1) {
+        msg = msg.split("\n")
+        for (let i=0; i < msg.length; i++){
+          if (msg[i].length > length) {
+            length = msg[i].length
+          }
+        }
+      }
+    else {
+        length = msg.length
+        msg = [msg]
+      }
+
+    console.log("+" + "-".repeat(length + 2) + "+")
+    for (let i=0; i < msg.length; i++){
+        let len = length - msg[i].length
+
+        if ((len%2) == 1){
+          console.log("+ " + " ".repeat(Math.floor(len/2)) + msg[i] +
+                      " ".repeat(Math.floor(len/2+1))+ " +")
+        }
+        else{
+          console.log("+ " + " ".repeat(Math.floor(len/2)) + msg[i] +
+                      " ".repeat(Math.floor(len/2))+ " +")
+          }
+      }
+    console.log("+" + "-".repeat(length + 2) + "+")
 }
 
 module.exports = XOHandler

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -256,7 +256,7 @@ class XOHandler extends TransactionHandler {
         } else if (update.action === 'take') {
           handlerFn = _handleTake
         } else {
-          throw new InvalidTransaction(`Action must be create or take not ${verb}`)
+          throw new InvalidTransaction(`Action must be create or take not ${update.action}`)
         }
 
         let address = XO_NAMESPACE + _hash(update.name)

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -259,7 +259,7 @@ class XOHandler extends TransactionHandler {
           throw new InvalidTransaction(`Action must be create or take not ${update.action}`)
         }
 
-        let address = XO_NAMESPACE + _hash(update.name)
+        let address = XO_NAMESPACE + _hash(update.name).slice(-64)
 
         return state.get([address]).then(handlerFn(state, address, update, player))
           .then((addresses) => {

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -141,6 +141,12 @@ def _validate_name(name):
     if not name:
         raise InvalidTransaction('Name is required')
 
+    bad_chars = ',', '|'
+
+    if any([bad_char in name for bad_char in bad_chars]):
+        raise InvalidTransaction(
+            'Name cannot contain "," or "|"')
+
 
 def _validate_action_and_space(action, space):
     if not action:

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -33,7 +33,7 @@ XO_NAMESPACE = _hash_name(FAMILY_NAME)[:6]
 
 
 def make_xo_address(name):
-    return XO_NAMESPACE + _hash_name(name)
+    return XO_NAMESPACE + _hash_name(name)[-64:]
 
 
 # encodings

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -24,13 +24,22 @@ from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 LOGGER = logging.getLogger(__name__)
 
 
-class XoTransactionHandler:
-    def __init__(self, namespace_prefix):
-        self._namespace_prefix = namespace_prefix
+# namespace
+def hash_name(name):
+    return hashlib.sha512(name.encode('utf-8')).hexdigest()
 
+FAMILY_NAME = 'xo'
+XO_NAMESPACE = hash_name(FAMILY_NAME)[:6]
+
+
+def make_xo_address(name):
+    return XO_NAMESPACE + hash_name(name)
+
+
+class XoTransactionHandler:
     @property
     def family_name(self):
-        return 'xo'
+        return FAMILY_NAME
 
     @property
     def family_versions(self):
@@ -42,7 +51,7 @@ class XoTransactionHandler:
 
     @property
     def namespaces(self):
-        return [self._namespace_prefix]
+        return [XO_NAMESPACE]
 
     def apply(self, transaction, state_store):
 
@@ -83,8 +92,7 @@ class XoTransactionHandler:
 
         # Use the namespace prefix + the has of the game name to create the
         # storage address
-        game_address = self._namespace_prefix \
-            + hashlib.sha512(name.encode("utf-8")).hexdigest()
+        game_address = make_xo_address(name)
 
         # Get data from address
         state_entries = state_store.get([game_address])

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -111,7 +111,7 @@ def _unpack_transaction(transaction):
     signer = header.signer_pubkey
 
     try:
-        name, action, space = decode_txn_payload(transaction.payload)
+        action, name, space = decode_txn_payload(transaction.payload)
     except:
         raise InvalidTransaction('Invalid payload serialization')
 

--- a/sdk/examples/xo_python/sawtooth_xo/processor/main.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/main.py
@@ -13,16 +13,15 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import hashlib
 import sys
 import argparse
 
+from sawtooth_xo.processor.handler import XoTransactionHandler
 from sawtooth_sdk.processor.core import TransactionProcessor
 from sawtooth_sdk.client.config import get_log_dir
 from sawtooth_sdk.client.config import get_log_config
 from sawtooth_sdk.client.log import init_console_logging
 from sawtooth_sdk.client.log import log_configuration
-from sawtooth_xo.processor.handler import XoTransactionHandler
 
 
 def parse_args(args):
@@ -58,10 +57,7 @@ def main(args=sys.argv[1:]):
 
         init_console_logging(verbose_level=opts.verbose)
 
-        # The prefix should eventually be looked up from the
-        # validator's namespace registry.
-        xo_prefix = hashlib.sha512('xo'.encode("utf-8")).hexdigest()[0:6]
-        handler = XoTransactionHandler(namespace_prefix=xo_prefix)
+        handler = XoTransactionHandler()
 
         processor.add_handler(handler)
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -222,11 +222,8 @@ def do_list(args, config):
     if game_list is not None:
         fmt = "%-15s %-15.15s %-15.15s %-9s %s"
         print(fmt % ('GAME', 'PLAYER 1', 'PLAYER 2', 'BOARD', 'STATE'))
-        for game_data in game_list:
-
-            board, game_state, player1, player2, name = \
-                game_data.decode().split(",")
-
+        for name, game_data in game_list.items():
+            board, game_state, player1, player2 = game_data
             print(fmt % (name, player1[:6], player2[:6], board, game_state))
     else:
         raise XoException("Could not retrieve game listing.")
@@ -239,12 +236,10 @@ def do_show(args, config):
     key_file = config.get('DEFAULT', 'key_file')
 
     client = XoClient(base_url=url, keyfile=key_file)
-    game = client.show(name).decode()
+    game = client.show(name)
 
     if game is not None:
-
-        board_str, game_state, player1, player2, name = \
-            game.split(",")
+        board_str, game_state, player1, player2 = game
 
         board = list(board_str.replace("-", " "))
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -30,6 +30,11 @@ from sawtooth_sdk.protobuf.batch_pb2 import Batch
 from sawtooth_xo.xo_exceptions import XoException
 
 
+# encodings
+def encode_txn_payload(action, name, space):
+    return ','.join([action, name, space]).encode()
+
+
 def _sha512(data):
     return hashlib.sha512(data).hexdigest()
 
@@ -49,10 +54,10 @@ class XoClient:
         self._public_key = signing.generate_pubkey(self._private_key)
 
     def create(self, name):
-        return self._send_xo_txn(name, "create")
+        return self._send_xo_txn("create", name)
 
     def take(self, name, space):
-        return self._send_xo_txn(name, "take", space)
+        return self._send_xo_txn("take", name, space)
 
     def list(self):
         xo_prefix = self._get_prefix()
@@ -110,10 +115,10 @@ class XoClient:
 
         return result.text
 
-    def _send_xo_txn(self, name, action, space=""):
+    def _send_xo_txn(self, action, name, space=""):
 
         # Serialization is just a delimited utf-8 encoded string
-        payload = ",".join([name, action, str(space)]).encode()
+        payload = encode_txn_payload(action, name, str(space))
 
         # Construct the address
         address = self._get_address(name)

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -30,13 +30,21 @@ from sawtooth_sdk.protobuf.batch_pb2 import Batch
 from sawtooth_xo.xo_exceptions import XoException
 
 
+# namespace
+def _hash_name(name):
+    return hashlib.sha512(name.encode('utf-8')).hexdigest()
+
+FAMILY_NAME = 'xo'
+XO_NAMESPACE = _hash_name(FAMILY_NAME)[:6]
+
+
+def make_xo_address(name):
+    return XO_NAMESPACE + _hash_name(name)[-64:]
+
+
 # encodings
 def encode_txn_payload(action, name, space):
     return ','.join([action, name, space]).encode()
-
-
-def _sha512(data):
-    return hashlib.sha512(data).hexdigest()
 
 
 class XoClient:
@@ -60,9 +68,7 @@ class XoClient:
         return self._send_xo_txn("take", name, space)
 
     def list(self):
-        xo_prefix = self._get_prefix()
-
-        result = self._send_request("state?address={}".format(xo_prefix))
+        result = self._send_request("state?address={}".format(XO_NAMESPACE))
 
         try:
             encoded_entries = yaml.safe_load(result)["data"]
@@ -75,7 +81,7 @@ class XoClient:
             return None
 
     def show(self, name):
-        address = self._get_address(name)
+        address = make_xo_address(name)
 
         result = self._send_request("state/{}".format(address))
 
@@ -84,14 +90,6 @@ class XoClient:
 
         except BaseException:
             return None
-
-    def _get_prefix(self):
-        return _sha512('xo'.encode('utf-8'))[0:6]
-
-    def _get_address(self, name):
-        xo_prefix = self._get_prefix()
-        game_address = _sha512(name.encode('utf-8'))
-        return xo_prefix + game_address
 
     def _send_request(self, suffix, data=None, content_type=None):
         url = "http://{}/{}".format(self._base_url, suffix)
@@ -121,11 +119,11 @@ class XoClient:
         payload = encode_txn_payload(action, name, str(space))
 
         # Construct the address
-        address = self._get_address(name)
+        address = make_xo_address(name)
 
         header = TransactionHeader(
             signer_pubkey=self._public_key,
-            family_name="xo",
+            family_name=FAMILY_NAME,
             family_version="1.0",
             inputs=[address],
             outputs=[address],
@@ -169,3 +167,7 @@ class XoClient:
             header_signature=signature
         )
         return BatchList(batches=[batch])
+
+
+def _sha512(data):
+    return hashlib.sha512(data).hexdigest()

--- a/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
@@ -35,69 +35,88 @@ def encode_txn_payload(action, name, space):
     return ','.join([action, name, str(space)]).encode()
 
 
+def encode_state_data(state_data_dict, name, board, state, player_1, player_2):
+    state_data_dict[name] = [board, state, player_1, player_2]
+
+    game_list = [
+        [name] + data
+        for name, data in state_data_dict.items()
+    ]
+
+    return '|'.join(sorted([
+        ','.join(game)
+        for game in game_list
+    ])).encode()
+
+
 class XoMessageFactory:
     def __init__(self, private=None, public=None):
         self._factory = MessageFactory(
-            encoding="csv-utf8",
+            encoding='csv-utf8',
             family_name=FAMILY_NAME,
-            family_version="1.0",
+            family_version='1.0',
             namespace=XO_NAMESPACE,
             private=private,
             public=public)
 
         self.public_key = self._factory.get_public_key()
 
-    def create_tp_register(self):
-        return self._factory.create_tp_register()
+    # transactions
 
-    def create_tp_response(self, status):
-        return self._factory.create_tp_response(status)
+    def _create_txn(self, txn_function, action, name, space=None):
+        payload = encode_txn_payload(action, name, space)
 
-    def _create_txn(self, txn_function, action, game, space=None):
-        payload = encode_txn_payload(action, game, space)
-
-        addresses = [make_xo_address(game)]
+        addresses = [make_xo_address(name)]
 
         return txn_function(payload, addresses, addresses, [])
 
-    def create_tp_process_request(self, action, game, space=None):
+    def create_tp_process_request(self, action, name, space=None):
         txn_function = self._factory.create_tp_process_request
-        return self._create_txn(txn_function, action, game, space)
+        return self._create_txn(txn_function, action, name, space)
 
     def create_transaction(self, game, action, space=None):
         txn_function = self._factory.create_transaction
         return self._create_txn(txn_function, action, game, space)
 
-    def create_get_request(self, game):
-        addresses = [make_xo_address(game)]
+    # state messages
+    def _create_state_message(self, msg_function,
+                              name, board='---------',
+                              state='P1-NEXT', player_1='', player_2=''):
+        address = make_xo_address(name)
+
+        data = None if board is None else encode_state_data(
+            {}, name, board, state, player_1, player_2)
+
+        return msg_function({address: data})
+
+    def create_get_response(self, name, board='---------',
+                            state='P1-NEXT', player_1='', player_2=''):
+
+        msg_function = self._factory.create_get_response
+
+        return self._create_state_message(
+            msg_function, name, board, state, player_1, player_2)
+
+    def create_set_request(self, name, board='---------',
+                           state='P1-NEXT', player_1='', player_2=''):
+
+        msg_function = self._factory.create_get_response
+
+        return self._create_state_message(
+            msg_function, name, board, state, player_1, player_2)
+
+    def create_get_request(self, name):
+        addresses = [make_xo_address(name)]
         return self._factory.create_get_request(addresses)
 
-    def create_get_response(
-        self, game, board="---------", state="P1-NEXT", player1="", player2=""
-    ):
-        address = make_xo_address(game)
-
-        data = None
-        if board is not None:
-            data = ",".join([board, state, player1, player2, game]).encode()
-        else:
-            data = None
-
-        return self._factory.create_get_response({address: data})
-
-    def create_set_request(
-        self, game, board="---------", state="P1-NEXT", player1="", player2=""
-    ):
-        address = make_xo_address(game)
-
-        data = None
-        if state is not None:
-            data = ",".join([board, state, player1, player2, game]).encode()
-        else:
-            data = None
-
-        return self._factory.create_get_response({address: data})
-
-    def create_set_response(self, game):
-        addresses = [make_xo_address(game)]
+    def create_set_response(self, name):
+        addresses = [make_xo_address(name)]
         return self._factory.create_set_response(addresses)
+
+    # registering
+
+    def create_tp_register(self):
+        return self._factory.create_tp_register()
+
+    def create_tp_response(self, status):
+        return self._factory.create_tp_response(status)

--- a/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
@@ -29,10 +29,12 @@ class XoMessageFactory:
             family_version="1.0",
             namespace="",
             private=private,
-            public=public
-        )
+            public=public)
+
         self._factory.namespace = self._factory.sha512(
             "xo".encode("utf-8"))[0:6]
+
+        self.public_key = self._factory.get_public_key()
 
     def _game_to_address(self, game):
         return self._factory.namespace + \
@@ -92,6 +94,3 @@ class XoMessageFactory:
     def create_set_response(self, game):
         addresses = [self._game_to_address(game)]
         return self._factory.create_set_response(addresses)
-
-    def get_public_key(self):
-        return self._factory.get_public_key()

--- a/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
@@ -16,6 +16,11 @@
 from sawtooth_processor_test.message_factory import MessageFactory
 
 
+# encodings
+def encode_txn_payload(action, name, space):
+    return ','.join([action, name, str(space)]).encode()
+
+
 class XoMessageFactory:
     def __init__(self, private=None, public=None):
         self._factory = MessageFactory(
@@ -39,10 +44,8 @@ class XoMessageFactory:
     def create_tp_response(self, status):
         return self._factory.create_tp_response(status)
 
-    def _create_txn(self, txn_function, game, action, space=None):
-        payload = ",".join([
-            str(game), str(action), str(space)
-        ]).encode()
+    def _create_txn(self, txn_function, action, game, space=None):
+        payload = encode_txn_payload(action, game, space)
 
         addresses = [self._game_to_address(game)]
 
@@ -50,11 +53,11 @@ class XoMessageFactory:
 
     def create_tp_process_request(self, action, game, space=None):
         txn_function = self._factory.create_tp_process_request
-        return self._create_txn(txn_function, game, action, space)
+        return self._create_txn(txn_function, action, game, space)
 
     def create_transaction(self, game, action, space=None):
         txn_function = self._factory.create_transaction
-        return self._create_txn(txn_function, game, action, space)
+        return self._create_txn(txn_function, action, game, space)
 
     def create_get_request(self, game):
         addresses = [self._game_to_address(game)]

--- a/sdk/examples/xo_python/tests/test_tp_xo.py
+++ b/sdk/examples/xo_python/tests/test_tp_xo.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import logging
+from unittest import skip
 
 from sawtooth_processor_test.transaction_processor_test_case \
     import TransactionProcessorTestCase
@@ -52,6 +53,16 @@ class TestXo(TransactionProcessorTestCase):
 
         self.expect_invalid()
 
+    @skip('JS throws InternalError instead of InvalidTransaction')
+    def test_too_many_commas(self):
+        self.send_transaction('comma,action', 'name', 5)
+
+        self.expect_invalid()
+
+        self.send_transaction('action', 'comma,action', 6)
+
+        self.expect_invalid()
+
     # create
 
     def test_create_game_valid(self):
@@ -77,6 +88,11 @@ class TestXo(TransactionProcessorTestCase):
         self.send_get_response(
             game='already-created',
             board='---------')
+
+        self.expect_invalid()
+
+    def test_create_bar_name(self):
+        self.create_game('has|bar')
 
         self.expect_invalid()
 

--- a/sdk/examples/xo_python/tests/test_tp_xo.py
+++ b/sdk/examples/xo_python/tests/test_tp_xo.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import logging
+
 from sawtooth_processor_test.transaction_processor_test_case \
     import TransactionProcessorTestCase
 from sawtooth_xo.xo_message_factory import XoMessageFactory
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TestXo(TransactionProcessorTestCase):
@@ -23,75 +28,289 @@ class TestXo(TransactionProcessorTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.factory = XoMessageFactory()
 
-    def test_create_game(self):
-        self.validator_sends_tp_process_request(
-            action='create',
-            game='game000')
+        cls.player_1 = XoMessageFactory()
+        cls.public_key_1 = cls.player_1.public_key
 
-        get_message = self.validator_expects_get_request('game000')
+        cls.player_2 = XoMessageFactory()
+        cls.public_key_2 = cls.player_2.public_key
 
-        self.validator_responds_to_get_request(
-            get_message,
-            game='game000', board=None,
-            state=None, player1=None, player2=None)
+    # invalid inputs
 
-        set_message = self.validator_expects_set_request(
-            game='game000', board='---------',
-            state='P1-NEXT', player1='', player2='')
+    def test_no_action(self):
+        self.send_transaction('', 'no-action', 9)
 
-        self.validator_responds_to_set_request(set_message, 'game000')
+        self.expect_invalid()
 
-        self.validator_expects_tp_response('OK')
+    def test_invalid_action(self):
+        self.send_transaction('blorp', 'invalid-action', 8)
+
+        self.expect_invalid()
+
+    def test_no_name(self):
+        self.send_transaction('take', '', 4)
+
+        self.expect_invalid()
+
+    # create
+
+    def test_create_game_valid(self):
+        self.create_game('create-game')
+
+        self.send_get_response(
+            game='create-game',
+            board=None,
+            state=None,
+            player_1=None,
+            player_2=None)
+
+        self.expect_set_request(
+            game='create-game',
+            board='---------',
+            state='P1-NEXT',
+            player_1='',
+            player_2='')
+
+    def test_create_already_created(self):
+        self.create_game('already-created')
+
+        self.send_get_response(
+            game='already-created',
+            board='---------')
+
+        self.expect_invalid()
+
+    # take
 
     def test_take_space(self):
-        player1 = self.factory.get_public_key()
+        # player 1 takes a space
+        self.take_space('take-space', 3, signer=1)
 
-        self.validator_sends_tp_process_request(
-            action='take',
-            game='game000',
-            space=3)
+        self.send_get_response(
+            game='take-space',
+            board='---------',
+            state='P1-NEXT',
+            player_1='',
+            player_2='')
 
-        get_message = self.validator_expects_get_request('game000')
+        self.expect_set_request(
+            game='take-space',
+            board='--X------',
+            state='P2-NEXT',
+            player_1=self.public_key_1,
+            player_2='')
 
-        self.validator_responds_to_get_request(
-            get_message,
-            game='game000', board='---------',
-            state='P1-NEXT', player1='', player2='')
+        # player 2 takes a space
+        self.take_space('take-space', 7, signer=2)
 
-        set_message = self.validator_expects_set_request(
-            game='game000', board='--X------',
-            state='P2-NEXT', player1=player1, player2='')
+        self.send_get_response(
+            game='take-space',
+            board='--X------',
+            state='P2-NEXT',
+            player_1=self.public_key_1,
+            player_2='')
 
-        self.validator_responds_to_set_request(set_message, 'game000')
+        self.expect_set_request(
+            game='take-space',
+            board='--X---O--',
+            state='P1-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
 
-        self.validator_expects_tp_response('OK')
+        # player 1 goes again
+        self.take_space('take-space', 9, signer=1)
 
-    # helper functions
+        self.send_get_response(
+            game='take-space',
+            board='--X---O--',
+            state='P1-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
 
-    def validator_sends_tp_process_request(self, *args, **kwargs):
+        self.expect_set_request(
+            game='take-space',
+            board='--X---O-X',
+            state='P2-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+        # player 2 goes again
+        self.take_space('take-space', 1, signer=2)
+
+        self.send_get_response(
+            game='take-space',
+            board='--X---O-X',
+            state='P2-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+        self.expect_set_request(
+            game='take-space',
+            board='O-X---O-X',
+            state='P1-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+    def test_take_win(self):
+        moves_1 = (
+            (3, 'XX-----OO', 'XXX----OO'), (5, 'O--X-X--O', 'O--XXX--O'),
+            (7, 'OO-----XX', 'OO----XXX'), (1, '-O-XO-X--', 'XO-XO-X--'),
+            (5, 'OX----OX-', 'OX--X-OX-'), (9, '-OX-OX---', '-OX-OX--X'),
+            (5, 'X-O---O-X', 'X-O-X-O-X'), (5, 'O-X---X-O', 'O-X-X-X-O'),
+        )
+
+        moves_2 = (
+            (2, 'O-O-X-X-X', 'OOO-X-X-X'), (4, 'OX---XO-X', 'OX-O-XO-X'),
+            (6, 'XX-OO---X', 'XX-OOO--X'), (8, 'XO-XO---X', 'XO-XO--OX'),
+        )
+
+        for signer in (1, 2):
+            moves = moves_1 if signer == 1 else moves_2
+            for space, board, winner in moves:
+                self.take_space('win', space, signer=signer)
+
+                self.send_get_response(
+                    game='win',
+                    board=board,
+                    state=('P1-NEXT' if signer == 1 else 'P2-NEXT'),
+                    player_1=self.public_key_1,
+                    player_2=self.public_key_2)
+
+                self.expect_set_request(
+                    game='win',
+                    board=winner,
+                    state=('P1-WIN' if signer == 1 else 'P2-WIN'),
+                    player_1=self.public_key_1,
+                    player_2=self.public_key_2)
+
+    def test_take_tie(self):
+        self.take_space('tie', 8, signer=1)
+
+        self.send_get_response(
+            game='tie',
+            board='XOXOOXX-O',
+            state='P1-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+        self.expect_set_request(
+            game='tie',
+            board='XOXOOXXXO',
+            state='TIE',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+    def test_take_space_already_taken(self):
+        self.take_space('already-taken', 4)
+
+        self.send_get_response(
+            game='already-taken',
+            board='---X-----')
+
+        self.expect_invalid()
+
+    def test_take_wrong_turn(self):
+        '''
+        If the signer's public key matches player_1 and
+        the state is P2-NEXT, the transaction is invalid,
+        and vice versa.
+        '''
+
+        # player 2 going on player 1's turn
+        self.take_space('wrong-turn-1', 4, signer=2)
+
+        self.send_get_response(
+            game='wrong-turn-1',
+            board='--X---O--',
+            state='P1-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+        self.expect_invalid()
+
+        # player 1 going on player 2's turn
+        self.take_space('wrong-turn-2', 4, signer=1)
+
+        self.send_get_response(
+            game='wrong-turn-2',
+            board='--X---O--',
+            state='P2-NEXT',
+            player_1=self.public_key_1,
+            player_2=self.public_key_2)
+
+        self.expect_invalid()
+
+    def test_take_game_ended(self):
+        for state in 'P1-WIN', 'P2-WIN', 'TIE':
+            self.take_space('game-ended', 9, signer=1)
+
+            self.send_get_response(
+                game='game-ended',
+                board='XXXOO----',
+                state=state)
+
+            self.expect_invalid()
+
+    # message functions (gamed from the perspective of the validator)
+
+    def create_game(self, game, signer=1):
+        self.send_transaction('create', game, signer=signer)
+
+    def take_space(self, game, space, signer=1):
+        self.send_transaction('take', game, space, signer=signer)
+
+    def send_transaction(self, action, game, space='', signer=1):
+        factory = self.player_1 if signer == 1 else self.player_2
+
         self.validator.send(
-            self.factory.create_tp_process_request(*args, **kwargs))
+            factory.create_tp_process_request(
+                action, game, space))
 
-    def validator_expects_get_request(self, key):
-        return self.validator.expect(
-            self.factory.create_get_request(key))
+    def try_transaction_with_all_actions(self, game, space=''):
+        for action in ('create', 'take'):
+            self.send_transaction(action, game, space)
 
-    def validator_responds_to_get_request(self, message, *args, **kwargs):
+            self.expect_invalid()
+
+    # low-level message functions
+
+    def send_get_response(self, game, board,
+                          state='P1-NEXT',
+                          player_1='', player_2=''):
+
+        received = self.validator.expect(
+            self.player_1.create_get_request(
+                game))
+
         self.validator.respond(
-            self.factory.create_get_response(*args, **kwargs),
-            message)
+            self.player_1.create_get_response(
+                game, board, state, player_1, player_2),
+            received)
 
-    def validator_expects_set_request(self, *args, **kwargs):
-        return self.validator.expect(
-            self.factory.create_set_request(*args, **kwargs))
+    def expect_set_request(self, game,
+                           board='---------',
+                           state='P1-NEXT',
+                           player_1='',
+                           player_2=''):
 
-    def validator_responds_to_set_request(self, message, *args, **kwargs):
+        received = self.validator.expect(
+            self.player_1.create_set_request(
+                game, board, state, player_1, player_2))
+
         self.validator.respond(
-            self.factory.create_set_response(*args, **kwargs),
-            message)
+            self.player_1.create_set_response(
+                game),
+            received)
 
-    def validator_expects_tp_response(self, status):
-        return self.validator.expect(
-            self.factory.create_tp_response(status))
+        self.expect_ok()
+
+    def expect_ok(self):
+        self.expect_tp_response('OK')
+
+    def expect_invalid(self):
+        self.expect_tp_response('INVALID_TRANSACTION')
+
+    def expect_tp_response(self, response):
+        self.validator.expect(
+            self.player_1.create_tp_response(
+                response))


### PR DESCRIPTION
The xo spec hasn't been written yet, but the xo TP test is intended to show what will go into the spec. Note that the xo message factory also contains information that will go into the spec, since it determines the format of xo state data.

This PR makes several changes to xo message formats: 1) the format of transactions has been changed from `(name, action, space)` to `(action, name, space)` (the latter being how transactions are submitted at the CLI); 2) xo addresses are like intkey addresses -- the first six characters of the hash of the family name plus the last 64 characters of the hash of the game name; and 3) the data stored at an address is now a JSON string in the following format: `{"game_name": "board,state,player_1,player_2"}`.

The Python xo implementation has been rewritten to more or less match the documentation, and a few errors have been fixed in the JS implementation.