### PR TITLE
Fix the bug of document

### DIFF
--- a/docs/source/app_developers_guide/intro_to_sawtooth.rst
+++ b/docs/source/app_developers_guide/intro_to_sawtooth.rst
@@ -210,8 +210,8 @@ Or from the Docker CLI:
   $ intkey load -f batches.intkey -U http://rest_api:8080
 
 You can observe the processing of the intkey transactions by observing the
-logging output of the validator. A truncated example of the validator's output
-is shown below:
+logging output of the intkey transaction processor. A truncated example of
+the intkey transaction processor's output is shown below:
 
 .. code-block:: console
 


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

The output shown below isn't the logging output of the validator, but the logging output of the intkey transaction processor.