### PR TITLE
Implement capability to use a validator config file

### DIFF
--- a/ci/sawtooth-build-debs
+++ b/ci/sawtooth-build-debs
@@ -60,6 +60,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/0.8/stable xenial universe" >> /etc
     python3-grpcio=1.1.3-1 \
     python3-lmdb=0.92-1 \
     python3-multidict=2.1.4-1 \
+    python3-netifaces=0.10.4-0.1build2 \
     python3-protobuf=3.2.0-1 \
     python3-pycares=2.1.1-1 \
     python3-pytest-runner=2.6.2-1 \

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -62,6 +62,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     python3-grpcio=1.1.3-1 \
     python3-lmdb=0.92-1 \
     python3-multidict=2.1.4-1 \
+    python3-netifaces=0.10.4-0.1build2 \
     python3-nose2 \
     python3-pip \
     python3-protobuf=3.2.0-1 \

--- a/tools/package_groups/ubuntu-16.04-deps
+++ b/tools/package_groups/ubuntu-16.04-deps
@@ -7,5 +7,6 @@ python3-nose2
 python3-cbor
 python3-colorlog
 python3-lmdb
+python3-netifaces
 python3-toml
 python3-zmq

--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -1,0 +1,35 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://127.0.0.1:8800",
+  "component:tcp://127.0.0.1:40000"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "static"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://127.0.0.1:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = ["tcp://127.0.0.1:8801"]
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+peers = ["tcp://127.0.0.1:8801"]

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -1,0 +1,179 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import collections
+import logging
+import os
+
+import toml
+
+from sawtooth_validator.exceptions import LocalConfigurationError
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_default_validator_config():
+    return ValidatorConfig(
+        bind_network='tcp://127.0.0.1:8800',
+        bind_component='tcp://127.0.0.1:40000',
+        endpoint=None,
+        peering='static')
+
+
+def load_toml_validator_config(filename):
+    """Returns a ValidatorConfig created by loading a TOML file from the
+    filesystem.
+    """
+    if not os.path.exists(filename):
+        LOGGER.info(
+            "Skipping validator config loading from non-existent config file:"
+            " %s", filename)
+        return ValidatorConfig()
+
+    LOGGER.info("Loading validator information from config: %s", filename)
+
+    try:
+        with open(filename) as fd:
+            raw_config = fd.read()
+    except IOError as e:
+        raise LocalConfigurationError(
+            "Unable to load validator configuration file: {}".format(str(e)))
+
+    toml_config = toml.loads(raw_config)
+
+    invalid_keys = set(toml_config.keys()).difference(
+        ['bind', 'endpoint', 'peering', 'seeds', 'peers'])
+    if len(invalid_keys) > 0:
+        raise LocalConfigurationError(
+            "Invalid keys in validator config: "
+            "{}".format(", ".join(sorted(list(invalid_keys)))))
+    bind_network = None
+    bind_component = None
+    for bind in toml_config.get("bind"):
+        if "network" in bind:
+            bind_network = bind[bind.find(":")+1:]
+        if "component" in bind:
+            bind_component = bind[bind.find(":")+1:]
+
+    config = ValidatorConfig(
+         bind_network=bind_network,
+         bind_component=bind_component,
+         endpoint=toml_config.get("endpoint", None),
+         peering=toml_config.get("peering", None),
+         seeds=toml_config.get("seeds", None),
+         peers=toml_config.get("peers", None),
+    )
+
+    return config
+
+
+def merge_validator_config(configs):
+    """
+    Given a list of ValidatorConfig object, merges them into a single
+    ValidatorConfig, giving priority in the order of the configs
+    (first has highest priority).
+    """
+    bind_network = None
+    bind_component = None
+    endpoint = None
+    peering = None
+    seeds = None
+    peers = None
+
+    for config in reversed(configs):
+        if config.bind_network is not None:
+            bind_network = config.bind_network
+        if config.bind_component is not None:
+            bind_component = config.bind_component
+        if config.endpoint is not None:
+            endpoint = config.endpoint
+        if config.peering is not None:
+            peering = config.peering
+        if config.seeds is not None:
+            seeds = config.seeds
+        if config.peers is not None:
+            peers = config.peers
+
+    return ValidatorConfig(
+         bind_network=bind_network,
+         bind_component=bind_component,
+         endpoint=endpoint,
+         peering=peering,
+         seeds=seeds,
+         peers=peers
+    )
+
+
+class ValidatorConfig:
+    def __init__(self, bind_network=None, bind_component=None,
+                 endpoint=None, peering=None, seeds=None,
+                 peers=None):
+
+        self._bind_network = bind_network
+        self._bind_component = bind_component
+        self._endpoint = endpoint
+        self._peering = peering
+        self._seeds = seeds
+        self._peers = peers
+
+    @property
+    def bind_network(self):
+        return self._bind_network
+
+    @property
+    def bind_component(self):
+        return self._bind_component
+
+    @property
+    def endpoint(self):
+        return self._endpoint
+
+    @property
+    def peering(self):
+        return self._peering
+
+    @property
+    def seeds(self):
+        return self._seeds
+
+    @property
+    def peers(self):
+        return self._peers
+
+    def __repr__(self):
+        return \
+            "{}(bind_network={}, bind_component={}, " \
+            "endpoint={}, peering={}, seeds={}, peers={})".format(
+                self.__class__.__name__,
+                repr(self._bind_network),
+                repr(self._bind_component),
+                repr(self._endpoint),
+                repr(self._peering),
+                repr(self._seeds),
+                repr(self._peers))
+
+    def to_dict(self):
+        return collections.OrderedDict([
+            ('bind_network', self._bind_network),
+            ('bind_component', self._bind_component),
+            ('endpoint', self._endpoint),
+            ('peering', self._peering),
+            ('seeds', self._seeds),
+            ('peers', self._peers)
+        ])
+
+    def to_toml_string(self):
+        return toml.dumps(self.to_dict()).strip().split('\n')

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -17,10 +17,15 @@ import logging
 import sys
 import argparse
 import os
+import netifaces
 
 import sawtooth_signing as signing
 
 from sawtooth_validator.config.path import load_path_config
+from sawtooth_validator.config.validator import load_default_validator_config
+from sawtooth_validator.config.validator import load_toml_validator_config
+from sawtooth_validator.config.validator import merge_validator_config
+from sawtooth_validator.config.validator import ValidatorConfig
 from sawtooth_validator.config.logs import get_log_config
 from sawtooth_validator.server.core import Validator
 from sawtooth_validator.server.keys import load_identity_signing_key
@@ -42,11 +47,9 @@ def parse_args(args):
                         type=str)
     parser.add_argument('--network-endpoint',
                         help='Network endpoint URL',
-                        default='tcp://127.0.0.1:8800',
                         type=str)
     parser.add_argument('--component-endpoint',
                         help='Validator component service endpoint',
-                        default='tcp://127.0.0.1:40000',
                         type=str)
     parser.add_argument('--peering',
                         help='The type of peering approach the validator '
@@ -58,11 +61,9 @@ def parse_args(args):
                              'will be processed first, prior to the topology '
                              'buildout starting',
                         choices=['static', 'dynamic'],
-                        default='static',
                         type=str)
     parser.add_argument('--public-uri',
                         help='Advertised network endpoint URL',
-                        required=True,
                         type=str)
     parser.add_argument('--join',
                         help='uri(s) to connect to in order to initially '
@@ -137,6 +138,26 @@ def _split_comma_append_args(arg_list):
     return new_arg_list
 
 
+def load_validator_config(first_config, config_dir):
+    default_validator_config = load_default_validator_config()
+    conf_file = os.path.join(config_dir, 'validator.toml')
+
+    toml_config = load_toml_validator_config(conf_file)
+
+    return merge_validator_config(
+        configs=[first_config, toml_config, default_validator_config])
+
+
+def create_validator_config(opts):
+    return ValidatorConfig(
+        bind_network=opts.network_endpoint,
+        bind_component=opts.component_endpoint,
+        endpoint=opts.public_uri,
+        peering=opts.peering,
+        seeds=opts.join,
+        peers=opts.peers)
+
+
 def main(args=sys.argv[1:]):
     opts = parse_args(args)
     verbose_level = opts.verbose
@@ -153,6 +174,14 @@ def main(args=sys.argv[1:]):
 
     try:
         path_config = load_path_config(config_dir=opts.config_dir)
+    except LocalConfigurationError as local_config_err:
+        LOGGER.error(str(local_config_err))
+        sys.exit(1)
+
+    try:
+        opts_config = create_validator_config(opts)
+        validator_config = \
+            load_validator_config(opts_config, path_config.config_dir)
     except LocalConfigurationError as local_config_err:
         LOGGER.error(str(local_config_err))
         sys.exit(1)
@@ -194,17 +223,31 @@ def main(args=sys.argv[1:]):
                            human_readable_name='Log'):
         init_errors = True
 
+    endpoint = validator_config.endpoint
+    if endpoint is None:
+        # Need to use join here to get the string "0.0.0.0". Otherwise,
+        # bandit thinks we are binding to all interfaces and returns a
+        # Medium security risk.
+        interfaces = ["*", ".".join(["0", "0", "0", "0"])]
+        interfaces += netifaces.interfaces()
+        endpoint = validator_config.network_endpoint
+        for interface in interfaces:
+            if interface in validator_config.network_endpoint:
+                LOGGER.error("Endpoint must be set when using %s", interface)
+                init_errors = True
+                break
+
     if init_errors:
         LOGGER.error("Initialization errors occurred (see previous log "
                      "ERROR messages), shutting down.")
         sys.exit(1)
 
-    validator = Validator(opts.network_endpoint,
-                          opts.component_endpoint,
-                          opts.public_uri,
-                          opts.peering,
-                          opts.join,
-                          opts.peers,
+    validator = Validator(validator_config.bind_network,
+                          validator_config.bind_component,
+                          endpoint,
+                          validator_config.peering,
+                          validator_config.seeds,
+                          validator_config.peers,
                           path_config.data_dir,
                           path_config.config_dir,
                           identity_signing_key)

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -59,6 +59,7 @@ setup(
         "sawtooth-signing",
         "toml",
         "pyzmq",
+        "netifaces"
     ],
     data_files=data_files,
     entry_points={


### PR DESCRIPTION
This commit adds a ValidatorConfig object, an example
validator config file, and updates the validator cli to
check for a config file and combine it with any command
line options set.

Important to note the public-uri is no longer "required" to
be set on the command line, but if it is not set by either
the command line or the config file the validator will
shutdown.

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>