### PR TITLE
Update docs and default docker compose file for config changes

### DIFF
--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -50,7 +50,9 @@ services:
     # start the validator with an empty genesis batch
     entrypoint: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth keygen my_key && \
+        sawtooth config genesis -k /root/.sawtooth/keys/my_key.priv && \
+        sawtooth admin genesis config-genesis.batch && \
         validator -vv \
           --public-uri tcp://validator:8800 \
           --component-endpoint tcp://eth0:40000 \


### PR DESCRIPTION
In order to be able to make config changes, the genesis block
must now contain the setting for the authorized key that
can submit config changes. Docs and default docker compose
file were updated to account for this, so that the intro doc
will work for both Ubuntu and docker installs.

Signed-off-by: Todd Ojala <todd@bitwise.io>