### PR TITLE
Add linting to Supply Chain

### DIFF
--- a/bin/run_lint
+++ b/bin/run_lint
@@ -148,20 +148,20 @@ lint signing "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/sdk/python
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/intkey_python
-PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/supplychain_python
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/xo_python
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 export PYTHONPATH
 lint sdk/python "$SINCE" || retval=1
 lint sdk/examples/intkey_python "$SINCE" || retval=1
-lint sdk/examples/supplychain_python "$SINCE" || retval=1
 lint sdk/examples/xo_python "$SINCE" || retval=1
 lint rest_api/sawtooth_rest_api "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/families/config
+PYTHONPATH=$top_dir/families/supplychain_python
 PYTHONPATH=$top_dir/sdk/python
 export PYTHONPATH
 lint families/config "$SINCE" || retval=1
+lint families/supplychain_python "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/validator

--- a/families/supplychain_python/sawtooth_supplychain_test/__init__.py
+++ b/families/supplychain_python/sawtooth_supplychain_test/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------


### PR DESCRIPTION
This corrects the the path that lint expects to find the supply chain family and fixes a lint import error. 

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>