### PR TITLE
Basic CORS Support

### DIFF
--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -92,6 +92,12 @@ async def access_logger(app, handler):
     return logging_handler
 
 
+async def cors_handler(request):
+    headers = {}
+    RouteHandler.add_cors_headers(request, headers)
+    return web.Response(headers=headers)
+
+
 def start_rest_api(host, port, stream, timeout):
     """Builds the web app, adds route handlers, and finally starts the app.
     """
@@ -101,6 +107,8 @@ def start_rest_api(host, port, stream, timeout):
     # Add routes to the web app
     LOGGER.info('Creating handlers for validator at %s', stream.url)
     handler = RouteHandler(loop, stream, timeout)
+
+    app.router.add_route('OPTIONS', '/{route_name}', cors_handler)
 
     app.router.add_post('/batches', handler.submit_batches)
     app.router.add_get('/batch_status', handler.list_statuses)


### PR DESCRIPTION
Basic CORS support is required if a user is going to query a running
REST API from another server (e.g. from a single-page-app that is
submitting transactions, but hosted elsewhere).

This is to support the OMI Summer Lab.  A task to add configuration options to the REST API cli tool has been created in [STL-313](https://jira.hyperledger.org/browse/STL-313)

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>