### PR TITLE
Fix XO create wait option

### DIFF
--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -81,9 +81,10 @@ def add_create_parser(subparsers, parent_parser):
 
     parser.add_argument(
         '--wait',
-        action='store_true',
-        default=False,
-        help='wait for this commit before exiting')
+        nargs='?',
+        const=sys.maxsize,
+        type=int,
+        help='wait for game to commit, set an integer to specify a timeout')
 
 
 def add_init_parser(subparsers, parent_parser):
@@ -272,7 +273,12 @@ def do_create(args, config):
 
     client = XoClient(base_url=url,
                       keyfile=key_file)
-    response = client.create(name)
+
+    if args.wait and args.wait > 0:
+        response = client.create(name, wait=args.wait)
+    else:
+        response = client.create(name)
+
     print("Response: {}".format(response))
 
 


### PR DESCRIPTION
Previously the --wait cli option for create was parsed but nothing was done with it. Now, when this argument is parsed the cli will pause until the transaction has been committed to the block or an error is returned.

Note: _Currently when the XO transaction processor finds that a transaction is invalid (such as in the case of a "Game already exists" error) the Rest API status remains as 'PENDING'. This means that the cli will pause until the specified timeout has elapsed, or until the batch cache is cleared (in the case of the --wait wait option being passed with no argument). This should be fixed in the future when invalid transactions are given an 'INVALID' status in the Rest API._

Signed-off-by: Darian Plumb <dplumb@bitwise.io>