### PR TITLE
Implement capability to use a rest api config file

### DIFF
--- a/integration/sawtooth_integration/docker/config-smoke.yaml
+++ b/integration/sawtooth_integration/docker/config-smoke.yaml
@@ -56,7 +56,7 @@ services:
       - 8080
     depends_on:
       - validator
-    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api --port 8080
     stop_signal: SIGKILL
 
   integration_test:

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -228,7 +228,7 @@ def start_processors(num, processor_func):
 # rest_api
 
 def rest_api_cmd(num):
-    return 'rest_api --stream-url {s} --port {p}'.format(
+    return 'rest_api --stream-url {s} --port {p} --host 127.0.0.1'.format(
         s=connenction_address(num),
         p=(8080 + num)
     )

--- a/rest_api/packaging/rest_api.toml.example
+++ b/rest_api/packaging/rest_api.toml.example
@@ -1,0 +1,12 @@
+#
+# Sawtooth Lake -- REST API Configuration
+#
+
+# The port and host  for the api to run on
+#   bind = ["127.0.0.1:8800"]
+
+# The url to connect to a running Validator
+#   connect = "tcp://localhost:40000"
+
+# Seconds to wait for a validator response
+#   timeout = 300

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -1,0 +1,127 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import collections
+import logging
+import os
+import toml
+
+from sawtooth_rest_api.exceptions import RestApiConfigurationError
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_default_rest_api_config():
+    return RestApiConfig(
+        bind=["127.0.0.1:8080"],
+        connect="tcp://localhost:40000",
+        timeout=300)
+
+
+def load_toml_rest_api_config(filename):
+    """Returns a RestApiConfig created by loading a TOML file from the
+    filesystem.
+    """
+    if not os.path.exists(filename):
+        LOGGER.info(
+            "Skipping rest api loading from non-existent config file: %s",
+            filename)
+        return RestApiConfig()
+
+    LOGGER.info("Loading rest api information from config: %s", filename)
+
+    try:
+        with open(filename) as fd:
+            raw_config = fd.read()
+    except IOError as e:
+        raise RestApiConfigurationError(
+            "Unable to load rest api configuration file: {}".format(str(e)))
+
+    toml_config = toml.loads(raw_config)
+
+    invalid_keys = set(toml_config.keys()).difference(
+        ['bind', 'connect', 'timeout'])
+    if len(invalid_keys) > 0:
+        raise RestApiConfigurationError(
+            "Invalid keys in rest api config: {}".format(
+                ", ".join(sorted(list(invalid_keys)))))
+    config = RestApiConfig(
+        bind=toml_config.get("bind", None),
+        connect=toml_config.get('connect', None),
+        timeout=toml_config.get('timeout', None)
+    )
+
+    return config
+
+
+def merge_rest_api_config(configs):
+    """
+    Given a list of PathConfig objects, merges them into a single PathConfig,
+    giving priority in the order of the configs (first has highest priority).
+    """
+    bind = None
+    connect = None
+    timeout = None
+
+    for config in reversed(configs):
+        if config.bind is not None:
+            bind = config.bind
+        if config.connect is not None:
+            connect = config.connect
+        if config.timeout is not None:
+            timeout = config.timeout
+
+    return RestApiConfig(
+        bind=bind,
+        connect=connect,
+        timeout=timeout)
+
+
+class RestApiConfig:
+    def __init__(self, bind=None, connect=None, timeout=None):
+        self._bind = bind
+        self._connect = connect
+        self._timeout = timeout
+
+    @property
+    def bind(self):
+        return self._bind
+
+    @property
+    def connect(self):
+        return self._connect
+
+    @property
+    def timeout(self):
+        return self._timeout
+
+    def __repr__(self):
+        return \
+            "{}(bind={}, connect={}, timeout={})".format(
+                self.__class__.__name__,
+                repr(self._bind),
+                repr(self._connect),
+                repr(self._timeout))
+
+    def to_dict(self):
+        return collections.OrderedDict([
+            ('bind', self._bind),
+            ('connect', self._connect),
+            ('timeout', self._timeout)
+        ])
+
+    def to_toml_string(self):
+        return toml.dumps(self.to_dict()).strip().split('\n')

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -17,6 +17,10 @@ import json
 from aiohttp.web import HTTPError
 
 
+class RestApiConfigurationError(Exception):
+    pass
+
+
 class _ApiError(HTTPError):
     """A parent class for all REST API errors. Extends aiohttp's HTTPError,
     so instances will be caught automatically be the API, and turned into a

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -1,0 +1,94 @@
+import os
+import unittest
+import shutil
+import sys
+import tempfile
+
+from sawtooth_rest_api.config import load_default_rest_api_config
+from sawtooth_rest_api.config import load_toml_rest_api_config
+from sawtooth_rest_api.exceptions import RestApiConfigurationError
+
+
+class TestRestApiConfig(unittest.TestCase):
+    def __init__(self, test_name):
+        super().__init__(test_name)
+
+    def test_rest_api_defaults_sawtooth_home(self):
+        """Tests the default REST API configuration.
+
+            - bind = ["127.0.0.1:8080"]
+            - connect = "tcp://localhost:40000"
+            - timeout = 300
+
+        """
+        config = load_default_rest_api_config()
+        self.assertEqual(config.bind , ["127.0.0.1:8080"])
+        self.assertEqual(config.connect, "tcp://localhost:40000")
+        self.assertEqual(config.timeout, 300)
+
+    def test_rest_api_config_load_from_file(self):
+        """Tests loading config settings from a TOML configuration file.
+
+        Sets the SAWTOOTH_HOME environment variable to a temporary directory,
+        writes a rest_api.toml config file, then loads that config and verifies
+        all the rest_api settings are their expected values.
+
+        The test also attempts to avoid environment variables from interfering
+        with the test by clearing os.environ and restoring it after the test.
+        """
+        orig_environ = dict(os.environ)
+        os.environ.clear()
+        directory = tempfile.mkdtemp(prefix="test-path-config-")
+        try:
+            os.environ['SAWTOOTH_HOME'] = directory
+
+            config_dir = os.path.join(directory, 'etc')
+            os.mkdir(config_dir)
+            filename = os.path.join(config_dir, 'rest_api.toml')
+            with open(filename, 'w') as fd:
+                fd.write('bind = ["test:1234"]')
+                fd.write(os.linesep)
+                fd.write('connect = "tcp://test:40000"')
+                fd.write(os.linesep)
+                fd.write('timeout = 10')
+
+            config = load_toml_rest_api_config(filename)
+            self.assertEqual(config.bind, ["test:1234"])
+            self.assertEqual(config.connect, "tcp://test:40000")
+            self.assertEqual(config.timeout, 10)
+
+        finally:
+            os.environ.clear()
+            os.environ.update(orig_environ)
+            shutil.rmtree(directory)
+
+    def test_path_config_invalid_setting_in_file(self):
+        """Tests detecting invalid settings defined in a TOML configuration
+        file.
+
+        Sets the SAWTOOTH_HOME environment variable to a temporary directory,
+        writes a rest_api.toml config file with an invalid setting inside, then
+        loads that config and verifies an exception is thrown.
+
+        The test also attempts to avoid environment variables from interfering
+        with the test by clearing os.environ and restoring it after the test.
+        """
+        orig_environ = dict(os.environ)
+        os.environ.clear()
+        directory = tempfile.mkdtemp(prefix="test-path-config-")
+        try:
+            os.environ['SAWTOOTH_HOME'] = directory
+
+            config_dir = os.path.join(directory, 'etc')
+            os.mkdir(config_dir)
+            filename = os.path.join(config_dir, 'rest_api.toml')
+            with open(filename, 'w') as fd:
+                fd.write('invalid = "a value"')
+                fd.write(os.linesep)
+
+            with self.assertRaises(RestApiConfigurationError):
+                load_toml_rest_api_config(filename)
+        finally:
+            os.environ.clear()
+            os.environ.update(orig_environ)
+            shutil.rmtree(directory)

--- a/sdk/python/sawtooth_sdk/client/config.py
+++ b/sdk/python/sawtooth_sdk/client/config.py
@@ -17,7 +17,7 @@ import sys
 import toml
 
 
-def _get_config_dir():
+def get_config_dir():
     """Returns the sawtooth configuration directory based on the
     SAWTOOTH_HOME environment variable (if set) or OS defaults.
     """
@@ -50,7 +50,7 @@ def _get_dir(toml_config_setting,
     Returns:
         directory (str): The path.
     """
-    conf_file = os.path.join(_get_config_dir(), 'path.toml')
+    conf_file = os.path.join(get_config_dir(), 'path.toml')
     if os.path.exists(conf_file):
         with open(conf_file) as fd:
             raw_config = fd.read()
@@ -80,7 +80,7 @@ def _get_log_config(filename=None):
         log_config (dict): The dictionary to pass to logging.config.dictConfig
     """
     if filename is not None:
-        conf_file = os.path.join(_get_config_dir(), filename)
+        conf_file = os.path.join(get_config_dir(), filename)
     if os.path.exists(conf_file):
         with open(conf_file) as fd:
             raw_config = fd.read()


### PR DESCRIPTION
This commit adds a RestApiConfig object, an example
rest_api config file, and updates the rest_api to check
for a config file and combine it with any command line
options set.