### PR TITLE
Update Validator Registry TP to Use Config Setting for Enclave Measurement

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/enclave.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/enclave.py
@@ -1,0 +1,58 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_poet_cli import config
+from sawtooth_poet_cli.poet_enclave_module_wrapper import \
+    PoetEnclaveModuleWrapper
+
+
+def add_enclave_parser(subparsers, parent_parser):
+    """Add argument parser arguments for the `poet enclave` sub-command.
+    """
+    parser = subparsers.add_parser('enclave')
+
+    parser.add_argument(
+        '--enclave_module',
+        default='simulator',
+        choices=['simulator', 'sgx'],
+        type=str,
+        help='the enclave module to query')
+    parser.add_argument(
+        'characteristic',
+        choices=['measurement', 'basename'],
+        type=str,
+        help='enclave characteristic to retrieve')
+
+
+def do_enclave(args):
+    """Executes the `poet enclave` sub-command.
+
+    This command reads the appropriate characteristic from the enclave.  The
+    available characteristics are:
+    measurement - the enclave measurement (also know as mr_enclave)
+    basename - the enclave basename
+
+    The resulting characteristic value is printed to stdout
+    """
+    with PoetEnclaveModuleWrapper(
+            enclave_module=args.enclave_module,
+            config_dir=config.get_config_dir()) as poet_enclave_module:
+        if args.characteristic == 'measurement':
+            print(poet_enclave_module.get_enclave_measurement())
+        elif args.characteristic == 'basename':
+            print(poet_enclave_module.get_enclave_basename())
+        else:
+            AssertionError(
+                'Unknown enclave characteristic type: {}'.format(args.type))

--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -61,7 +61,7 @@ def add_genesis_parser(subparsers, parent_parser):
         '-o', '--output',
         default='poet-genesis.batch',
         type=str,
-        help='the name of the file to ouput the resulting batches')
+        help='the name of the file to output the resulting batches')
 
 
 def do_genesis(args):

--- a/consensus/poet/cli/sawtooth_poet_cli/main.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/main.py
@@ -23,6 +23,8 @@ from colorlog import ColoredFormatter
 from sawtooth_poet_cli.exceptions import CliException
 from sawtooth_poet_cli.genesis import add_genesis_parser
 from sawtooth_poet_cli.genesis import do_genesis
+from sawtooth_poet_cli.enclave import add_enclave_parser
+from sawtooth_poet_cli.enclave import do_enclave
 
 
 def create_console_handler(verbose_level):
@@ -79,6 +81,7 @@ def create_parser(prog_name):
     subparsers.required = True
 
     add_genesis_parser(subparsers, parent_parser)
+    add_enclave_parser(subparsers, parent_parser)
 
     return parser
 
@@ -98,6 +101,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
 
     if args.command == 'genesis':
         do_genesis(args)
+    elif args.command == 'enclave':
+        do_enclave(args)
     else:
         raise AssertionError('invalid command: {}'.format(args.command))
 

--- a/consensus/poet/cli/sawtooth_poet_cli/poet_enclave_module_wrapper.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/poet_enclave_module_wrapper.py
@@ -1,0 +1,63 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import importlib
+
+
+class PoetEnclaveModuleWrapper(object):
+    """A convenience wrapper class around the PoET enclave module.  It takes
+    care of automatically initializing and shutting down the enclave.  Use it
+    like this:
+
+    with PoetEnclaveModuleWrapper(enclave_module=..., config_dir=...) as mod:
+        mod.function(...)
+
+    Call PoET enclave modules as you normally would.  It couldn't be more
+    simple =) and now you don't have to worry about cleaning up.
+    """
+    __SIMULATOR_MODULE = \
+        'sawtooth_poet_simulator.poet_enclave_simulator.poet_enclave_simulator'
+    __SGX_MODULE = 'poet_enclave_sgx.poet_enclave'
+
+    def __init__(self, enclave_module, config_dir):
+        """Create the PoET enclave wrapper
+
+        Args:
+            enclave_module (str): The type of enclave desired ("simulator" or`
+                "sgx")
+            config_dir (str): The directory where configuration files can be
+                found
+        """
+        if enclave_module == 'simulator':
+            module_name = self.__SIMULATOR_MODULE
+        elif enclave_module == 'sgx':
+            module_name = self.__SGX_MODULE
+        else:
+            raise \
+                AssertionError(
+                    'Unknown enclave module: {}'.format(enclave_module))
+
+        try:
+            self._poet_enclave_module = importlib.import_module(module_name)
+        except ImportError as e:
+            raise AssertionError(str(e))
+
+        self._poet_enclave_module.initialize(config_dir=config_dir)
+
+    def __enter__(self):
+        return self._poet_enclave_module
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._poet_enclave_module.shutdown()

--- a/consensus/poet/families/tests/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/validator_reg_message_factory.py
@@ -308,7 +308,7 @@ class ValidatorRegistryMessageFactory(object):
             {'000000a87cb5eafdcca6a87ccc804f5546a'
              'b8e97a7d614626e4500e3b0c44298fc1c14': data})
 
-    def create_get_response_simulator_report_key_pem(self, pem=None):
+    def create_get_response_simulator_report_key_pem(self):
         pem = '''-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArMvzZi8GT+lI9KeZiInn
 4CvFTiuyid+IN4dP1+mhTnfxX+I/ntt8LUKZMbI1R1izOUoxJRoX6VQ4S9VgDLEC
@@ -320,3 +320,28 @@ fQIDAQAB
 -----END PUBLIC KEY-----'''
 
         return self.create_get_response_report_key_pem(pem=pem)
+
+    def create_get_request_enclave_measurements(self):
+        return \
+            self._factory.create_get_request(
+                ['000000a87cb5eafdcca6a87ccc804f5546a'
+                 'b8e39ccaeec28506829e3b0c44298fc1c14'])
+
+    def create_get_response_enclave_measurements(self, measurements=None):
+        setting = Setting()
+        if measurements is not None:
+            entry = Setting.Entry(key='sawtooth.poet.'
+                                      'valid_enclave_measurements',
+                                  value=measurements)
+            setting.entries.extend([entry])
+
+        data = setting.SerializeToString()
+        return self._factory.create_get_response(
+            {'000000a87cb5eafdcca6a87ccc804f5546a'
+             'b8e39ccaeec28506829e3b0c44298fc1c14': data})
+
+    def create_get_response_simulator_enclave_measurements(self):
+        return \
+            self.create_get_response_enclave_measurements(
+                measurements='c99f21955e38dbb03d2ca838d3af6e43'
+                             'ef438926ed02db4cc729380c8c7a174e')

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -162,6 +162,10 @@ class _PoetEnclaveSimulator(object):
         cls._anti_sybil_id = hashlib.sha256(validator_id.encode()).hexdigest()
 
     @classmethod
+    def shutdown(cls):
+        pass
+
+    @classmethod
     def get_enclave_measurement(cls):
         return cls.__VALID_ENCLAVE_MEASUREMENT__.hex()
 
@@ -482,6 +486,10 @@ class _PoetEnclaveSimulator(object):
 
 def initialize(config_dir):
     _PoetEnclaveSimulator.initialize(config_dir=config_dir)
+
+
+def shutdown():
+    _PoetEnclaveSimulator.shutdown()
 
 
 def get_enclave_measurement():

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -162,6 +162,14 @@ class _PoetEnclaveSimulator(object):
         cls._anti_sybil_id = hashlib.sha256(validator_id.encode()).hexdigest()
 
     @classmethod
+    def get_enclave_measurement(cls):
+        return cls.__VALID_ENCLAVE_MEASUREMENT__.hex()
+
+    @classmethod
+    def get_enclave_basename(cls):
+        return cls.__VALID_BASENAME__.hex()
+
+    @classmethod
     def create_signup_info(cls,
                            originator_public_key_hash,
                            nonce):
@@ -474,6 +482,14 @@ class _PoetEnclaveSimulator(object):
 
 def initialize(config_dir):
     _PoetEnclaveSimulator.initialize(config_dir=config_dir)
+
+
+def get_enclave_measurement():
+    return _PoetEnclaveSimulator.get_enclave_measurement()
+
+
+def get_enclave_basename():
+    return _PoetEnclaveSimulator.get_enclave_basename()
 
 
 def create_signup_info(validator_address,

--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -34,6 +34,7 @@ services:
           sawtooth.consensus.algorithm=poet \
           sawtooth.poet.report_public_key_pem=\
           \\\"$$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)\\\" \
+          sawtooth.poet.valid_enclave_measurements=$$(poet enclave measurement) \
           -o config.batch && \
         poet genesis -o poet.batch && \
         sawtooth admin genesis \

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -138,11 +138,22 @@ def validator_cmds(num,
         'simulator_rk_pub.pem') as fd:
         public_key_pem = fd.read()
 
+    # Use the poet CLI to get the enclave measurement so that we can put the
+    # value in the settings config for the validator registry transaction
+    # processor
+    result = \
+        subprocess.run(
+            ['poet', 'enclave', 'measurement'],
+            stdout=subprocess.PIPE)
+    enclave_measurement = result.stdout.decode('utf-8')
+
     config_proposal = ' '.join([
         'sawtooth config proposal create',
         '-k {}'.format(priv),
         'sawtooth.consensus.algorithm=poet',
         'sawtooth.poet.report_public_key_pem="{}"'.format(public_key_pem),
+        'sawtooth.poet.valid_enclave_measurements={}'.format(
+            enclave_measurement),
         'sawtooth.poet.target_wait_time={}'.format(target_wait_time),
         'sawtooth.poet.initial_wait_time={}'.format(initial_wait_time),
         'sawtooth.poet.minimum_wait_time={}'.format(minimum_wait_time),


### PR DESCRIPTION
This updates the VR TP to use valid enclave measurement values found in the config settings on the blockchain.   Updates include:

* Add functions to retrieve the enclave measurement and basename for the simulator enclave
* Add a shutdown function to simulator enclave to bring it into alignment with the SGX implementation
* Adds a wrapper around the enclave for convenience of the poet CLI
* Adds a new sub-command to the poet CLI to print out the enclave measurement
* Updates the VR TP to use the config settings for valid enclave measurement values
* Updates all affected tests

Resolves: STL-144

To test:

To test this locally, start up a validator as such (the instructions assume you are running inside Vagrant VM):
```
sawtooth admin keygen validator
sawtooth config genesis --key ~/sawtooth/keys/validator.priv -o config-genesis.batch
sawtooth config proposal create -k ~/sawtooth/keys/validator.priv sawtooth.consensus.algorithm=poet sawtooth.poet.report_public_key_pem="$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)" sawtooth.poet.valid_enclave_measurements=$(poet characteristic measurement) -o config.batch
poet genesis -k ~/sawtooth/keys/validator.priv -o poet_genesis.batch
sawtooth admin genesis config-genesis.batch config.batch poet_genesis.batch
validator -vv --public-uri http://localhost:8080
```
NOTE: order is important in the `sawtooth admin genesis` command as the proposal to create `sawtooth.poet.report_public_key` and `sawtooth.poet.valid_enclave_measurements` (`config.batch`) has to appear before the validator registry transaction for the genesis validator (`poet_genesis.batch`) as the validator registry TP needs to be able to fetch the value when verifying the VR transaction.

Start up a config TP:
`tp_config -vv tcp://localhost:40000`

Start up a validator registry TP:
`tp_validator_registry -vv tcp://localhost:40000`

All three should start up successfully.