### PR TITLE
Create Burrow EVM TP

### DIFF
--- a/bin/build_go
+++ b/bin/build_go
@@ -32,7 +32,11 @@ cd $top_dir/sdk/examples/noop_go/src/sawtooth_noop
 mkdir -p $top_dir/sdk/examples/noop_go/bin
 go build -o $top_dir/sdk/examples/noop_go/bin/tp_noop_go
 
+mkdir -p $top_dir/families/burrow_evm/bin
 echo -e "\033[0;32m--- Building tp_burrow_evm ---\n\033[0m"
 cd $top_dir/families/burrow_evm/src/sawtooth_burrow_evm
-mkdir -p $top_dir/families/burrow_evm/bin
 go build -o $top_dir/families/burrow_evm/bin/tp_burrow_evm
+
+echo -e "\033[0;32m--- Building seth ---\n\033[0m"
+cd $top_dir/families/burrow_evm/src/sawtooth_burrow_evm/client
+go build -o $top_dir/families/burrow_evm/bin/seth

--- a/bin/run_go_fmt
+++ b/bin/run_go_fmt
@@ -12,6 +12,7 @@ $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey
 $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey/handler
 $top_dir/families/burrow_evm/src/sawtooth_burrow_evm
 $top_dir/families/burrow_evm/src/sawtooth_burrow_evm/handler
+$top_dir/families/burrow_evm/src/sawtooth_burrow_evm/client
 "
 
 exitcode=0

--- a/bin/seth
+++ b/bin/seth
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+bin=$top_dir/families/burrow_evm/bin/seth
+
+if [ -e $bin ]
+then
+    $bin $*
+else
+    echo "Please build seth first with 'build_all -l go' or 'build_go'"
+fi

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -51,7 +51,8 @@ RUN mkdir /go \
     github.com/satori/go.uuid \
     github.com/btcsuite/btcd/btcec \
     gopkg.in/fatih/set.v0 \
-    golang.org/x/crypto/ripemd160
+    golang.org/x/crypto/ripemd160 \
+    github.com/jessevdk/go-flags
 
 EXPOSE 40000/tcp
 

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/create.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/create.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	"io/ioutil"
+	"sawtooth_sdk/client"
+)
+
+type Create struct {
+	Output string `short:"o" long:"out" description:"Name of files to create to store the generated keys and address"`
+}
+
+func (c *Create) Name() string {
+	return "create"
+}
+
+func (c *Create) Register(p *flags.Parser) error {
+	_, err := p.AddCommand("create", "Create a new account", "", c)
+	return err
+}
+
+func (c *Create) Do() error {
+	priv, pub, addr, err := gen()
+	if err != nil {
+		return err
+	}
+
+	if c.Output != "" {
+		err = write(c.Output+".priv", priv)
+		if err != nil {
+			return err
+		}
+		err = write(c.Output+".pub", pub)
+		if err != nil {
+			return err
+		}
+		err = write(c.Output+".addr", addr)
+		if err != nil {
+			return err
+		}
+
+	} else {
+		fmt.Println(priv)
+		fmt.Println(pub)
+		fmt.Println(addr)
+	}
+
+	return nil
+}
+
+func gen() (string, string, string, error) {
+	priv := client.GenPrivKey()
+	pub := client.GenPubKey(priv)
+	addr, err := PubToAddr(pub)
+	return client.MustEncode(priv), client.MustEncode(pub), addr[6 : 6+40], err
+}
+
+func write(name, s string) error {
+	return ioutil.WriteFile(name, []byte(s+"\n"), 0644)
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/exec.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/exec.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/jessevdk/go-flags"
+	"net/http"
+	. "sawtooth_burrow_evm/protobuf/evm_pb2"
+	"sawtooth_sdk/client"
+)
+
+type Exec struct {
+	Private string `short:"k" long:"key" required:"true" description:"A hex encoded private key to make the message call with."`
+	To      string `short:"t" long:"to" required:"true" description:"A 160 bit hex encoded address of an account to call."`
+	Data    string `short:"d" long:"data" description:"Hex encoded data to call the account with."`
+	Url     string `short:"U" long:"url" description:"The REST API URL to connect to when sending the transaction." default:"http://127.0.0.1:8080"`
+	Gas     uint64 `short:"g" long:"gas" description:"Amount of gas to supply the transaction with." default:"1000"`
+}
+
+func (e *Exec) Name() string {
+	return "exec"
+}
+
+func (e *Exec) Register(p *flags.Parser) error {
+	_, err := p.AddCommand("exec", "Call an existing account", "", e)
+	return err
+}
+
+func (e *Exec) Do() error {
+	priv := client.MustDecode(e.Private)
+	to := client.MustDecode(e.To)
+	data := client.MustDecode(e.Data)
+
+	transaction := &EvmTransaction{
+		GasLimit: e.Gas,
+		Data:     data,
+		To:       to,
+	}
+
+	fromAddr, err := PrivToAddr(priv)
+	toAddr, err := VmAddrToAddr(to)
+	if err != nil {
+		return err
+	}
+
+	encoder := client.NewEncoder(priv, client.TransactionParams{
+		FamilyName:      FAMILY_NAME,
+		FamilyVersion:   FAMILY_VERSION,
+		PayloadEncoding: ENCODING,
+		Inputs:          []string{fromAddr, toAddr},
+		Outputs:         []string{fromAddr, toAddr},
+	})
+
+	payload, err := proto.Marshal(transaction)
+	if err != nil {
+		return fmt.Errorf("Couldn't serialize transaction: %v", err)
+	}
+
+	txn := encoder.NewTransaction(payload, client.TransactionParams{})
+	batch := encoder.NewBatch([]*client.Transaction{txn})
+	b := client.SerializeBatches([]*client.Batch{batch})
+
+	buf := bytes.NewReader(b)
+
+	resp, err := http.Post(
+		e.Url+"/batches", "application/octet-stream", buf,
+	)
+	if err != nil {
+		return fmt.Errorf("Couldn't send transaction: %v", err)
+	}
+
+	body, err := ParseRespBody(resp)
+	if err != nil {
+		return fmt.Errorf("Couldn't parse response")
+	}
+	fmt.Println(body)
+
+	return nil
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/load.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/load.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/jessevdk/go-flags"
+	"net/http"
+	. "sawtooth_burrow_evm/protobuf/evm_pb2"
+	"sawtooth_sdk/client"
+)
+
+type Load struct {
+	Private string `short:"k" long:"key" required:"true" description:"A hex encoded private key to create the account with. See 'sawtooth keygen' for creation."`
+	Init    string `short:"i" long:"init" description:"Hex encoded initialization code to run on account creation."`
+	Url     string `short:"U" long:"url" description:"The REST API URL to connect to when sending the transaction." default:"http://127.0.0.1:8080"`
+	Gas     uint64 `short:"g" long:"gas" description:"Amount of gas to supply the transaction with." default:"1000"`
+}
+
+func (c *Load) Name() string {
+	return "load"
+}
+
+func (c *Load) Register(p *flags.Parser) error {
+	_, err := p.AddCommand("load", "Load a new account into state", "", c)
+	return err
+}
+
+func (c *Load) Do() error {
+	priv := client.MustDecode(c.Private)
+
+	init := client.MustDecode(c.Init)
+
+	transaction := &EvmTransaction{
+		GasLimit: c.Gas,
+		Init:     init,
+	}
+
+	address, err := PrivToAddr(priv)
+	if err != nil {
+		return err
+	}
+
+	encoder := client.NewEncoder(priv, client.TransactionParams{
+		FamilyName:      FAMILY_NAME,
+		FamilyVersion:   FAMILY_VERSION,
+		PayloadEncoding: ENCODING,
+		Inputs:          []string{address},
+		Outputs:         []string{address},
+	})
+
+	payload, err := proto.Marshal(transaction)
+	if err != nil {
+		return fmt.Errorf("Couldn't serialize transaction: %v", err)
+	}
+
+	txn := encoder.NewTransaction(payload, client.TransactionParams{})
+	batch := encoder.NewBatch([]*client.Transaction{txn})
+	b := client.SerializeBatches([]*client.Batch{batch})
+
+	buf := bytes.NewReader(b)
+
+	resp, err := http.Post(
+		c.Url+"/batches", "application/octet-stream", buf,
+	)
+
+	if err != nil {
+		return fmt.Errorf("Couldn't send transaction: %v", err)
+	}
+
+	body, err := ParseRespBody(resp)
+	if err != nil {
+		return fmt.Errorf("Couldn't parse response")
+	}
+	fmt.Println(body)
+
+	return nil
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/main.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	"os"
+	"sawtooth_sdk/logging"
+)
+
+var logger *logging.Logger = logging.Get()
+
+const (
+	FAMILY_NAME    = "burrow-evm"
+	FAMILY_VERSION = "1.0"
+	ENCODING       = "application/protobuf"
+	PREFIX         = "a84eda"
+)
+
+// All subcommands implement this interface
+type Command interface {
+	Register(*flags.Parser) error
+	Name() string
+	Do() error
+}
+
+// Opts to the main command
+type MainOpts struct {
+	Verbose []bool `short:"v" long:"verbose" description:"Set the log level"`
+}
+
+func main() {
+
+	var opts MainOpts
+
+	// Create top-level parser
+	parser := flags.NewParser(&opts, flags.Default)
+	parser.Command.Name = "seth"
+
+	// Add sub-commands
+	commands := []Command{
+		&Create{},
+		&Exec{},
+		&Load{},
+		&Show{},
+	}
+	for _, cmd := range commands {
+		err := cmd.Register(parser)
+		if err != nil {
+			logger.Errorf("Couldn't register command %v: %v", cmd.Name(), err)
+			os.Exit(1)
+		}
+	}
+
+	// Parse the args
+	remaining, err := parser.Parse()
+	if e, ok := err.(*flags.Error); ok {
+		if e.Type == flags.ErrHelp {
+			return
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	if len(remaining) > 0 {
+		fmt.Printf("Error: Unrecognized arguments passed: %v\n", remaining)
+		os.Exit(2)
+	}
+
+	switch len(opts.Verbose) {
+	case 2:
+		logger.SetLevel(logging.DEBUG)
+	case 1:
+		logger.SetLevel(logging.INFO)
+	default:
+		logger.SetLevel(logging.WARN)
+	}
+
+	// If a sub-command was passed, run it
+	if parser.Command.Active == nil {
+		os.Exit(2)
+	}
+
+	name := parser.Command.Active.Name
+	for _, cmd := range commands {
+		if cmd.Name() == name {
+			err := cmd.Do()
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+	}
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/show.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/show.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/jessevdk/go-flags"
+	"net/http"
+	. "sawtooth_burrow_evm/protobuf/evm_pb2"
+	"sawtooth_sdk/client"
+)
+
+type Show struct {
+	Private string `short:"k" long:"key" description:"A hex encoded private key to derive an address from for accessing state."`
+	Public  string `short:"p" long:"public" description:"A hex encoded public key to derive an address from for accessing state."`
+	Address string `short:"a" long:"address" description:"A hex encoded VM address for accessing state."`
+	Url     string `short:"U" long:"url" description:"The REST API URL to connect to when sending the transaction." default:"http://127.0.0.1:8080"`
+}
+
+func (s *Show) Name() string {
+	return "show"
+}
+
+func (s *Show) Register(p *flags.Parser) error {
+	_, err := p.AddCommand("show", "Show all data associated with the given address", "", s)
+	return err
+}
+
+func (s *Show) Do() (err error) {
+	n := 0
+	if s.Private != "" {
+		n += 1
+	}
+	if s.Public != "" {
+		n += 1
+	}
+	if s.Address != "" {
+		n += 1
+	}
+
+	if n != 1 {
+		return fmt.Errorf("Must pass exactly one of {-k PRIVATE, -p PUBLIC, -a ADDRESS}")
+	}
+
+	var address string
+	if s.Private != "" {
+		priv := client.MustDecode(s.Private)
+		address, err = PrivToAddr(priv)
+		if err != nil {
+			return
+		}
+	}
+	if s.Public != "" {
+		pub := client.MustDecode(s.Public)
+		address, err = PubToAddr(pub)
+		if err != nil {
+			return
+		}
+	}
+	if s.Address != "" {
+		vm := client.MustDecode(s.Address)
+		address, err = VmAddrToAddr(vm)
+		if err != nil {
+			return
+		}
+	}
+
+	entry, err := GetEntry(s.Url, address)
+	if err != nil {
+		return
+	}
+
+	DisplayEntry(entry)
+
+	return nil
+}
+
+type respBody struct {
+	Data string
+	Link string
+	Head string
+}
+
+func GetEntry(url, address string) (*EvmEntry, error) {
+	resp, err := http.Get(url + "/state/" + address)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ParseRespBody(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	buf, err := base64.StdEncoding.DecodeString(body.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	entry := &EvmEntry{}
+	err = proto.Unmarshal(buf, entry)
+	if err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func DisplayEntry(entry *EvmEntry) {
+	if entry == nil {
+		fmt.Println("Entry is nil")
+		return
+	}
+
+	act := entry.GetAccount()
+	stg := entry.GetStorage()
+
+	if len(act.GetAddress()) == 0 {
+		fmt.Println("Account does not exist")
+		return
+	}
+
+	fmt.Printf(`
+Address: %v
+Balance: %v
+Code   : %v
+Nonce  : %v
+`, client.MustEncode(act.GetAddress()[:20]), act.GetBalance(), client.MustEncode(act.GetCode()), act.GetNonce())
+
+	if len(stg) == 0 {
+		fmt.Println("(No Storage Set)\n")
+		return
+	}
+
+	fmt.Println("Storage:")
+	for _, pair := range stg {
+		key := client.MustEncode(pair.GetKey())
+		val := client.MustEncode(pair.GetValue())
+		fmt.Printf("%v -> %v", key, val)
+	}
+	fmt.Println("")
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/client/utils.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/client/utils.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"burrow/evm/sha3"
+	. "burrow/word256"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sawtooth_sdk/client"
+)
+
+const (
+	PRIVLEN   = 32
+	PUBLEN    = 33
+	ADDRLEN   = 35 * 2
+	VMADDRLEN = 20
+)
+
+func PrivToAddr(priv []byte) (string, error) {
+	if len(priv) != PRIVLEN {
+		return "", fmt.Errorf(
+			"Incorrect private key length (%v), should be %v",
+			len(priv), PRIVLEN,
+		)
+	}
+	pub := client.GenPubKey(priv)
+	return PubToAddr(pub)
+}
+
+func PubToAddr(pub []byte) (string, error) {
+	if len(pub) != PUBLEN {
+		return "", fmt.Errorf(
+			"Incorrect public key length (%v), should be %v",
+			len(pub), PUBLEN,
+		)
+	}
+	sha := sha3.Sha3(pub)[:20]
+	return VmAddrToAddr(sha)
+}
+
+func VmAddrToAddr(vm []byte) (string, error) {
+	if len(vm) != VMADDRLEN {
+		return "", fmt.Errorf(
+			"Incorrect EVM address length (%v), should be %v",
+			len(vm), VMADDRLEN,
+		)
+	}
+	a := PREFIX + client.MustEncode(RightPadBytes(vm, 32))
+	if len(a) != ADDRLEN {
+		return "", fmt.Errorf(
+			"Malformed address (%v): Incorrect length (%v != 70)", a, len(a),
+		)
+	}
+	return a, nil
+}
+
+type RespBody struct {
+	Data string
+	Link string
+	Head string
+}
+
+func (r *RespBody) String() string {
+	return fmt.Sprintf(`
+Data: %v
+Link: %v
+Head: %v
+`, r.Data, r.Link, r.Head)
+}
+
+func ParseRespBody(resp *http.Response) (*RespBody, error) {
+	defer resp.Body.Close()
+	buf, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(buf) == 0 {
+		return nil, fmt.Errorf("Nothing at that address")
+	}
+
+	body := new(RespBody)
+	err = json.Unmarshal(buf, body)
+
+	return body, err
+}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/handler/handler.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/handler/handler.go
@@ -1,28 +1,31 @@
 package handler
 
 import (
-	"crypto/sha512"
+	evm "burrow/evm"
+	. "burrow/word256"
 	"encoding/hex"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	. "sawtooth_burrow_evm/protobuf/evm_pb2"
+	"sawtooth_sdk/client"
 	"sawtooth_sdk/logging"
 	"sawtooth_sdk/processor"
 	"sawtooth_sdk/protobuf/processor_pb2"
+	"sawtooth_sdk/protobuf/transaction_pb2"
 	"strings"
+)
+
+const (
+	PREFIX    = "a84eda"
+	GAS_LIMIT = 1 << 31
 )
 
 var logger *logging.Logger = logging.Get()
 
-type BurrowEVMPayload struct {
-	Data []byte
-}
+type BurrowEVMHandler struct{}
 
-type BurrowEVMHandler struct {
-	namespace string
-}
-
-func NewBurrowEVMHandler(namespace string) *BurrowEVMHandler {
-	return &BurrowEVMHandler{
-		namespace: namespace,
-	}
+func NewBurrowEVMHandler() *BurrowEVMHandler {
+	return &BurrowEVMHandler{}
 }
 
 func (self *BurrowEVMHandler) FamilyName() string {
@@ -32,24 +35,226 @@ func (self *BurrowEVMHandler) FamilyVersion() string {
 	return "1.0"
 }
 func (self *BurrowEVMHandler) Encoding() string {
-	return "application/cbor"
+	return "application/protobuf"
 }
 func (self *BurrowEVMHandler) Namespaces() []string {
-	return []string{self.namespace}
+	return []string{PREFIX}
 }
 
 func (self *BurrowEVMHandler) Apply(request *processor_pb2.TpProcessRequest, state *processor.State) error {
-	payloadData := request.GetPayload()
-	if payloadData == nil {
-		return &processor.InvalidTransactionError{"Must contain payload"}
+
+	// Unpack and validate transaction
+	transaction, err := unpackPayload(request.GetPayload())
+	if err != nil {
+		return err
+	}
+
+	// Unpack and validate header
+	header, err := unpackHeader(request.GetHeader())
+	if err != nil {
+		return err
+	}
+
+	// Construct address of sender. This is the address used by the EVM to
+	// access the account.
+	pubkey := client.MustDecode(header.GetSignerPubkey())
+	senderAddress := createVmAddress(pubkey).Bytes()
+	sm := NewStateManager(PREFIX, state)
+
+	if transaction.GetTo() == nil {
+		err = loadContract(senderAddress, transaction, sm)
+	} else {
+		err = execContract(senderAddress, transaction, sm)
+	}
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
-func Hexdigest(str string) string {
-	hash := sha512.New()
-	hash.Write([]byte(str))
-	hashBytes := hash.Sum(nil)
-	return strings.ToLower(hex.EncodeToString(hashBytes))
+func loadContract(senderAddress []byte, txn *EvmTransaction, sm *StateManager) error {
+
+	// Load the entry for the sender from global state
+	senderEntry, err := sm.GetEntry(senderAddress)
+	if err != nil {
+		return &processor.InternalError{err.Error()}
+	}
+
+	var newEntryAddress []byte
+	// If the entry doesn't already exist, this is a new Externally Owned
+	// Account and it will be created at the sender's address.
+	if senderEntry == nil {
+		logger.Debugf("Creating new EOA")
+		if txn.GetNonce() != 0 {
+			return &processor.InvalidTransactionError{
+				"Nonce must be 0 when creating new Externally Owned Account",
+			}
+		}
+		newEntryAddress = senderAddress
+
+		// If the entry does already exist, this is a new Contract Account and it
+		// will be created at a new address derived from the existing account.
+	} else {
+		logger.Debugf("Creating new CA")
+		senderAccount := toVmAccount(senderEntry.GetAccount())
+		if senderAccount == nil {
+			return &processor.InternalError{fmt.Sprintf(
+				"Entry exists but no account (%v)", senderAddress,
+			)}
+		}
+		if txn.GetNonce() != uint64(senderEntry.GetAccount().GetNonce()) {
+			return &processor.InvalidTransactionError{fmt.Sprintf(
+				"Nonces do not match: Transaction (%v), State (%v)",
+				txn.GetNonce(), senderEntry.GetAccount().GetNonce(),
+			)}
+		}
+		newEntryAddress = deriveNewVmAddress(toVmAccount(senderEntry.GetAccount())).Bytes()
+	}
+
+	// Create the account
+	newEntry, err := sm.NewEntry(newEntryAddress)
+
+	// If there is an error creating the entry, something has gone very
+	// wrong, for example, an invalid public key making it passed the validator.
+	if err != nil {
+		return &processor.InternalError{fmt.Sprintf(
+			"Couldn't create account at %v: %v",
+			newEntryAddress, err,
+		)}
+	}
+
+	// If code was supplied, run it and set the account's code to the
+	// output.
+	if txn.GetInit() != nil {
+		newVmAccount := toVmAccount(newEntry.GetAccount())
+
+		init := txn.GetInit()[:]
+		gas := txn.GetGasLimit()
+
+		out, err := callVm(sm, newVmAccount, nil, init, nil, gas)
+		if err != nil {
+			return &processor.InternalError{err.Error()}
+		}
+		newVmAccount.Code = out
+
+		newEntry.Account = toStateAccount(newVmAccount)
+		err = sm.SetEntry(newEntryAddress, newEntry)
+
+		if err != nil {
+			return &processor.InternalError{fmt.Sprintf(
+				"Couldn't create account at %v: %v",
+				newEntryAddress, err,
+			)}
+		}
+	}
+
+	return nil
+}
+
+func execContract(senderAddress []byte, txn *EvmTransaction, sm *StateManager) error {
+
+	// Load the entry of the sender from global state
+	senderEntry, err := sm.GetEntry(senderAddress)
+	if err != nil {
+		return &processor.InternalError{err.Error()}
+	}
+	senderAccount := toVmAccount(senderEntry.GetAccount())
+
+	if senderEntry == nil || senderAccount == nil {
+		return &processor.InvalidTransactionError{fmt.Sprintf(
+			"Message call from non-existent account (%v)", senderAddress,
+		)}
+	}
+
+	if txn.GetNonce() != uint64(senderAccount.Nonce) {
+		return &processor.InvalidTransactionError{fmt.Sprintf(
+			"Nonces do not match: Transaction (%v), State (%v)",
+			txn.GetNonce(), senderEntry.GetAccount().GetNonce(),
+		)}
+	}
+
+	// Load the entry of the contract to be called from global state
+	receiverEntry, err := sm.GetEntry(txn.GetTo())
+	if err != nil {
+		return &processor.InvalidTransactionError{err.Error()}
+	}
+	receiverAccount := toVmAccount(receiverEntry.GetAccount())
+
+	if receiverEntry == nil || receiverAccount == nil {
+		return &processor.InvalidTransactionError{fmt.Sprintf(
+			"Call to non-existent account (%v)", txn.GetTo(),
+		)}
+	}
+
+	code := receiverAccount.Code
+	data := txn.GetData()[:]
+	gas := txn.GetGasLimit()
+
+	// Run the contract
+	out, err := callVm(sm, senderAccount, receiverAccount, code, data, gas)
+	if err != nil {
+		return &processor.InternalError{err.Error()}
+	}
+
+	logger.Debug("EVM Output: ", strings.ToLower(hex.EncodeToString(out)))
+	return nil
+}
+
+// ---
+
+func callVm(sm *StateManager, sender, receiver *evm.Account, code, input []byte, gas uint64) ([]byte, error) {
+
+	sas := NewSawtoothAppState(sm)
+
+	// Create EVM
+	params := evm.Params{
+		BlockHeight: 0,
+		BlockHash:   Zero256,
+		BlockTime:   0,
+		GasLimit:    GAS_LIMIT,
+	}
+	vm := evm.NewVM(sas, params, Zero256, nil)
+
+	// Convert the gas to a signed int to be compatible with the burrow EVM
+	sGas := int64(gas)
+
+	if receiver == nil {
+		receiver = sender
+	}
+	return vm.Call(sender, receiver, code, input, 0, &sGas)
+}
+
+func unpackPayload(payload []byte) (*EvmTransaction, error) {
+	if payload == nil {
+		return nil, &processor.InvalidTransactionError{
+			"Request must contain payload",
+		}
+	}
+
+	transaction := &EvmTransaction{}
+	err := proto.Unmarshal(payload, transaction)
+	if err != nil {
+		return nil, &processor.InvalidTransactionError{
+			"Malformed request payload",
+		}
+	}
+
+	return transaction, nil
+}
+
+func unpackHeader(headerBytes []byte) (*transaction_pb2.TransactionHeader, error) {
+	header := &transaction_pb2.TransactionHeader{}
+	err := proto.Unmarshal(headerBytes, header)
+	if err != nil {
+		return nil, &processor.InvalidTransactionError{
+			"Malformed request header",
+		}
+	}
+
+	if header.GetSignerPubkey() == "" {
+		return nil, &processor.InvalidTransactionError{"Public Key not set"}
+	}
+
+	return header, nil
 }

--- a/families/burrow_evm/src/sawtooth_burrow_evm/handler/state_manager.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/handler/state_manager.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"burrow/word256"
 	"fmt"
 	"github.com/golang/protobuf/proto"
 	. "sawtooth_burrow_evm/protobuf/evm_pb2"
@@ -10,6 +11,7 @@ import (
 
 // -- AppState --
 
+// StateManager simplifies accessing EVM related data stored in state
 type StateManager struct {
 	state  *processor.State
 	prefix string
@@ -152,5 +154,8 @@ func (mgr *StateManager) MustSetEntry(vmAddress []byte, entry *EvmEntry) {
 // Convert the byte representation of an address used by the EVM to the string
 // representation used by global state.
 func toStateAddress(prefix string, b []byte) string {
-	return prefix + client.Encode(b, "hex")
+	// Make sure the address is padded correctly
+	b = word256.RightPadBytes(b, 32)
+
+	return prefix + client.MustEncode(b)
 }

--- a/families/burrow_evm/src/sawtooth_burrow_evm/main.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/main.go
@@ -1,41 +1,59 @@
 package main
 
 import (
-	"flag"
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	"os"
 	burrow_evm "sawtooth_burrow_evm/handler"
 	"sawtooth_sdk/logging"
 	"sawtooth_sdk/processor"
 	"syscall"
 )
 
+type Opts struct {
+	Verbose []bool `short:"v" long:"verbose" description:"Increase verbosity"`
+}
+
 func main() {
-	v := flag.Bool("v", false, "Info level logging")
-	vv := flag.Bool("vv", false, "Debug level logging")
-	endpoint := "tcp://localhost:40000"
 
-	flag.Parse()
-	args := flag.Args()
-	if len(args) > 0 {
-		// Overwrite the default endpoint if specified
-		endpoint = args[0]
-	}
-
-	level := logging.WARN
-	if *v {
-		level = logging.INFO
-	}
-	if *vv {
-		level = logging.DEBUG
-	}
+	var opts Opts
 
 	logger := logging.Get()
-	logger.SetLevel(level)
+
+	parser := flags.NewParser(&opts, flags.Default)
+	remaining, err := parser.Parse()
+	if err != nil {
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
+			logger.Errorf("Failed to parse args: %v", err)
+			os.Exit(2)
+		}
+	}
+	if len(remaining) > 1 {
+		fmt.Println("Must pass one or fewer endpoints")
+		os.Exit(2)
+	}
+
+	endpoint := "tcp://localhost:40000"
+	if len(remaining) == 1 {
+		endpoint = remaining[0]
+	}
+
+	switch len(opts.Verbose) {
+	case 2:
+		logger.SetLevel(logging.DEBUG)
+	case 1:
+		logger.SetLevel(logging.INFO)
+	default:
+		logger.SetLevel(logging.WARN)
+	}
 
 	handler := burrow_evm.NewBurrowEVMHandler()
 	processor := processor.NewTransactionProcessor(endpoint)
 	processor.AddHandler(handler)
 	processor.ShutdownOnSignal(syscall.SIGINT, syscall.SIGTERM)
-	err := processor.Start()
+	err = processor.Start()
 	if err != nil {
 		logger.Error("Processor stopped: ", err)
 	}

--- a/families/burrow_evm/src/sawtooth_burrow_evm/main.go
+++ b/families/burrow_evm/src/sawtooth_burrow_evm/main.go
@@ -1,20 +1,42 @@
 package main
 
 import (
-	"os"
+	"flag"
 	burrow_evm "sawtooth_burrow_evm/handler"
+	"sawtooth_sdk/logging"
 	"sawtooth_sdk/processor"
+	"syscall"
 )
 
 func main() {
+	v := flag.Bool("v", false, "Info level logging")
+	vv := flag.Bool("vv", false, "Debug level logging")
 	endpoint := "tcp://localhost:40000"
-	if len(os.Args) > 1 {
-		endpoint = os.Args[2]
+
+	flag.Parse()
+	args := flag.Args()
+	if len(args) > 0 {
+		// Overwrite the default endpoint if specified
+		endpoint = args[0]
 	}
 
-	prefix := burrow_evm.Hexdigest("burrow_evm")[:6]
-	handler := burrow_evm.NewBurrowEVMHandler(prefix)
+	level := logging.WARN
+	if *v {
+		level = logging.INFO
+	}
+	if *vv {
+		level = logging.DEBUG
+	}
+
+	logger := logging.Get()
+	logger.SetLevel(level)
+
+	handler := burrow_evm.NewBurrowEVMHandler()
 	processor := processor.NewTransactionProcessor(endpoint)
 	processor.AddHandler(handler)
-	processor.Start()
+	processor.ShutdownOnSignal(syscall.SIGINT, syscall.SIGTERM)
+	err := processor.Start()
+	if err != nil {
+		logger.Error("Processor stopped: ", err)
+	}
 }

--- a/tools/plugins/install_go_tools.sh
+++ b/tools/plugins/install_go_tools.sh
@@ -18,7 +18,8 @@ go get -u \
     github.com/satori/go.uuid \
     github.com/btcsuite/btcd/btcec \
     gopkg.in/fatih/set.v0 \
-    golang.org/x/crypto/ripemd160
+    golang.org/x/crypto/ripemd160 \
+    github.com/jessevdk/go-flags
 
 chown -R $VAGRANT_USER:$VAGRANT_USER $GOPATH
 chown -R $VAGRANT_USER:$VAGRANT_USER $GOPATH/bin


### PR DESCRIPTION
NOTE: The first 4 Go SDK commits are also in a separate PR against master.

To start the TP:
```
build_go
tp_burrow_evm -vv
```

To test the TP with the client, you can use:
```
seth load -k 8ff78a756a018e41cdd0364bfe88cb4547867eae27a0ee03fd3a585000775d90 -i 6060604052341561000c57fe5b5b60b08061001b6000396000f300606060405263ffffffff7c010000000000000000000000000000000000000000000000000000000060003504166360fe47b1811460435780636d4ce63c146055575bfe5b3415604a57fe5b60536004356074565b005b3415605c57fe5b6062607d565b60408051918252519081900360200190f35b60008190555b50565b6000545b905600a165627a7a72305820ec5f770aeda092d29c5a11c326a9ca0c377f3342db5d8eabfdbc2f8ffc23e25d0029 --url http://rest_api:8080

seth exec -k 8ff78a756a018e41cdd0364bfe88cb4547867eae27a0ee03fd3a585000775d90 -t 6fb1aca9b78709b7a9fe94b9dce0d946adf48907 -d 60fe47b1000000000000000000000000000000000000000000000000000000000000002a --url http://rest_api:8080

seth exec -k 8ff78a756a018e41cdd0364bfe88cb4547867eae27a0ee03fd3a585000775d90 -t 6fb1aca9b78709b7a9fe94b9dce0d946adf48907 -d 6d4ce63c --url http://rest_api:8080

seth show -k 8ff78a756a018e41cdd0364bfe88cb4547867eae27a0ee03fd3a585000775d90 --url http://rest_api:8080
```

The load command creates a new smart contract that has two functions, set() and get(). The first exec command calls set(42). The second calls get(). The show command dumps out the information associated with the given account (private key).