### PR TITLE
Update Validator Registry TP to Use Config Setting for Enclave Basename

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -128,7 +128,7 @@ def do_genesis(args):
         [ConfigView.setting_address('sawtooth.poet.report_public_key_pem'),
          ConfigView.setting_address('sawtooth.poet.'
                                     'valid_enclave_measurements'),
-         ConfigView.setting_address('sawtooth.poet.valid_basename')]
+         ConfigView.setting_address('sawtooth.poet.valid_enclave_basenames')]
 
     header = \
         txn_pb.TransactionHeader(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -160,9 +160,10 @@ class PoetBlockPublisher(BlockPublisherInterface):
         input_addresses = \
             output_addresses + \
             [ConfigView.setting_address('sawtooth.poet.report_public_key_pem'),
-             ConfigView.setting_address('sawtooth.poet.'
-                                        'valid_enclave_measurements'),
-             ConfigView.setting_address('sawtooth.poet.valid_basename')]
+             ConfigView.setting_address(
+                 'sawtooth.poet.valid_enclave_measurements'),
+             ConfigView.setting_address(
+                 'sawtooth.poet.valid_enclave_basenames')]
 
         header = \
             txn_pb.TransactionHeader(

--- a/consensus/poet/families/tests/test_tp_validator_registry.py
+++ b/consensus/poet/families/tests/test_tp_validator_registry.py
@@ -79,6 +79,15 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
             self.factory.create_get_response_simulator_enclave_measurements(),
             received)
 
+        # Expect Request for the address for valid enclave basenames
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_basenames())
+
+        # Respond with the simulator valid enclave basenames
+        self.validator.respond(
+            self.factory.create_get_response_simulator_enclave_basenames(),
+            received)
+
         # Expect Request for the ValidatorMap
         received = self.validator.expect(
             self.factory.create_get_request_validator_map())
@@ -137,6 +146,15 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         # Respond with the simulator valid enclave measurements
         self.validator.respond(
             self.factory.create_get_response_simulator_enclave_measurements(),
+            received)
+
+        # Expect Request for the address for valid enclave basenames
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_basenames())
+
+        # Respond with the simulator valid enclave basenames
+        self.validator.respond(
+            self.factory.create_get_response_simulator_enclave_basenames(),
             received)
 
         # Expect Request for the ValidatorMap
@@ -263,6 +281,15 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
             self.factory.create_get_response_simulator_enclave_measurements(),
             received)
 
+        # Expect Request for the address for valid enclave basenames
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_basenames())
+
+        # Respond with the simulator valid enclave basenames
+        self.validator.respond(
+            self.factory.create_get_response_simulator_enclave_basenames(),
+            received)
+
         self._expect_invalid_transaction()
 
     def _test_bad_signup_info(self, signup_info, expect_config=True):
@@ -294,6 +321,15 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
             self.validator.respond(
                 self.factory.
                 create_get_response_simulator_enclave_measurements(),
+                received)
+
+            # Expect Request for the address for valid enclave basenames
+            received = self.validator.expect(
+                self.factory.create_get_request_enclave_basenames())
+
+            # Respond with the simulator valid enclave basenames
+            self.validator.respond(
+                self.factory.create_get_response_simulator_enclave_basenames(),
                 received)
 
         self._expect_invalid_transaction()
@@ -753,6 +789,99 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         self.validator.respond(
             self.factory.create_get_response_enclave_measurements(
                 measurements='invalid'),
+            received)
+
+        # Expect that the transaction will be rejected
+        self._expect_invalid_transaction()
+
+    def test_missing_enclave_basenames(self):
+        """
+        Testing validator registry unable to retrieve the valid enclave
+        basenames from the config setting.
+        """
+        signup_info = self.factory.create_signup_info(
+            self.factory.pubkey_hash, "000")
+
+        payload = ValidatorRegistryPayload(
+            verb="reg", name="val_1", id=self.factory.public_key,
+            signup_info=signup_info)
+
+        # Send validator registry payload
+        self.validator.send(
+            self.factory.create_tp_process_request(payload.id, payload))
+
+        # Expect Request for the address for report key PEM
+        received = self.validator.expect(
+            self.factory.create_get_request_report_key_pem())
+
+        # Respond with the simulator report key PEM
+        self.validator.respond(
+            self.factory.create_get_response_simulator_report_key_pem(),
+            received)
+
+        # Expect Request for the address for valid enclave measurements
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_measurements())
+
+        # Respond with simulator valid enclave measurements
+        self.validator.respond(
+            self.factory.create_get_response_simulator_enclave_measurements(),
+            received)
+
+        # Expect Request for the address for valid enclave basenames
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_basenames())
+
+        # Respond with empty enclave basenames
+        self.validator.respond(
+            self.factory.create_get_response_enclave_basenames(),
+            received)
+
+        # Expect that the transaction will be rejected
+        self._expect_invalid_transaction()
+
+    def test_invalid_enclave_basenames(self):
+        """
+        Testing validator registry unable to successfully parse the valid
+        enclave basenames from the config setting.
+        """
+        signup_info = self.factory.create_signup_info(
+            self.factory.pubkey_hash, "000")
+
+        payload = ValidatorRegistryPayload(
+            verb="reg", name="val_1", id=self.factory.public_key,
+            signup_info=signup_info)
+
+        # Send validator registry payload
+        self.validator.send(
+            self.factory.create_tp_process_request(payload.id, payload))
+
+        # Expect Request for the address for report key PEM
+        received = self.validator.expect(
+            self.factory.create_get_request_report_key_pem())
+
+        # Respond with the simulator report key PEM
+        self.validator.respond(
+            self.factory.create_get_response_simulator_report_key_pem(),
+            received)
+
+        # Expect Request for the address for valid enclave measurements
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_measurements())
+
+        # Respond with simulator valid enclave measurements
+        self.validator.respond(
+            self.factory.create_get_response_simulator_enclave_measurements(),
+            received)
+
+        # Expect Request for the address for valid enclave basenames
+        received = self.validator.expect(
+            self.factory.create_get_request_enclave_basenames())
+
+        # Respond with empty enclave basenames
+        self.validator.respond(
+            self.factory.create_get_response_enclave_basenames(
+                basenames='invalid'),
             received)
 
         # Expect that the transaction will be rejected

--- a/consensus/poet/families/tests/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/validator_reg_message_factory.py
@@ -345,3 +345,28 @@ fQIDAQAB
             self.create_get_response_enclave_measurements(
                 measurements='c99f21955e38dbb03d2ca838d3af6e43'
                              'ef438926ed02db4cc729380c8c7a174e')
+
+    def create_get_request_enclave_basenames(self):
+        return \
+            self._factory.create_get_request(
+                ['000000a87cb5eafdcca6a87ccc804f5546a'
+                 'b8ebec3b47bc008b27de3b0c44298fc1c14'])
+
+    def create_get_response_enclave_basenames(self, basenames=None):
+        setting = Setting()
+        if basenames is not None:
+            entry = Setting.Entry(key='sawtooth.poet.'
+                                      'valid_enclave_basenames',
+                                  value=basenames)
+            setting.entries.extend([entry])
+
+        data = setting.SerializeToString()
+        return self._factory.create_get_response(
+            {'000000a87cb5eafdcca6a87ccc804f5546a'
+             'b8ebec3b47bc008b27de3b0c44298fc1c14': data})
+
+    def create_get_response_simulator_enclave_basenames(self):
+        return \
+            self.create_get_response_enclave_basenames(
+                basenames='b785c58b77152cbe7fd55ee3851c4990'
+                          '00000000000000000000000000000000')

--- a/integration/sawtooth_integration/docker/poet-smoke.yaml
+++ b/integration/sawtooth_integration/docker/poet-smoke.yaml
@@ -35,6 +35,7 @@ services:
           sawtooth.poet.report_public_key_pem=\
           \\\"$$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)\\\" \
           sawtooth.poet.valid_enclave_measurements=$$(poet enclave measurement) \
+          sawtooth.poet.valid_enclave_basenames=$$(poet enclave basename) \
           -o config.batch && \
         poet genesis -o poet.batch && \
         sawtooth admin genesis \

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -147,6 +147,15 @@ def validator_cmds(num,
             stdout=subprocess.PIPE)
     enclave_measurement = result.stdout.decode('utf-8')
 
+    # Use the poet CLI to get the enclave basename so that we can put the
+    # value in the settings config for the validator registry transaction
+    # processor
+    result = \
+        subprocess.run(
+            ['poet', 'enclave', 'basename'],
+            stdout=subprocess.PIPE)
+    enclave_basename = result.stdout.decode('utf-8')
+
     config_proposal = ' '.join([
         'sawtooth config proposal create',
         '-k {}'.format(priv),
@@ -154,6 +163,7 @@ def validator_cmds(num,
         'sawtooth.poet.report_public_key_pem="{}"'.format(public_key_pem),
         'sawtooth.poet.valid_enclave_measurements={}'.format(
             enclave_measurement),
+        'sawtooth.poet.valid_enclave_basenames={}'.format(enclave_basename),
         'sawtooth.poet.target_wait_time={}'.format(target_wait_time),
         'sawtooth.poet.initial_wait_time={}'.format(initial_wait_time),
         'sawtooth.poet.minimum_wait_time={}'.format(minimum_wait_time),


### PR DESCRIPTION
NOTE - This PR is built on STL-144 (PR #534).  That PR needs to be merged before this PR.  I will rebase it once that PR is merged.  Only the last two commits are new code for this PR.

This updates the VR TP to use valid enclave basename values found in the config settings on the blockchain.   Updates include:

* Updates the VR TP to use the config settings for valid enclave basename values
* Updates all affected tests

Resolves: STL-146

To test:

To test this locally, start up a validator as such (the instructions assume you are running inside Vagrant VM):
```
sawtooth admin keygen validator
sawtooth config genesis --key ~/sawtooth/keys/validator.priv -o config-genesis.batch
sawtooth config proposal create -k ~/sawtooth/keys/validator.priv sawtooth.consensus.algorithm=poet sawtooth.poet.report_public_key_pem="$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)" sawtooth.poet.valid_enclave_measurements=$(poet characteristic measurement) sawtooth.poet.valid_enclave_basenames=$(poet characteristic basename) -o config.batch
poet genesis -k ~/sawtooth/keys/validator.priv -o poet_genesis.batch
sawtooth admin genesis config-genesis.batch config.batch poet_genesis.batch
validator -vv --public-uri http://localhost:8080
```
NOTE: order is important in the `sawtooth admin genesis` command as the proposal to create `sawtooth.poet.report_public_key`, `sawtooth.poet.valid_enclave_measurements`, and `sawtooth.poet.valid_enclave_basenames` (`config.batch`) has to appear before the validator registry transaction for the genesis validator (`poet_genesis.batch`) as the validator registry TP needs to be able to fetch the value when verifying the VR transaction.

Start up a config TP:
`tp_config -vv tcp://localhost:40000`

Start up a validator registry TP:
`tp_validator_registry -vv tcp://localhost:40000`

All three should start up successfully.