### PR TITLE
Update REST API to handle proxying properly

### DIFF
--- a/bin/build_all
+++ b/bin/build_all
@@ -102,6 +102,8 @@ main() {
     # Start in project directory
     cd $top_dir
 
+    build_external
+
     if [[ $BUILD_MODE == $DEBS ]]
     then
         build_debs
@@ -194,6 +196,10 @@ docker_build() {
         --build-arg http_proxy=$http_proxy \
         --build-arg HTTPS_PROXY=$HTTPS_PROXY \
         --build-arg HTTP_PROXY=$HTTP_PROXY
+}
+
+build_external() {
+    docker_build docker/apache-basic_auth_proxy docker/ apache-basic_auth_proxy
 }
 
 build_debs() {

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -280,6 +280,8 @@ test_python_sdk() {
 test_integration() {
     run_docker_test dynamic-network -s integration_test --timeout 600
     copy_coverage .coverage.dynamic-network
+    run_docker_test basic-auth-proxy -s integration_test
+    copy_coverage .coverage.basic-auth-proxy
 }
 
 test_deployment() {

--- a/docker/apache-basic_auth_proxy
+++ b/docker/apache-basic_auth_proxy
@@ -1,0 +1,74 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image to be used in testing using authentication proxies with the
+#   REST API. Redirects from 'basic_auth_proxy/sawtooth' to 'rest_api:8080'.
+#
+# Build:
+#   $ cd sawtooth-core/docker
+#   $ docker build . \
+#     -f apache-basic_auth_proxy \
+#     -t apache-basic_auth_proxy
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -v $(pwd):/project/sawtooth-core \
+#     -v /var/run/docker.sock:/var/run/docker.sock \
+#     apache-basic_auth_proxy
+
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+    apache2 \
+ && a2enmod proxy_http \
+ && a2enmod headers
+
+RUN echo "\nServerName basic_auth_proxy\n" >> /etc/apache2/apache2.conf
+
+RUN echo "\
+sawtooth:\$apr1\$cyAIkitu\$Cv6M2hHJlNgnVvKbUdlFr.\n\
+\n\
+" >/tmp/.password
+
+RUN echo "\
+<VirtualHost *:80>\n\
+        ServerAdmin sawtooth@sawtooth\n\
+        DocumentRoot /var/www/html\n\
+\n\
+        ErrorLog ${APACHE_LOG_DIR}/error.log\n\
+        CustomLog ${APACHE_LOG_DIR}/access.log combined\n\
+\n\
+        <Location />\n\
+                Options Indexes FollowSymLinks\n\
+                AllowOverride None\n\
+                AuthType Basic\n\
+                AuthName \"Enter password\"\n\
+                AuthUserFile \"/tmp/.password\"\n\
+                Require user sawtooth\n\
+                Require all denied\n\
+        </Location>\n\
+</VirtualHost>\n\
+\n\
+ProxyPass /sawtooth http://rest_api:8080\n\
+ProxyPassReverse /sawtooth http://rest_api:8080\n\
+RequestHeader set X-Forwarded-Path \"/sawtooth\"\n\
+\n\
+" >/etc/apache2/sites-enabled/000-default.conf
+
+EXPOSE 80
+EXPOSE 8080
+
+CMD ["apachectl start"]

--- a/integration/sawtooth_integration/docker/basic-auth-proxy.yaml
+++ b/integration/sawtooth_integration/docker/basic-auth-proxy.yaml
@@ -1,0 +1,84 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        validator -v \
+            --public-uri tcp://validator:8800 \
+            --component-endpoint tcp://eth0:40000 \
+            --network-endpoint tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest_api:
+    image: sawtooth-rest_api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8080
+    depends_on:
+      - validator
+    command: rest_api -v --stream-url tcp://validator:40000 --host rest_api
+    stop_signal: SIGKILL
+
+  basic_auth_proxy:
+    image: apache-basic_auth_proxy:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 80
+      - 8080
+    depends_on:
+      - validator
+      - rest_api
+    command: "bash -c \"\
+        apachectl start && \
+        tail -f /dev/null \
+        \""
+    stop_signal: SIGKILL
+
+  integration_test:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 80
+    depends_on:
+      - validator
+      - rest_api
+      - basic_auth_proxy
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_basic_auth_proxy.TestBasicAuth
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:"

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -1,0 +1,68 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+import logging
+import json
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+from base64 import b64encode
+
+from sawtooth_integration.tests.integration_tools import wait_until_status
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+class TestBasicAuth(unittest.TestCase):
+
+    def setUp(self):
+        wait_until_status('http://basic_auth_proxy/sawtooth', status_code=401)
+
+    def test_fetch_blocks(self):
+        """Checks that an authenticated request can be made through a proxy
+        to the REST API, and that the returned "link" parameter properly
+        reflects the url of the proxy.
+
+        The proxy should redirect from `http://basic_auth_proxy/sawtooth` to
+        `http://rest_api:8080`, and be configured with a Basic Auth
+        username:password combination of 'sawtooth:sawtooth'.
+
+        In order to get back the correct link, the proxy must both forward the
+        host and add a custom RequestHeader of 'X-Forwarded-Path: /sawtooth'.
+        """
+        url = 'http://basic_auth_proxy/sawtooth/blocks'
+        auth = 'Basic {}'.format(b64encode(b'sawtooth:sawtooth').decode())
+        LOGGER.info(('\n'
+                     'Sending request to "{}",\n'
+                     'with "Authorition: {}"').format(url, auth))
+
+        try:
+            response = urlopen(Request(url, headers={'Authorization': auth}))
+        except HTTPError as e:
+            response = e.file
+            error = json.loads(response.read().decode())['error']
+            LOGGER.error('{} - {}:'.format(error['code'], error['title']))
+            LOGGER.error(error['message'])
+
+        self.assertEqual(200, response.getcode())
+        LOGGER.info('Authorization succeeded, 200 response received.')
+
+        link = json.loads(response.read().decode())['link']
+
+        LOGGER.info('Verifying link: "{:.50}..."'.format(link))
+        self.assertTrue(link.startswith(url))
+        LOGGER.info('Link verified.')

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -215,7 +215,7 @@ class PostBatchTests(BaseApiTest):
         self.assertEqual(202, request.status)
 
         response = await request.json()
-        self.assert_has_valid_link(response, '/batch_status?id=pending')
+        self.assert_has_valid_link(response, '/batch_status?id=pending&wait')
         self.assert_statuses_match(statuses, response['data'])
 
 


### PR DESCRIPTION
Updates the REST API to handle proxy urls when building a response `link`. It will now look for an `X-Forwarded-Host` header, and an `X-Forwarded-Path` header, and prefer those to the default host/path.

Also includes a new integration test which will set up an Apache 2 Basic Auth proxy in front of the REST API, and confirm it can be properly authorized, and sends back correct links.