### PR TITLE
Explicitly set GOPATH in bin/build_go

### DIFF
--- a/bin/build_go
+++ b/bin/build_go
@@ -23,11 +23,13 @@ echo -e "\033[0;32m--- Running protogen go ---\n\033[0m"
 $top_dir/bin/protogen go
 
 echo -e "\033[0;32m--- Building tp_intkey_go ---\n\033[0m"
+export GOPATH=/go:$top_dir/sdk/go:$top_dir/sdk/examples/intkey_go
 cd $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey
 mkdir -p $top_dir/sdk/examples/intkey_go/bin
 go build -o $top_dir/sdk/examples/intkey_go/bin/tp_intkey_go
 
 echo -e "\033[0;32m--- Building tp_noop_go ---\n\033[0m"
+export GOPATH=/go:$top_dir/sdk/go:$top_dir/sdk/examples/noop_go
 cd $top_dir/sdk/examples/noop_go/src/sawtooth_noop
 mkdir -p $top_dir/sdk/examples/noop_go/bin
 go build -o $top_dir/sdk/examples/noop_go/bin/tp_noop_go


### PR DESCRIPTION
This is intended to allow running bin/build_go without having
GOPATH set in the developer's environment.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>