### PR TITLE
Add Basic Auth support to Sawtooth CLI

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -64,7 +64,7 @@ def do_batch(args):
         Args:
             args: The parsed arguments sent to the command at runtime
     """
-    rest_client = RestClient(args.url)
+    rest_client = RestClient(args.url, args.user)
 
     if args.subcommand == 'list':
         batches = rest_client.list_batches()

--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -17,6 +17,9 @@ import argparse
 from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
 from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.parent_parsers import base_http_parser
+from sawtooth_cli.parent_parsers import base_list_parser
+from sawtooth_cli.parent_parsers import base_show_parser
 
 
 def add_batch_parser(subparsers, parent_parser):
@@ -31,24 +34,15 @@ def add_batch_parser(subparsers, parent_parser):
     grand_parsers = parser.add_subparsers(title='grandchildcommands',
                                           dest='subcommand')
     grand_parsers.required = True
+
     epilog = '''details:
         Lists committed batches from newest to oldest, including their id (i.e.
     header signature), transaction count, and their signer's public key.
     '''
-
-    list_parser = grand_parsers.add_parser(
+    grand_parsers.add_parser(
         'list', epilog=epilog,
+        parents=[base_http_parser(), base_list_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    list_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    list_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='default',
-        choices=['csv', 'json', 'yaml', 'default'],
-        help='the format of the output, options: csv, json or yaml')
 
     epilog = '''details:
         Shows the data for a single batch, or for a particular property within
@@ -56,25 +50,12 @@ def add_batch_parser(subparsers, parent_parser):
     '''
     show_parser = grand_parsers.add_parser(
         'show', epilog=epilog,
+        parents=[base_http_parser(), base_show_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'batch_id',
         type=str,
         help='the id (i.e. header_signature) of the batch')
-    show_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    show_parser.add_argument(
-        '-k', '--key',
-        type=str,
-        help='specify to show a single property from the batch or header')
-    show_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='yaml',
-        choices=['yaml', 'json'],
-        help='the format of the output, options: yaml (default), or json')
 
 
 def do_batch(args):

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -65,7 +65,7 @@ def do_block(args):
         Args:
             args: The parsed arguments sent to the command at runtime
     """
-    rest_client = RestClient(args.url)
+    rest_client = RestClient(args.url, args.user)
 
     if args.subcommand == 'list':
         blocks = rest_client.list_blocks()

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -17,6 +17,9 @@ import argparse
 from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
 from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.parent_parsers import base_http_parser
+from sawtooth_cli.parent_parsers import base_list_parser
+from sawtooth_cli.parent_parsers import base_show_parser
 
 
 def add_block_parser(subparsers, parent_parser):
@@ -31,25 +34,16 @@ def add_block_parser(subparsers, parent_parser):
     grand_parsers = parser.add_subparsers(title='grandchildcommands',
                                           dest='subcommand')
     grand_parsers.required = True
+
     epilog = '''details:
         Lists committed blocks from the newest to the oldest, including
     their id (i.e. header signature), batch and transaction count, and
     their signer's public key.
     '''
-
-    list_parser = grand_parsers.add_parser(
+    grand_parsers.add_parser(
         'list', epilog=epilog,
+        parents=[base_http_parser(), base_list_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    list_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    list_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='default',
-        choices=['csv', 'json', 'yaml', 'default'],
-        help='the format of the output, options: csv, json or yaml')
 
     epilog = '''details:
         Shows the data for a single block, or for a particular property within
@@ -57,25 +51,12 @@ def add_block_parser(subparsers, parent_parser):
     '''
     show_parser = grand_parsers.add_parser(
         'show', epilog=epilog,
+        parents=[base_http_parser(), base_show_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'block_id',
         type=str,
         help='the id (i.e. header_signature) of the block')
-    show_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    show_parser.add_argument(
-        '-k', '--key',
-        type=str,
-        help='specify to show a single property from the block or header')
-    show_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='yaml',
-        choices=['yaml', 'json'],
-        help='the format of the output, options: yaml (default), or json')
 
 
 def do_block(args):

--- a/cli/sawtooth_cli/parent_parsers.py
+++ b/cli/sawtooth_cli/parent_parsers.py
@@ -30,6 +30,11 @@ def base_http_parser():
         type=str,
         default='http://localhost:8080',
         help="the URL of the validator's REST API")
+    base_parser.add_argument(
+        '-u', '--user',
+        type=str,
+        metavar='USERNAME[:PASSWORD]',
+        help='user login info to authorize request')
 
     return base_parser
 

--- a/cli/sawtooth_cli/parent_parsers.py
+++ b/cli/sawtooth_cli/parent_parsers.py
@@ -1,0 +1,76 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from argparse import ArgumentParser
+
+
+def base_http_parser():
+    """Creates a parser with arguments specific to sending an HTTP request
+    to the REST API.
+
+    Returns:
+        {ArgumentParser}: Base parser with default HTTP args
+    """
+    base_parser = ArgumentParser(add_help=False)
+
+    base_parser.add_argument(
+        '--url',
+        type=str,
+        default='http://localhost:8080',
+        help="the URL of the validator's REST API")
+
+    return base_parser
+
+
+def base_list_parser():
+    """Creates a parser with arguments specific to formatting lists
+    of resources.
+
+    Returns:
+        {ArgumentParser}: Base parser with defaul list args
+    """
+    base_parser = ArgumentParser(add_help=False)
+
+    base_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='default',
+        choices=['csv', 'json', 'yaml', 'default'],
+        help='the format to use when printing the output')
+
+    return base_parser
+
+
+def base_show_parser():
+    """Creates a parser with arguments specific to formatting a
+    single resource.
+
+    Returns:
+        {ArgumentParser}: Base parser with default show args
+    """
+    base_parser = ArgumentParser(add_help=False)
+
+    base_parser.add_argument(
+        '-k', '--key',
+        type=str,
+        help='specify to show a single property from the block or header')
+    base_parser.add_argument(
+        '-F', '--format',
+        action='store',
+        default='yaml',
+        choices=['yaml', 'json'],
+        help='the format to use for printing the output (defaults to yaml)')
+
+    return base_parser

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import json
+from base64 import b64encode
 from http.client import RemoteDisconnected
 import requests
 # pylint: disable=no-name-in-module,import-error
@@ -24,8 +25,14 @@ from sawtooth_cli.exceptions import CliException
 
 
 class RestClient(object):
-    def __init__(self, base_url=None):
+    def __init__(self, base_url=None, user=None):
         self._base_url = base_url or 'http://localhost:8080'
+
+        if user:
+            b64_string = b64encode(user.encode()).decode()
+            self._auth_header = 'Basic {}'.format(b64_string)
+        else:
+            self._auth_header = None
 
     def list_blocks(self):
         return self._get('/blocks')['data']
@@ -138,6 +145,12 @@ class RestClient(object):
         Raises:
             `CliException`: If any issues occur with the URL.
         """
+        if headers is None:
+            headers = {}
+
+        if self._auth_header is not None:
+            headers['Authorization'] = self._auth_header
+
         try:
             if method == 'POST':
                 result = requests.post(

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -78,7 +78,7 @@ def do_state(args):
         Args:
             args: The parsed arguments sent to the command at runtime
     """
-    rest_client = RestClient(args.url)
+    rest_client = RestClient(args.url, args.user)
 
     if args.subcommand == 'list':
         response = rest_client.list_state(args.subtree, args.head)

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -18,6 +18,8 @@ from base64 import b64decode
 from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
 from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.parent_parsers import base_http_parser
+from sawtooth_cli.parent_parsers import base_list_parser
 
 
 def add_state_parser(subparsers, parent_parser):
@@ -32,13 +34,14 @@ def add_state_parser(subparsers, parent_parser):
     grand_parsers = parser.add_subparsers(title='grandchildcommands',
                                           dest='subcommand')
     grand_parsers.required = True
+
     epilog = '''details:
         Lists state in the form of leaves from the merkle tree. List can be
     narrowed using the address of a subtree.
     '''
-
     list_parser = grand_parsers.add_parser(
         'list', epilog=epilog,
+        parents=[base_http_parser(), base_list_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
     list_parser.add_argument(
         'subtree',
@@ -47,35 +50,21 @@ def add_state_parser(subparsers, parent_parser):
         default=None,
         help='the address of a subtree to filter list by')
     list_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    list_parser.add_argument(
         '--head',
         action='store',
         default=None,
         help='the id of the block to set as the chain head')
-    list_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='default',
-        choices=['csv', 'json', 'yaml', 'default'],
-        help='the format of the output, options: csv, json or yaml')
 
     epilog = '''details:
         Shows the data for a single leaf on the merkle tree.
     '''
     show_parser = grand_parsers.add_parser(
-        'show', epilog=epilog,
+        'show', epilog=epilog, parents=[base_http_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'address',
         type=str,
         help='the address of the leaf')
-    show_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
     show_parser.add_argument(
         '--head',
         action='store',

--- a/cli/sawtooth_cli/submit.py
+++ b/cli/sawtooth_cli/submit.py
@@ -19,6 +19,7 @@ from sys import maxsize
 
 from sawtooth_cli.exceptions import CliException
 from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli.parent_parsers import base_http_parser
 import sawtooth_cli.protobuf.batch_pb2 as batch_pb2
 
 LOGGER = logging.getLogger(__file__)
@@ -84,7 +85,7 @@ def do_submit(args):
 def add_submit_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'submit',
-        parents=[parent_parser])
+        parents=[base_http_parser(), parent_parser])
 
     parser.add_argument(
         '--wait',
@@ -98,12 +99,6 @@ def add_submit_parser(subparsers, parent_parser):
         type=str,
         help='location of input file',
         default='batches.intkey')
-
-    parser.add_argument(
-        '-U', '--url',
-        type=str,
-        help='connection URL for validator',
-        default='http://localhost:8080')
 
     parser.add_argument(
         '--batch-size-limit',

--- a/cli/sawtooth_cli/submit.py
+++ b/cli/sawtooth_cli/submit.py
@@ -45,7 +45,7 @@ def do_submit(args):
     except IOError as e:
         raise CliException(e)
 
-    rest_client = RestClient(args.url)
+    rest_client = RestClient(args.url, args.user)
 
     start = time.time()
 

--- a/cli/sawtooth_cli/transaction.py
+++ b/cli/sawtooth_cli/transaction.py
@@ -18,6 +18,9 @@ from base64 import b64decode
 from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
 from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.parent_parsers import base_http_parser
+from sawtooth_cli.parent_parsers import base_list_parser
+from sawtooth_cli.parent_parsers import base_show_parser
 
 
 def add_transaction_parser(subparsers, parent_parser):
@@ -32,24 +35,15 @@ def add_transaction_parser(subparsers, parent_parser):
     grand_parsers = parser.add_subparsers(title='grandchildcommands',
                                           dest='subcommand')
     grand_parsers.required = True
+
     epilog = '''details:
         Lists committed transactions from newest to oldest, including their id
     (i.e. header_signature), transaction family and version, and their payload.
     '''
-
-    list_parser = grand_parsers.add_parser(
+    grand_parsers.add_parser(
         'list', epilog=epilog,
+        parents=[base_http_parser(), base_list_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    list_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    list_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='default',
-        choices=['csv', 'json', 'yaml', 'default'],
-        help='the format of the output, options: csv, json or yaml')
 
     epilog = '''details:
         Shows the data for a single transaction, or for a particular property
@@ -58,25 +52,12 @@ def add_transaction_parser(subparsers, parent_parser):
     '''
     show_parser = grand_parsers.add_parser(
         'show', epilog=epilog,
+        parents=[base_http_parser(), base_show_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
     show_parser.add_argument(
         'transaction_id',
         type=str,
         help='the id (i.e. header_signature) of the transaction')
-    show_parser.add_argument(
-        '--url',
-        type=str,
-        help="the URL of the validator's REST API")
-    show_parser.add_argument(
-        '-k', '--key',
-        type=str,
-        help='specify to show one property from the transaction or header')
-    show_parser.add_argument(
-        '-F', '--format',
-        action='store',
-        default='yaml',
-        choices=['yaml', 'json'],
-        help='the format of the output, options: yaml (default), or json')
 
 
 def do_transaction(args):

--- a/cli/sawtooth_cli/transaction.py
+++ b/cli/sawtooth_cli/transaction.py
@@ -66,7 +66,7 @@ def do_transaction(args):
         Args:
             args: The parsed arguments sent to the command at runtime
     """
-    rest_client = RestClient(args.url)
+    rest_client = RestClient(args.url, args.user)
 
     if args.subcommand == 'list':
         transactions = rest_client.list_transactions()


### PR DESCRIPTION
# To Test This PR

This PR adds support for Basic Auth proxies. In order to test it, you'll need to build one. These are the instructions for setting up a simple authed Apache proxy in vagrant.

## Install Apache

```
% sudo apt-get update
% sudo apt-get install -y apache2
% sudo a2enmod headers
% sudo a2enmod proxy_http
```

## Set up a password file
```
% vi /tmp/.password
```

Edit the file to look like this:
```
sawtooth:$apr1$VHIPQ4Wi$k7PbIPqcfVp1NVKWhkIbS0

```

This saves the password `"sawtooth"` for the user `sawtooth`. You can generate new files like this at the site: http://www.htaccesstools.com/htpasswd-generator/. However, the config file below only allows the user `sawtooth`, so that would need to be modified as well.

## Set up the site configuration

```
% sudo vi /etc/apache2/sites-enabled/000-default.conf
```

Edit the file to look like this:
```
<VirtualHost *:80>
        ServerAdmin sawtooth@sawtooth
        DocumentRoot /var/www/html

        ErrorLog ${APACHE_LOG_DIR}/error.log
        CustomLog ${APACHE_LOG_DIR}/access.log combined

        <Location />
                Options Indexes FollowSymLinks
                AllowOverride None
                AuthType Basic
                AuthName "Enter password"
                AuthUserFile "/tmp/.password"
                Require user sawtooth
                Require all denied
        </Location>
</VirtualHost>

ProxyPass /sawtooth http://localhost:8080
ProxyPassReverse /sawtooth http://localhost:8080
RequestHeader set X-Forwarded-Path "/sawtooth"
```

## Start and/or restart Apache

```
% sudo apachectl start
```

```
% sudo apachectl restart
```

## Make sure everything is set up properly

Start up a validator and the REST API normally. When you query the REST API, you should get back some block data as JSON:
```
% curl localhost:8080/blocks
```

You should also be able to get a `401` by querying the proxy without authorization:
```
% curl localhost/sawtooth/blocks
```

And finally, you should be able to get the same JSON by querying the proxy with authorization:
```
% curl localhost/sawtooth/blocks -u sawtooth:sawtooth
```

## Test the sawtooth CLI

With everything working above, you should be able to:
```
sawtooth blocks list --url http://localhost/sawtooth -u sawtooth:sawtooth
```

## What to do if you have permissioning issues around port 80

Sometimes vagrant seems to get angry when you try to run the proxy on port `80`. You can switch it to port `8000` by changing two files.
```
% sudo vi /etc/apache2/ports.conf
```

Switch `Listen 80` -> `Listen 8000`.

```
% sudo vi /etc/apache2/sites-enabled/000-default.conf
```

Switch `<VirtualHost *:80>` -> `<VirtualHost *:8000>`

Then:
```
% sudo apachectl restart
```

Afterwards the above example should work fine, but the proxy url will be `localhost:8000/sawtooth` instead of `localhost/sawtooth`.