### PR TITLE
Remove validator address from functions that don't need it

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -81,7 +81,6 @@ def do_genesis(args):
             data_dir=config.get_data_dir()) as poet_enclave_module:
         signup_info = SignupInfo.create_signup_info(
             poet_enclave_module=poet_enclave_module,
-            validator_address=pubkey,
             originator_public_key_hash=public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -127,7 +127,6 @@ class PoetBlockPublisher(BlockPublisherInterface):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=poet_enclave_module,
-                validator_address=block_header.signer_pubkey,
                 originator_public_key_hash=public_key_hash,
                 nonce=block_header.previous_block_id)
 
@@ -291,7 +290,6 @@ class PoetBlockPublisher(BlockPublisherInterface):
             active_poet_public_key = \
                 SignupInfo.unseal_signup_data(
                     poet_enclave_module=poet_enclave_module,
-                    validator_address=block_header.signer_pubkey,
                     sealed_signup_data=poet_key_state.sealed_signup_data)
             self._poet_key_state_store.active_key = active_poet_public_key
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
@@ -36,7 +36,6 @@ class SignupInfo(object):
     @classmethod
     def create_signup_info(cls,
                            poet_enclave_module,
-                           validator_address,
                            originator_public_key_hash,
                            nonce):
         """
@@ -46,8 +45,6 @@ class SignupInfo(object):
         Args:
             poet_enclave_module (module): The module that implements the
                 underlying PoET enclave.
-            validator_address (str): A string representing the address of the
-                validator requesting signup info.
             originator_public_key_hash (str): A string representing SHA256
                 hash (i.e., hashlib.sha256(OPK).hexdigest()) of the
                 originator's public key
@@ -60,7 +57,6 @@ class SignupInfo(object):
 
         enclave_signup_info = \
             poet_enclave_module.create_signup_info(
-                validator_address,
                 originator_public_key_hash,
                 nonce)
         signup_info = cls(enclave_signup_info)
@@ -88,7 +84,6 @@ class SignupInfo(object):
     @classmethod
     def unseal_signup_data(cls,
                            poet_enclave_module,
-                           validator_address,
                            sealed_signup_data):
         """
         Takes sealed data from a previous call to create_signup_info and
@@ -97,8 +92,6 @@ class SignupInfo(object):
         Args:
             poet_enclave_module (module): The module that implements the
                 underlying PoET enclave.
-            validator_address (str): A string representing the address of the
-                validator that is requesting signup data be unsealed.
             sealed_signup_data: The sealed signup data that was previously
                 returned as part of the signup info returned from
                 create_signup_info.
@@ -107,10 +100,7 @@ class SignupInfo(object):
             The encoded PoET public key corresponding to private key used by
             PoET to sign wait certificates.
         """
-        return \
-            poet_enclave_module.unseal_signup_data(
-                validator_address,
-                sealed_signup_data)
+        return poet_enclave_module.unseal_signup_data(sealed_signup_data)
 
     def __init__(self, enclave_signup_info):
         self.poet_public_key = enclave_signup_info.poet_public_key

--- a/consensus/poet/core/tests/test_consensus/test_signup_info.py
+++ b/consensus/poet/core/tests/test_consensus/test_signup_info.py
@@ -44,7 +44,6 @@ class TestSignupInfo(unittest.TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=poet_enclave,
-                validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -57,7 +56,6 @@ class TestSignupInfo(unittest.TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=poet_enclave,
-                validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
         serialized = signup_info.serialize()
@@ -79,13 +77,11 @@ class TestSignupInfo(unittest.TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=poet_enclave,
-                validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
         poet_public_key = \
             SignupInfo.unseal_signup_data(
                 poet_enclave_module=poet_enclave,
-                validator_address='1660 Pennsylvania Avenue NW',
                 sealed_signup_data=signup_info.sealed_signup_data)
 
         self.assertEqual(

--- a/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
@@ -77,7 +77,6 @@ class TestWaitCertificate(TestCase):
         # Need to create signup information
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -93,7 +92,6 @@ class TestWaitCertificate(TestCase):
         # Need to create signup information
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -131,7 +129,6 @@ class TestWaitCertificate(TestCase):
         # Need to create signup information
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -171,7 +168,6 @@ class TestWaitCertificate(TestCase):
         # Need to create signup information
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -209,7 +205,6 @@ class TestWaitCertificate(TestCase):
         # Need to create signup information
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -266,7 +261,6 @@ class TestWaitCertificate(TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=self.poet_enclave_module,
-                validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -351,7 +345,6 @@ class TestWaitCertificate(TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=self.poet_enclave_module,
-                validator_address='1660 Pennsylvania Avenue NW',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
 

--- a/consensus/poet/core/tests/test_consensus/test_wait_timer.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_timer.py
@@ -78,7 +78,6 @@ class TestWaitTimer(TestCase):
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=self.poet_enclave_module,
-                validator_address='1060 W Addison Street',
                 originator_public_key_hash=self._originator_public_key_hash,
                 nonce=NULL_BLOCK_IDENTIFIER)
 
@@ -121,7 +120,6 @@ class TestWaitTimer(TestCase):
         # Initialize the enclave with sealed signup data
         SignupInfo.unseal_signup_data(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             sealed_signup_data=signup_info.sealed_signup_data)
 
         stake_in_the_sand = time.time()
@@ -152,7 +150,6 @@ class TestWaitTimer(TestCase):
         # Need to create signup information first
         SignupInfo.create_signup_info(
             poet_enclave_module=self.poet_enclave_module,
-            validator_address='1660 Pennsylvania Avenue NW',
             originator_public_key_hash=self._originator_public_key_hash,
             nonce=NULL_BLOCK_IDENTIFIER)
 

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -500,8 +500,7 @@ def get_enclave_basename():
     return _PoetEnclaveSimulator.get_enclave_basename()
 
 
-def create_signup_info(validator_address,
-                       originator_public_key_hash,
+def create_signup_info(originator_public_key_hash,
                        nonce):
     return \
         _PoetEnclaveSimulator.create_signup_info(
@@ -514,7 +513,7 @@ def deserialize_signup_info(serialized_signup_info):
         serialized_signup_info=serialized_signup_info)
 
 
-def unseal_signup_data(validator_address, sealed_signup_data):
+def unseal_signup_data(sealed_signup_data):
     return _PoetEnclaveSimulator.unseal_signup_data(sealed_signup_data)
 
 


### PR DESCRIPTION
This change supports the removal of multi-tenancy support in the PoET enclave.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>