### PR TITLE
Move the Curve ZMQ keys into the validator config file. 

### DIFF
--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -33,3 +33,10 @@ seeds = ["tcp://127.0.0.1:8801"]
 # A list of peers to attempt to connect to in the format tcp://hostname:port.
 # It defaults to None.
 peers = ["tcp://127.0.0.1:8801"]
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = b'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)',
+network_private_key = b'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -259,6 +259,12 @@ def main(args=sys.argv[1:]):
     if "tcp://" not in bind_component:
         bind_component = "tcp://" + bind_component
 
+    if validator_config.network_public_key is None or \
+            validator_config.network_private_key is None:
+        LOGGER.warning("Network key pair is not configured, Network "
+                       "communications between validators will not be "
+                       "authenticated or encrypted.")
+
     validator = Validator(bind_network,
                           bind_component,
                           endpoint,
@@ -267,7 +273,9 @@ def main(args=sys.argv[1:]):
                           validator_config.peers,
                           path_config.data_dir,
                           path_config.config_dir,
-                          identity_signing_key)
+                          identity_signing_key,
+                          validator_config.network_public_key,
+                          validator_config.network_private_key)
 
     # pylint: disable=broad-except
     try:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -86,7 +86,8 @@ LOGGER = logging.getLogger(__name__)
 class Validator(object):
     def __init__(self, bind_network, bind_component, endpoint,
                  peering, seeds_list, peer_list, data_dir, config_dir,
-                 identity_signing_key):
+                 identity_signing_key, network_public_key=None,
+                 network_private_key=None):
         """Constructs a validator instance.
 
         Args:
@@ -171,21 +172,17 @@ class Validator(object):
 
         self._network_dispatcher = Dispatcher()
 
-        # Server public and private keys are hardcoded here due to
-        # the decision to avoid having separate identities for each
-        # validator's server socket. This is appropriate for a public
-        # network. For a permissioned network with requirements for
-        # server endpoint authentication at the network level, this can
-        # be augmented with a local lookup service for side-band provided
-        # endpoint, public_key pairs and a local configuration option
-        # for 'server' side private keys.
+        secure = False
+        if network_public_key is not None and network_private_key is not None:
+            secure = True
+
         self._network = Interconnect(
             bind_network,
             dispatcher=self._network_dispatcher,
             zmq_identity=zmq_identity,
-            secured=True,
-            server_public_key=b'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)',
-            server_private_key=b'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*',
+            secured=secure,
+            server_public_key=network_public_key,
+            server_private_key=network_private_key,
             heartbeat=True,
             public_endpoint=endpoint,
             connection_timeout=30,


### PR DESCRIPTION
If the network key pair is not defined or if there is no validator config file, the network will default to being unsecure. 

This PR is build on top of #541 