### PR TITLE
Update Vagrant plugins and ports

### DIFF
--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -102,13 +102,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   if conf['VAGRANT_FORWARD_PORTS']
       config.vm.network "forwarded_port", guest: 8800, host: 8800, host_ip: "127.0.0.1"
-      config.vm.network "forwarded_port", guest: 8900, host: 8900, host_ip: "127.0.0.1"
+      config.vm.network "forwarded_port", guest: 40000, host: 40000, host_ip: "127.0.0.1"
 
-      # rethinkdb
-      config.vm.network "forwarded_port", guest: 18080, host: 18080, host_ip: "127.0.0.1"
-
-      # nodejs
-      config.vm.network "forwarded_port", guest: 3000, host: 3000, host_ip: "127.0.0.1"
+      # rest api
+      config.vm.network "forwarded_port", guest: 8080, host: 18080, host_ip: "127.0.0.1"
   end
   config.vm.provision :shell, path: "bootstrap.sh"
 

--- a/tools/plugins/install_cryptography.sh
+++ b/tools/plugins/install_cryptography.sh
@@ -3,7 +3,9 @@
 set -e
 
 # Make sure that the cryptography package dependencies are installed
-apt-get install build-essential libssl-dev libffi-dev python3-dev
-
 apt-get install -y -q \
-   python3-cryptography=1.7.2-1
+    build-essential \
+    libssl-dev \
+    libffi-dev \
+    python3-dev \
+    python3-cryptography=1.7.2-1

--- a/tools/plugins/install_js_tools.sh
+++ b/tools/plugins/install_js_tools.sh
@@ -18,34 +18,8 @@ if [ ! -e cache/setup-node.sh ]; then
 fi
 ./cache/setup-node.sh
 
-# Install lein
-if [ ! -e cache/lein ]; then
-    curl -s -S -o cache/lein \
-       https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
-    chmod +x cache/lein
-fi
-mv cache/lein /usr/local/bin/lein
-
-
-VER=$(lsb_release -sr)
-
-if [ "$VER" = "16.04" ] ; then
-    apt-get install -y -q \
-        ruby\
-        openjdk-8-jdk
-    GEM=gem
-else
-    # Run setup-node.sh
-    apt-get install -y -q \
-        ruby2.0\
-        openjdk-7-jdk
-    GEM=gem2.0
-fi
-
 # Run setup-node.sh
 apt-get install -y -q \
-    phantomjs \
     nodejs
-$GEM install sass
 
 sudo -i -u $VAGRANT_USER npm set progress=false


### PR DESCRIPTION
## Fix apt-get args for install_cryptography

Fix the apt-get args to include `-y -q` for all dependencies, as a change
in the dependencies caused the need for interaction during `vagrant up`

## Remove old, unused JS tools

This includes, leiningen, ruby and sass

## Update forwarded ports to match currently used ports

Match the ports currently used by the validator and rest api: 8800, 40000, 8080->18080