### PR TITLE
Re-enable poet-smoke test

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -278,6 +278,8 @@ test_python_sdk() {
 }
 
 test_integration() {
+    run_docker_test poet-smoke -s integration_test
+    copy_coverage .coverage.poet-smoke
     run_docker_test dynamic-network -s integration_test --timeout 600
     copy_coverage .coverage.dynamic-network
 }


### PR DESCRIPTION
I deleted these lines while working on the dynamic-network test and
accidentally included the deletion in a previous commit.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>