### PR TITLE
Add HTTPS test to auth proxy integration tests

### DIFF
--- a/docker/apache-basic_auth_proxy
+++ b/docker/apache-basic_auth_proxy
@@ -31,36 +31,45 @@
 
 FROM ubuntu:xenial
 
-RUN apt-get update && apt-get install -y \
-    apache2 \
- && a2enmod proxy_http \
- && a2enmod headers
+RUN apt-get update \
+    && apt-get install -y apache2 \
+    && a2enmod proxy_http \
+    && a2enmod headers \
+    && a2enmod ssl
 
-RUN echo "\nServerName basic_auth_proxy\n" >> /etc/apache2/apache2.conf
+RUN openssl req -x509 -nodes -days 7300 -newkey rsa:2048 \
+    -keyout /tmp/.ssl.key -out /tmp/.ssl.crt \
+    -subj /C=US/ST=MN/L=Mpls/O=Sawtooth/CN=basic_auth_proxy
+
+RUN echo "sawtooth:\$apr1\$cyAIkitu\$Cv6M2hHJlNgnVvKbUdlFr." >/tmp/.password
 
 RUN echo "\
-sawtooth:\$apr1\$cyAIkitu\$Cv6M2hHJlNgnVvKbUdlFr.\n\
 \n\
-" >/tmp/.password
+ServerName basic_auth_proxy\n\
+ServerAdmin sawtooth@sawtooth\n\
+DocumentRoot /var/www/html\n\
+\n\
+" >>/etc/apache2/apache2.conf
 
 RUN echo "\
 <VirtualHost *:80>\n\
-        ServerAdmin sawtooth@sawtooth\n\
-        DocumentRoot /var/www/html\n\
-\n\
-        ErrorLog ${APACHE_LOG_DIR}/error.log\n\
-        CustomLog ${APACHE_LOG_DIR}/access.log combined\n\
-\n\
-        <Location />\n\
-                Options Indexes FollowSymLinks\n\
-                AllowOverride None\n\
-                AuthType Basic\n\
-                AuthName \"Enter password\"\n\
-                AuthUserFile \"/tmp/.password\"\n\
-                Require user sawtooth\n\
-                Require all denied\n\
-        </Location>\n\
 </VirtualHost>\n\
+\n\
+<VirtualHost *:443>\n\
+        SSLEngine on\n\
+        SSLCertificateFile /tmp/.ssl.crt\n\
+        SSLCertificateKeyFile /tmp/.ssl.key\n\
+        RequestHeader set X-Forwarded-Proto \"https\"\n\
+</VirtualHost>\n\
+\n\
+<Location />\n\
+        Options Indexes FollowSymLinks\n\
+        AuthType Basic\n\
+        AuthName \"Enter password\"\n\
+        AuthUserFile \"/tmp/.password\"\n\
+        Require user sawtooth\n\
+        Require all denied\n\
+</Location>\n\
 \n\
 ProxyPass /sawtooth http://rest_api:8080\n\
 ProxyPassReverse /sawtooth http://rest_api:8080\n\
@@ -69,6 +78,7 @@ RequestHeader set X-Forwarded-Path \"/sawtooth\"\n\
 " >/etc/apache2/sites-enabled/000-default.conf
 
 EXPOSE 80
+EXPOSE 443
 EXPOSE 8080
 
 CMD ["apachectl start"]

--- a/integration/sawtooth_integration/docker/basic-auth-proxy.yaml
+++ b/integration/sawtooth_integration/docker/basic-auth-proxy.yaml
@@ -53,6 +53,7 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 80
+      - 443
       - 8080
     depends_on:
       - validator
@@ -69,6 +70,7 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 80
+      - 443
     depends_on:
       - validator
       - rest_api

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -68,10 +68,16 @@ class TestBasicAuth(unittest.TestCase):
         try:
             response = urlopen(request, context=context)
         except HTTPError as e:
-            response = e.file
-            error = json.loads(response.read().decode())['error']
-            LOGGER.error('{} - {}:'.format(error['code'], error['title']))
+            try:
+                error = json.loads(e.file.read().decode())['error']
+            except json.decoder.JSONDecodeError:
+                raise e
+
+            LOGGER.error('REST API Error: {} - {}:'.format(
+                error['code'], error['title']))
             LOGGER.error(error['message'])
+
+            raise e
 
         self.assertEqual(200, response.getcode())
         LOGGER.info('Authorization succeeded, 200 response received.')

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -15,6 +15,7 @@
 
 import unittest
 import logging
+import ssl
 import json
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
@@ -32,26 +33,40 @@ class TestBasicAuth(unittest.TestCase):
     def setUp(self):
         wait_until_status('http://basic_auth_proxy/sawtooth', status_code=401)
 
-    def test_fetch_blocks(self):
-        """Checks that an authenticated request can be made through a proxy
-        to the REST API, and that the returned "link" parameter properly
+    def test_http_basic_auth(self):
+        """Checks that a Basic Auth request can be made with unencrypted HTTP.
+        """
+        url = 'http://basic_auth_proxy/sawtooth/blocks'
+        self._assert_valid_authed_request(url)
+
+    def test_ssl_basic_auth(self):
+        """Checks that a Basic Auth request can be made with encrypted HTTPS.
+        """
+        url = 'https://basic_auth_proxy/sawtooth/blocks'
+        self._assert_valid_authed_request(url)
+
+    def _assert_valid_authed_request(self, url):
+        """Asserts that a Basic Auth request was made successfully through a
+        proxy to the REST API, and that the returned "link" parameter properly
         reflects the url of the proxy.
 
-        The proxy should redirect from `http://basic_auth_proxy/sawtooth` to
+        The proxy should redirect from the passed url's domain to
         `http://rest_api:8080`, and be configured with a Basic Auth
         username:password combination of 'sawtooth:sawtooth'.
 
         In order to get back the correct link, the proxy must both forward the
         host and add a custom RequestHeader of 'X-Forwarded-Path: /sawtooth'.
         """
-        url = 'http://basic_auth_proxy/sawtooth/blocks'
         auth = 'Basic {}'.format(b64encode(b'sawtooth:sawtooth').decode())
         LOGGER.info(('\n'
                      'Sending request to "{}",\n'
                      'with "Authorition: {}"').format(url, auth))
 
+        request = Request(url, headers={'Authorization': auth})
+        context = ssl._create_unverified_context()
+
         try:
-            response = urlopen(Request(url, headers={'Authorization': auth}))
+            response = urlopen(request, context=context)
         except HTTPError as e:
             response = e.file
             error = json.loads(response.read().decode())['error']


### PR DESCRIPTION
Adds proper scheme/protocol, host, and path parsing to REST API using either the standard `Forwarded` header, or more commonly used `X-Forwarded` headers.

Adds a test to `basic_auth_proxy`, ensuring it works properly in with both HTTP and HTTPS.