### PR TITLE
Remove unnecessary double deserialization of wait certificate

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -274,9 +274,7 @@ class PoetForkResolver(ForkResolverInterface):
                         poet_enclave_module=poet_enclave_module)
                 consensus_state.validator_did_claim_block(
                     validator_info=validator_info,
-                    wait_certificate=utils.deserialize_wait_certificate(
-                        block=new_fork_head,
-                        poet_enclave_module=poet_enclave_module),
+                    wait_certificate=new_fork_wait_certificate,
                     poet_config_view=PoetConfigView(state_view))
                 self._consensus_state_store[new_fork_head.identifier] = \
                     consensus_state


### PR DESCRIPTION
When refactoring PoET fork resolver code, accidentally left in a second deserialization of the new fork head wait certificate.  Removed it.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>