### PR TITLE
Wait for expected block num

### DIFF
--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -89,7 +89,10 @@ class TestIntkeySmoke(unittest.TestCase):
         batch = IntkeyMessageFactory().create_batch(batch)
         LOGGER.info('Posting batch')
         _post_batch(batch)
-        time.sleep(1)
+
+        while (how_many_updates + 1) > _get_block_num():
+            time.sleep(1)
+
         self.verify_state_after_n_updates(how_many_updates)
 
     def verify_state_after_n_updates(self, num):
@@ -133,6 +136,12 @@ def _get_data():
 def _get_state():
     response = _query_rest_api('/state')
     return response['data']
+
+
+def _get_block_num():
+    response = _query_rest_api('/blocks?count=1')
+    return response['data'][0]['header']['block_num']
+
 
 def _query_rest_api(suffix='', data=None, headers={}):
     url = 'http://rest_api:8080' + suffix


### PR DESCRIPTION
Intkey smoke occasionally fails tests due to block commits occasionally
taking longer than 1 second.  Wait for the expected block number before
verifying the state to mitigate this issue.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>