### PR TITLE
Fix truncated committed status for the submit cli

### DIFF
--- a/cli/sawtooth_cli/submit.py
+++ b/cli/sawtooth_cli/submit.py
@@ -78,7 +78,7 @@ def do_submit(args):
 
         print('Wait timed out! Some batches have not yet been committed...')
         for batch_id, status in statuses.items():
-            print('{:128.128}  {:8.8}'.format(batch_id, status))
+            print('{:128.128}  {:10.10}'.format(batch_id, status))
         exit(1)
 
 


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

When the status of a batch is COMMITTED, the printing output is COMMITTE. Fixed it.