### PR TITLE
Allow Executor to recover after a TP Crash.

### DIFF
--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -102,3 +102,15 @@ message TpProcessResponse {
     // data that will be propagated back to the transaction submitter.
     bytes extended_data = 3;
 }
+
+message TpPing {
+}
+
+message TpPingResponse {
+    enum Status {
+        OK = 0;
+        ERROR = 1;
+    }
+
+    Status status = 1;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -58,6 +58,11 @@ message Message {
         TP_STATE_DEL_REQUEST = 11;
         // State delete response from the validator/context_manager to the transaction processor
         TP_STATE_DEL_RESPONSE = 12;
+        // Message to check if a transaction processor is still connected.
+        TP_PING = 13;
+        // Response from transaction processor to tell the validator it received the ping
+        TP_PING_RESPONSE = 14;
+
         // Submission of a batchlist from the web api or another client to the validator
         CLIENT_BATCH_SUBMIT_REQUEST = 100;
         // Response from the validator to the web api/client that the submission was accepted

--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -34,6 +34,7 @@ from sawtooth_sdk.protobuf.processor_pb2 import TpUnregisterRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpUnregisterResponse
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse
+from sawtooth_sdk.protobuf.processor_pb2 import TpPingResponse
 from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
@@ -184,6 +185,13 @@ class TransactionProcessor(object):
             LOGGER.debug(
                 'received message of type: %s',
                 Message.MessageType.Name(msg.message_type))
+            if msg.message_type == Message.TP_PING:
+                self._stream.send_back(
+                    message_type=Message.TP_PING_RESPONSE,
+                    correlation_id=msg.correlation_id,
+                    content=TpPingResponse(
+                        status=TpPingResponse.OK).SerializeToString())
+                return
             self._process(msg)
 
     def _register(self):

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2016, 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -65,6 +65,12 @@ class ProcessorIteratorCollection(object):
             if processor_type in self:
                 return self[processor_type].next_processor()
             return None
+
+    def get_all_processors(self):
+        processors = []
+        for processor in self._processors.values():
+            processors += processor.processor_identities()
+        return processors
 
     def __setitem__(self, key, value):
         """Either create a new ProcessorIterator, if none exists for a
@@ -238,7 +244,7 @@ class RoundRobinProcessorIterator(ProcessorIterator):
         with self._lock:
             return repr(self._processors)
 
-    def _processor_identities(self):
+    def processor_identities(self):
         with self._lock:
             return [p.connection_id for p in self._processors]
 
@@ -249,7 +255,7 @@ class RoundRobinProcessorIterator(ProcessorIterator):
 
     def remove_processor(self, processor_identity):
         with self._lock:
-            idx = self._processor_identities().index(processor_identity)
+            idx = self.processor_identities().index(processor_identity)
             self._processors.pop(idx)
             self._inf_iterator = itertools.cycle(self._processors)
 

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -69,7 +69,7 @@ class _SendReceive(object):
                  zmq_identity=None, dispatcher=None, secured=False,
                  server_public_key=None, server_private_key=None,
                  heartbeat=False, heartbeat_interval=10,
-                 connection_timeout=60):
+                 connection_timeout=60, monitor=False):
         """
         Constructor for _SendReceive.
 
@@ -128,6 +128,11 @@ class _SendReceive(object):
 
         self._connections = connections
         self._identities_to_connection_ids = ThreadsafeDict()
+        self._monitor = monitor
+
+        self._check_connections = None
+        self._monitor_fd = None
+        self._monitor_sock = None
 
     @property
     def connection(self):
@@ -224,19 +229,20 @@ class _SendReceive(object):
                              get_enum_name(message.message_type),
                              sys.getsizeof(msg_bytes))
 
+                if zmq_identity is not None:
+                    connection_id = \
+                        self._identity_to_connection_id(zmq_identity)
+                else:
+                    connection_id = \
+                        self._identity_to_connection_id(
+                            self._connection.encode())
                 try:
                     self._futures.set_result(
                         message.correlation_id,
                         future.FutureResult(message_type=message.message_type,
-                                            content=message.content))
+                                            content=message.content,
+                                            connection_id=connection_id))
                 except future.FutureCollectionKeyError:
-                    if zmq_identity is not None:
-                        connection_id = \
-                            self._identity_to_connection_id(zmq_identity)
-                    else:
-                        connection_id = \
-                            self._identity_to_connection_id(
-                                self._connection.encode())
                     self._dispatcher.dispatch(self._connection,
                                               message,
                                               connection_id)
@@ -363,6 +369,14 @@ class _SendReceive(object):
                                               self.send_message)
             asyncio.ensure_future(self._receive_message(),
                                   loop=self._event_loop)
+            if self._monitor:
+                self._monitor_fd = "inproc://monitor.s-{}".format(
+                    _generate_id()[0:5])
+                self._monitor_sock = self._socket.get_monitor_socket(
+                    zmq.EVENT_DISCONNECTED,
+                    addr=self._monitor_fd)
+                asyncio.ensure_future(self._monitor_disconnects(),
+                                      loop=self._event_loop)
 
         except Exception as e:
             # Put the exception on the queue where in start we are waiting
@@ -383,7 +397,18 @@ class _SendReceive(object):
         # of run_forever then it can be closed and the context destroyed.
         self._event_loop.close()
         self._socket.close(linger=0)
+        if self._monitor:
+            self._monitor_sock.close(linger=0)
         self._context.destroy(linger=0)
+
+    @asyncio.coroutine
+    def _monitor_disconnects(self):
+        while True:
+            yield from self._monitor_sock.recv_multipart()
+            self._check_connections()
+
+    def set_check_connections(self, function):
+        self._check_connections = function
 
     @asyncio.coroutine
     def _stop_auth(self):
@@ -447,7 +472,8 @@ class Interconnect(object):
                  heartbeat=False,
                  public_endpoint=None,
                  connection_timeout=60,
-                 max_incoming_connections=100):
+                 max_incoming_connections=100,
+                 monitor=False):
         """
         Constructor for Interconnect.
 
@@ -486,9 +512,13 @@ class Interconnect(object):
             server_public_key=server_public_key,
             server_private_key=server_private_key,
             heartbeat=heartbeat,
-            connection_timeout=connection_timeout)
+            connection_timeout=connection_timeout,
+            monitor=monitor)
 
         self._thread = None
+
+    def set_check_connections(self, function):
+        self._send_receive_thread.set_check_connections(function)
 
     def allow_inbound_connection(self):
         """Determines if an additional incoming network connection

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -152,13 +152,15 @@ class Validator(object):
                                      self._dispatcher,
                                      secured=False,
                                      heartbeat=False,
-                                     max_incoming_connections=20)
+                                     max_incoming_connections=20,
+                                     monitor=True)
 
         executor = TransactionExecutor(service=self._service,
                                        context_manager=context_manager,
                                        config_view_factory=ConfigViewFactory(
                                            StateViewFactory(merkle_db)))
         self._executor = executor
+        self._service.set_check_connections(executor.check_connections)
 
         state_delta_processor = StateDeltaProcessor(self._service,
                                                     state_delta_store,


### PR DESCRIPTION
This PR currently only works for python transaction processor. If solution is approved handling of TpPings will need to be added to all other sdks. 

A monitor socket is listening for disconnect events and notifies the executor that it should check all connected transaction processors to see if they are still connected. This is done by sending a TpPing response and waiting for a TpPingResponse is returned. If a transaction processor is found to not be connected, it should be removed from processors and all pending futures are set to an internal error (causing them to be rescheduled on a new processor).

The reasons that this ping message is needed, is that the zmq disconnect event only returns the following information: remote endpoint, event int, and a FD. I was not able to correlate a FD with a connection id for the transaction processor. Also a rest_api starts up/disconnects it creates the same type of connect/disconnect event as a transaction processor. 

Open issues I am looking for feed back on:
Currently, while waiting for the future to be set or a timeout to occur the executor thread is locked up waiting to know if a transaction processor should be removed. For example if the timeout is set to 10 seconds (the current timeout), and a processor crashes, it will take 10 seconds to continue processing. 