### PR TITLE
Restrict signup information nonce to 32 bytes

### DIFF
--- a/consensus/poet/cli/sawtooth_poet_cli/genesis.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/genesis.py
@@ -82,7 +82,7 @@ def do_genesis(args):
         signup_info = SignupInfo.create_signup_info(
             poet_enclave_module=poet_enclave_module,
             originator_public_key_hash=public_key_hash,
-            nonce=NULL_BLOCK_IDENTIFIER)
+            nonce=SignupInfo.block_id_to_nonce(NULL_BLOCK_IDENTIFIER))
 
     print(
         'Writing key state for PoET public key: {}...{}'.format(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -25,6 +25,7 @@ import cbor
 
 from sawtooth_poet.poet_consensus import utils
 from sawtooth_poet.poet_consensus.poet_config_view import PoetConfigView
+from sawtooth_poet.poet_consensus.signup_info import SignupInfo
 
 from sawtooth_poet_common.validator_registry_view.validator_registry_view \
     import ValidatorRegistryView
@@ -600,7 +601,8 @@ class ConsensusState(object):
         # success (i.e., the validator signup info passed the freshness
         # test) while the other two cases are failure.
         for _ in range(poet_config_view.signup_commit_maximum_delay + 1):
-            if block.previous_block_id == validator_info.signup_info.nonce:
+            if SignupInfo.block_id_to_nonce(block.previous_block_id) == \
+                    validator_info.signup_info.nonce:
                 LOGGER.debug(
                     'Validator %s (ID=%s...%s): Signup committed block %s, '
                     'chain head was block %s',
@@ -626,12 +628,12 @@ class ConsensusState(object):
 
         LOGGER.error(
             'Validator %s (ID=%s...%s): Signup committed block %s, failed to '
-            'find block %s in %d previous block(s)',
+            'find block with ID ending in %s in %d previous block(s)',
             validator_info.name,
             validator_info.id[:8],
             validator_info.id[-8:],
             commit_block_id[:8],
-            validator_info.signup_info.nonce[:8],
+            validator_info.signup_info.nonce,
             poet_config_view.signup_commit_maximum_delay + 1)
         return True
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -124,11 +124,12 @@ class PoetBlockPublisher(BlockPublisherInterface):
         public_key_hash = \
             hashlib.sha256(
                 block_header.signer_pubkey.encode()).hexdigest()
+        nonce = SignupInfo.block_id_to_nonce(block_header.previous_block_id)
         signup_info = \
             SignupInfo.create_signup_info(
                 poet_enclave_module=poet_enclave_module,
                 originator_public_key_hash=public_key_hash,
-                nonce=block_header.previous_block_id)
+                nonce=nonce)
 
         # Create the validator registry payload
         payload = \
@@ -140,7 +141,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     poet_public_key=signup_info.poet_public_key,
                     proof_data=signup_info.proof_data,
                     anti_sybil_id=signup_info.anti_sybil_id,
-                    nonce=block_header.previous_block_id),
+                    nonce=nonce),
             )
         serialized = payload.SerializeToString()
 
@@ -193,7 +194,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
             payload.id[-8:],
             payload.signup_info.poet_public_key[:8],
             payload.signup_info.poet_public_key[-8:],
-            block_header.previous_block_id[:8])
+            nonce)
 
         self._batch_publisher.send([transaction])
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
@@ -33,6 +33,21 @@ class SignupInfo(object):
             enclave.
     """
 
+    __MAXIMUM_NONCE_LENGTH__ = 32
+
+    @staticmethod
+    def block_id_to_nonce(block_id):
+        """
+        A convenience method to convert a block ID to an acceptable nonce.
+
+        Args:
+            block_id (str): The block ID to convert to a nonce
+
+        Returns:
+            An acceptable nonce for calling create_signup_info with
+        """
+        return block_id[-SignupInfo.__MAXIMUM_NONCE_LENGTH__:]
+
     @classmethod
     def create_signup_info(cls,
                            poet_enclave_module,
@@ -51,14 +66,23 @@ class SignupInfo(object):
             nonce (str): A value that is to be stored in the nonce field of
                 the attestation verification report.
 
+                NOTE - the nonce field is limited to __MAXIMUM_NONCE_LENGTH__
+                bytes.  If the nonce field is longer than
+                __MAXIMUM_NONCE_LENGTH__ bytes then the LAST
+                __MAXIMUM_NONCE_LENGTH__ bytes are used.
+
         Returns:
             SignupInfo: A signup info object.
         """
 
+        # NOTE - because of underlying restrictions on what can be put in the
+        # attestation verification report request nonce field, we are limiting
+        # to at most the last __MAXIMUM_NONCE_LENGTH__ bytes of the nonce.
+
         enclave_signup_info = \
             poet_enclave_module.create_signup_info(
                 originator_public_key_hash,
-                nonce)
+                nonce[-cls.__MAXIMUM_NONCE_LENGTH__:])
         signup_info = cls(enclave_signup_info)
 
         return signup_info

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -107,6 +107,7 @@ class TestPoetBlockPublisher(TestCase):
                 proof_data='proof data',
                 anti_sybil_id='anti-sybil ID',
                 sealed_signup_data='sealed signup data')
+        mock_signup_info.block_id_to_nonce.return_value = 'nonce'
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
@@ -178,7 +179,8 @@ class TestPoetBlockPublisher(TestCase):
                 name='validator_001',
                 id='validator_deadbeef',
                 signup_info=SignUpInfo(
-                    poet_public_key='00112233445566778899aabbccddeeff'))
+                    poet_public_key='00112233445566778899aabbccddeeff',
+                    nonce='nonce'))
 
         # create a mock_wait_certificate that does nothing in check_valid
         mock_wait_certificate = mock.Mock()
@@ -209,7 +211,7 @@ class TestPoetBlockPublisher(TestCase):
                 proof_data='proof data',
                 anti_sybil_id='anti-sybil ID',
                 sealed_signup_data='sealed signup data')
-
+        mock_signup_info.block_id_to_nonce.return_value = 'nonce'
         mock_signup_info.unseal_signup_data.return_value = \
             '00112233445566778899aabbccddeeff'
 


### PR DESCRIPTION
The nonce field in the request for the attestation verification report from IAS is limited to 32 bytes.  When creating signup information, restrict the nonce to 32 bytes.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>

If you want to try to run it (you need SGX hardware and be able to build for Linux):

Rename `poet_enclave_sgx.toml.example` to `poet_enclave_sgx.toml` and move to the validator's configuration directory.  Edit the file to have the correct SPID and path to SPID cert PEM file.

In a console:
```
sawtooth admin keygen validator
sawtooth config genesis --key <path>/validator.priv -o config-genesis.batch
sawtooth config proposal create -k <path>/validator.priv \
    sawtooth.consensus.algorithm=poet \
    sawtooth.poet.enclave_module_name=poet_enclave_sgx.poet_enclave \
    sawtooth.poet.report_public_key_pem="$(cat <path>/sawtooth-poet/packaging/ias_rk_pub.pem)" \
    sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement) \
    sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename) \
    -o config.batch
poet genesis -k <path>/validator.priv --enclave-module sgx -o poet_genesis.batch
sawtooth admin genesis config-genesis.batch config.batch poet_genesis.batch
validator -vv --endpoint tcp://127.0.0.1:8800 --bind network:tcp://127.0.0.1:8800 --bind component:tcp://127.0.0.1:40000
```
In another console: `tp_validator_registry -vv tcp://localhost:40000`
In another console: `tp_config -vv tcp://localhost:40000`