### PR TITLE
Revert the intkey smoke fix

### DIFF
--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -90,8 +90,7 @@ class TestIntkeySmoke(unittest.TestCase):
         LOGGER.info('Posting batch')
         _post_batch(batch)
 
-        while (how_many_updates + 1) > _get_block_num():
-            time.sleep(1)
+        time.sleep(10)
 
         self.verify_state_after_n_updates(how_many_updates)
 
@@ -136,12 +135,6 @@ def _get_data():
 def _get_state():
     response = _query_rest_api('/state')
     return response['data']
-
-
-def _get_block_num():
-    response = _query_rest_api('/blocks?count=1')
-    return response['data'][0]['header']['block_num']
-
 
 def _query_rest_api(suffix='', data=None, headers={}):
     url = 'http://rest_api:8080' + suffix


### PR DESCRIPTION
Revert the fix to intkey smoke that waited for successful block updates.
This failed by timeout out the tests, as this would never return.
Restored the use of a simple sleep, though the time has been bumped up
to 10 seconds.

This should be correctly fixed with issue [STL-321](https://jira.hyperledger.org/browse/STL-321)

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>