### PR TITLE
Fix missing python3 netifaces dependencies in the CI docs build.

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -52,6 +52,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/ap
     python3-grpcio=1.1.3-1 \
     python3-lmdb=0.92-1 \
     python3-multidict=2.1.4-1 \
+    python3-netifaces=0.10.4-0.1build2 \
     python3-pip \
     python3-protobuf=3.2.0-1 \
     python3-pycares=2.1.1-1 \


### PR DESCRIPTION
Removes this error:
Traceback (most recent call last):
  File "/project/sawtooth-core/bin/validator", line 34, in <module>
    from sawtooth_validator.server.cli import main
  File "/project/sawtooth-core/validator/sawtooth_validator/server/cli.py", line 20, in <module>
    import netifaces
ImportError: No module named 'netifaces'

Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>