### PR TITLE
Add previous_block_id to StateDeltaEvent

### DIFF
--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -49,8 +49,12 @@ message StateDeltaEvent {
     int32 block_num = 2;
     // The state root hash which resulted from the changes.
     string state_root_hash = 3;
+
+    // The previous block id
+    string previous_block_id = 4;
+
     // The collection of StateChange objects
-    repeated StateChange state_changes = 4;
+    repeated StateChange state_changes = 5;
 }
 
 // Registers a subscriber for StateDeltaEvent objects.  The

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -195,7 +195,8 @@ class StateDeltaProcessor(object):
         state_change_evt = StateDeltaEvent(
             block_id=block.header_signature,
             block_num=block.header.block_num,
-            state_root_hash=block.header.state_root_hash)
+            state_root_hash=block.header.state_root_hash,
+            previous_block_id=block.header.previous_block_id)
 
         for subscriber in self._subscribers.values():
             acceptable_changes = subscriber.deltas_of_interest(deltas)
@@ -214,6 +215,7 @@ class StateDeltaProcessor(object):
             block_id=block.header_signature,
             block_num=block.header.block_num,
             state_root_hash=block.header.state_root_hash,
+            previous_block_id=block.header.previous_block_id,
             state_changes=subscriber.deltas_of_interest(deltas))
 
         LOGGER.debug('sending change event to %s', subscriber.connection_id)
@@ -336,6 +338,7 @@ class GetStateDeltaEventsHandler(Handler):
                 block_id=block_id,
                 block_num=block.header.block_num,
                 state_root_hash=block.header.state_root_hash,
+                previous_block_id=block.header.previous_block_id,
                 state_changes=temp_subscriber.deltas_of_interest(deltas))
 
             events.append(event)

--- a/validator/tests/test_state_delta_processor/tests.py
+++ b/validator/tests/test_state_delta_processor/tests.py
@@ -205,11 +205,13 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
         self.assertEqual(GetStateDeltaEventsResponse.OK,
                          response.message_out.status)
 
+        chain_head = block_tree_manager.chain_head
         self.assertEqual(
             [StateDeltaEvent(
-                 block_id=block_tree_manager.chain_head.identifier,
-                 block_num=block_tree_manager.chain_head.block_num,
-                 state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                 block_id=chain_head.identifier,
+                 block_num=chain_head.block_num,
+                 state_root_hash=chain_head.state_root_hash,
+                 previous_block_id=chain_head.previous_block_id,
                  state_changes=[StateChange(address='deadbeef0000000',
                                 value='my_genesis_value'.encode(),
                                 type=StateChange.SET)])],
@@ -245,11 +247,13 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
         self.assertEqual(GetStateDeltaEventsResponse.OK,
                          response.message_out.status)
 
+        chain_head = block_tree_manager.chain_head
         self.assertEqual(
             [StateDeltaEvent(
-                 block_id=block_tree_manager.chain_head.identifier,
-                 block_num=block_tree_manager.chain_head.block_num,
-                 state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                 block_id=chain_head.identifier,
+                 block_num=chain_head.block_num,
+                 state_root_hash=chain_head.state_root_hash,
+                 previous_block_id=chain_head.previous_block_id,
                  state_changes=[StateChange(address='deadbeef0000000',
                                 value='my_genesis_value'.encode(),
                                 type=StateChange.SET)])],
@@ -318,12 +322,14 @@ class StateDeltaProcessorTest(unittest.TestCase):
         # test that it catches up, and receives the events from the chain head.
         # In this case, it should just be once, as the chain head is the
         # genesis block
+        chain_head = block_tree_manager.chain_head
         mock_service.send.assert_called_with(
             validator_pb2.Message.STATE_DELTA_EVENT,
             StateDeltaEvent(
-                block_id=block_tree_manager.chain_head.identifier,
-                block_num=block_tree_manager.chain_head.block_num,
-                state_root_hash=block_tree_manager.chain_head.state_root_hash,
+                block_id=chain_head.identifier,
+                block_num=chain_head.block_num,
+                state_root_hash=chain_head.state_root_hash,
+                previous_block_id=chain_head.previous_block_id,
                 state_changes=[StateChange(address='deadbeef0000000',
                                value='my_genesis_value'.encode(),
                                type=StateChange.SET)]
@@ -432,6 +438,7 @@ class StateDeltaProcessorTest(unittest.TestCase):
                 block_id=next_block.identifier,
                 block_num=next_block.header.block_num,
                 state_root_hash=next_block.header.state_root_hash,
+                previous_block_id=next_block.header.previous_block_id,
                 state_changes=[StateChange(address='deadbeef01',
                                value='my_state_Value'.encode(),
                                type=StateChange.SET)]
@@ -479,6 +486,7 @@ class StateDeltaProcessorTest(unittest.TestCase):
                 block_id=next_block.identifier,
                 block_num=next_block.header.block_num,
                 state_root_hash=next_block.header.state_root_hash,
+                previous_block_id=next_block.header.previous_block_id,
                 state_changes=[]
             ).SerializeToString(),
             connection_id='settings_conn_id')
@@ -514,6 +522,7 @@ class StateDeltaProcessorTest(unittest.TestCase):
                 block_id=next_block.identifier,
                 block_num=next_block.header.block_num,
                 state_root_hash=next_block.header.state_root_hash,
+                previous_block_id=next_block.header.previous_block_id,
                 state_changes=[]
             ).SerializeToString(),
             connection_id='subscriber_conn_id')


### PR DESCRIPTION
Add `previous_block_id` to `StateDeltaEvent`, to enable subscribers to fetch deltas for blocks they may have missed.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>