### PR TITLE
Add error information to TpProcessResponse

### DIFF
--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -92,4 +92,13 @@ message TpProcessResponse {
     }
 
     Status status = 1;
+
+    // A message to include on responses in the cases where
+    // status is either INVALID_TRANSACTION or INTERNAL_ERROR
+    string message = 2;
+
+    // Information that may be included with the response.
+    // This information is an opaque, application-specific encoded block of
+    // data that will be propagated back to the transaction submitter.
+    bytes extended_data = 3;
 }


### PR DESCRIPTION
Add a message field for a standard error message, for use on Internal
Error or Invalid Transaction statuses

Add extended_data to provide a field for application-specific data that
can be passed from a transaction processor to a client.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>