### PR TITLE
Report Errors in JS SDK Transaction Processors

### DIFF
--- a/sdk/javascript/processor/exceptions.js
+++ b/sdk/javascript/processor/exceptions.js
@@ -17,21 +17,67 @@
 
 'use strict'
 
-class InvalidTransaction extends Error {
-  constructor (message = '') {
+class _TransactionProcessorError extends Error {
+  constructor (message = '', extendedData = null) {
     super(message)
+    this.name = this.constructor.name
+
+    if (extendedData) {
+      if (Buffer.isBuffer(extendedData) || extendedData instanceof Uint8Array) {
+        this.extendedData = extendedData
+      } else {
+        throw new TypeError('extendedData must be a Buffer or a Uint8Array')
+      }
+    }
+  }
+}
+
+/**
+ * Thrown for an Invalid Transaction.
+ */
+class InvalidTransaction extends _TransactionProcessorError {
+  /**
+   * Constructs a new InvalidTransaction.
+   *
+   * @param {string} [message] - an optional message, defaults to the empty
+   * string
+   * @param {Buffer|Uint8Array} [extendedData] - optional, application-specific
+   * serialized data to returned to the transaction submitter.
+   */
+  constructor (message, extendedData) {
+    super(message, extendedData)
     this.name = this.constructor.name
   }
 }
 
-class InternalError extends Error {
-  constructor (message = '') {
-    super(message)
+/**
+ * Thrown when an internal error occurs during transaction processing.
+ */
+class InternalError extends _TransactionProcessorError {
+  /**
+   * Constructs a new InternalError
+   * @param {string} [message] - an optional message, defaults to the empty
+   * string
+   * @param {Buffer|Uint8Array} [extendedData] - optional, application-specific
+   * serialized data to returned to the transaction submitter.
+   */
+  constructor (message, extendedData) {
+    super(message, extendedData)
     this.name = this.constructor.name
   }
 }
 
+/**
+ * Thrown when a connection error occurs between the validator and the
+ * transaction processor
+ */
 class ValidatorConnectionError extends Error {
+  /**
+   * Construcs a new ValidatorConnectionError
+   *
+   * @param {string} [message] - an optional message, defaults to the empty
+   * string
+   */
   constructor (message = '') {
     super(message)
     this.name = this.constructor.name

--- a/sdk/javascript/processor/index.js
+++ b/sdk/javascript/processor/index.js
@@ -75,19 +75,24 @@ class TransactionProcessor {
                 if (e instanceof InvalidTransaction) {
                   console.log(e)
                   return TpProcessResponse.create({
-                    status: TpProcessResponse.Status.INVALID_TRANSACTION
+                    status: TpProcessResponse.Status.INVALID_TRANSACTION,
+                    message: e.message,
+                    extendedData: e.extendedData
                   })
                 } else if (e instanceof InternalError) {
                   console.log('Internal Error Occurred', e)
                   return TpProcessResponse.create({
-                    status: TpProcessResponse.Status.INTERNAL_ERROR
+                    status: TpProcessResponse.Status.INTERNAL_ERROR,
+                    message: e.message,
+                    extendedData: e.extendedData
                   })
                 } else if (e instanceof ValidatorConnectionError) {
                   console.log('Validator disconnected.  Ignoring.')
                 } else {
                   console.log('Unhandled exception, returning INTERNAL_ERROR', e)
                   return TpProcessResponse.create({
-                    status: TpProcessResponse.Status.INTERNAL_ERROR
+                    status: TpProcessResponse.Status.INTERNAL_ERROR,
+                    message: `Unhandled exception in ${txnHeader.familyName} ${txnHeader.familyVersion}`
                   })
                 }
               })

--- a/sdk/python/sawtooth_processor_test/mock_validator.py
+++ b/sdk/python/sawtooth_processor_test/mock_validator.py
@@ -62,6 +62,8 @@ class MockValidator(object):
         # The set request comparison is a little more complex by default
         self.register_comparator(Message.TP_STATE_SET_REQUEST,
                                  compare_set_request)
+        self.register_comparator(Message.TP_PROCESS_RESPONSE,
+                                 compare_tp_process_response_status_only)
 
     def listen(self, url):
         """
@@ -263,6 +265,10 @@ class MockValidator(object):
 
     def _compare(self, obj1, obj2):
         msg_type = to_message_type(obj1)
+        msg_type2 = to_message_type(obj1)
+
+        if msg_type != msg_type2:
+            raise UnexpectedMessageException(msg_type, obj1, obj2)
 
         if msg_type in self._comparators:
             return self._comparators[msg_type](obj1, obj2)
@@ -280,3 +286,7 @@ def compare_set_request(req1, req2):
         return False
 
     return True
+
+
+def compare_tp_process_response_status_only(res1, res2):
+    return res1.status == res2.status


### PR DESCRIPTION
Report the error and extended information back to the validator via the new fields on TpProcessRequest. 

Additionally, add a timeout to the State `get` and `set` methods.