### PR TITLE
Send messages and data from Python SDK on TP errors

### DIFF
--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -134,7 +134,9 @@ class TransactionProcessor(object):
                     message_type=Message.TP_PROCESS_RESPONSE,
                     correlation_id=msg.correlation_id,
                     content=TpProcessResponse(
-                        status=TpProcessResponse.INVALID_TRANSACTION
+                        status=TpProcessResponse.INVALID_TRANSACTION,
+                        message=str(it),
+                        extended_data=it.extended_data
                     ).SerializeToString())
             except ValidatorConnectionError as vce:
                 # TP_PROCESS_REQUEST has made it through the
@@ -149,7 +151,9 @@ class TransactionProcessor(object):
                     message_type=Message.TP_PROCESS_RESPONSE,
                     correlation_id=msg.correlation_id,
                     content=TpProcessResponse(
-                        status=TpProcessResponse.INTERNAL_ERROR
+                        status=TpProcessResponse.INTERNAL_ERROR,
+                        message=str(ie),
+                        extended_data=ie.extended_data
                     ).SerializeToString())
             except ValidatorConnectionError as vce:
                 # Same as the prior except block, but an internal error has

--- a/sdk/python/sawtooth_sdk/processor/exceptions.py
+++ b/sdk/python/sawtooth_sdk/processor/exceptions.py
@@ -14,9 +14,25 @@
 # ------------------------------------------------------------------------------
 
 
-class InvalidTransaction(Exception):
+class _TpResponseError(Exception):
+    """Parent class for errors that will be parsed and sent to a validator.
+
+    Args:
+        message (str): Standard error message to be logged or sent back
+        extended_data (bytes, optional): Byte-encoded data to be parsed later
+            by the app developer. Opaque to the validator and Sawtooth.
+    """
+    def __init__(self, message, extended_data=None):
+        super().__init__(message)
+
+        if extended_data is not None and not isinstance(extended_data, bytes):
+            raise TypeError("extended_data must be byte-encoded")
+        self.extended_data = extended_data
+
+
+class InvalidTransaction(_TpResponseError):
     pass
 
 
-class InternalError(Exception):
+class InternalError(_TpResponseError):
     pass


### PR DESCRIPTION
Transaction Processors developed with the Python SDK, which reject a
transaction with the InvalidTransaction or InternalError exceptions,
will now automatically send the error messages back to the validator,
as well as optional byte-encoded data.

Signed-off-by: Zac Delventhal <delventhalz@gmail.com>