### PR TITLE
Implement signing key-based client batch submit permissioning

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -23,6 +23,7 @@ MODULE_LIST="
     rest_api
     poet
     settings
+    permission
     validator
     go_sdk
     java_sdk
@@ -156,6 +157,9 @@ main() {
                 supplychain)
                     test_supplychain
                     ;;
+                permission)
+                  test_permission
+                  ;;
                 validator)
                     test_validator
                     ;;
@@ -233,6 +237,11 @@ test_settings() {
     copy_coverage .coverage.config
     run_docker_test config-smoke -s integration_test
     copy_coverage .coverage.config-smoke
+}
+
+test_permission() {
+  run_docker_test permission -s integration_test
+  copy_coverage .coverage.permission
 }
 
 test_supplychain() {

--- a/integration/sawtooth_integration/docker/permission.yaml
+++ b/integration/sawtooth_integration/docker/permission.yaml
@@ -1,0 +1,82 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  tp_settings:
+    image: sawtooth-tp_settings:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+    depends_on:
+      - validator
+    command: tp_settings -vv tcp://validator:40000
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
+        sawtooth admin keygen && \
+        sawtooth config genesis -k test.priv -o setting-genesis.batch && \
+        sawtooth admin genesis setting-genesis.batch  && \
+        validator -v --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:40000 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest_api:
+    image: sawtooth-rest_api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 40000
+      - 8080
+    depends_on:
+      - validator
+    command: rest_api -v --connect tcp://validator:40000 --bind rest_api:8080
+    stop_signal: SIGKILL
+
+  integration_test:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    depends_on:
+      - validator
+      - rest_api
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_permission.TestPermission
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli:\
+        /project/sawtooth-core/manage"

--- a/integration/sawtooth_integration/tests/test_permission.py
+++ b/integration/sawtooth_integration/tests/test_permission.py
@@ -1,0 +1,254 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import unittest
+import traceback
+import tempfile
+import os
+import subprocess
+import time
+from sawtooth_cli.main import main
+import sys
+from io import StringIO
+
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.StreamHandler())
+LOGGER.setLevel(logging.DEBUG)
+
+TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
+TEST_PUBKEY = \
+    '033775c26a68a3872f03314ccd080b8d8ec828572469737c7d3aa467f853a069d5'
+
+
+class TestPermission(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis(['rest_api:8080'])
+
+    def setUp(self):
+        self._temp_dir = tempfile.mkdtemp()
+        self._data_dir = os.path.join(self._temp_dir, 'data')
+        os.makedirs(self._data_dir)
+
+        # create a wif key for signing
+        self._wif_file = os.path.join(self._temp_dir, 'test.priv')
+        with open(self._wif_file, 'wb') as wif:
+            wif.write(TEST_WIF.encode())
+
+    def _run(self, args):
+        try:
+            LOGGER.debug("Running %s", " ".join(args))
+            proc = subprocess.run(args,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE,
+                                  check=True)
+            LOGGER.debug(proc.stdout.decode())
+        except subprocess.CalledProcessError as err:
+            LOGGER.debug(err)
+
+    def _read_from_stdout(self, cmd, args):
+        # Retrieve string of setting contents for comparison to input settings
+        backup = sys.stdout  # backup the environment
+        sys.stdout = StringIO()  # Capture the output of next statement
+
+        main(cmd, args)
+        settings = sys.stdout.getvalue()  # release the output and store
+        sys.stdout.close()
+        # Restore the environment
+        sys.stdout = backup
+        return settings
+
+    def _try_to_get_output(self, cmd, args, required):
+        # Temporary function until --wait is added to sawtooth config
+        for i in range(10):
+            settings = self._read_from_stdout(cmd, args)
+            if required in settings:
+                return settings
+            time.sleep(1)
+        self.fail("Changes were not committed in 5 seconds.")
+
+    def _assert_line_starts_match(self, raw_output, expected_line_starts):
+        output_lines = raw_output.split('\n')
+
+        for output, expected in zip(output_lines, expected_line_starts):
+            self.assertTrue(
+                output.startswith(expected),
+                'List output "{}" did not match "{}"'.format(output, expected))
+
+
+    def test_allowed_signing_keys(self):
+        ''' Test that keys set at sawtooth.validator.allowed_signing_keys are
+            allowed to sumbit batches and other keys are not allowed.
+            1. Test no keys set. In this case any public key may submit batches
+            2. One key is set and can sumbit batches.
+            3. Multiple keys can be set and one of those public keys may Submit
+               batches.
+            4. A public key, not in the allowed list, sends a batch. This
+               batch should not be accepted and the settings list should not
+               change.
+
+        '''
+        self._check_no_signing_keys_set()
+        self._check_allowed_signing_key()
+        self._check_multiple_allowed_signing_keys()
+        self._check_unallowed_signing_key()
+
+    def _check_no_signing_keys_set(self):
+        ''' Test ability to sumbit a batch when no allowd signing keys are set.
+            If no keys are set, any public key should be able to sumbit a
+            batch.
+
+            Try to set setting x=1 and check it was set correctly
+
+        '''
+        # Submit transaction, then list it using subprocess
+        cmds = [
+            ['sawtooth', 'config', 'proposal', 'create', '-k', self._wif_file,
+             '--url', 'http://rest_api:8080', 'x=1'],
+            ['sawtooth', 'config', 'settings', 'list', '--url',
+             'http://rest_api:8080']
+        ]
+        for cmd in cmds:
+            self._run(cmd)
+
+        command = 'sawtooth'
+        args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
+        settings = self._try_to_get_output(command, args, 'x: 1')
+        _expected_output = [
+            'sawtooth.settings.vote.authorized_keys: {}'.format(
+                TEST_PUBKEY[:15]),
+            'x: 1']
+        _fail_msg ='Setting results did not match.'
+        self._assert_line_starts_match(settings, _expected_output)
+
+    def _check_allowed_signing_key(self):
+        ''' Test ability to set approved signing key and check that a setting
+            is added when set with an approved key.
+
+            Add public_key to allowed_signing_keys and see if that key can
+            can set y=1. Check settings output.
+
+        '''
+        # Set allowed_signing_keys
+        command = 'sawtooth'
+        args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
+        _fail_msg ='Setting results did not match.'
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                  self._wif_file, '--url', 'http://rest_api:8080',
+                  'sawtooth.validator.allowed_signing_keys={}'
+                  .format(TEST_PUBKEY)])
+        self._try_to_get_output(command, args,
+            'sawtooth.validator.allowed_signing_keys')
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                 self._wif_file, '--url', 'http://rest_api:8080', 'y=1'])
+        # Wait for block to be processed
+        self._run(['sawtooth', 'config', 'settings', 'list', '--url',
+                  'http://rest_api:8080'])
+
+        settings = self._try_to_get_output(command, args, 'y: 1')
+        _expected_output = [
+            'sawtooth.settings.vote.authorized_keys: {}'
+                .format(TEST_PUBKEY[:15]),
+            'sawtooth.validator.allowed_signing_keys: {}'
+                .format(TEST_PUBKEY[:15]),
+            'x: 1',
+            'y: 1']
+        self._assert_line_starts_match(settings, _expected_output)
+
+    def _check_multiple_allowed_signing_keys(self):
+        ''' Test ability to set multiple approved signing keys and check that
+            a setting is added when set with an approved key.
+
+            Set allowed signing key to a different key to SomeOtherKey and
+            the public key. See if the public key can still set z=1.
+            Check settings output.
+
+        '''
+        command = 'sawtooth'
+        args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
+        _fail_msg ='Setting results did not match.'
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                  self._wif_file, '--url', 'http://rest_api:8080',
+                  'sawtooth.validator.allowed_signing_keys=SomeOtherKey,{}'
+                  .format(TEST_PUBKEY)])
+        self._try_to_get_output(command, args, 'SomeOtherKey')
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                 self._wif_file, '--url', 'http://rest_api:8080', 'z=1'])
+        # Wait for block to be processed
+        self._run(['sawtooth', 'config', 'settings', 'list', '--url',
+                  'http://rest_api:8080'])
+        # Check that allowed_signing_keys is set.
+        settings = self._try_to_get_output(command, args, 'z: 1')
+        _expected_output = [
+            'sawtooth.settings.vote.authorized_keys: {}'
+                .format(TEST_PUBKEY[:15]),
+            'sawtooth.validator.allowed_signing_keys: SomeOtherKey,{}'
+                .format(TEST_PUBKEY[:2]),
+            'x: 1',
+            'y: 1',
+            'z: 1']
+        self._assert_line_starts_match(settings, _expected_output)
+
+    def _check_unallowed_signing_key(self):
+        ''' Test ability to set approved signing keys and check that a setting
+            is not added when set with an unapproved key.
+
+            Set allowed siging key to just SomeOtherKey.
+            This should make any batches sent from the configured keys
+            fail. Try to set a=1. This should fail, and not change the
+            set settings.
+
+        '''
+        command = 'sawtooth'
+        args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
+        _fail_msg ='Setting results did not match.'
+        # Set allowed signing key to a different key to "SomeOtherKey".
+        # This should make any batches sent from the configured keys fail.
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                  self._wif_file, '--url', 'http://rest_api:8080',
+                  'sawtooth.validator.allowed_signing_keys=SomeOtherKey'])
+        # Wait for block to be processed
+        time.sleep(1)
+        self._run(['sawtooth', 'config', 'settings', 'list', '--url',
+                  'http://rest_api:8080'])
+
+        # Check that allowed_signing_key is set.
+        settings = self._try_to_get_output(
+            command, args,
+            "sawtooth.validator.allowed_signing_keys: SomeOtherKey")
+        _expected_output = [
+            'sawtooth.settings.vote.authorized_keys: {}'
+                .format(TEST_PUBKEY[:15]),
+            'sawtooth.validator.allowed_signing_keys: SomeOtherKey',
+            'x: 1',
+            'y: 1',
+            'z: 1']
+        self._assert_line_starts_match(settings, _expected_output)
+
+        self._run(['sawtooth', 'config', 'proposal', 'create', '-k',
+                 self._wif_file, '--url', 'http://rest_api:8080', 'a=1'])
+        # Wait for block to be processed
+        time.sleep(3)
+        self._run(['sawtooth', 'config', 'settings', 'list', '--url',
+                  'http://rest_api:8080'])
+        settings = self._read_from_stdout(command, args)
+
+        # Same _expected_setting_result as the last assert
+        self._assert_line_starts_match(settings, _expected_output)
+        self.assertTrue('a=1' not in settings)

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -1,0 +1,74 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import logging
+# pylint: disable=import-error,no-name-in-module
+# needed for google.protobuf import
+from google.protobuf.message import DecodeError
+
+from sawtooth_validator.protobuf import client_pb2
+from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
+from sawtooth_validator.protobuf.validator_pb2 import Message
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.networking.dispatch import Handler
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def is_batch_signer_authorized(batch, allowed_pubkeys):
+    header = BatchHeader()
+    header.ParseFromString(batch.header)
+    if header.signer_pubkey not in allowed_pubkeys:
+        LOGGER.info("Batch was signed by an unauthorized signing key %s",
+                    header.signer_pubkey)
+        return False
+    return True
+
+
+class BatchListPermissionVerifier(Handler):
+    def __init__(self, settings_view_factory, current_root_func):
+        self.settings_view_factory = settings_view_factory
+        self.current_root_func = current_root_func
+
+    def handle(self, connection_id, message_content):
+        response_proto = client_pb2.ClientBatchSubmitResponse
+        allowed_pubkeys = None
+        try:
+            state_root = self.current_root_func()
+            settings_view = \
+                self.settings_view_factory.create_settings_view(state_root)
+            allowed_pubkeys = settings_view.get_setting(
+                "sawtooth.validator.allowed_signing_keys")
+        except AttributeError:
+            LOGGER.debug("Chain head not yet set")
+
+        def make_response(out_status):
+            return HandlerResult(
+                status=HandlerStatus.RETURN,
+                message_out=response_proto(status=out_status),
+                message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
+        try:
+
+            if allowed_pubkeys is not None:
+                request = client_pb2.ClientBatchSubmitRequest()
+                request.ParseFromString(message_content)
+                if not all(is_batch_signer_authorized(batch, allowed_pubkeys)
+                           for batch in request.batches):
+                    return make_response(response_proto.INVALID_BATCH)
+        except DecodeError:
+            return make_response(response_proto.INTERNAL_ERROR)
+
+        return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -64,6 +64,8 @@ from sawtooth_validator.state.state_delta_processor import \
 from sawtooth_validator.state.state_delta_store import StateDeltaStore
 from sawtooth_validator.state.state_view import StateViewFactory
 from sawtooth_validator.gossip import signature_verifier
+from sawtooth_validator.gossip.permission_verifier import \
+    BatchListPermissionVerifier
 from sawtooth_validator.networking.interconnect import Interconnect
 from sawtooth_validator.gossip.gossip import Gossip
 from sawtooth_validator.gossip.gossip_handlers import GossipBroadcastHandler
@@ -411,6 +413,15 @@ class Validator(object):
             validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
             ResponderBatchResponseHandler(responder, self._gossip),
             network_thread_pool)
+
+        self._dispatcher.add_handler(
+            validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
+            BatchListPermissionVerifier(
+                settings_view_factory=SettingsViewFactory(
+                    StateViewFactory(merkle_db)),
+                current_root_func=self._journal.get_current_root,
+            ),
+            sig_pool)
 
         self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,


### PR DESCRIPTION
The signing keys that are allowed to submit batches will be
stored in the validator setting sawtooth.validator.allowed_signing_key.
A batch signed by an unknown signing key will cause the batch to be
dropped. If no signing keys are set, all signing keys are accepted.