### PR TITLE
Lint

### DIFF
--- a/bin/protogen
+++ b/bin/protogen
@@ -34,7 +34,9 @@ JOIN = os.path.join
 TOP_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     # 1. Generate and distribute top-level protos
     proto_dir = JOIN(TOP_DIR, "protos")
 

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -70,7 +70,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/ap
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
-    pylint==1.6.5 \
+    pylint \
     bandit
 
 RUN apt-get update && apt-get install -y -q \

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -88,10 +88,10 @@ def _validate_depedencies(batches):
             txn_header = TransactionHeader()
             txn_header.ParseFromString(txn.header)
 
-            if len(txn_header.dependencies) > 0:
+            if txn_header.dependencies:
                 unsatisfied_deps = [id for id in txn_header.dependencies
                                     if id not in transaction_ids]
-                if len(unsatisfied_deps) != 0:
+                if unsatisfied_deps:
                     raise CliException(
                         'Unsatisfied dependency in given transactions:'
                         ' {}'.format(unsatisfied_deps))

--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -229,7 +229,7 @@ def _split_batch_list(args, batch_list):
         if len(new_list) == args.batch_size_limit:
             yield batch_pb2.BatchList(batches=new_list)
             new_list = []
-    if len(new_list) > 0:
+    if new_list:
         yield batch_pb2.BatchList(batches=new_list)
 
 

--- a/cli/sawtooth_cli/cluster.py
+++ b/cli/sawtooth_cli/cluster.py
@@ -419,7 +419,7 @@ def do_cluster_extend(args):
 def do_cluster_logs(args):
     state = load_state()
 
-    supported_types = 'docker',
+    supported_types = ('docker',)
     if state['Manage'] in supported_types:
         prefix = 'sawtooth-cluster-0'
 

--- a/cli/sawtooth_cli/cluster.py
+++ b/cli/sawtooth_cli/cluster.py
@@ -301,7 +301,7 @@ def do_cluster_stop(args):
         node_controller=node_controller,
         node_command_generator=node_command_generator)
 
-    if len(args.node_names) > 0:
+    if args.node_names:
         node_names = args.node_names
     else:
         node_names = vnm.get_node_names()
@@ -325,7 +325,7 @@ def do_cluster_stop(args):
 
     timeout = 16
     mark = time.time()
-    while len(find_still_up(node_names)) > 0:
+    while find_still_up(node_names):
         if time.time() - mark > timeout:
             break
         time.sleep(1)
@@ -345,7 +345,7 @@ def do_cluster_status(args):
         node_controller=node_controller,
         node_command_generator=node_command_generator)
 
-    if len(args.node_names) > 0:
+    if args.node_names:
         node_names = args.node_names
         node_superset = vnm.get_node_names()
         for node_name in args.node_names:

--- a/cli/sawtooth_cli/exceptions.py
+++ b/cli/sawtooth_cli/exceptions.py
@@ -15,5 +15,4 @@
 
 
 class CliException(Exception):
-    def __init__(self, msg):
-        super(CliException, self).__init__(msg)
+    pass

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -107,9 +107,11 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
+def main(prog_name=os.path.basename(sys.argv[0]), args=None,
          with_loggers=True):
     parser = create_parser(prog_name)
+    if args is None:
+        args = sys.argv[1:]
     args = parser.parse_args(args)
 
     if with_loggers is True:

--- a/consensus/poet/cli/sawtooth_poet_cli/exceptions.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/exceptions.py
@@ -15,5 +15,4 @@
 
 
 class CliException(Exception):
-    def __init__(self, msg):
-        super(CliException, self).__init__(msg)
+    pass

--- a/consensus/poet/cli/sawtooth_poet_cli/main.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/main.py
@@ -86,9 +86,11 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
+def main(prog_name=os.path.basename(sys.argv[0]), args=None,
          with_loggers=True):
 
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -198,7 +198,7 @@ class ConsensusState(object):
             # yet or the last block we processed was a PoET block, put a
             # placeholder in the list so that when we get to it we know that we
             # need to reset the statistics.
-            elif len(blocks) == 0 or previous_wait_certificate is not None:
+            elif not blocks or previous_wait_certificate is not None:
                 blocks[current_id] = \
                     ConsensusState._BlockInfo(
                         wait_certificate=None,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state_store.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state_store.py
@@ -139,6 +139,7 @@ class ConsensusStateStore(MutableMapping):
 
         return ', '.join(out)
 
+    # pylint: disable=arguments-differ
     def get(self, block_id, default=None):
         """Return the consensus state corresponding to block ID or the default
         value if none exists

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_key_state_store.py
@@ -118,7 +118,7 @@ class PoetKeyStateStore(MutableMapping):
         try:
             if not isinstance(poet_key_state.sealed_signup_data, str):
                 raise ValueError('sealed_signup_data must be a string')
-            elif len(poet_key_state.sealed_signup_data) == 0:
+            elif not poet_key_state.sealed_signup_data:
                 raise ValueError('sealed_signup_data must not be empty')
 
             # Although this won't catch everything, verify that the sealed

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_settings_view.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_settings_view.py
@@ -139,7 +139,8 @@ class PoetSettingsView(object):
                     name='sawtooth.poet.enclave_module_name',
                     value_type=str,
                     default_value=PoetSettingsView._ENCLAVE_MODULE_NAME_,
-                    validate_function=lambda value: len(value) > 0)
+                    # function should return true if value is nonempty
+                    validate_function=lambda value: value)
 
         return self._enclave_module_name
 

--- a/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_key_state_store.py
@@ -520,11 +520,9 @@ class TestPoetKeyStateStore(unittest.TestCase):
         mock_lmdb.return_value.__getitem__.side_effect = ValueError()
         with self.assertRaises(ValueError):
             _ = store['ppk']
-        # pylint: disable=redefined-variable-type
         mock_lmdb.return_value.__getitem__.side_effect = TypeError()
         with self.assertRaises(ValueError):
             _ = store['ppk']
-        # pylint: disable=redefined-variable-type
         mock_lmdb.return_value.__getitem__.side_effect = AttributeError()
         with self.assertRaises(ValueError):
             _ = store['ppk']

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
@@ -75,7 +75,9 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     opts = parse_args(args)
 
     init_console_logging(verbose_level=opts.verbose)

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -82,7 +82,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
-    pylint==1.6.5 \
+    pylint \
     bandit \
     coverage --upgrade
 

--- a/extensions/arcade/sawtooth_battleship/battleship_cli.py
+++ b/extensions/arcade/sawtooth_battleship/battleship_cli.py
@@ -586,7 +586,9 @@ def load_data(config):
     return data
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+def main(prog_name=os.path.basename(sys.argv[0]), args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/families/settings/sawtooth_settings/processor/handler.py
+++ b/families/settings/sawtooth_settings/processor/handler.py
@@ -66,7 +66,7 @@ class SettingsTransactionHandler(object):
         pubkey = txn_header.signer_pubkey
 
         auth_keys = _get_auth_keys(state)
-        if len(auth_keys) > 0 and pubkey not in auth_keys:
+        if auth_keys and pubkey not in auth_keys:
             raise InvalidTransaction(
                 '{} is not authorized to change settings'.format(pubkey))
 
@@ -207,17 +207,17 @@ def _get_auth_keys(state):
 
 
 def _split_ignore_empties(value):
-    return [v.strip() for v in value.split(',') if len(v) > 0]
+    return [v.strip() for v in value.split(',') if v]
 
 
 def _validate_setting(auth_keys, setting, value):
-    if len(auth_keys) == 0 and \
+    if not auth_keys and \
             setting != 'sawtooth.settings.vote.authorized_keys':
         raise InvalidTransaction(
             'Cannot set {} until authorized_keys is set.'.format(setting))
 
     if setting == 'sawtooth.settings.vote.authorized_keys':
-        if len(_split_ignore_empties(value)) == 0:
+        if not _split_ignore_empties(value):
             raise InvalidTransaction('authorized_keys must not be empty.')
 
     if setting == 'sawtooth.settings.vote.approval_threshold':
@@ -292,7 +292,7 @@ def _get_setting_entry(state, address):
         LOGGER.warning('Timeout occured on state.get([%s])', address)
         raise InternalError('Unable to get {}'.format(address))
 
-    if len(entries_list) != 0:
+    if entries_list:
         setting.ParseFromString(entries_list[0].data)
 
     return setting

--- a/families/settings/sawtooth_settings/processor/main.py
+++ b/families/settings/sawtooth_settings/processor/main.py
@@ -74,8 +74,10 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:],
+def main(prog_name=os.path.basename(sys.argv[0]), args=None,
          with_loggers=True):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/families/supplychain/python/sawtooth_supplychain/processor/main.py
+++ b/families/supplychain/python/sawtooth_supplychain/processor/main.py
@@ -41,7 +41,9 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main(args=sys.argv[1:]):  # pylint: disable=dangerous-default-value
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     opts = parse_args(args)
     processor = None
     try:

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -141,7 +141,7 @@ class DockerNodeController(NodeController):
         else:
             command = 'bash -c "sawtooth admin keygen && \
             validator {} -v --endpoint tcp://{}:8800"'
-        if len(peers) > 0:
+        if peers:
             command = command.format('--peers ' + ",".join(peers), node_name)
         else:
             command = command.format('', node_name)

--- a/manage/sawtooth_manage/docker.py
+++ b/manage/sawtooth_manage/docker.py
@@ -113,11 +113,11 @@ class DockerNodeController(NodeController):
             raise ManagementError(str(e))
         return ['tcp://' + str(p) + ':8800' for p in peers if len(p) > 4]
 
-    def start(self, node_config):
+    def start(self, node_args):
         base_network_port = 8800
         base_component_port = 4004
-        node_name = node_config.node_name
-        http_port = node_config.http_port
+        node_name = node_args.node_name
+        http_port = node_args.http_port
 
         # The first time a node is started, it should start a bridge
         # network. Subsequent nodes should wait until the network
@@ -134,7 +134,7 @@ class DockerNodeController(NodeController):
         LOGGER.debug('starting %s: %s', node_name, self._join_args(start_args))
         peers = self._find_peers()
 
-        if node_config.genesis:
+        if node_args.genesis:
             command = 'bash -c "sawtooth admin keygen && \
             sawtooth admin genesis && \
             validator {} -v --endpoint tcp://{}:8800"'

--- a/manage/sawtooth_manage/exceptions.py
+++ b/manage/sawtooth_manage/exceptions.py
@@ -15,10 +15,8 @@
 
 
 class SawtoothException(Exception):
-    def __init__(self, msg):
-        super(SawtoothException, self).__init__(msg)
+    pass
 
 
 class ManagementError(SawtoothException):
-    def __init__(self, msg):
-        super(ManagementError, self).__init__(msg)
+    pass

--- a/manage/sawtooth_manage/subproc.py
+++ b/manage/sawtooth_manage/subproc.py
@@ -117,7 +117,7 @@ class SubprocessNodeController(NodeController):
                 if peers:
                     peers_flag = tuple(peers)
                 flags = component + network + endpoint
-                if len(peer_list) > 0:
+                if peer_list:
                     flags += peers_flag
                 flags += tuple(['-vv'])
 

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -124,4 +124,4 @@ class RestApiConfig:
         ])
 
     def to_toml_string(self):
-        return toml.dumps(self.to_dict()).strip().split('\n')
+        return str(toml.dumps(self.to_dict())).strip().split('\n')

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -54,7 +54,7 @@ def load_toml_rest_api_config(filename):
 
     invalid_keys = set(toml_config.keys()).difference(
         ['bind', 'connect', 'timeout'])
-    if len(invalid_keys) > 0:
+    if invalid_keys:
         raise RestApiConfigurationError(
             "Invalid keys in rest api config: {}".format(
                 ", ".join(sorted(list(invalid_keys)))))

--- a/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/main.py
+++ b/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/main.py
@@ -72,7 +72,9 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+def main(prog_name=os.path.basename(sys.argv[0]), args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
@@ -56,7 +56,7 @@ def _split_batch_list(batch_list):
         if len(new_list) == 100:
             yield batch_pb2.BatchList(batches=new_list)
             new_list = []
-    if len(new_list) > 0:
+    if new_list:
         yield batch_pb2.BatchList(batches=new_list)
 
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/main.py
@@ -96,7 +96,9 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+def main(prog_name=os.path.basename(sys.argv[0]), args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
@@ -146,8 +146,7 @@ class IntKeyWorkload(Workload):
 
     def _create_new_key(self):
         with self._lock:
-            url = random.choice(self._urls) if \
-                len(self._urls) > 0 else None
+            url = random.choice(self._urls) if self._urls else None
 
         batch_id = None
         if url is not None:

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
@@ -40,7 +40,9 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     opts = parse_args(args)
     processor = None
     try:

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/main.py
@@ -84,7 +84,9 @@ def create_parser(prog_name):
     return parser
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+def main(prog_name=os.path.basename(sys.argv[0]), args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -94,7 +94,7 @@ class XoTransactionHandler:
 
         # state_store.get() returns a list. If no data has been stored yet
         # at the given address, it will be empty.
-        if len(state_entries) != 0:
+        if state_entries:
             try:
                 state_data = state_entries[0].data
 

--- a/sdk/examples/xo_python/sawtooth_xo/processor/main.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/main.py
@@ -41,7 +41,9 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     opts = parse_args(args)
     processor = None
     try:

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -370,7 +370,9 @@ def _get_auth_info(args):
     return auth_user, auth_password
 
 
-def main(prog_name=os.path.basename(sys.argv[0]), args=sys.argv[1:]):
+def main(prog_name=os.path.basename(sys.argv[0]), args=None):
+    if args is None:
+        args = sys.argv[1:]
     parser = create_parser(prog_name)
     args = parser.parse_args(args)
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_exceptions.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_exceptions.py
@@ -15,5 +15,4 @@
 
 
 class XoException(Exception):
-    def __init__(self, msg):
-        super(XoException, self).__init__(msg)
+    pass

--- a/sdk/python/sawtooth_sdk/workload/sawtooth_workload.py
+++ b/sdk/python/sawtooth_sdk/workload/sawtooth_workload.py
@@ -112,7 +112,7 @@ class Workload(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def on_batch_committed(self, transaction_id):
+    def on_batch_committed(self, batch_id):
         """
         In the normal course of running the workload generator, this is called
         by the generator to let the workload know that a previously-

--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -120,7 +120,7 @@ class WorkloadGenerator(object):
                 # one.
                 batch = \
                     self._pending_batches.popleft() \
-                    if len(self._pending_batches) > 0 else None
+                    if self._pending_batches else None
                 self.loop.run_in_executor(
                     self.thread_pool, self._check_on_batch, batch)
 

--- a/tools/bootstrap.d/30-python-lib-install.sh
+++ b/tools/bootstrap.d/30-python-lib-install.sh
@@ -3,5 +3,5 @@
 set -e
 
 pip3 install \
-    pylint==1.6.5 \
+    pylint \
     bandit

--- a/validator/sawtooth_validator/config/path.py
+++ b/validator/sawtooth_validator/config/path.py
@@ -79,7 +79,7 @@ def load_toml_path_config(filename):
 
     invalid_keys = set(toml_config.keys()).difference(
         ['data_dir', 'key_dir', 'log_dir'])
-    if len(invalid_keys) > 0:
+    if invalid_keys:
         raise LocalConfigurationError("Invalid keys in path config: {}".format(
             ", ".join(sorted(list(invalid_keys)))))
 

--- a/validator/sawtooth_validator/config/path.py
+++ b/validator/sawtooth_validator/config/path.py
@@ -180,4 +180,4 @@ class PathConfig:
         ])
 
     def to_toml_string(self):
-        return toml.dumps(self.to_dict()).strip().split('\n')
+        return str(toml.dumps(self.to_dict())).strip().split('\n')

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -212,4 +212,4 @@ class ValidatorConfig:
         ])
 
     def to_toml_string(self):
-        return toml.dumps(self.to_dict()).strip().split('\n')
+        return str(toml.dumps(self.to_dict())).strip().split('\n')

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -57,7 +57,7 @@ def load_toml_validator_config(filename):
     invalid_keys = set(toml_config.keys()).difference(
         ['bind', 'endpoint', 'peering', 'seeds', 'peers', 'network_public_key',
          'network_private_key'])
-    if len(invalid_keys) > 0:
+    if invalid_keys:
         raise LocalConfigurationError(
             "Invalid keys in validator config: "
             "{}".format(", ".join(sorted(list(invalid_keys)))))

--- a/validator/sawtooth_validator/database/lmdb_nolock_database.py
+++ b/validator/sawtooth_validator/database/lmdb_nolock_database.py
@@ -54,6 +54,7 @@ class LMDBNoLockDatabase(database.Database):
                                       create=create,
                                       lock=True)
 
+    # pylint: disable=no-value-for-parameter
     def __len__(self):
         with self._lmdb.begin() as txn:
             return txn.stat()['entries']

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -366,7 +366,7 @@ class ContextManager(object):
 
         contexts_asked_not_found = [cid for cid in base_contexts
                                     if cid not in self._contexts]
-        if len(contexts_asked_not_found) > 0:
+        if contexts_asked_not_found:
             raise KeyError(
                 "Basing a new context off of context ids {} "
                 "that are not in context manager".format(
@@ -383,7 +383,7 @@ class ContextManager(object):
         # are being searched for have been found, or we run out of contexts
         # in the chain of contexts.
 
-        while len(reads) > 0:
+        while reads:
             try:
                 current_c_id = contexts_in_chain.popleft()
             except IndexError:
@@ -427,7 +427,7 @@ class ContextManager(object):
 
         self._contexts[context.session_id] = context
 
-        if len(reads) > 0:
+        if reads:
             context.create_prefetch(reads)
             self._address_queue.put_nowait(
                 (context.session_id, state_hash, reads))
@@ -522,7 +522,7 @@ class ContextManager(object):
             # There is only one exit condition and that is when all the
             # contexts have been accessed once.
             updates = dict()
-            while len(contexts_in_chain) > 0:
+            while contexts_in_chain:
                 current_c_id = contexts_in_chain.popleft()
                 current_context = self._contexts[current_c_id]
                 if not current_context.is_read_only():
@@ -540,7 +540,7 @@ class ContextManager(object):
                         contexts_in_chain.append(c_id)
                         context_ids_already_searched.append(c_id)
 
-            if len(updates) == 0:
+            if not updates:
                 return state_root
 
             tree = MerkleDatabase(self._database, state_root)

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -143,8 +143,8 @@ class TransactionExecutorThread(object):
 
             # First check if the transaction should be failed
             # based on configuration
-            if processor_type not in required_transaction_processors \
-                    and len(required_transaction_processors) > 0:
+            if required_transaction_processors and \
+                    processor_type not in required_transaction_processors:
                 # The txn processor type is not in the required
                 # transaction processors so
                 # failing transaction right away

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -122,7 +122,7 @@ class ProcessorIteratorCollection(object):
                     del self._processors[processor_type]
 
     def __repr__(self):
-        return ",".join([repr(k) for k in self._processors.keys()])
+        return ",".join([repr(k) for k in self._processors])
 
     def cancellable_wait(self, processor_type, cancelled_event):
         """Waits for a particular processor type to register or until

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -118,7 +118,7 @@ class ProcessorIteratorCollection(object):
                     continue
                 self._processors[processor_type].remove_processor(
                     processor_identity=processor_identity)
-                if len(self._processors[processor_type]) == 0:
+                if not self._processors[processor_type]:
                     del self._processors[processor_type]
 
     def __repr__(self):

--- a/validator/sawtooth_validator/execution/scheduler_exceptions.py
+++ b/validator/sawtooth_validator/execution/scheduler_exceptions.py
@@ -15,5 +15,4 @@
 
 
 class SchedulerError(Exception):
-    def __init__(self, msg):
-        super().__init__(msg)
+    pass

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -26,11 +26,11 @@ class PredecessorTreeNode:
     def __repr__(self):
         retval = {}
 
-        if len(self.readers) > 0:
+        if self.readers:
             retval['readers'] = self.readers
         if self.writer is not None:
             retval['writer'] = self.writer
-        if len(self.children) > 0:
+        if self.children:
             retval['children'] = \
                 {k: literal_eval(repr(v)) for k, v in self.children.items()}
 
@@ -155,7 +155,7 @@ class PredecessorTree:
 
         to_process = deque()
         to_process.extendleft(node.children.values())
-        while len(to_process) > 0:
+        while to_process:
             node = to_process.pop()
             predecessors.update(node.readers)
             if node.writer is not None:
@@ -229,7 +229,7 @@ class PredecessorTree:
 
         to_process = deque()
         to_process.extendleft(node.children.values())
-        while len(to_process) > 0:
+        while to_process:
             node = to_process.pop()
             if node.writer is not None:
                 predecessors.add(node.writer)

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -132,8 +132,8 @@ class BlockStore(MutableMapping):
         """
         if not starting_block:
             return _BlockPredecessorIterator(self, start_block=self.chain_head)
-        else:
-            return _BlockPredecessorIterator(self, start_block=starting_block)
+
+        return _BlockPredecessorIterator(self, start_block=starting_block)
 
     def wait_for_batch_commits(self, batch_ids=None, timeout=None):
         """Waits for a set of batch ids to be committed to the block chain,

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -23,9 +23,9 @@ class BlockStatus(Enum):
     """
         The status of a block as the journal is concerned.
     """
-    Unknown = 0,  # Block is present but not yet validated
-    Invalid = 1,  # Block failed block validation.
-    Valid = 2,  # Block has been validated and id valid to appear in a chain.
+    Unknown = 0  # Block is present but not yet validated
+    Invalid = 1  # Block failed block validation.
+    Valid = 2  # Block has been validated and id valid to appear in a chain.
     Missing = 3  # we know about the block, possibly by a successor, but
     # we do not have it.
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -155,7 +155,7 @@ class BlockValidator(object):
         return True
 
     def _verify_block_batches(self, blkw, committed_txn):
-        if len(blkw.block.batches) > 0:
+        if blkw.block.batches:
 
             prev_state = self._get_previous_block_root_state_hash(blkw)
             scheduler = self._executor.create_scheduler(

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -106,9 +106,8 @@ class BlockValidator(object):
     def _get_previous_block_root_state_hash(self, blkw):
         if blkw.previous_block_id == NULL_BLOCK_IDENTIFIER:
             return INIT_ROOT_KEY
-        else:
-            prev_blkw = self._block_cache[blkw.previous_block_id]
-            return prev_blkw.state_root_hash
+
+        return self._block_cache[blkw.previous_block_id].state_root_hash
 
     def _is_block_complete(self, blkw):
         """

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -140,6 +140,7 @@ class BlockPublisher(BlockPublisherInterface):
 class BlockVerifier(BlockVerifierInterface):
     """DevMode BlockVerifier implementation
     """
+    # pylint: disable=useless-super-delegation
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -161,6 +162,7 @@ class ForkResolver(ForkResolverInterface):
     """Provides the fork resolution interface for the BlockValidator to use
     when deciding between 2 forks.
     """
+    # pylint: disable=useless-super-delegation
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -231,7 +231,9 @@ class ForkResolver(ForkResolverInterface):
                 new_fork_head.header.signer_pubkey,
                 new_fork_head.header.previous_block_id)
 
-            return new_fork_hash < cur_fork_hash
+            result = new_fork_hash < cur_fork_hash
 
         else:
-            return new_fork_head.block_num > cur_fork_head.block_num
+            result = new_fork_head.block_num > cur_fork_head.block_num
+
+        return result

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -69,6 +69,7 @@ class BlockVerifier(BlockVerifierInterface):
     other case, verification will fail.  This requires that any block beyond
     the genesis block must use a proper consensus module.
     """
+    # pylint: disable=useless-super-delegation
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -91,6 +92,7 @@ class BlockVerifier(BlockVerifierInterface):
 class ForkResolver(ForkResolverInterface):
     """The genesis ForkResolver should not ever be used.
     """
+    # pylint: disable=useless-super-delegation
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -153,7 +153,7 @@ class GenesisController(object):
         initial_state_root = self._context_manager.get_first_root()
 
         genesis_batches = [batch for batch in genesis_data.batches]
-        if len(genesis_batches) > 0:
+        if genesis_batches:
             scheduler = SerialScheduler(
                 self._context_manager.get_squash_handler(),
                 initial_state_root,

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -132,13 +132,13 @@ class ResponderBlockResponseHandler(Handler):
         if open_request is None:
             return HandlerResult(status=HandlerStatus.PASS)
 
-        for connection_id in open_request:
+        for connection in open_request:
             LOGGER.debug("Responding to block request: Send %s to %s",
                          block.header_signature,
-                         connection_id)
+                         connection)
             self._gossip.send(validator_pb2.Message.GOSSIP_BLOCK_RESPONSE,
                               message_content,
-                              connection_id)
+                              connection)
 
         self._responder.remove_request(block.header_signature)
         self._responder.purge_requests()
@@ -266,13 +266,13 @@ class ResponderBatchResponseHandler(Handler):
                 open_request += requests_by_txn
                 requests_to_remove += [txn.header_signature]
 
-        for connection_id in open_request:
+        for connection in open_request:
             LOGGER.debug("Responding to batch requests: Send %s to %s",
                          batch.header_signature,
-                         connection_id)
+                         connection)
             self._gossip.send(validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
                               message_content,
-                              connection_id)
+                              connection)
 
         for requested_id in requests_to_remove:
             self._responder.remove_request(requested_id)

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -157,7 +157,7 @@ class Dispatcher(Thread):
                             get_enum_name(message.message_type), connection_id,
                             connection)
         with self._condition:
-            if len(self._message_information) == 0:
+            if not self._message_information:
                 self._condition.notify()
 
     def run(self):
@@ -175,7 +175,7 @@ class Dispatcher(Thread):
         useful for unit tests.
         """
         with self._condition:
-            if len(self._message_information) > 0:
+            if self._message_information:
                 self._condition.wait()
 
 

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -445,7 +445,7 @@ class _SendReceive(object):
         tasks = asyncio.Task.all_tasks(self._event_loop)
         for task in tasks:
             self._event_loop.call_soon_threadsafe(task.cancel)
-        while len(tasks) > 0:
+        while tasks:
             for task in tasks.copy():
                 if task.done() is True:
                     tasks.remove(task)

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -531,10 +531,7 @@ class Interconnect(object):
                      "be allowed. num connections: %s max %s",
                      len(self._connections),
                      self._max_incoming_connections)
-        if len(self._connections) > self._max_incoming_connections:
-            return False
-        else:
-            return True
+        return self._max_incoming_connections >= len(self._connections)
 
     def add_outbound_connection(self, uri,
                                 success_callback=None,

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -167,7 +167,9 @@ def create_validator_config(opts):
         peers=opts.peers)
 
 
-def main(args=sys.argv[1:]):
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
     opts = parse_args(args)
     verbose_level = opts.verbose
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -561,7 +561,7 @@ class Validator(object):
         # a sys.exit() or exit of main().
         threads.remove(threading.current_thread())
 
-        while len(threads) > 0:
+        while threads:
             if len(threads) < 4:
                 LOGGER.info(
                     "remaining threads: %s",
@@ -572,7 +572,7 @@ class Validator(object):
                 if not t.is_alive():
                     t.join()
                     threads.remove(t)
-                if len(threads) > 0:
+                if threads:
                     time.sleep(1)
 
         LOGGER.info("All threads have been stopped and joined")

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -313,7 +313,7 @@ class _Pager(object):
             list: The paginated list of resources
             object: The PagingResponse to be sent back to the client
         """
-        if len(resources) == 0:
+        if not resources:
             return resources, client_pb2.PagingResponse(total_resources=0)
 
         paging = request.paging

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -82,11 +82,11 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
         self._block_store = block_store
         self._batch_cache = batch_cache
 
-    def handle(self, identity, message_content):
+    def handle(self, connection_id, message_content):
         """Handles parsing incoming requests, and wrapping the final response.
 
         Args:
-            identity (str): ZMQ identity sent over ZMQ socket
+            connection_id (str): ZMQ identity sent over ZMQ socket
             message_content (bytes): Byte encoded request protobuf to be parsed
 
         Returns:

--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -237,10 +237,7 @@ class MerkleDatabase(object):
 
     def _get_kv(self, key):
         packed = self._database.get(key)
-        if packed is not None:
-            return self._decode(packed)
-        else:
-            return None
+        return self._decode(packed) if packed is not None else None
 
     def _set_kv(self, value):
         packed = self._encode(value)

--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -153,7 +153,7 @@ class MerkleDatabase(object):
             parent_address = path[:-TOKEN_SIZE]
             path_branch = path[-TOKEN_SIZE:]
 
-            if len(path_map[path]['c']) > 0 or path == '':
+            if path_map[path]['c'] or path == '':
                 leaf_branch = False
 
             if not leaf_branch:

--- a/validator/sawtooth_validator/state/settings_view.py
+++ b/validator/sawtooth_validator/state/settings_view.py
@@ -100,9 +100,11 @@ class SettingsView(object):
         """
         value = self.get_setting(key)
         if value is not None:
-            return [value_type(v) for v in value.split(delimiter)]
+            setting_list = [value_type(v) for v in value.split(delimiter)]
         else:
-            return default_value
+            setting_list = default_value
+
+        return setting_list
 
     @staticmethod
     @lru_cache(maxsize=128)

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -245,16 +245,18 @@ class StateDeltaSubscriberValidationHandler(Handler):
         if self._delta_processor.is_valid_subscription(
                 request.last_known_block_ids):
             ack.status = ack.OK
-            return HandlerResult(
+            result = HandlerResult(
                 HandlerStatus.RETURN_AND_PASS,
                 message_out=ack,
                 message_type=self._msg_type)
         else:
             ack.status = ack.UNKNOWN_BLOCK
-            return HandlerResult(
+            result = HandlerResult(
                 HandlerStatus.RETURN,
                 message_out=ack,
                 message_type=self._msg_type)
+
+        return result
 
 
 class StateDeltaAddSubscriberHandler(Handler):

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -182,7 +182,7 @@ class StateDeltaProcessor(object):
 
         deltas = self._get_delta(state_root_hash)
 
-        if len(self._subscribers) > 0:
+        if self._subscribers:
             self._broadcast_changes(block, deltas)
 
     def _get_delta(self, state_root_hash):
@@ -202,7 +202,7 @@ class StateDeltaProcessor(object):
             acceptable_changes = subscriber.deltas_of_interest(deltas)
             state_change_evt.ClearField('state_changes')
 
-            if len(acceptable_changes) > 0:
+            if acceptable_changes:
                 state_change_evt.state_changes.extend(acceptable_changes)
 
             LOGGER.debug('sending change event to %s',
@@ -343,7 +343,7 @@ class GetStateDeltaEventsHandler(Handler):
 
             events.append(event)
 
-        status = GetStateDeltaEventsResponse.OK if len(events) > 0 else \
+        status = GetStateDeltaEventsResponse.OK if events else \
             GetStateDeltaEventsResponse.NO_VALID_BLOCKS_SPECIFIED
 
         ack = GetStateDeltaEventsResponse(status=status, events=events)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -1728,7 +1728,7 @@ def node_to_string(node, indent=2):
         string += ' Writer: {}'.format(writer)
 
     readers = node.readers
-    if len(readers) > 0:
+    if readers:
         string += ' Readers: {}'.format(readers)
 
     for child_address in node.children:

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -467,7 +467,7 @@ class SchedulerTester(object):
                 # If any process attempt doesn't produce a new batch,
                 # there is probably a cyclic dependency
                 break
-            if len(b) > 0:
+            if b:
                 for batch, key in b:
                     ind = batches.index(key)
                     batches[ind] = batch
@@ -475,7 +475,7 @@ class SchedulerTester(object):
             batches_waiting = b_w
         # Here process the batches with transaction dependencies that can't
         # be computed for some reason, so just strip them out.
-        if len(batches_waiting) > 0:
+        if batches_waiting:
             b, b_r, b_w = self._process_prev_batches(
                 batches_waiting,
                 priv_key=priv_key,


### PR DESCRIPTION
This PR unpins the pylint version and fixes all resulting lint errors but one. That last error is fixed in https://github.com/hyperledger/sawtooth-core/pull/612, which needs to be merged before this one.

Notes:

1) This PR doesn't extend `run_lint` coverage, so there are still files not being linted.

2) The current version of pylint sometimes triggers a recursion error and spits out a big ugly recursion error stack trace. This makes reading the output very annoying, but it doesn't cause `run_lint` to fail.