### PR TITLE
Modify TransactionProcessorTestCase to work outside docker

### DIFF
--- a/consensus/poet/families/tests/tp-validator-registry.yaml
+++ b/consensus/poet/families/tests/tp-validator-registry.yaml
@@ -43,6 +43,7 @@ services:
         test_tp_validator_registry
     stop_signal: SIGKILL
     environment:
+        TEST_BIND: "tcp://eth0:4004"
         PYTHONPATH: "/project/sawtooth-core/consensus/poet/families:\
             /project/sawtooth-core/consensus/poet/families/tests:\
             /project/sawtooth-core/consensus/poet/families/sawtooth_validator_registry:\

--- a/families/config/tests/tp-config.yaml
+++ b/families/config/tests/tp-config.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_config
     stop_signal: SIGKILL
     environment:
+        TEST_BIND: "tcp://eth0:4004"
         PYTHONPATH: "/project/sawtooth-core/families/config:\
             /project/sawtooth-core/families/config/tests:\
             /project/sawtooth-core/sdk/python:\

--- a/families/supplychain/python/tests/tp-supplychain-python.yaml
+++ b/families/supplychain/python/tests/tp-supplychain-python.yaml
@@ -38,6 +38,7 @@ services:
         -s /project/sawtooth-core/families/supplychain/python/tests
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/families/supplychain/python:\
         /project/sawtooth-core/integration:\

--- a/sdk/examples/intkey_python/tests/tp-intkey-go.yaml
+++ b/sdk/examples/intkey_python/tests/tp-intkey-go.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_intkey
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/intkey_python:\
         /project/sawtooth-core/integration:\

--- a/sdk/examples/intkey_python/tests/tp-intkey-java.yaml
+++ b/sdk/examples/intkey_python/tests/tp-intkey-java.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_intkey
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/intkey_python:\
         /project/sawtooth-core/integration:\

--- a/sdk/examples/intkey_python/tests/tp-intkey-javascript.yaml
+++ b/sdk/examples/intkey_python/tests/tp-intkey-javascript.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_intkey
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/intkey_python:\
         /project/sawtooth-core/integration:\

--- a/sdk/examples/intkey_python/tests/tp-intkey-python.yaml
+++ b/sdk/examples/intkey_python/tests/tp-intkey-python.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_intkey
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/intkey_python:\
         /project/sawtooth-core/integration:\

--- a/sdk/examples/xo_python/tests/tp-xo-javascript.yaml
+++ b/sdk/examples/xo_python/tests/tp-xo-javascript.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_xo
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "\
         /project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/xo_python:\

--- a/sdk/examples/xo_python/tests/tp-xo-python.yaml
+++ b/sdk/examples/xo_python/tests/tp-xo-python.yaml
@@ -39,6 +39,7 @@ services:
         test_tp_xo
     stop_signal: SIGKILL
     environment:
+      TEST_BIND: "tcp://eth0:4004"
       PYTHONPATH: "\
         /project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/xo_python:\

--- a/sdk/python/sawtooth_processor_test/mock_validator.py
+++ b/sdk/python/sawtooth_processor_test/mock_validator.py
@@ -82,7 +82,7 @@ class MockValidator(object):
         LOGGER.debug("Binding to " + self._url)
         self._socket.set(zmq.LINGER, 0)
         try:
-            self._socket.bind("tcp://" + self._url)
+            self._socket.bind(self._url)
 
         # Catch errors with binding and print out more debug info
         except zmq.error.ZMQError:

--- a/sdk/python/sawtooth_processor_test/transaction_processor_test_case.py
+++ b/sdk/python/sawtooth_processor_test/transaction_processor_test_case.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import os
 import unittest
 
 from sawtooth_processor_test.mock_validator import MockValidator
@@ -21,7 +22,7 @@ from sawtooth_processor_test.mock_validator import MockValidator
 class TransactionProcessorTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        url = 'eth0:4004'
+        url = os.getenv('TEST_BIND', 'tcp://127.0.0.1:4004')
 
         cls.validator = MockValidator()
 


### PR DESCRIPTION
This changes the default bind address of the mock validator used for
TP tests, then implements an environment variable to override the
new default when executed within docker-compose-based tests.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>