### PR TITLE
Using Sawtooth with Docker cleanup

### DIFF
--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -24,6 +24,7 @@ import yaml
 
 from sawtooth_cli.exceptions import CliException
 from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli import tty
 
 from sawtooth_cli.protobuf.settings_pb2 import SettingsPayload
 from sawtooth_cli.protobuf.settings_pb2 import SettingProposal
@@ -40,8 +41,8 @@ import sawtooth_signing as signing
 
 
 SETTINGS_NAMESPACE = '000000'
-DEFAULT_COL_WIDTH = 15
 
+_MIN_PRINT_WIDTH = 15
 _MAX_KEY_PARTS = 4
 _ADDRESS_PART_SIZE = 16
 
@@ -372,9 +373,13 @@ def _do_config_list(args):
     printable_settings.sort(key=lambda s: s.key)
 
     if args.format == 'default':
+        tty_width = tty.width()
         for setting in printable_settings:
-            value = (setting.value[:DEFAULT_COL_WIDTH] + '...'
-                     if len(setting.value) > DEFAULT_COL_WIDTH
+            # Set value width to the available terminal space, or the min width
+            width = tty_width - len(setting.key) - 3
+            width = width if width > _MIN_PRINT_WIDTH else _MIN_PRINT_WIDTH
+            value = (setting.value[:width] + '...'
+                     if len(setting.value) > width
                      else setting.value)
             print('{}: {}'.format(setting.key, value))
     elif args.format == 'csv':

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -154,7 +154,7 @@ containers have all shut down run 'docker-compose -f sawtooth-default.yaml down'
   % docker-compose -f sawtooth-default.yaml down
 
 
-Confirming Connectivity 
+Confirming Connectivity
 =======================
 
 To confirm that a validator is up and running, and reachable from the client
@@ -276,7 +276,7 @@ transactions of the following types:
 * sawtooth_config
 
 To create and submit the batch containing the new configuration, enter the
-following commands: 
+following commands:
 
 .. note::
 
@@ -302,8 +302,8 @@ and output similar to the following appears in the validator terminal:
 
 .. code-block:: console
 
-  sawtooth.settings.vote.authorized_keys: 035bd41bf6ea872...
-  sawtooth.validator.transaction_families: [{"family": "in...
+  sawtooth.settings.vote.authorized_keys: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+  sawtooth.validator.transaction_families: [{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_settings", "versi...
 
 
 Viewing Blocks And State

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -233,7 +233,7 @@ Run the following commands from the client container:
 
 .. code-block:: console
 
-  $ intkey create_batch
+  $ intkey create_batch --count 10 --key-count 5
   $ intkey load -f batches.intkey -U http://rest_api:8080
 
 The terminal window in which you ran the docker-compose command will begin

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -36,12 +36,15 @@ depicted.
 Installing Docker Engine and Docker Compose
 ===========================================
 
-On Windows and macOS, install the latest version of `Docker Engine <https://docs.docker.com/engine/installation/>`_.
+On Windows and macOS, install the latest version of
+`Docker Engine <https://docs.docker.com/engine/installation/>`_.
 
   - On Windows and macOS, Docker Compose is installed automatically
     when you install Docker Engine.
 
-On Linux, install both `Docker Engine <https://docs.docker.com/engine/installation/>`_ and `Docker Compose <https://docs.docker.com/compose/install/>`_.
+On Linux, install both
+`Docker Engine <https://docs.docker.com/engine/installation/>`_ and
+`Docker Compose <https://docs.docker.com/compose/install/>`_.
 
 .. warning::
 
@@ -131,10 +134,10 @@ directory into the container. See `Docker's documentation
 Resetting The Environment
 -------------------------
 
-If the environment needs to be reset for any reason, it can be returned to
-the default state by logging out of the client container, then pressing
-CTRL-c from the window where you originally ran docker-compose. Once the
-containers have all shut down run 'docker-compose -f sawtooth-default.yaml down'.
+If the environment needs to be reset for any reason, it can be returned to the
+default state by logging out of the client container, then pressing CTRL-c from
+the window where you originally ran docker-compose. Once the containers have
+all shut down run 'docker-compose -f sawtooth-default.yaml down'.
 
 .. code-block:: console
 
@@ -163,8 +166,8 @@ container, you can use this curl command:
 .. note::
 
   If you have reset your environment as described above in
-  `Resetting The Environment`_, then be sure to restart_ your environment
-  again before trying this command.
+  `Resetting The Environment`_, then be sure to restart your environment again
+  before trying this command.
 
 .. code-block:: console
 
@@ -211,25 +214,20 @@ transaction processors automatically:
 * tp_intkey_python
 * tp_xo_python
 
-These transaction processors handle transactions for the config, intkey, and XO transaction families, and are written in Python.
+These transaction processors handle transactions for the Settings, IntKey, and
+Xo transaction families, and are written in Python.
 
 
 Creating And Submitting Transactions
 ====================================
 
-The **intkey** command is provided to create sample transactions of the intkey
-transaction type for testing purposes.
+The **intkey** CLI command is provided to create sample transactions of the
+intkey transaction type for testing purposes. Using it you will be able prepare
+batches of intkey transactions that *set* a few keys to random values, then
+randomly *inc* and *dec* those values. These batches will be saved locally, and
+then can then be submitted to the validator.
 
-This section will show you how to:
-
-1. Prepare a batch of intkey transactions that set some keys to random values.
-
-2. Generate *inc* (increment) and *dec* (decrement) transactions to modify the
-   the existing state stored in the blockchain.
-
-3. Submit these transactions to the validator.
-
-Run the following commands from the client container:
+To use, run the following commands from the client container:
 
 .. code-block:: console
 
@@ -261,22 +259,22 @@ Settings Transaction Family Usage
 
 Sawtooth provides a :doc:`settings transaction family
 <../transaction_family_specifications/settings_transaction_family>` that stores
-on-chain configuration settings, along with a config family transaction
+on-chain configuration settings, along with a Settings family transaction
 processor written in Python.
 
 One of the on-chain settings is the list of supported transaction families.
-In the example below, a JSON array is submitted to the `sawtooth config`
+In the example below, a JSON array is submitted to the ``sawtooth config``
 command, which creates and submits a batch of transactions containing the
 configuration change.
 
-The JSON array used tells the validator or validator network to accept
+The submitted JSON array tells the validator or validator network to accept
 transactions of the following types:
 
 * intkey
-* sawtooth_config
+* sawtooth_settings
 
-To create and submit the batch containing the new configuration, enter the
-following commands:
+To create and submit the batch containing the new setting, enter the following
+commands:
 
 .. note::
 
@@ -293,7 +291,10 @@ Then run the following commands from the validator container:
 
 .. code-block:: console
 
-  $ sawtooth config proposal create --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_config", "version":"1.0", "encoding":"application/protobuf"}]' --url http://rest_api:8080
+  $ sawtooth config proposal create \
+    --url http://rest_api:8080 \
+    --key /root/.sawtooth/keys/my_key.priv \
+    sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0", "encoding": "application/protobuf"}, {"family":"sawtooth_settings", "version":"1.0", "encoding":"application/protobuf"}]'
   $ sawtooth config settings list --url http://rest_api:8080
 
 
@@ -315,12 +316,12 @@ tree, using the sawtooth CLI.
 .. note::
 
   The sawtooth CLI provides help for all subcommands. For example, to get help
-  for the `block` subcommand, enter the command `sawtooth block -h`.
+  for the ``block`` subcommand, enter the command ``sawtooth block -h``.
 
 Viewing List Of Blocks
 ----------------------
 
-Enter the command `sawtooth block list` to view the blocks stored by the state:
+Enter the command ``sawtooth block list`` to view the blocks stored by the state:
 
 .. code-block:: console
 
@@ -345,49 +346,62 @@ The output of the command will be similar to this:
 Viewing A Particular Block
 --------------------------
 
-Using the `sawtooth block list` command as shown above, copy the block id you want to
-view, then use the `sawtooth block show` command (truncated output shown):
+From the output generated by the ``sawtooth block list`` command, copy the id
+of a block you want to get more info about, then paste it where specified below
+in the ``sawtooth block show`` command:
 
 .. code-block:: console
 
-    $ sawtooth block show --url http://rest_api:8080 22e79778855768ea380537fb13ad210b84ca5dd1cdd555db7792a9d029113b0a183d5d71cc5558e04d10a9a9d49031de6e86d6a7ddb25325392d15bb7ccfd5b7
+  $ sawtooth block show --url http://rest_api:8080 {BLOCK ID}
 
-The output of the command will be similar to this:
+The output of this command includes all data stored under that block, and can be
+quite lengthy. Is should look something like this:
 
 .. code-block:: console
 
-    batches:
+  batches:
   - header:
-      signer_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
+      signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
       transaction_ids:
-      - c498c916da09450597053ada1938858a11d94e2ed5c18f92cd7d34b865af646144d180bdc121a48eb753b4abd326baa3ea26ee8a29b07119052320370d24ab84
-      - c68de164421bbcfcc9ea60b725bae289aecd02ddde6f520e6e85b3227337e2971e89bbff468bdebe408e0facc343c612a32db98e5ac4da2296a7acf4033073cd
-      - faf9121f9744716363253cb0ff4b6011093ada6e19dae63ae04a58a1fca25424779a13628a047c009d2e73d0e7baddc95b428b4a22cf1c60961d6dcae8ee60fa
-    header_signature: 2ff874edfa80a8e6b718e7d10e91970150fcc3fcfd46d38eb18f356e7a733baa40d9e816247985d7ea7ef2492c09cd9c1830267471c6e35dca0d19f5c6d2b61e
+      - 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
+    header_signature: a93731646a8fd2bce03b3a17bc2cb3192d8597da93ce735950dccbf0e3cf0b005468fadb94732e013be0bc2afb320be159b452cf835b35870db5fa953220fb35
     transactions:
     - header:
-        batcher_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
-        dependencies:
-        - 19ad647bd292c980e00f05eed6078b471ca2d603b842bc4eaecf301d61f15c0d3705a4ec8d915ceb646f35d443da43569f58c906faf3713853fe638c7a0ea410
-        family_name: intkey
+        batcher_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+        dependencies: []
+        family_name: sawtooth_settings
         family_version: '1.0'
         inputs:
-        - 1cf126c15b04cb20206d45c4d0e432d036420401dbd90f064683399fae55b99af1a543f7de79cfafa4f220a22fa248f8346fb1ad0343fcf8d7708565ebb8a3deaac09d
-        nonce: 0x1.63021cad39ceep+30
+        - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c1c0cbf0fbcaf64c0b
+        - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c12840f169a04216b7
+        - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c1918142591ba4e8a7
+        - 000000a87cb5eafdcca6a8f82af32160bc531176b5001cb05e10bce3b0c44298fc1c14
+        nonce: ''
         outputs:
-        - 1cf126c15b04cb20206d45c4d0e432d036420401dbd90f064683399fae55b99af1a543f7de79cfafa4f220a22fa248f8346fb1ad0343fcf8d7708565ebb8a3deaac09d
-        payload_encoding: application/cbor
-        payload_sha512: 942a09c0254c4a5712ffd152dc6218fc5453451726d935ac1ba67de93147b5e7be605da7ab91245f48029b41f493a1cc8dfc45bb090ac97420580eb1bdded01f
-        signer_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
-      header_signature: c498c916da09450597053ada1938858a11d94e2ed5c18f92cd7d34b865af646144d180bdc121a48eb753b4abd326baa3ea26ee8a29b07119052320370d24ab84
-      payload: o2ROYW1lZnFrbGR1emVWYWx1ZQFkVmVyYmNpbmM=
+        - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c1c0cbf0fbcaf64c0b
+        - 000000a87cb5eafdcca6a8f82af32160bc531176b5001cb05e10bce3b0c44298fc1c14
+        payload_encoding: application/protobuf
+        payload_sha512: 944b6b55e831a2ba37261d904b14b4e729399e4a7c41bd22fcb09c46f0b3821cd41750e38640e33f79b6b5745a20225a1f5427bd5085f3800c166bbb7fb899e8
+        signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+      header_signature: 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
+      payload: EtwBCidzYXd0b290aC52YWxpZGF0b3IudHJhbnNhY3Rpb25fZmFtaWxpZXMSngFbeyJmYW1pbHkiOiAiaW50a2V5IiwgInZlcnNpb24iOiAiMS4wIiwgImVuY29kaW5nIjogImFwcGxpY2F0aW9uL3Byb3RvYnVmIn0sIHsiZmFtaWx5Ijoic2F3dG9vdGhfY29uZmlnIiwgInZlcnNpb24iOiIxLjAiLCAiZW5jb2RpbmciOiJhcHBsaWNhdGlvbi9wcm90b2J1ZiJ9XRoQMTQ5NzQ0ODgzMy4zODI5Mw==
+  header:
+    batch_ids:
+    - a93731646a8fd2bce03b3a17bc2cb3192d8597da93ce735950dccbf0e3cf0b005468fadb94732e013be0bc2afb320be159b452cf835b35870db5fa953220fb35
+    block_num: 3
+    consensus: RGV2bW9kZQ==
+    previous_block_id: 042f08e1ff49bbf16914a53dc9056fb6e522ca0e2cff872547eac9555c1de2a6200e67fb9daae6dfb90f02bef6a9088e94e5bdece04f622bce67ccecd678d56e
+    signer_pubkey: 033fbed13b51eafaca8d1a27abc0d4daf14aab8c0cbc1bb4735c01ff80d6581c52
+    state_root_hash: 5d5ea37cbbf8fe793b6ea4c1ba6738f5eee8fc4c73cdca797736f5afeb41fbef
+  header_signature: ff4f6705bf57e2a1498dc1b649cc9b6a4da2cc8367f1b70c02bc6e7f648a28b53b5f6ad7c2aa639673d873959f5d3fcc11129858ecfcb4d22c79b6845f96c5e3
+
 
 
 
 Viewing Global State
 --------------------
 
-Use the command `sawtooth state list` to list the nodes in the Merkle tree
+Use the command ``sawtooth state list`` to list the nodes in the Merkle tree
 (truncated list):
 
 .. code-block:: console
@@ -412,15 +426,18 @@ The output of the command will be similar to this:
 Viewing Data At An Address
 --------------------------
 
-Using the `sawtooth state list` command show above, copy the address want to
-view, then use the `sawtooth state show` command to view the address:
+From the output generated by the ``sawtooth state list`` command, copy the
+address you want to view, then paste it where where specified below in the
+``sawtooth state show`` command:
 
 .. code-block:: console
 
-  $ sawtooth state show --url http://rest_api:8080 1cf126ddb507c936e4ee2ed07aa253c2f4e7487af3a0425f0dc7321f94be02950a081ab7058bf046c788dbaf0f10a980763e023cde0ee282585b9855e6e5f3715bf1fe
+  $ sawtooth state show --url http://rest_api:8080 {STATE ADDRESS}
 
 
-The output of the command will be similar to this:
+The output of the command will include both the bytes stored at that address,
+and the block id of the *chain head* the current state is tied to. It should
+look similar to this:
 
 .. code-block:: console
 

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -96,10 +96,14 @@ class TestConfigSmoke(unittest.TestCase):
 
         command = 'sawtooth'
         args = ['config', 'settings', 'list', '--url', 'http://rest_api:8080']
-        settings = self._read_from_stdout(command, args)
+        settings = self._read_from_stdout(command, args).split('\n')
 
-        _expected_setting_results = \
-            'sawtooth.settings.vote.authorized_keys: {}...\nx: 1\ny: 1\n'.format(
-                TEST_PUBKEY[:15])
-        self.assertEqual(settings, _expected_setting_results,
-                         'Setting results did not match.')
+        _expected_output = [
+            'sawtooth.settings.vote.authorized_keys: {:15}'.format(TEST_PUBKEY),
+            'x: 1',
+            'y: 1']
+        _fail_msg = 'Setting results did not match.'
+
+        self.assertTrue(settings[0].startswith(_expected_output[0]), _fail_msg)
+        self.assertEqual(settings[1], _expected_output[1], _fail_msg)
+        self.assertEqual(settings[2], _expected_output[2], _fail_msg)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -143,14 +143,14 @@ def generate_word_list(count):
         return {generate_word(): None for _ in range(0, count)}
 
 
-def do_populate(args, batches, words):
+def do_populate(args, batches, keys):
     private_key = signing.generate_privkey()
     public_key = signing.generate_pubkey(private_key)
 
     total_txn_count = 0
     txns = []
-    for i in range(0, len(words)):
-        name = list(words)[i]
+    for i in range(0, len(keys)):
+        name = list(keys)[i]
         txn = create_intkey_transaction(
             verb='set',
             name=name,
@@ -162,7 +162,7 @@ def do_populate(args, batches, words):
         txns.append(txn)
         # Establish the signature of the txn associated with the word
         # so we can create good dependencies later
-        words[name] = txn.header_signature
+        keys[name] = txn.header_signature
 
     batch = create_batch(
         transactions=txns,
@@ -172,7 +172,7 @@ def do_populate(args, batches, words):
     batches.append(batch)
 
 
-def do_generate(args, batches, words):
+def do_generate(args, batches, keys):
     private_key = signing.generate_privkey()
     public_key = signing.generate_pubkey(private_key)
 
@@ -180,13 +180,13 @@ def do_generate(args, batches, words):
     total_txn_count = 0
     for i in range(0, args.count):
         txns = []
-        for _ in range(0, random.randint(1, args.batch_max_size)):
-            name = random.choice(list(words))
+        for _ in range(0, random.randint(1, args.max_batch_size)):
+            name = random.choice(list(keys))
             txn = create_intkey_transaction(
                 verb=random.choice(['inc', 'dec']),
                 name=name,
-                value=1,
-                deps=[words[name]],
+                value=random.randint(1, 10),
+                deps=[keys[name]],
                 private_key=private_key,
                 public_key=public_key)
             total_txn_count += 1
@@ -224,9 +224,9 @@ def write_batch_file(args, batches):
 
 def do_create_batch(args):
     batches = []
-    words = generate_word_list(args.pool_size)
-    do_populate(args, batches, words)
-    do_generate(args, batches, words)
+    keys = generate_word_list(args.key_count)
+    do_populate(args, batches, keys)
+    do_generate(args, batches, keys)
     write_batch_file(args, batches)
 
 
@@ -234,9 +234,9 @@ def add_create_batch_parser(subparsers, parent_parser):
 
     epilog = '''
     details:
-     create sample batch of intkey transactions.
-     populates state with intkey word/value pairs
-     then generates inc and dec transactions.
+     create sample batch(es) of intkey transactions.
+     populates state with intkey key/value pairs
+     then generates batches with inc and dec transactions.
     '''
 
     parser = subparsers.add_parser(
@@ -255,20 +255,20 @@ def add_create_batch_parser(subparsers, parent_parser):
     parser.add_argument(
         '-c', '--count',
         type=int,
-        help='number of batches',
+        help='number of batches modifying random keys',
         default=1000,
         metavar='')
 
     parser.add_argument(
-        '-B', '--batch-max-size',
+        '-B', '--max-batch-size',
         type=int,
-        help='max size of the batch',
+        help='max transactions per batch',
         default=20,
         metavar='')
 
     parser.add_argument(
-        '-P', '--pool-size',
+        '-K', '--key-count',
         type=int,
-        help='size of the word pool',
+        help='number of keys to set initially',
         default=100,
         metavar='')

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -256,19 +256,19 @@ def add_create_batch_parser(subparsers, parent_parser):
         '-c', '--count',
         type=int,
         help='number of batches modifying random keys',
-        default=1000,
+        default=1,
         metavar='')
 
     parser.add_argument(
         '-B', '--max-batch-size',
         type=int,
         help='max transactions per batch',
-        default=20,
+        default=10,
         metavar='')
 
     parser.add_argument(
         '-K', '--key-count',
         type=int,
         help='number of keys to set initially',
-        default=100,
+        default=1,
         metavar='')


### PR DESCRIPTION
- Rewords the Docker tutorial for clarity and accuracy.
- Modifies the behavior of `sawtooth config settings list` to truncate at screen width instead of after just 15 characters.
- Modifies the args and help text of `intkey create_batch` for clarity, substituting _"key count"_ for the non-standard _"word pool"_
- Reduces defaults of `intkey create_batch` to just a single batch with a few transactions.