### PR TITLE
Implement auth for Intkey CLI

### DIFF
--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -40,6 +40,7 @@ class WorkloadGenerator(object):
     """
     def __init__(self, args):
         self._workload = None
+        self._auth_info = args.auth_info
         self._lock = Lock()
         # needs to be locked
         self._pending_batches = deque()
@@ -145,7 +146,8 @@ class WorkloadGenerator(object):
                        the url the batch was submitted to.
         """
         if batch is not None:
-            status = self._status_request([batch.id], batch.url)
+            status = self._status_request([batch.id], batch.url,
+                                          auth_info=self._auth_info)
             if status == "COMMITTED":
                 with self._lock:
                     self._committed_batches_sample += 1
@@ -194,10 +196,12 @@ class WorkloadGenerator(object):
                 self._pending_batches.append(
                     PendingBatch(id=batch_id, url=url))
 
-    def _status_request(self, batch_id, url):
+    def _status_request(self, batch_id, url, auth_info=None):
         data = json.dumps(batch_id).encode()
         headers = {'Content-Type': 'application/json'}
         headers['Content-Length'] = '%d' % len(data)
+        if auth_info is not None:
+            headers['Authorization'] = 'Basic {}'.format(auth_info)
 
         try:
             result = requests.post(
@@ -218,6 +222,10 @@ class WorkloadGenerator(object):
 
                 LOGGER.debug("(%s): %s", code, message)
                 return "UNKNOWN"
+
+        except json.decoder.JSONDecodeError as e:
+            LOGGER.warning('Unable to retrieve status')
+            return "UNKNOWN"
 
         except requests.exceptions.HTTPError as e:
             error_code = e.response.json()['error']['code']


### PR DESCRIPTION
## To test this PR
### Setup apache proxy:
% sudo apt-get update % sudo apt-get install -y apache2 % sudo a2enmod headers % sudo a2enmod proxy_http
% vi /tmp/.password
.password should match this:

sawtooth:$apr1$cyAIkitu$Cv6M2hHJlNgnVvKbUdlFr.

#EOF
% sudo vi /etc/apache2/sites-enabled/000-default.conf
000-default.conf should match this:

<VirtualHost *:80>
        ServerAdmin sawtooth@sawtooth
        DocumentRoot /var/www/html

        ErrorLog ${APACHE_LOG_DIR}/error.log
        CustomLog ${APACHE_LOG_DIR}/access.log combined

        <Location />
                Options Indexes FollowSymLinks
                AllowOverride None
                AuthType Basic
                AuthName "Enter password"
                AuthUserFile "/tmp/.password"
                Require user sawtooth
                Require all denied
        </Location>
</VirtualHost>

ProxyPass /sawtooth http://localhost:8080
ProxyPassReverse /sawtooth http://localhost:8080
RequestHeader set X-Forwarded-Path "/sawtooth"

### Use intkey commands
`load` and `workload` commands can be used with `--auth-user` and `--auth-password` options. To test using the auth proxy, use option `--url http://localhost/sawtooth`. Entering an argument for `--auth-user` without an argument for `--auth-password` will result in a CLI prompt for the password.


Signed-off-by: Darian Plumb <dplumb@bitwise.io>