### PR TITLE
Fix Xo wait response message

### DIFF
--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -179,7 +179,7 @@ class XoClient:
         if wait and wait > 0:
             wait_time = 0
             start_time = time.time()
-            self._send_request(
+            response = self._send_request(
                 "batches", batch_list.SerializeToString(),
                 'application/octet-stream',
                 auth_user=auth_user,
@@ -194,19 +194,10 @@ class XoClient:
                 )
                 wait_time = time.time() - start_time
 
-                if status[batch_id] == 'COMMITTED':
-                    return 'Game created in {:.6} sec'.format(wait_time)
-                elif status[batch_id] == 'INVALID':
-                    return ('Error: You chose an invalid game name. '
-                            'Try again with a different name')
-                elif status[batch_id] == 'UNKNOWN':
-                    return ('Error: Something went wrong with your game. '
-                            'Try again with a different name.')
-                # Wait a moment so as not to hammer the Rest Api
-                time.sleep(0.2)
+                if status[batch_id] != 'PENDING':
+                    return response
 
-            return ('Timed out while waiting for game to be created. '
-                    'It may need to be resubmitted.')
+            return response
 
         return self._send_request(
             "batches", batch_list.SerializeToString(),


### PR DESCRIPTION
Currently using the `--wait` option with `xo create` causes a different response than all other commands. This PR fixes this inconsistency.

_note: A future PR should add more descriptive responses for all Xo transactions._



Signed-off-by: Darian Plumb <dplumb@bitwise.io>