### PR TITLE
Implement state handling for parallel scheduler

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -306,7 +306,8 @@ class TransactionExecutor(object):
                                    always_persist=always_persist)
         elif self._scheduler_type == "parallel":
             return ParallelScheduler(squash_handler=squash_handler,
-                                     first_state_hash=first_state_root)
+                                     first_state_hash=first_state_root,
+                                     always_persist=always_persist)
 
         else:
             raise AssertionError(

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -265,13 +265,15 @@ class TransactionExecutionResult:
 
 
 class ParallelScheduler(Scheduler):
-    def __init__(self, squash_handler, first_state_hash):
+    def __init__(self, squash_handler, first_state_hash, always_persist):
         self._squash = squash_handler
         self._first_state_hash = first_state_hash
         self._last_state_hash = first_state_hash
         self._condition = Condition()
         self._predecessor_tree = PredecessorTree()
         self._txn_predecessors = {}
+
+        self._always_persist = always_persist
 
         # Transaction identifiers which have been scheduled.  Stored as a list,
         # since order is important; SchedulerIterator instances, for example,
@@ -482,7 +484,7 @@ class ParallelScheduler(Scheduler):
                 contexts = self._get_contexts_for_squash(batch_signature)
                 state_hash = self._squash(self._first_state_hash,
                                           contexts,
-                                          persist=False,
+                                          persist=self._always_persist,
                                           clean_up=True)
             return BatchExecutionResult(is_valid=True, state_hash=state_hash)
 

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -62,6 +62,15 @@ class TestSchedulersWithYaml(unittest.TestCase):
         return context_manager, scheduler
 
     def test_parallel_simple_scheduler_test(self):
+        """Tests the parallel scheduler against the
+        test_scheduler/data/simple_scheduler_test.yaml file.
+
+        Notes:
+            To get a good understanding of the dependencies look at
+            simple_scheduler_test.yaml. In general, there are 4 batches,
+            2 are invalid. There will be 1 state root produced.
+        """
+
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
@@ -69,6 +78,15 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='simple_scheduler_test.yaml')
 
     def test_serial_simple_scheduler_test(self):
+        """Tests the serial scheduler against the
+        test_scheduler/data/simple_scheduler_test.yaml file.
+
+        Notes:
+            To get a good understanding of the dependencies look at
+            simple_scheduler_test.yaml. In general, there are 4 batches,
+            2 are invalid. There will be 1 state root produced.
+        """
+
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
@@ -76,6 +94,16 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='simple_scheduler_test.yaml')
 
     def test_parallel_intkey_small_batch(self):
+        """Tests the parallel scheduler against the
+        test_scheduler/data/intkey_small_batch.yaml file.
+
+        Notes:
+            In general, there are 8 batches, all valid, with intkey style
+            txns where the single input is the same as the single output.
+            The txn in batch 4 has an implicit dependency on the txn in
+            batch 3. There will be 1 state root produced
+        """
+
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
@@ -83,6 +111,15 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='intkey_small_batch.yaml')
 
     def test_serial_intkey_small_batch(self):
+        """Tests the parallel scheduler against the
+                test_scheduler/data/intkey_small_batch.yaml file.
+
+        Notes:
+            In general, there are 8 batches, all valid, with intkey style
+            txns where the single input is the same as the single output.
+            The txn in batch 4 has an implicit dependency on the txn in
+            batch 3. There will be 1 state root produced
+        """
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
@@ -226,27 +263,38 @@ class TestSchedulers(unittest.TestCase):
         return context_manager, scheduler
 
     def test_serial_completion_on_finalize(self):
-            context_manager, scheduler = self._setup_serial_scheduler()
-            self._completion_on_finalize(scheduler)
+        """Tests that iteration will stop when finalized is called on an
+        otherwise complete serial scheduler.
+        """
+
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._completion_on_finalize(scheduler)
 
     def test_parallel_completion_on_finalize(self):
-            context_manager, scheduler = self._setup_parallel_scheduler()
-            self._completion_on_finalize(scheduler)
+        """Tests that iteration will stop when finalized is called on an
+        otherwise complete parallel scheduler.
+        """
+
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._completion_on_finalize(scheduler)
 
     def _completion_on_finalize(self, scheduler):
         """Tests that iteration will stop when finalized is called on an
         otherwise complete scheduler.
-        Adds one batch and transaction, then verifies the iterable returns
-        that transaction.  Sets the execution result and then calls finalize.
-        Since the the scheduler is complete (all transactions have had
-        results set, and it's been finalized), we should get a StopIteration.
-        This check is useful in making sure the finalize() can occur after
-        all set_transaction_execution_result()s have been performed, because
-        in a normal situation, finalize will probably occur prior to those
-        calls.
+
+        Notes:
+            Adds one batch and transaction, then verifies the iterable returns
+            that transaction.  Sets the execution result and then calls finalize.
+            Since the the scheduler is complete (all transactions have had
+            results set, and it's been finalized), we should get a StopIteration.
+            This check is useful in making sure the finalize() can occur after
+            all set_transaction_execution_result()s have been performed, because
+            in a normal situation, finalize will probably occur prior to those
+            calls.
 
         This test should work for both a serial and parallel scheduler.
         """
+
         private_key = signing.generate_privkey()
         public_key = signing.generate_pubkey(private_key)
 
@@ -276,23 +324,34 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_completion_on_finalize_only_when_done(self):
+        """Tests that complete will only be true when the serial scheduler
+        has had finalize called and all txns have execution result set.
+        """
+
         context_manager, scheduler = self._setup_serial_scheduler()
         self._completion_on_finalize_only_when_done(scheduler)
 
     def test_parallel_completion_on_finalize_only_when_done(self):
+        """Tests that complete will only be true when the parallel scheduler
+        has had finalize called and all txns have execution result set.
+        """
+
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._completion_on_finalize_only_when_done(scheduler)
 
     def _completion_on_finalize_only_when_done(self, scheduler):
-        """Tests that iteration will stop when finalized is called on an
-        otherwise complete scheduler.
-        Adds one batch and transaction, then verifies the iterable returns
-        that transaction.  Finalizes then sets the execution result. The
-        schedule should not be marked as complete.
-        This check is useful in making sure the finalize() can occur after
-        all set_transaction_execution_result()s have been performed, because
-        in a normal situation, finalize will probably occur prior to those
-        calls.
+        """Tests that complete will only be true when the scheduler
+        has had finalize called and all txns have execution result set.
+
+        Notes:
+            Adds one batch and transaction, then verifies the iterable returns
+            that transaction.  Finalizes then sets the execution result. The
+            schedule should not be marked as complete until after the
+            execution result is set.
+            This check is useful in making sure the finalize() can occur after
+            all set_transaction_execution_result()s have been performed, because
+            in a normal situation, finalize will probably occur prior to those
+            calls.
 
         This test should work for both a serial and parallel scheduler.
         """
@@ -326,10 +385,17 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_add_batch_after_empty_iteration(self):
+        """Tests that iterations of the serial scheduler will continue
+        as result of add_batch().
+        """
+
         context_manager, scheduler = self._setup_serial_scheduler()
         self._add_batch_after_empty_iteration(scheduler)
 
     def test_parallel_add_batch_after_empty_iteration(self):
+        """Tests that iterations of the parallel scheduler will continue
+        as result of add_batch().
+        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._add_batch_after_empty_iteration(scheduler)
@@ -427,16 +493,24 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_valid_batch_invalid_batch(self):
+        """Tests the squash function. That the correct state hash is found
+        at the end of valid and invalid batches, similar to block publishing.
+        """
+
         context_manager, scheduler = self._setup_serial_scheduler()
         self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
     def test_parallel_add_valid_batch_invalid_batch(self):
+        """Tests the squash function. That the correct state hash is found
+        at the end of valid and invalid batches, similar to block publishing.
+        """
+
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
     def _add_valid_batch_invalid_batch(self, scheduler, context_manager):
-        """Tests the squash function. That the correct hash is being used
-        for each txn and that the batch ending state hash is being set.
+        """Tests the squash function. That the correct state hash is found
+        at the end of valid and invalid batches, similar to block publishing.
 
          Basically:
             1. Adds two batches, one where all the txns are valid,
@@ -534,7 +608,21 @@ class TestSchedulers(unittest.TestCase):
         self.assertEqual(batch3_result.state_hash, state_root_end)
 
     def test_serial_sequential_add_batch_after_all_results_set(self):
+        """Tests that adding a new batch only after setting all of the
+        txn results will produce only expected state roots.
+        """
+
         context_manager, scheduler = self._setup_serial_scheduler()
+        self._sequential_add_batch_after_all_results_set(
+            scheduler=scheduler,
+            context_manager=context_manager)
+
+    def test_parallel_sequential_add_batch_after_all_results_set(self):
+        """Tests that adding a new batch only after setting all of the
+        txn results will produce only expected state roots.
+        """
+
+        context_manager, scheduler = self._setup_parallel_scheduler()
         self._sequential_add_batch_after_all_results_set(
             scheduler=scheduler,
             context_manager=context_manager)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -196,9 +196,17 @@ def _get_address_from_txn(txn_info):
 
 class TestSchedulers(unittest.TestCase):
 
+    def setUp(self):
+        self._context_manager = ContextManager(
+            dict_database.DictDatabase(),
+            state_delta_store=Mock())
+
+    def tearDown(self):
+        self._context_manager.stop()
+
     def _setup_serial_scheduler(self):
-        context_manager = ContextManager(dict_database.DictDatabase(),
-                                         state_delta_store=Mock())
+        context_manager = self._context_manager
+
         squash_handler = context_manager.get_squash_handler()
         first_state_root = context_manager.get_first_root()
         scheduler = SerialScheduler(squash_handler,
@@ -207,8 +215,8 @@ class TestSchedulers(unittest.TestCase):
         return context_manager, scheduler
 
     def _setup_parallel_scheduler(self):
-        context_manager = ContextManager(dict_database.DictDatabase(),
-                                         state_delta_store=Mock())
+        context_manager = self._context_manager
+
         squash_handler = context_manager.get_squash_handler()
         first_state_root = context_manager.get_first_root()
         scheduler = ParallelScheduler(squash_handler,
@@ -216,18 +224,12 @@ class TestSchedulers(unittest.TestCase):
         return context_manager, scheduler
 
     def test_serial_completion_on_finalize(self):
-        try:
             context_manager, scheduler = self._setup_serial_scheduler()
             self._completion_on_finalize(scheduler)
-        finally:
-            context_manager.stop()
 
     def test_parallel_completion_on_finalize(self):
-        try:
             context_manager, scheduler = self._setup_parallel_scheduler()
             self._completion_on_finalize(scheduler)
-        finally:
-            context_manager.stop()
 
     def _completion_on_finalize(self, scheduler):
         """Tests that iteration will stop when finalized is called on an
@@ -272,18 +274,12 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_completion_on_finalize_only_when_done(self):
-        try:
-            context_manager, scheduler = self._setup_serial_scheduler()
-            self._completion_on_finalize_only_when_done(scheduler)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._completion_on_finalize_only_when_done(scheduler)
 
     def test_parallel_completion_on_finalize_only_when_done(self):
-        try:
-            context_manager, scheduler = self._setup_parallel_scheduler()
-            self._completion_on_finalize_only_when_done(scheduler)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._completion_on_finalize_only_when_done(scheduler)
 
     def _completion_on_finalize_only_when_done(self, scheduler):
         """Tests that iteration will stop when finalized is called on an
@@ -328,18 +324,13 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_add_batch_after_empty_iteration(self):
-        try:
-            context_manager, scheduler = self._setup_serial_scheduler()
-            self._add_batch_after_empty_iteration(scheduler)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._add_batch_after_empty_iteration(scheduler)
 
     def test_parallel_add_batch_after_empty_iteration(self):
-        try:
-            context_manager, scheduler = self._setup_parallel_scheduler()
-            self._add_batch_after_empty_iteration(scheduler)
-        finally:
-            context_manager.stop()
+
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._add_batch_after_empty_iteration(scheduler)
 
     def _add_batch_after_empty_iteration(self, scheduler):
         """Tests that iterations will continue as result of add_batch().
@@ -434,18 +425,12 @@ class TestSchedulers(unittest.TestCase):
             next(iterable)
 
     def test_serial_valid_batch_invalid_batch(self):
-        try:
-            context_manager, scheduler = self._setup_serial_scheduler()
-            self._add_valid_batch_invalid_batch(scheduler, context_manager)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
     def test_parallel_add_valid_batch_invalid_batch(self):
-        try:
-            context_manager, scheduler = self._setup_parallel_scheduler()
-            self._valid_batch_invalid_batch(scheduler, context_manager)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
     def _add_valid_batch_invalid_batch(self, scheduler, context_manager):
         """Tests the squash function. That the correct hash is being used
@@ -547,13 +532,10 @@ class TestSchedulers(unittest.TestCase):
         self.assertEqual(batch3_result.state_hash, state_root_end)
 
     def test_serial_sequential_add_batch_after_all_results_set(self):
-        try:
-            context_manager, scheduler = self._setup_serial_scheduler()
-            self._sequential_add_batch_after_all_results_set(
-                scheduler=scheduler,
-                context_manager=context_manager)
-        finally:
-            context_manager.stop()
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._sequential_add_batch_after_all_results_set(
+            scheduler=scheduler,
+            context_manager=context_manager)
 
     def _sequential_add_batch_after_all_results_set(self,
                                                     scheduler,

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -43,7 +43,55 @@ LOGGER = logging.getLogger(__name__)
 
 class TestSchedulersWithYaml(unittest.TestCase):
 
-    def test_single_block_files_individually(self):
+    def _setup_serial_scheduler(self):
+        context_manager = self._context_manager
+        squash_handler = context_manager.get_squash_handler()
+        first_state_root = context_manager.get_first_root()
+        scheduler = SerialScheduler(squash_handler,
+                                    first_state_root,
+                                    always_persist=False)
+        return context_manager, scheduler
+
+    def _setup_parallel_scheduler(self):
+        context_manager = self._context_manager
+        squash_handler = context_manager.get_squash_handler()
+        first_state_root = context_manager.get_first_root()
+        scheduler = ParallelScheduler(squash_handler,
+                                      first_state_root)
+        return context_manager, scheduler
+
+    def test_parallel_simple_scheduler_test(self):
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='simple_scheduler_test.yaml')
+
+    def test_serial_simple_scheduler_test(self):
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='simple_scheduler_test.yaml')
+
+    def test_parallel_intkey_small_batch(self):
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='intkey_small_batch.yaml')
+
+    def test_serial_intkey_small_batch(self):
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='intkey_small_batch.yaml')
+
+    def _single_block_files_individually(self,
+                                         scheduler,
+                                         context_manager,
+                                         name):
         """Tests scheduler(s) with yaml files that represent a single
         block.
 
@@ -53,41 +101,30 @@ class TestSchedulersWithYaml(unittest.TestCase):
 
         """
 
-        files_with_one_block = ['simple_scheduler_test.yaml',
-                                'intkey_small_batch.yaml']
-        for name in files_with_one_block:
-            file_name = self._path_to_yaml_file(name)
-            serial_scheduler = SerialScheduler(
-                squash_handler=self._context_manager.get_squash_handler(),
-                first_state_hash=self._context_manager.get_first_root(),
-                always_persist=False)
-            tester = SchedulerTester(file_name)
-            defined_batch_results_dict = tester.batch_results
-            batch_results = tester.run_scheduler(
-                scheduler=serial_scheduler,
-                context_manager=self._context_manager)
-            self.assert_batch_validity(
-                defined_batch_results_dict,
-                batch_results)
-            self.assert_one_state_hash(batch_results=batch_results)
-            sched_state_roots = self._get_state_roots(
-                batch_results=batch_results)
-            calc_state_hash = tester.compute_state_hashes_wo_scheduler()
+        file_name = self._path_to_yaml_file(name)
+        tester = SchedulerTester(file_name)
+        defined_batch_results_dict = tester.batch_results
+        batch_results = tester.run_scheduler(
+            scheduler=scheduler,
+            context_manager=context_manager)
+        self.assert_batch_validity(
+            defined_batch_results_dict,
+            batch_results)
+        self.assert_one_state_hash(batch_results=batch_results)
+        sched_state_roots = self._get_state_roots(
+            batch_results=batch_results)
+        calc_state_hash = tester.compute_state_hashes_wo_scheduler()
 
-            self.assertEquals(
-                sched_state_roots,
-                calc_state_hash,
-                "The state hashes calculated by the scheduler must"
-                " be the same as calculated by the tester")
-
-    def _create_context_manager(self):
-        database = dict_database.DictDatabase()
-        context_manager = ContextManager(database=database,
-                                         state_delta_store=Mock())
-        return context_manager
+        self.assertEquals(
+            sched_state_roots,
+            calc_state_hash,
+            "The state hashes calculated by the scheduler for yaml file {}"
+            " must be the same as calculated by the tester".format(name))
 
     def setUp(self):
-        self._context_manager = self._create_context_manager()
+        self._context_manager = ContextManager(
+            dict_database.DictDatabase(),
+            state_delta_store=Mock())
 
     def tearDown(self):
         self._context_manager.stop()
@@ -241,7 +278,6 @@ class TestSchedulers(unittest.TestCase):
         finally:
             context_manager.stop()
 
-    @unittest.skip("Scheduler.complete is not finished")
     def test_parallel_completion_on_finalize_only_when_done(self):
         try:
             context_manager, scheduler = self._setup_parallel_scheduler()
@@ -404,7 +440,6 @@ class TestSchedulers(unittest.TestCase):
         finally:
             context_manager.stop()
 
-    @unittest.skip("Scheduler does not have batch_results")
     def test_parallel_add_valid_batch_invalid_batch(self):
         try:
             context_manager, scheduler = self._setup_parallel_scheduler()
@@ -994,7 +1029,7 @@ class TestParallelScheduler(unittest.TestCase):
         scheduled_txn_info.append(next(iterable))
         self.assertIsNotNone(scheduled_txn_info[3])
         self.assertEquals(txns[2].payload, scheduled_txn_info[3].txn.payload)
-        self.assertTrue(self.scheduler.complete(block=False))
+        self.assertFalse(self.scheduler.complete(block=False))
 
         self.assertEquals(0, self.scheduler.available())
         context_id3 = self.context_manager.create_context(

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -57,7 +57,8 @@ class TestSchedulersWithYaml(unittest.TestCase):
         squash_handler = context_manager.get_squash_handler()
         first_state_root = context_manager.get_first_root()
         scheduler = ParallelScheduler(squash_handler,
-                                      first_state_root)
+                                      first_state_root,
+                                      always_persist=False)
         return context_manager, scheduler
 
     def test_parallel_simple_scheduler_test(self):
@@ -220,7 +221,8 @@ class TestSchedulers(unittest.TestCase):
         squash_handler = context_manager.get_squash_handler()
         first_state_root = context_manager.get_first_root()
         scheduler = ParallelScheduler(squash_handler,
-                                      first_state_root)
+                                      first_state_root,
+                                      always_persist=False)
         return context_manager, scheduler
 
     def test_serial_completion_on_finalize(self):
@@ -801,7 +803,8 @@ class TestParallelScheduler(unittest.TestCase):
         squash_handler = self.context_manager.get_squash_handler()
         self.first_state_root = self.context_manager.get_first_root()
         self.scheduler = ParallelScheduler(squash_handler,
-                                           self.first_state_root)
+                                           self.first_state_root,
+                                           always_persist=False)
 
     def tearDown(self):
         self.context_manager.stop()


### PR DESCRIPTION
As of this PR, all scheduler unit tests pass and poet-smoke with a heterogeneous scheduler network passes often, but not always. STL-488 and STL-476 will hopefully improve that.

Note: Any transaction that uses dependencies will not work with the parallel scheduler at this point. https://jira.hyperledger.org/browse/STL-499 When STL-499 is complete, dependencies will work with the parallel scheduler.