### PR TITLE
Send back transaction failure information via the Java SDK

### DIFF
--- a/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -28,7 +28,6 @@ import sawtooth.sdk.protobuf.TpProcessRequest;
 import sawtooth.sdk.protobuf.TpProcessResponse;
 import sawtooth.sdk.protobuf.TpRegisterRequest;
 import sawtooth.sdk.protobuf.TpUnregisterRequest;
-import sawtooth.sdk.protobuf.TpUnregisterResponse;
 import sawtooth.sdk.protobuf.TransactionHeader;
 
 import java.util.ArrayList;

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -140,31 +140,29 @@ public class TransactionProcessor implements Runnable {
       TpProcessRequest transactionRequest = TpProcessRequest
               .parseFrom(message.getContent());
       State state = new State(stream, transactionRequest.getContextId());
+
+      TpProcessResponse.Builder builder = TpProcessResponse.newBuilder();
       try {
         handler.apply(transactionRequest, state);
-        TpProcessResponse response = TpProcessResponse.newBuilder()
-                .setStatus(TpProcessResponse.Status.OK).build();
-
-        stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE,
-                message.getCorrelationId(),
-                response.toByteString());
+        builder.setStatus(TpProcessResponse.Status.OK);
       } catch (InvalidTransactionException ite) {
         logger.log(Level.WARNING, "Invalid Transaction: " + ite.toString());
-        TpProcessResponse response = TpProcessResponse.newBuilder()
-                .setStatus(TpProcessResponse.Status.INVALID_TRANSACTION)
-                .build();
-        stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE,
-                message.getCorrelationId(),
-                response.toByteString());
+        builder.setStatus(TpProcessResponse.Status.INVALID_TRANSACTION);
+        builder.setMessage(ite.getMessage());
+        if (ite.getExtendedData() != null) {
+          builder.setExtendedData(ByteString.copyFrom(ite.getExtendedData()));
+        }
       } catch (InternalError ie) {
         logger.log(Level.WARNING, "State Exception!: " + ie.toString());
-        TpProcessResponse response = TpProcessResponse.newBuilder()
-                .setStatus(TpProcessResponse.Status.INTERNAL_ERROR)
-                .build();
-        stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE,
-                message.getCorrelationId(),
-                response.toByteString());
+        builder.setStatus(TpProcessResponse.Status.INTERNAL_ERROR);
+        builder.setMessage(ie.getMessage());
+        if (ie.getExtendedData() != null) {
+          builder.setExtendedData(ByteString.copyFrom(ie.getExtendedData()));
+        }
       }
+      stream.sendBack(Message.MessageType.TP_PROCESS_RESPONSE,
+              message.getCorrelationId(),
+              builder.build().toByteString());
 
     } catch (InvalidProtocolBufferException ipbe) {
       logger.info(

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/InternalError.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/InternalError.java
@@ -15,9 +15,12 @@
 package sawtooth.sdk.processor.exceptions;
 
 
-public class InternalError extends Exception {
-
+public class InternalError extends SawtoothException {
   public InternalError(String message) {
     super(message);
+  }
+
+  public InternalError(String message, byte[] extendedData) {
+    super(message, extendedData);
   }
 }

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/InvalidTransactionException.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/InvalidTransactionException.java
@@ -14,9 +14,12 @@
 
 package sawtooth.sdk.processor.exceptions;
 
-public class InvalidTransactionException extends Exception {
-
+public class InvalidTransactionException extends SawtoothException {
   public InvalidTransactionException(String message) {
     super(message);
+  }
+
+  public InvalidTransactionException(String message, byte[] extendedData) {
+    super(message, extendedData);
   }
 }

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/SawtoothException.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/exceptions/SawtoothException.java
@@ -1,0 +1,37 @@
+package sawtooth.sdk.processor.exceptions;
+
+/**
+ * Base Exception for exceptions that included opaque extended data that must be
+ * returned on the response.
+ */
+public class SawtoothException extends Exception {
+  private final byte[] extendedData;
+
+  /**
+   * Creates an exception.
+   * @param message the message to return on the response
+   */
+  public SawtoothException(final String message) {
+    super(message);
+    this.extendedData = null;
+  }
+
+  /**
+   * Creates an exception with extended data.
+   * @param message the message to returned on the response
+   * @param extendedData opaque, application-specific encoded data to be
+   *     returned on the response
+   */
+  public SawtoothException(final String message, final byte[] extendedData) {
+    super(message);
+    this.extendedData = extendedData;
+  }
+
+  /**
+   * The extended data associated with this exception.
+   * @return opaque, application-specific encoded data
+   */
+  public byte[] getExtendedData() {
+    return extendedData;
+  }
+}


### PR DESCRIPTION
Send back the message and optional extended data on the `TpProcessResponse`.