### PR TITLE
Add a version option for cli

### DIFF
--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -20,6 +20,7 @@ import logging
 import os
 import traceback
 import sys
+import pkg_resources
 
 from colorlog import ColoredFormatter
 
@@ -82,6 +83,18 @@ def create_parent_parser(prog_name):
         '-v', '--verbose',
         action='count',
         help='enable more verbose output')
+
+    try:
+        version = pkg_resources.get_distribution('sawtooth-cli').version
+    except pkg_resources.DistributionNotFound:
+        version = 'UNKNOWN'
+
+    parent_parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version='sawtooth-cli (Hyperledger Sawtooth) version {}'
+                .format(version),
+        help='print version information')
 
     return parent_parser
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -15,7 +15,6 @@
 
 from __future__ import print_function
 
-import os
 import subprocess
 
 from setuptools import setup, find_packages


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Ref #644
Implement a "--version, -V" argument for the sawtooth command. And if this way is accepted, I'll make the same for all installed commands.

