### PR TITLE
Remove JS Examples from "No SDK" Txn Submit Doc

### DIFF
--- a/bin/make_templated_docs
+++ b/bin/make_templated_docs
@@ -50,6 +50,10 @@ env = Environment(
     keep_trailing_newline=True)
 warning = env.get_template('partials/warning_header')
 
+# Remove old templated docs
+for file_rel in os.listdir(output_abs):
+    os.unlink(os.path.join(output_abs, file_rel))
+
 # Render templates
 for name, target in conf['targets'].items():
     template = env.get_template(target['template'])

--- a/docs/source/_templates/sdk_submit_tutorial.rst
+++ b/docs/source/_templates/sdk_submit_tutorial.rst
@@ -12,9 +12,7 @@ generally non-trivial. A series of cryptographic safeguards are used to
 confirm identity and data validity. *Hyperledger Sawtooth* is no different, but
 the {{ language }} SDK does provide client functionality that abstracts away
 most of these details, and greatly simplifies the process of making changes to
-the blockchain. If you are interested in getting into these details, you
-should check out the
-:doc:`txn_submit_tutorial_{{ short_lang }}` instead.
+the blockchain.
 
 
 Creating a Private Key

--- a/docs/source/_templates/template_config.yaml
+++ b/docs/source/_templates/template_config.yaml
@@ -8,15 +8,8 @@
 
 targets:
 
-  txn_submit_tutorial_python:
+  txn_submit_tutorial:
     template: txn_submit_tutorial.rst
-    args:
-      language: Python 3
-
-  txn_submit_tutorial_js:
-    template: txn_submit_tutorial.rst
-    args:
-      language: JavaScript
 
   sdk_submit_tutorial_js:
     template: sdk_submit_tutorial.rst

--- a/docs/source/app_developers_guide.rst
+++ b/docs/source/app_developers_guide.rst
@@ -16,8 +16,8 @@ SDKs are provided in several languages: C++, Go, Java, Javascript, and Python.
    :maxdepth: 2
 
    app_developers_guide/installing_sawtooth
-   app_developers_guide/writing_clients
    app_developers_guide/address_and_namespace
    app_developers_guide/testing
    app_developers_guide/javascript_sdk
    app_developers_guide/python_sdk
+   app_developers_guide/no_sdk

--- a/docs/source/app_developers_guide/no_sdk.rst
+++ b/docs/source/app_developers_guide/no_sdk.rst
@@ -1,0 +1,24 @@
+**************************
+Development Without an SDK
+**************************
+
+*Hyperledger Sawtooth* provides SDKs in a variety of languages to abstract away
+a great deal of complexity and simplify developing applications for the
+platform. The recommended way to work with Sawtooth is through one of these
+SDKs wherever possible. However, if there is no SDK for your language of
+choice, the SDK is missing some functionality, or you just want a deeper
+understanding of what is going on underneath the hood, this guide will cover
+developing for Sawtooth *without* the help of an SDK.
+
+.. note::
+
+   In addition to an overview of the underlying concepts, each guide includes
+   copious code examples in *Python 3*. This is intended simply as a concrete
+   demonstration in a common readable language. The material covered should
+   apply to almost any language, and actual Python development should typically
+   happen with the :doc:`Python SDK <python_sdk>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   ../_autogen/txn_submit_tutorial

--- a/docs/source/app_developers_guide/writing_clients.rst
+++ b/docs/source/app_developers_guide/writing_clients.rst
@@ -1,9 +1,0 @@
-*********************************
-Writing Clients with the REST API
-*********************************
-
-.. toctree::
-   :maxdepth: 2
-
-   ../_autogen/txn_submit_tutorial_python
-   ../_autogen/txn_submit_tutorial_js


### PR DESCRIPTION
Makes Python 3 the only language used for example code for manually generating transactions and submitting them to a validator. Also includes some necessary rewording, some rewording for clarity, some ToC rejiggering, and a tweak to the doc generation script.

Closes #STL-438