### PR TITLE
Update Settings Specification for authorized key change

### DIFF
--- a/docs/source/transaction_family_specifications/settings_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/settings_transaction_family.rst
@@ -266,7 +266,8 @@ Initially, the transaction processor gets the current values of
 *sawtooth.settings.vote.authorized_keys* from the state.
 
 The public key of the transaction signer is checked against the values in
-the list of authorized keys.  If it is empty, all public keys are allowed.
+the list of authorized keys.  If it is empty, no settings can be proposed,
+save for the authorized keys.
 
 A Propose action is validated.  If it fails, it is considered an invalid
 transaction.  A *proposal_id* is calculated by taking the sha256 hash of


### PR DESCRIPTION
Before the doc said that if authorized keys are empty
all public keys are allowed, now no proposal can be
made until a key is set.

Signed-off-by: Andrea Gunderson <andreax.gunderson@intel.com>