### PR TITLE
Refactor existing wait/status functionality with new BatchTracker

### DIFF
--- a/protos/client.proto
+++ b/protos/client.proto
@@ -30,6 +30,18 @@ message Leaf {
     bytes data = 2;
 }
 
+// Possible commit statuses for a batch submitted to a validator
+//   * COMMITTED - the batch was accepted and has been committed to the chain
+//   * INVALID - the batch failed validation, it should be resubmitted
+//   * PENDING - the batch is still being processed
+//   * UNKNOWN - no status for the batch could be found (possibly invalid)
+enum BatchStatus {
+    COMMITTED = 0;
+    INVALID = 1;
+    PENDING = 2;
+    UNKNOWN = 3;
+}
+
 // Paging controls to be sent with List requests.
 // Attributes:
 //     start_id: The id of a resource to start the page with
@@ -87,22 +99,11 @@ message ClientBatchSubmitRequest {
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
-// BatchesStatuses:
-//   * COMMITTED - the batch was accepted and has been committed to the chain
-//   * INVALID - the batch failed validation, it should be resubmitted
-//   * UNKNOWN - no status for the batch could be found (possibly invalid)
-//   * PENDING - the batch is still being processed
 message ClientBatchSubmitResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         INVALID_BATCH = 2;
-    }
-    enum BatchStatus {
-        COMMITTED = 0;
-        INVALID = 1;
-        UNKNOWN = 2;
-        PENDING = 3;
     }
     Status status = 1;
     map<string, BatchStatus> batch_statuses = 2;
@@ -126,22 +127,11 @@ message ClientBatchStatusRequest {
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * NO_RESOURCE - the response contains no data, likely because
 //     no ids were specified in the request
-// BatchesStatuses:
-//   * COMMITTED - the batch was accepted and has been committed to the chain
-//   * INVALID - the batch failed validation, it should be resubmitted
-//   * UNKNOWN - no status for the batch could be found (possibly invalid)
-//   * PENDING - the batch is still being processed
 message ClientBatchStatusResponse {
     enum Status {
         OK = 0;
         INTERNAL_ERROR = 1;
         NO_RESOURCE = 4;
-    }
-    enum BatchStatus {
-        COMMITTED = 0;
-        INVALID = 1;
-        UNKNOWN = 2;
-        PENDING = 3;
     }
     Status status = 1;
     map<string, BatchStatus> batch_statuses = 2;

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -19,6 +19,7 @@ from aiohttp.test_utils import AioHTTPTestCase
 from base64 import b64decode
 
 from sawtooth_rest_api.route_handlers import RouteHandler
+from sawtooth_rest_api.protobuf import client_pb2
 from sawtooth_rest_api.protobuf.client_pb2 import Leaf
 from sawtooth_rest_api.protobuf.client_pb2 import PagingControls
 from sawtooth_rest_api.protobuf.client_pb2 import PagingResponse
@@ -306,7 +307,7 @@ class BaseApiTest(AioHTTPTestCase):
         self.assertEqual(len(enum_statuses), len(json_statuses))
         for batch_id, status_string in json_statuses.items():
             self.assertIn(batch_id, enum_statuses)
-            status_enum = self.status.BatchStatus.Name(enum_statuses[batch_id])
+            status_enum = client_pb2.BatchStatus.Name(enum_statuses[batch_id])
             self.assertEqual(status_string, status_enum)
 
     def assert_blocks_well_formed(self, blocks, *expected_ids):

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -172,7 +172,7 @@ class PostBatchTests(BaseApiTest):
             - a link property that ends in '/batches?id=a'
         """
         batches = Mocks.make_batches('a')
-        statuses = {'a': self.status.COMMITTED}
+        statuses = {'a': client_pb2.COMMITTED}
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.post_batches(batches, wait=True)
@@ -204,7 +204,7 @@ class PostBatchTests(BaseApiTest):
             - a data property matching the batch statuses received
         """
         batches = Mocks.make_batches('pending')
-        statuses = {'pending': self.status.PENDING}
+        statuses = {'pending': client_pb2.PENDING}
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.post_batches(batches, wait=True)
@@ -245,7 +245,7 @@ class BatchStatusTests(BaseApiTest):
             - a link property that ends in '/batch_status?id=pending'
             - a data property matching the batch statuses received
         """
-        statuses = {'pending': self.status.PENDING}
+        statuses = {'pending': client_pb2.PENDING}
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200('/batch_status?id=pending')
@@ -303,7 +303,7 @@ class BatchStatusTests(BaseApiTest):
             - a link property that ends in '/batch_status?id=pending&wait'
             - a data property matching the batch statuses received
         """
-        statuses = {'pending': self.status.COMMITTED}
+        statuses = {'pending': client_pb2.COMMITTED}
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200('/batch_status?id=pending&wait')
@@ -334,9 +334,9 @@ class BatchStatusTests(BaseApiTest):
             - a data property matching the batch statuses received
         """
         statuses = {
-            'committed': self.status.COMMITTED,
-            'unknown': self.status.UNKNOWN,
-            'bad': self.status.UNKNOWN}
+            'committed': client_pb2.COMMITTED,
+            'unknown': client_pb2.UNKNOWN,
+            'bad': client_pb2.UNKNOWN}
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200(
@@ -380,9 +380,9 @@ class BatchStatusTests(BaseApiTest):
             - a data property matching the batch statuses received
         """
         statuses = {
-            'committed': self.status.COMMITTED,
-            'pending': self.status.PENDING,
-            'bad': self.status.UNKNOWN}
+            'committed': client_pb2.COMMITTED,
+            'pending': client_pb2.PENDING,
+            'bad': client_pb2.UNKNOWN}
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.client.post(

--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -1,0 +1,148 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import abc
+from threading import RLock
+from sawtooth_validator.protobuf import client_pb2
+from sawtooth_validator.journal.timed_cache import TimedCache
+from sawtooth_validator.journal.block_store import StoreUpdateObserver
+from sawtooth_validator.journal.journal import PendingBatchObserver
+
+
+# By default pending batch ids will be kept for one hour
+PENDING_KEEP_TIME = 3600
+
+
+class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
+    """Tracks batch statuses for this local validator, allowing interested
+    components to check where a batch is in the validation process. It should
+    only be relied on for batches submitted locally, and is not persisted
+    after restart.
+
+    When a batch moves from one component to another, the appropriate notify
+    method should be called in the appropriate component, as specified by the
+    relevant Observer class, and implemented here.
+
+    Args:
+        block_store (BlockStore): For querying if a batch is committed
+    """
+    def __init__(self, block_store):
+        self._block_store = block_store
+        self._pending = TimedCache(keep_time=PENDING_KEEP_TIME)
+
+        self._lock = RLock()
+        self._observers = {}
+
+    def notify_store_updated(self):
+        """Removes batches from the pending cache if found in the block store,
+        and notifies any observers.
+        """
+        with self._lock:
+            for batch_id in set(self._pending):
+                if self._block_store.has_batch(batch_id):
+                    self._pending.pop(batch_id)
+                    self._update_observers(batch_id, client_pb2.COMMITTED)
+
+    def notify_batch_pending(self, batch_id):
+        """Adds a batch to the pending list.
+
+        Args:
+            batch_id (str): The id of the pending batch
+        """
+        with self._lock:
+            self._pending[batch_id] = True
+            self._update_observers(batch_id, client_pb2.PENDING)
+
+    def get_status(self, batch_id):
+        """Returns the status enum for a batch.
+
+        Args:
+            batch_id (str): The id of the batch to get the status for
+
+        Returns:
+            int: The status enum
+        """
+        with self._lock:
+            if self._block_store.has_batch(batch_id):
+                return client_pb2.COMMITTED
+            if batch_id in self._pending:
+                return client_pb2.PENDING
+            return client_pb2.UNKNOWN
+
+    def get_statuses(self, batch_ids):
+        """Returns a statuses dict for the requested batches.
+
+        Args:
+            batch_ids (list of str): The ids of the batches to get statuses for
+
+        Returns:
+            dict: A dict with keys of batch ids, and values of status enums
+        """
+        with self._lock:
+            return {b: self.get_status(b) for b in batch_ids}
+
+    def watch_statuses(self, observer, batch_ids):
+        """Allows a component to register to be notified when a set of
+        batches is no longer PENDING. Expects to be able to call the
+        "notify_batches_finished" method on the registered component, sending
+        the statuses of the batches.
+
+        Args:
+            observer (object): Must implement "notify_batches_finished" method
+            batch_ids (list of str): The ids of the batches to watch
+        """
+        with self._lock:
+            statuses = self.get_statuses(batch_ids)
+            if self._has_no_pendings(statuses):
+                observer.notify_finished(statuses)
+            else:
+                self._observers[observer] = statuses
+
+    def _update_observers(self, batch_id, status):
+        """Updates each observer tracking a particular batch with its new
+        status. If all statuses are no longer pending, notifies the observer
+        and removes it from the list.
+        """
+        for observer, statuses in self._observers.copy().items():
+            if batch_id in statuses:
+                statuses[batch_id] = status
+                if self._has_no_pendings(statuses):
+                    observer.notify_batches_finished(statuses)
+                    self._observers.pop(observer)
+
+    def _has_no_pendings(self, statuses):
+        """Returns True if a statuses dict has no PENDING statuses.
+        """
+        return all(s != client_pb2.PENDING for s in statuses.values())
+
+
+class BatchFinishObserver(metaclass=abc.ABCMeta):
+    """An interface class for components wishing to be notified by a
+    BatchTracker whenever a set of batches is finished being processed.
+
+    Observers register what batches they are interested in by calling  a
+    BatchTracker's "watch_statuses" method.
+    """
+    @abc.abstractmethod
+    def notify_batches_finished(self, statuses):
+        """This method will be called when every Batch in a set of Batches is
+        no longer PENDING. Each should be committed or not found.
+
+        Args:
+            statuses (dict of int): A dict with keys of batch ids, and values
+                of status enums
+        """
+        raise NotImplementedError('BatchFinishObservers must have a '
+                                  '"notify_batches_finished" method')

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -286,11 +286,11 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
         statuses = {}
         for batch_id in batch_ids:
             if self._block_store.has_batch(batch_id):
-                statuses[batch_id] = self._status.COMMITTED
+                statuses[batch_id] = client_pb2.COMMITTED
             elif batch_id in self._batch_cache:
-                statuses[batch_id] = self._status.PENDING
+                statuses[batch_id] = client_pb2.PENDING
             else:
-                statuses[batch_id] = self._status.UNKNOWN
+                statuses[batch_id] = client_pb2.UNKNOWN
         return statuses
 
 

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -15,12 +15,15 @@
 
 import abc
 import logging
+from time import time
 from functools import cmp_to_key
+from threading import Condition
 # pylint: disable=import-error,no-name-in-module
 # needed for google.protobuf import
 from google.protobuf.message import DecodeError
 
 from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.state.batch_tracker import BatchFinishObserver
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
@@ -271,28 +274,6 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
 
         return resources
 
-    def _get_statuses(self, batch_ids):
-        """Fetches the committed statuses for a set of batch ids.
-
-        Note:
-            This method will fail without a `_block_store` and `_batch_cache`
-
-        Args:
-            batch_ids (list of str): The set of batch ids to be queried
-
-        Returns:
-            dict of enum: keys are batch ids, and values are their status enum
-        """
-        statuses = {}
-        for batch_id in batch_ids:
-            if self._block_store.has_batch(batch_id):
-                statuses[batch_id] = client_pb2.COMMITTED
-            elif batch_id in self._batch_cache:
-                statuses[batch_id] = client_pb2.PENDING
-            else:
-                statuses[batch_id] = client_pb2.UNKNOWN
-        return statuses
-
 
 class _Pager(object):
     """A static class containing methods to paginate lists of resources.
@@ -497,45 +478,91 @@ class _Sorter(object):
             return header
 
 
+class _BatchWaiter(BatchFinishObserver):
+    """An observer which provides a method which locks until every batch in a
+    set of ids is committed.
+
+    Args:
+        batch_tracker (BatchTracker): The BatchTracker that will notify the
+            BatchWaiter that all of the batches it is interested in are no
+            longer PENDING.
+    """
+    def __init__(self, batch_tracker):
+        self._batch_tracker = batch_tracker
+        self._wait_condition = Condition()
+        self._statuses = None
+
+    def notify_batches_finished(self, statuses):
+        """Called by the BatchTracker the _BatchWaiter is observing. Should not
+        be called by handlers.
+
+        Args:
+            statuses (dict of int): A dict with keys of batch ids, and values
+                of status enums
+        """
+        with self._wait_condition:
+            self._statuses = statuses
+            self._wait_condition.notify()
+
+    def wait_for_batches(self, batch_ids, timeout=None):
+        """Locks until a list of batch ids is committed to the block chain
+        or a timeout is exceeded. Returns the statuses of those batches.
+
+        Args:
+            batch_ids (list of str): The ids of the batches to wait for
+            timeout(int): Maximum time in seconds to wait for
+
+        Returns:
+            dict of int: Statuses dict, with batch ids as keys, and committed
+                status enum as the values.
+        """
+        self._batch_tracker.watch_statuses(self, batch_ids)
+        timeout = timeout or DEFAULT_TIMEOUT
+        start_time = time()
+
+        with self._wait_condition:
+            while True:
+                if self._statuses or time() - start_time > timeout:
+                    return self._statuses
+                self._wait_condition.wait(timeout - (time() - start_time))
+
+
 class BatchSubmitFinisher(_ClientRequestHandler):
-    def __init__(self, block_store, batch_cache):
+    def __init__(self, batch_tracker):
+        self._batch_tracker = batch_tracker
         super().__init__(
             client_pb2.ClientBatchSubmitRequest,
             client_pb2.ClientBatchSubmitResponse,
-            validator_pb2.Message.CLIENT_BATCH_SUBMIT_RESPONSE,
-            block_store=block_store,
-            batch_cache=batch_cache)
+            validator_pb2.Message.CLIENT_BATCH_SUBMIT_RESPONSE)
 
     def _respond(self, request):
         if not request.wait_for_commit:
             return self._status.OK
 
+        waiter = _BatchWaiter(self._batch_tracker)
         batch_ids = [b.header_signature for b in request.batches]
+        statuses = waiter.wait_for_batches(batch_ids, request.timeout)
 
-        self._block_store.wait_for_batch_commits(
-            batch_ids=batch_ids,
-            timeout=request.timeout or DEFAULT_TIMEOUT)
-
-        statuses = self._get_statuses(batch_ids)
         return self._wrap_response(batch_statuses=statuses)
 
 
 class BatchStatusRequest(_ClientRequestHandler):
-    def __init__(self, block_store, batch_cache):
+    def __init__(self, batch_tracker):
+        self._batch_tracker = batch_tracker
         super().__init__(
             client_pb2.ClientBatchStatusRequest,
             client_pb2.ClientBatchStatusResponse,
-            validator_pb2.Message.CLIENT_BATCH_STATUS_RESPONSE,
-            block_store=block_store,
-            batch_cache=batch_cache)
+            validator_pb2.Message.CLIENT_BATCH_STATUS_RESPONSE)
 
     def _respond(self, request):
         if request.wait_for_commit:
-            self._block_store.wait_for_batch_commits(
-                batch_ids=request.batch_ids,
-                timeout=request.timeout or DEFAULT_TIMEOUT)
+            waiter = _BatchWaiter(self._batch_tracker)
+            statuses = waiter.wait_for_batches(
+                request.batch_ids,
+                request.timeout)
+        else:
+            statuses = self._batch_tracker.get_statuses(request.batch_ids)
 
-        statuses = self._get_statuses(request.batch_ids)
         if not statuses:
             return self._status.NO_RESOURCE
 

--- a/validator/tests/test_client_request_handlers/base_case.py
+++ b/validator/tests/test_client_request_handlers/base_case.py
@@ -22,11 +22,12 @@ class ClientHandlerTestCase(unittest.TestCase):
     Run initialize as part of setUp, and then call make_request in each test.
     """
     def initialize(self, handler, request_proto, response_proto,
-                    store=None, roots=None):
+                    store=None, roots=None, tracker=None):
         self._identity = '1234567'
         self._handler = handler
         self._request_proto = request_proto
         self._store = store
+        self._tracker = tracker
         self.status = response_proto
         self.roots = roots
 

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -79,7 +79,7 @@ class TestBatchSubmitFinisher(ClientHandlerTestCase):
 
         self.assertGreater(8, time() - start_time)
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-new'], self.status.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-new'], client_pb2.COMMITTED)
 
 
 class TestBatchStatusRequests(ClientHandlerTestCase):
@@ -107,7 +107,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         response = self.make_request(batch_ids=['b-0'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-0'], self.status.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-0'], client_pb2.COMMITTED)
 
     def test_batch_status_bad_request(self):
         """Verifies bad requests for status of a batch break properly.
@@ -145,7 +145,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         response = self.make_request(batch_ids=['b-3'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-3'], self.status.PENDING)
+        self.assertEqual(response.batch_statuses['b-3'], client_pb2.PENDING)
 
     def test_batch_status_when_missing(self):
         """Verifies requests for status of a batch that is not found work.
@@ -157,7 +157,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         response = self.make_request(batch_ids=['z'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['z'], self.status.UNKNOWN)
+        self.assertEqual(response.batch_statuses['z'], client_pb2.UNKNOWN)
 
     def test_batch_status_in_store_and_cache(self):
         """Verifies requests for status of batch in both store and cache work.
@@ -178,7 +178,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         response = self.make_request(batch_ids=['b-2'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-2'], self.status.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-2'], client_pb2.COMMITTED)
 
     def test_batch_status_for_many_batches(self):
         """Verifies requests for status of many batches work properly.
@@ -202,10 +202,10 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         response = self.make_request(batch_ids=['b-1', 'b-2', 'b-3', 'y'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-1'], self.status.COMMITTED)
-        self.assertEqual(response.batch_statuses['b-2'], self.status.COMMITTED)
-        self.assertEqual(response.batch_statuses['b-3'], self.status.PENDING)
-        self.assertEqual(response.batch_statuses['y'], self.status.UNKNOWN)
+        self.assertEqual(response.batch_statuses['b-1'], client_pb2.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-2'], client_pb2.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-3'], client_pb2.PENDING)
+        self.assertEqual(response.batch_statuses['y'], client_pb2.UNKNOWN)
 
     def test_batch_status_with_wait(self):
         """Verifies requests for status that wait for commit work properly.
@@ -231,4 +231,4 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
 
         self.assertGreater(8, time() - start_time)
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses['b-new'], self.status.COMMITTED)
+        self.assertEqual(response.batch_statuses['b-new'], client_pb2.COMMITTED)


### PR DESCRIPTION
BatchTracker utilizes the observer pattern to collect notifications from elsewhere in the validator about the progress of submitted batches. Other validator components call the appropriate notify method at points where a status change has occurred.
    
All batch status and wait-for-commit client code, including unit tests, has been refactored to query this new BatchTracker, which can be queried for the current statuses of batches, or send out a notification itself when all specified batches are no longer PENDING.