### PR TITLE
REST API: Replace SDK Stream with asyncio Connection

### DIFF
--- a/rest_api/sawtooth_rest_api/messaging.py
+++ b/rest_api/sawtooth_rest_api/messaging.py
@@ -1,0 +1,288 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import asyncio
+import logging
+import uuid
+
+from google.protobuf.message import DecodeError
+
+import zmq
+from zmq.asyncio import Context
+
+from sawtooth_rest_api.protobuf.validator_pb2 import Message
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class _MessageRouter:
+    """Manages message, routing them either to an incoming queue or to the
+    futures for expected replies.
+    """
+    def __init__(self):
+        self._queue = asyncio.Queue()
+        self._futures = {}
+
+    async def _push_incoming(self, msg):
+        return await self._queue.put(msg)
+
+    async def incoming(self):
+        """Returns the next incoming message.
+        """
+        return await self._queue.get()
+
+    def expect_reply(self, correlation_id):
+        """Informs the router that a reply to the given correlation_id is
+        expected.
+        """
+        self._futures[correlation_id] = asyncio.Future()
+
+    def expected_replies(self):
+        """Returns the correlation ids for the expected replies.
+        """
+        return (c_id for c_id in self._futures)
+
+    async def await_reply(self, correlation_id, timeout=None):
+        """Wait for a reply to a given correlation id.  If a timeout is
+        provided, it will raise a asyncio.TimeoutError.
+        """
+        result = await asyncio.wait_for(
+            self._futures[correlation_id], timeout=timeout)
+
+        del self._futures[correlation_id]
+
+        return result
+
+    def _set_reply(self, correlation_id, msg):
+        if correlation_id in self._futures:
+            self._futures[correlation_id].set_result(msg)
+
+    def _fail_reply(self, correlation_id, err):
+        if correlation_id in self._futures and \
+                not self._futures[correlation_id].done():
+            self._futures[correlation_id].set_exception(err)
+
+    def fail_all(self, err):
+        """Fail all the expected replies with a given error.
+        """
+        for c_id in self._futures:
+            self._fail_reply(c_id, err)
+
+    async def route_msg(self, msg):
+        """Given a message, route it either to the incoming queue, or to the
+        future associated with its correlation_id.
+        """
+        if msg.correlation_id in self._futures:
+            self._set_reply(msg.correlation_id, msg)
+        else:
+            await self._push_incoming(msg)
+
+
+class _Receiver:
+    """Receives messages and forwards them to a _MessageRouter.
+    """
+
+    def __init__(self, socket, msg_router):
+        self._socket = socket
+        self._msg_router = msg_router
+
+        self._is_running = False
+
+    async def start(self):
+        """Starts receiving messages on the underlying socket and passes them
+        to the message router.
+        """
+        self._is_running = True
+
+        while self._is_running:
+            try:
+                zmq_msg = await self._socket.recv_multipart()
+
+                message = Message()
+                message.ParseFromString(zmq_msg[-1])
+
+                await self._msg_router.route_msg(message)
+            except DecodeError as e:
+                LOGGER.warning('Unable to decode: %s', e)
+            except zmq.ZMQError as e:
+                LOGGER.warning('Unable to receive: %s', e)
+                return
+            except asyncio.CancelledError:
+                self._is_running = False
+
+    def cancel(self):
+        self._is_running = False
+
+
+class _Sender:
+    """Manages Sending messages over a ZMQ socket.
+    """
+
+    def __init__(self, socket, msg_router):
+        self._msg_router = msg_router
+        self._socket = socket
+
+    async def send(self, message_type, message_content, timeout=None):
+        correlation_id = uuid.uuid4().hex
+
+        self._msg_router.expect_reply(correlation_id)
+
+        message = Message(
+            correlation_id=correlation_id,
+            content=message_content,
+            message_type=message_type)
+
+        try:
+            await self._socket.send_multipart([message.SerializeToString()])
+        except asyncio.CancelledError:
+            return None
+
+        return await self._msg_router.await_reply(correlation_id,
+                                                  timeout=timeout)
+
+
+class DisconnectError(Exception):
+    """Raised when a connection disconnects.
+    """
+    def __init__(self):
+        super().__init__("The connection was lost")
+
+
+class Connection:
+    """A connection, over which validator Message objects may be sent.
+    """
+    def __init__(self, url):
+        self._url = url
+
+        self._ctx = Context.instance()
+        self._socket = self._ctx.socket(zmq.DEALER)
+        self._socket.identity = uuid.uuid4().hex.encode()[0:16]
+
+        self._msg_router = _MessageRouter()
+        self._receiver = _Receiver(self._socket, self._msg_router)
+        self._sender = _Sender(self._socket, self._msg_router)
+
+        self._recv_task = None
+
+        # Monitoring properties
+        self._monitor_sock = None
+        self._monitor_fd = None
+        self._monitor_task = None
+
+    @property
+    def url(self):
+        return self._url
+
+    def open(self):
+        """Opens the connection.
+
+        An open connection will monitor for disconnects from the remote end.
+        Messages are either received as replies to outgoing messages, or
+        received from an incoming queue.
+        """
+        LOGGER.info('Connecting to %s', self._url)
+        asyncio.ensure_future(self._do_start())
+
+    async def _do_start(self):
+        self._socket.connect(self._url)
+
+        self._monitor_fd = "inproc://monitor.s-{}".format(
+            uuid.uuid4().hex[0:5])
+        self._monitor_sock = self._socket.get_monitor_socket(
+            zmq.EVENT_DISCONNECTED,
+            addr=self._monitor_fd)
+
+        self._recv_task = asyncio.ensure_future(self._receiver.start())
+
+        self._monitor_task = asyncio.ensure_future(self._monitor_disconnects())
+
+    async def send(self, message_type, message_content, timeout=None):
+        """Sends a message and returns a future for the response.
+        """
+        return await self._sender.send(
+            message_type, message_content, timeout=timeout)
+
+    async def receive(self):
+        """Returns a future for an incoming message.
+        """
+        return await self._msg_router.incoming()
+
+    def close(self):
+        """Closes the connection.
+
+        All outstanding futures for replies will be sent a DisconnectError.
+        """
+        if self._recv_task:
+            self._recv_task.cancel()
+
+        self._disable_monitoring()
+
+        if self._monitor_task and not self._monitor_task.done():
+            self._monitor_task.cancel()
+
+        self._receiver.cancel()
+        self._socket.close(linger=0)
+
+        self._msg_router.fail_all(DisconnectError())
+
+    def _disable_monitoring(self):
+        if self._socket.closed:
+            return
+
+        self._socket.disable_monitor()
+
+        if self._monitor_sock:
+            self._monitor_sock.disconnect(self._monitor_fd)
+            self._monitor_sock.close(linger=0)
+
+            self._monitor_fd = None
+            self._monitor_sock = None
+
+    async def _monitor_disconnects(self):
+        try:
+            cancelled = False
+            try:
+                await self._monitor_sock.recv_multipart()
+            except asyncio.CancelledError:
+                cancelled = True
+
+            # Only message received will be a disconnect event
+            self._disable_monitoring()
+
+            if not self._socket.closed:
+                self._socket.disconnect(self._url)
+
+            # Inform the msg router that all replies failed.
+            self._msg_router.fail_all(DisconnectError())
+
+            self._recv_task.cancel()
+            self._recv_task = None
+
+            if cancelled:
+                return
+
+            # start it back up, but first wait a bit to give the other end time
+            # to reappear
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                # We've been cancelled, so let's just exit
+                return
+
+            asyncio.ensure_future(self._do_start())
+        except zmq.ZMQError as e:
+            # The monitor socket was probably closed
+            LOGGER.warning('Error occurred while monitoring the socket: %s', e)

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import asyncio
 import re
 import logging
 import json
 import base64
-from concurrent.futures import ThreadPoolExecutor
 from aiohttp import web
 
 # pylint: disable=no-name-in-module,import-error
@@ -25,12 +25,11 @@ from aiohttp import web
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.message import DecodeError
 
-from sawtooth_sdk.messaging.exceptions import ValidatorConnectionError
-from sawtooth_sdk.messaging.future import FutureTimeoutError
-from sawtooth_sdk.protobuf.validator_pb2 import Message
+from sawtooth_rest_api.protobuf.validator_pb2 import Message
 
 import sawtooth_rest_api.exceptions as errors
 import sawtooth_rest_api.error_handlers as error_handlers
+from sawtooth_rest_api.messaging import DisconnectError
 from sawtooth_rest_api.protobuf import client_pb2
 from sawtooth_rest_api.protobuf.block_pb2 import BlockHeader
 from sawtooth_rest_api.protobuf.batch_pb2 import BatchList
@@ -54,15 +53,14 @@ class RouteHandler(object):
     instead.
 
     Args:
-        stream (:obj: messaging.stream.Stream): The object that communicates
+        connection (:obj: messaging.Connection): The object that communicates
             with the validator.
         timeout (int, optional): The time in seconds before the Api should
             cancel a request and report that the validator is unavailable.
     """
-    def __init__(self, loop, stream, timeout=DEFAULT_TIMEOUT):
-        loop.set_default_executor(ThreadPoolExecutor())
+    def __init__(self, loop, connection, timeout=DEFAULT_TIMEOUT):
         self._loop = loop
-        self._stream = stream
+        self._connection = connection
         self._timeout = timeout
 
     async def submit_batches(self, request):
@@ -450,14 +448,17 @@ class RouteHandler(object):
 
     async def _send_request(self, request_type, payload):
         """Uses an executor to send an asynchronous ZMQ request to the validator
-        with the handler's Stream.
+        with the handler's Connection
         """
-        future = self._stream.send(message_type=request_type, content=payload)
-
         try:
-            return await self._loop.run_in_executor(
-                None, future.result, self._timeout)
-        except FutureTimeoutError:
+            return await self._connection.send(
+                message_type=request_type,
+                message_content=payload,
+                timeout=self._timeout)
+        except DisconnectError:
+            LOGGER.warning('Validator disconnected while waiting for response')
+            raise errors.ValidatorDisconnected()
+        except asyncio.TimeoutError:
             LOGGER.warning('Timed out while waiting for validator response')
             raise errors.ValidatorTimedOut()
 
@@ -469,9 +470,6 @@ class RouteHandler(object):
             content = proto()
             content.ParseFromString(response.content)
             return content
-        except ValidatorConnectionError:
-            LOGGER.warning('Validator disconnected while waiting for response')
-            raise errors.ValidatorDisconnected()
         except (DecodeError, AttributeError):
             LOGGER.error('Validator response was not parsable: %s', response)
             raise errors.ValidatorResponseInvalid()

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -22,12 +22,12 @@ from sawtooth_rest_api.protobuf import client_pb2
 class BatchListTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_BATCH_LIST_REQUEST,
             client_pb2.ClientBatchListRequest,
             client_pb2.ClientBatchListResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/batches', handlers.list_batches)
 
     @unittest_run_loop
@@ -52,11 +52,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/batches?head=2')
@@ -75,7 +75,7 @@ class BatchListTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/batches', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -91,7 +91,7 @@ class BatchListTests(BaseApiTest):
             - a status of 503
             - an error property with a code of 15
         """
-        self.stream.preset_response(self.status.NOT_READY)
+        self.connection.preset_response(self.status.NOT_READY)
         response = await self.get_assert_status('/batches', 503)
 
         self.assert_has_valid_error(response, 15)
@@ -119,11 +119,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         batches = Mocks.make_batches('1', '0')
-        self.stream.preset_response(head_id='1', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='1', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
 
         self.assert_has_valid_head(response, '1')
         self.assert_has_valid_link(response, '/batches?head=1')
@@ -142,7 +142,7 @@ class BatchListTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 50
         """
-        self.stream.preset_response(self.status.NO_ROOT)
+        self.connection.preset_response(self.status.NO_ROOT)
         response = await self.get_assert_status('/batches?head=bad', 404)
 
         self.assert_has_valid_error(response, 50)
@@ -170,11 +170,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         batches = Mocks.make_batches('0', '2')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?id=0,2')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(batch_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(batch_ids=['0', '2'], paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/batches?head=2&id=0,2')
@@ -198,7 +198,7 @@ class BatchListTests(BaseApiTest):
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
-        self.stream.preset_response(
+        self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
@@ -233,11 +233,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 1)
         batches = Mocks.make_batches('0')
-        self.stream.preset_response(head_id='1', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='1', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?id=0&head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             head_id='1',
             batch_ids=['0'],
             paging=controls)
@@ -270,11 +270,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4)
         batches = Mocks.make_batches('c')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&min=1&count=1')
@@ -307,7 +307,7 @@ class BatchListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 54
         """
-        self.stream.preset_response(self.status.INVALID_PAGING)
+        self.connection.preset_response(self.status.INVALID_PAGING)
         response = await self.get_assert_status('/batches?min=-1', 400)
 
         self.assert_has_valid_error(response, 54)
@@ -334,11 +334,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         batches = Mocks.make_batches('d', 'c')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?count=2')
         controls = Mocks.make_paging_controls(2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&count=2')
@@ -369,11 +369,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(2, 4)
         batches = Mocks.make_batches('b', 'a')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&min=2')
@@ -407,11 +407,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d')
         batches = Mocks.make_batches('c', 'b', 'a')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&min=c&count=5')
@@ -446,11 +446,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
         batches = Mocks.make_batches('c', 'b')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&max=b&count=2')
@@ -482,11 +482,11 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         batches = Mocks.make_batches('d', 'c', 'b')
-        self.stream.preset_response(head_id='d', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/batches?head=d&max=2&count=7')
@@ -518,12 +518,12 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header_signature')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -545,7 +545,7 @@ class BatchListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 57
         """
-        self.stream.preset_response(self.status.INVALID_SORT)
+        self.connection.preset_response(self.status.INVALID_SORT)
         response = await self.get_assert_status('/batches?sort=bad', 400)
 
         self.assert_has_valid_error(response, 57)
@@ -573,13 +573,13 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200(
             '/batches?sort=header.signer_pubkey')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -613,13 +613,13 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls(
             'header_signature', reverse=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -653,12 +653,12 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=transactions.length')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('transactions', compare_length=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -694,14 +694,14 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         batches = Mocks.make_batches('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, batches=batches)
+        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200(
             '/batches?sort=-header_signature,transactions.length')
         page_controls = Mocks.make_paging_controls()
         sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
                    Mocks.make_sort_controls('transactions', compare_length=True))
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -716,12 +716,12 @@ class BatchListTests(BaseApiTest):
 class BatchGetTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_BATCH_GET_REQUEST,
             client_pb2.ClientBatchGetRequest,
             client_pb2.ClientBatchGetResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/batches/{batch_id}', handlers.fetch_batch)
 
     @unittest_run_loop
@@ -740,10 +740,10 @@ class BatchGetTests(BaseApiTest):
             - a link property that ends in '/batches/1'
             - a data property that is a full batch with an id of '1'
         """
-        self.stream.preset_response(batch=Mocks.make_batches('1')[0])
+        self.connection.preset_response(batch=Mocks.make_batches('1')[0])
 
         response = await self.get_assert_200('/batches/1')
-        self.stream.assert_valid_request_sent(batch_id='1')
+        self.connection.assert_valid_request_sent(batch_id='1')
 
         self.assertNotIn('head', response)
         self.assert_has_valid_link(response, '/batches/1')
@@ -761,7 +761,7 @@ class BatchGetTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/batches/1', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -777,7 +777,7 @@ class BatchGetTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 71
         """
-        self.stream.preset_response(self.status.NO_RESOURCE)
+        self.connection.preset_response(self.status.NO_RESOURCE)
         response = await self.get_assert_status('/batches/bad', 404)
 
         self.assert_has_valid_error(response, 71)

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -22,12 +22,12 @@ from sawtooth_rest_api.protobuf import client_pb2
 class BlockListTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_BLOCK_LIST_REQUEST,
             client_pb2.ClientBlockListRequest,
             client_pb2.ClientBlockListResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/blocks', handlers.list_blocks)
 
     @unittest_run_loop
@@ -52,11 +52,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/blocks?head=2')
@@ -75,7 +75,7 @@ class BlockListTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/blocks', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -91,7 +91,7 @@ class BlockListTests(BaseApiTest):
             - a status of 503
             - an error property with a code of 15
         """
-        self.stream.preset_response(self.status.NOT_READY)
+        self.connection.preset_response(self.status.NOT_READY)
         response = await self.get_assert_status('/blocks', 503)
 
         self.assert_has_valid_error(response, 15)
@@ -119,11 +119,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         blocks = Mocks.make_blocks('1', '0')
-        self.stream.preset_response(head_id='1', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='1', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
 
         self.assert_has_valid_head(response, '1')
         self.assert_has_valid_link(response, '/blocks?head=1')
@@ -142,7 +142,7 @@ class BlockListTests(BaseApiTest):
             - a status of 404
             - an error property with a code of 50
         """
-        self.stream.preset_response(self.status.NO_ROOT)
+        self.connection.preset_response(self.status.NO_ROOT)
         response = await self.get_assert_status('/blocks?head=bad', 404)
 
         self.assert_has_valid_error(response, 50)
@@ -170,11 +170,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         blocks = Mocks.make_blocks('0', '2')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?id=0,2')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(block_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(block_ids=['0', '2'], paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/blocks?head=2&id=0,2')
@@ -198,7 +198,7 @@ class BlockListTests(BaseApiTest):
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
-        self.stream.preset_response(
+        self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
@@ -233,10 +233,10 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 1)
         blocks = Mocks.make_blocks('0')
-        self.stream.preset_response(head_id='1', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='1', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?id=0&head=1')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             head_id='1',
             block_ids=['0'],
             paging=Mocks.make_paging_controls())
@@ -269,11 +269,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4)
         blocks = Mocks.make_blocks('c')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&min=1&count=1')
@@ -306,7 +306,7 @@ class BlockListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 54
         """
-        self.stream.preset_response(self.status.INVALID_PAGING)
+        self.connection.preset_response(self.status.INVALID_PAGING)
         response = await self.get_assert_status('/blocks?min=-1', 400)
 
         self.assert_has_valid_error(response, 54)
@@ -334,11 +334,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         blocks = Mocks.make_blocks('d', 'c')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?count=2')
         controls = Mocks.make_paging_controls(2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&count=2')
@@ -369,11 +369,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(2, 4)
         blocks = Mocks.make_blocks('b', 'a')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&min=2')
@@ -407,11 +407,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d')
         blocks = Mocks.make_blocks('c', 'b', 'a')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&min=c&count=5')
@@ -446,11 +446,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
         blocks = Mocks.make_blocks('c', 'b')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&max=b&count=2')
@@ -482,11 +482,11 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         blocks = Mocks.make_blocks('d', 'c', 'b')
-        self.stream.preset_response(head_id='d', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/blocks?head=d&max=2&count=7')
@@ -518,12 +518,12 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header_signature')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -545,7 +545,7 @@ class BlockListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 57
         """
-        self.stream.preset_response(self.status.INVALID_SORT)
+        self.connection.preset_response(self.status.INVALID_SORT)
         response = await self.get_assert_status('/blocks?sort=bad', 400)
 
         self.assert_has_valid_error(response, 57)
@@ -573,13 +573,13 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200(
             '/blocks?sort=header.signer_pubkey')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -613,13 +613,13 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls(
             'header_signature', reverse=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -653,12 +653,12 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=batches.length')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('batches', compare_length=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -694,14 +694,14 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         blocks = Mocks.make_blocks('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, blocks=blocks)
+        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200(
             '/blocks?sort=-header_signature,batches.length')
         page_controls = Mocks.make_paging_controls()
         sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
                    Mocks.make_sort_controls('batches', compare_length=True))
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -716,12 +716,12 @@ class BlockListTests(BaseApiTest):
 class BlockGetTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_BLOCK_GET_REQUEST,
             client_pb2.ClientBlockGetRequest,
             client_pb2.ClientBlockGetResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/blocks/{block_id}', handlers.fetch_block)
 
     @unittest_run_loop
@@ -740,10 +740,10 @@ class BlockGetTests(BaseApiTest):
             - a link property that ends in '/blocks/1'
             - a data property that is a full block with an id of '0'
         """
-        self.stream.preset_response(block=Mocks.make_blocks('1')[0])
+        self.connection.preset_response(block=Mocks.make_blocks('1')[0])
 
         response = await self.get_assert_200('/blocks/1')
-        self.stream.assert_valid_request_sent(block_id='1')
+        self.connection.assert_valid_request_sent(block_id='1')
 
         self.assertNotIn('head', response)
         self.assert_has_valid_link(response, '/blocks/1')
@@ -761,7 +761,7 @@ class BlockGetTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/blocks/1', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -777,7 +777,7 @@ class BlockGetTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 70
         """
-        self.stream.preset_response(self.status.NO_RESOURCE)
+        self.connection.preset_response(self.status.NO_RESOURCE)
         response = await self.get_assert_status('/blocks/bad', 404)
 
         self.assert_has_valid_error(response, 70)

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -23,12 +23,12 @@ from sawtooth_rest_api.protobuf import client_pb2
 class StateListTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_STATE_LIST_REQUEST,
             client_pb2.ClientStateListRequest,
             client_pb2.ClientStateListResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/state', handlers.list_state)
 
     @unittest_run_loop
@@ -56,11 +56,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         leaves = Mocks.make_leaves(a=b'3', b=b'5', c=b'7')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/state?head=2')
@@ -79,7 +79,7 @@ class StateListTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/state', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -95,7 +95,7 @@ class StateListTests(BaseApiTest):
             - a status of 503
             - an error property with a code of 15
         """
-        self.stream.preset_response(self.status.NOT_READY)
+        self.connection.preset_response(self.status.NOT_READY)
         response = await self.get_assert_status('/state', 503)
 
         self.assert_has_valid_error(response, 15)
@@ -125,11 +125,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         leaves = Mocks.make_leaves(a=b'2', b=b'4')
-        self.stream.preset_response(head_id='1', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='1', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
 
         self.assert_has_valid_head(response, '1')
         self.assert_has_valid_link(response, '/state?head=1')
@@ -148,7 +148,7 @@ class StateListTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 50
         """
-        self.stream.preset_response(self.status.NO_ROOT)
+        self.connection.preset_response(self.status.NO_ROOT)
         response = await self.get_assert_status('/state?head=bad', 404)
 
         self.assert_has_valid_error(response, 50)
@@ -176,11 +176,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 1)
         leaves = Mocks.make_leaves(c=b'7')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?address=c')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(address='c', paging=controls)
+        self.connection.assert_valid_request_sent(address='c', paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/state?head=2&address=c')
@@ -204,7 +204,7 @@ class StateListTests(BaseApiTest):
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
-        self.stream.preset_response(
+        self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
@@ -239,10 +239,10 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 1)
         leaves = Mocks.make_leaves(a=b'2')
-        self.stream.preset_response(head_id='1', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='1', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?address=a&head=1')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             head_id='1',
             address='a',
             paging=Mocks.make_paging_controls())
@@ -275,11 +275,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4)
         leaves = Mocks.make_leaves(c=b'3')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&min=1&count=1')
@@ -312,7 +312,7 @@ class StateListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 54
         """
-        self.stream.preset_response(self.status.INVALID_PAGING)
+        self.connection.preset_response(self.status.INVALID_PAGING)
         response = await self.get_assert_status('/state?min=-1', 400)
 
         self.assert_has_valid_error(response, 54)
@@ -339,11 +339,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         leaves = Mocks.make_leaves(d=b'4', c=b'3')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?count=2')
         controls = Mocks.make_paging_controls(2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&count=2')
@@ -374,11 +374,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(2, 4)
         leaves = Mocks.make_leaves(b=b'2', a=b'1')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&min=2')
@@ -412,11 +412,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d')
         leaves = Mocks.make_leaves(c=b'3', b=b'2', a=b'1')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&min=c&count=5')
@@ -451,11 +451,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
         leaves = Mocks.make_leaves(c=b'3', b=b'2')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&max=b&count=2')
@@ -487,11 +487,11 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 4)
         leaves = Mocks.make_leaves(d=b'4', c=b'3', b=b'2')
-        self.stream.preset_response(head_id='d', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='d', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/state?head=d&max=2&count=7')
@@ -526,12 +526,12 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         leaves = Mocks.make_leaves(a=b'3', b=b'5', c=b'7')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?sort=address')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('address')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -552,7 +552,7 @@ class StateListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 57
         """
-        self.stream.preset_response(self.status.INVALID_SORT)
+        self.connection.preset_response(self.status.INVALID_SORT)
         response = await self.get_assert_status('/state?sort=bad', 400)
 
         self.assert_has_valid_error(response, 57)
@@ -583,12 +583,12 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         leaves = Mocks.make_leaves(c=b'7', b=b'5', a=b'3')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?sort=-address')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('address', reverse=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -624,12 +624,12 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         leaves = Mocks.make_leaves(c=b'7', b=b'45', a=b'123')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200('/state?sort=value.length')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('value', compare_length=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -667,14 +667,14 @@ class StateListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         leaves = Mocks.make_leaves(c=b'7', b=b'5', a=b'3')
-        self.stream.preset_response(head_id='2', paging=paging, leaves=leaves)
+        self.connection.preset_response(head_id='2', paging=paging, leaves=leaves)
 
         response = await self.get_assert_200(
             '/state?sort=-address,value.length')
         page_controls = Mocks.make_paging_controls()
         sorting = (Mocks.make_sort_controls('address', reverse=True) +
                    Mocks.make_sort_controls('value', compare_length=True))
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -689,12 +689,12 @@ class StateListTests(BaseApiTest):
 class StateGetTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_STATE_GET_REQUEST,
             client_pb2.ClientStateGetRequest,
             client_pb2.ClientStateGetResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(loop, '/state/{address}', handlers.fetch_state)
 
     @unittest_run_loop
@@ -714,10 +714,10 @@ class StateGetTests(BaseApiTest):
             - a link property that ends in '/state/b?head=2'
             - a data property that b64decodes to b'3'
         """
-        self.stream.preset_response(head_id='2', value=b'3')
+        self.connection.preset_response(head_id='2', value=b'3')
 
         response = await self.get_assert_200('/state/a')
-        self.stream.assert_valid_request_sent(address='a')
+        self.connection.assert_valid_request_sent(address='a')
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/state/a?head=2')
@@ -738,7 +738,7 @@ class StateGetTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/state/a', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -754,7 +754,7 @@ class StateGetTests(BaseApiTest):
             - a status of 503
             - an error property with a code of 15
         """
-        self.stream.preset_response(self.status.NOT_READY)
+        self.connection.preset_response(self.status.NOT_READY)
         response = await self.get_assert_status('/state/a', 503)
 
         self.assert_has_valid_error(response, 15)
@@ -770,7 +770,7 @@ class StateGetTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 75
         """
-        self.stream.preset_response(self.status.NO_RESOURCE)
+        self.connection.preset_response(self.status.NO_RESOURCE)
         response = await self.get_assert_status('/state/bad', 404)
 
         self.assert_has_valid_error(response, 75)
@@ -793,10 +793,10 @@ class StateGetTests(BaseApiTest):
             - a link property that ends in '/state/b?head=2'
             - a data property that b64decodes to b'4'
         """
-        self.stream.preset_response(head_id='1', value=b'4')
+        self.connection.preset_response(head_id='1', value=b'4')
 
         response = await self.get_assert_200('/state/b?head=1')
-        self.stream.assert_valid_request_sent(head_id='1', address='b')
+        self.connection.assert_valid_request_sent(head_id='1', address='b')
 
         self.assert_has_valid_head(response, '1')
         self.assert_has_valid_link(response, '/state/b?head=1')
@@ -817,7 +817,7 @@ class StateGetTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 50
         """
-        self.stream.preset_response(self.status.NO_ROOT)
+        self.connection.preset_response(self.status.NO_ROOT)
         response = await self.get_assert_status('/state/b?head=bad', 404)
 
         self.assert_has_valid_error(response, 50)

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -22,12 +22,12 @@ from sawtooth_rest_api.protobuf import client_pb2
 class TransactionListTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_TRANSACTION_LIST_REQUEST,
             client_pb2.ClientTransactionListRequest,
             client_pb2.ClientTransactionListResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         app = self.build_app(loop, '/transactions', handlers.list_transactions)
         return app
 
@@ -52,14 +52,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids '2', '1', and '0'
         """
         paging = Mocks.make_paging_response(0, 3)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='2',
             paging=paging,
             transactions=Mocks.make_txns('2', '1', '0'))
 
         response = await self.get_assert_200('/transactions')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/transactions?head=2')
@@ -78,7 +78,7 @@ class TransactionListTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/transactions', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -94,7 +94,7 @@ class TransactionListTests(BaseApiTest):
             - a status of 503
             - an error property with a code of 15
         """
-        self.stream.preset_response(self.status.NOT_READY)
+        self.connection.preset_response(self.status.NOT_READY)
         response = await self.get_assert_status('/transactions', 503)
 
         self.assert_has_valid_error(response, 15)
@@ -121,14 +121,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids '1' and '0'
         """
         paging = Mocks.make_paging_response(0, 2)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='1',
             paging=paging,
             transactions=Mocks.make_txns('1', '0'))
 
         response = await self.get_assert_200('/transactions?head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
 
         self.assert_has_valid_head(response, '1')
         self.assert_has_valid_link(response, '/transactions?head=1')
@@ -147,7 +147,7 @@ class TransactionListTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 50
         """
-        self.stream.preset_response(self.status.NO_ROOT)
+        self.connection.preset_response(self.status.NO_ROOT)
         response = await self.get_assert_status('/transactions?head=bad', 404)
 
         self.assert_has_valid_error(response, 50)
@@ -175,11 +175,11 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 2)
         transactions = Mocks.make_txns('0', '2')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?id=0,2')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(transaction_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(transaction_ids=['0', '2'], paging=controls)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response, '/transactions?head=2&id=0,2')
@@ -203,7 +203,7 @@ class TransactionListTests(BaseApiTest):
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
-        self.stream.preset_response(
+        self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id='2',
             paging=paging)
@@ -237,14 +237,14 @@ class TransactionListTests(BaseApiTest):
             - that dict is a full transaction with an id of '0'
         """
         paging = Mocks.make_paging_response(0, 1)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='1',
             paging=paging,
             transactions=Mocks.make_txns('0'))
 
         response = await self.get_assert_200('/transactions?id=0&head=1')
         controls = Mocks.make_paging_controls()
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             head_id='1',
             transaction_ids=['0'],
             paging=controls)
@@ -276,14 +276,14 @@ class TransactionListTests(BaseApiTest):
             - that dict is a full transaction with the id 'c'
         """
         paging = Mocks.make_paging_response(1, 4)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('c'))
 
         response = await self.get_assert_200('/transactions?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&min=1&count=1')
@@ -316,7 +316,7 @@ class TransactionListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 54
         """
-        self.stream.preset_response(self.status.INVALID_PAGING)
+        self.connection.preset_response(self.status.INVALID_PAGING)
         response = await self.get_assert_status('/transactions?min=-1', 400)
 
         self.assert_has_valid_error(response, 54)
@@ -342,14 +342,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids 'd' and 'c'
         """
         paging = Mocks.make_paging_response(0, 4)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('d', 'c'))
 
         response = await self.get_assert_200('/transactions?count=2')
         controls = Mocks.make_paging_controls(2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&count=2')
@@ -379,14 +379,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids 'd' and 'c'
         """
         paging = Mocks.make_paging_response(2, 4)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('b', 'a'))
 
         response = await self.get_assert_200('/transactions?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&min=2')
@@ -419,14 +419,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids 'c', 'b', and 'a'
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d')
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('c', 'b', 'a'))
 
         response = await self.get_assert_200('/transactions?min=c&count=5')
         controls = Mocks.make_paging_controls(5, start_id='c')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&min=c&count=5')
@@ -460,14 +460,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids 'c' and 'b'
         """
         paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('c', 'b'))
 
         response = await self.get_assert_200('/transactions?max=b&count=2')
         controls = Mocks.make_paging_controls(2, end_id='b')
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&max=b&count=2')
@@ -498,14 +498,14 @@ class TransactionListTests(BaseApiTest):
             - those dicts are full transactions with ids 'd', 'c', and 'b'
         """
         paging = Mocks.make_paging_response(0, 4)
-        self.stream.preset_response(
+        self.connection.preset_response(
             head_id='d',
             paging=paging,
             transactions=Mocks.make_txns('d', 'c', 'b'))
 
         response = await self.get_assert_200('/transactions?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
-        self.stream.assert_valid_request_sent(paging=controls)
+        self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, 'd')
         self.assert_has_valid_link(response, '/transactions?head=d&max=2&count=7')
@@ -537,12 +537,12 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         transactions = Mocks.make_txns('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header_signature')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -564,7 +564,7 @@ class TransactionListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 57
         """
-        self.stream.preset_response(self.status.INVALID_SORT)
+        self.connection.preset_response(self.status.INVALID_SORT)
         response = await self.get_assert_status('/transactions?sort=bad', 400)
 
         self.assert_has_valid_error(response, 57)
@@ -592,13 +592,13 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         transactions = Mocks.make_txns('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200(
             '/transactions?sort=header.signer_pubkey')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -632,13 +632,13 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         transactions = Mocks.make_txns('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls(
             'header_signature', reverse=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -672,12 +672,12 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         transactions = Mocks.make_txns('0', '1', '2')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=payload.length')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls('payload', compare_length=True)
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -713,14 +713,14 @@ class TransactionListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(0, 3)
         transactions = Mocks.make_txns('2', '1', '0')
-        self.stream.preset_response(head_id='2', paging=paging, transactions=transactions)
+        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200(
             '/transactions?sort=-header_signature,payload.length')
         page_controls = Mocks.make_paging_controls()
         sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
                    Mocks.make_sort_controls('payload', compare_length=True))
-        self.stream.assert_valid_request_sent(
+        self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
@@ -735,12 +735,12 @@ class TransactionListTests(BaseApiTest):
 class TransactionGetTests(BaseApiTest):
 
     async def get_application(self, loop):
-        self.set_status_and_stream(
+        self.set_status_and_connection(
             Message.CLIENT_TRANSACTION_GET_REQUEST,
             client_pb2.ClientTransactionGetRequest,
             client_pb2.ClientTransactionGetResponse)
 
-        handlers = self.build_handlers(loop, self.stream)
+        handlers = self.build_handlers(loop, self.connection)
         return self.build_app(
             loop,
             '/transactions/{transaction_id}',
@@ -762,10 +762,10 @@ class TransactionGetTests(BaseApiTest):
             - a link property that ends in '/transactions/1'
             - a data property that is a full batch with an id of '1'
         """
-        self.stream.preset_response(transaction=Mocks.make_txns('1')[0])
+        self.connection.preset_response(transaction=Mocks.make_txns('1')[0])
 
         response = await self.get_assert_200('/transactions/1')
-        self.stream.assert_valid_request_sent(transaction_id='1')
+        self.connection.assert_valid_request_sent(transaction_id='1')
 
         self.assertNotIn('head', response)
         self.assert_has_valid_link(response, '/transactions/1')
@@ -783,7 +783,7 @@ class TransactionGetTests(BaseApiTest):
             - a status of 500
             - an error property with a code of 10
         """
-        self.stream.preset_response(self.status.INTERNAL_ERROR)
+        self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status('/transactions/1', 500)
 
         self.assert_has_valid_error(response, 10)
@@ -799,7 +799,7 @@ class TransactionGetTests(BaseApiTest):
             - a response status of 404
             - an error property with a code of 72
         """
-        self.stream.preset_response(self.status.NO_RESOURCE)
+        self.connection.preset_response(self.status.NO_RESOURCE)
         response = await self.get_assert_status('/transactions/bad', 404)
 
         self.assert_has_valid_error(response, 72)


### PR DESCRIPTION
Use of the sawtooth python SDK Stream required blocking for the results
of concurrent futures, within the confines of an asyncio loop.  In order
to avoid blocking the loop on waits, a thread pool executer was
introduced to handle these futures.

This commit replaces the concurrent stream with an asyncio-based
Connection class.  This class performs all operations on an asyncio
loop, which is shared with the aiohttp application.  All calls to and
from the validator are handled using coroutines.

This is in support of STL-223

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>