### PR TITLE
Send back invalid transaction data through APIs

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -266,7 +266,7 @@ def do_batch_submit(args):
                 args.wait - int(wait_time))
             wait_time = time.time() - start_time
 
-            if all(s == 'COMMITTED' for s in statuses.values()):
+            if all(s.status == 'COMMITTED' for s in statuses):
                 print('All batches committed in {:.6} sec'.format(wait_time))
                 return
 

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -68,7 +68,7 @@ class RestClient(object):
                 time in seconds has elapsed.
 
         Returns:
-            dict: A statuses map, with ids as keys, and statuses values
+            list of dict: Dicts with 'id' and 'status' properties
         """
         return self._post('/batch_status', batch_ids, wait=wait)['data']
 

--- a/docs/source/architecture/rest_api.rst
+++ b/docs/source/architecture/rest_api.rst
@@ -250,13 +250,16 @@ only once the batches are committed.
 
      .. code-block:: json
 
-        {
-          "data": {
-            "8980...029c": "COMMITTED",
-            "540a6...484a": "INVALID",
-            "65cd...47dd": "PENDING"
+        [
+          {
+            "id": "89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c",
+            "status": "COMMITTED"
+          },
+          {
+            "id": "c0c2075e708c04b34903c5374f65c9352f9dc9662f187e4bab0605aba3eb697e459bfa3a61a8050c428d1347d47a11b0cf81d481467a18cd48ab137001a5fa29",
+            "status": "PENDING"
           }
-        }
+        ]
 
 
 Future Development

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -30,16 +30,33 @@ message Leaf {
     bytes data = 2;
 }
 
-// Possible commit statuses for a batch submitted to a validator
-//   * COMMITTED - the batch was accepted and has been committed to the chain
-//   * INVALID - the batch failed validation, it should be resubmitted
-//   * PENDING - the batch is still being processed
-//   * UNKNOWN - no status for the batch could be found (possibly invalid)
-enum BatchStatus {
-    COMMITTED = 0;
-    INVALID = 1;
-    PENDING = 2;
-    UNKNOWN = 3;
+// Information about the status of a batch submitted to the validator.
+//
+// Attributes:
+//     batch_id: The id (header_signature) of the batch
+//     status: The committed status of the batch
+//     invalid_transactions: Info for transactions that failed, if any
+//
+// Statuses:
+//     COMMITTED - the batch was accepted and has been committed to the chain
+//     INVALID - the batch failed validation, it should be resubmitted
+//     PENDING - the batch is still being processed
+//     UNKNOWN - no status for the batch could be found (possibly invalid)
+message BatchStatus {
+    enum Status {
+        COMMITTED = 0;
+        INVALID = 1;
+        PENDING = 2;
+        UNKNOWN = 3;
+    }
+    message InvalidTransaction {
+        string transaction_id = 1;
+        string message = 2;
+        bytes extended_data = 3;
+    }
+    string batch_id = 1;
+    Status status = 2;
+    repeated InvalidTransaction invalid_transactions = 3;
 }
 
 // Paging controls to be sent with List requests.
@@ -94,7 +111,7 @@ message ClientBatchSubmitRequest {
 
 // This is a response to a submission of one or more Batches.
 // If `wait_for_commit` was set in the request, this response will include a
-// `batch_statuses` hashmap, with the status of each batch submitted.
+// `batch_statuses` property, with the status of each batch submitted.
 // Statuses:
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
@@ -106,7 +123,7 @@ message ClientBatchSubmitResponse {
         INVALID_BATCH = 2;
     }
     Status status = 1;
-    map<string, BatchStatus> batch_statuses = 2;
+    repeated BatchStatus batch_statuses = 2;
 }
 
 // A request for the status of one or more batches, specified by id.
@@ -119,9 +136,7 @@ message ClientBatchStatusRequest {
     int32 timeout = 3;
 }
 
-// This is a response to a request for the status of specific batches. The
-// batches_statuses field is a hashmap where the keys correspond to the ids
-// of the batches queried, and the values are their status.
+// This is a response to a request for the status of specific batches.
 // Statuses:
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
@@ -134,7 +149,7 @@ message ClientBatchStatusResponse {
         NO_RESOURCE = 4;
     }
     Status status = 1;
-    map<string, BatchStatus> batch_statuses = 2;
+    repeated BatchStatus batch_statuses = 2;
 }
 
 message ClientStateCurrentRequest {

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -125,10 +125,9 @@ paths:
     get:
       summary: Fetches the committed statuses for a set of batches
       description: |
-        Fetches an object with a status for each batch requested. The keys of
-        the data object will be the ids of the batch(es), while the values will
-        be a string status with the values `'COMMITTED'`, `'INVALID'`,
-        `'PENDING'`, or `'UNKNOWN'`.
+        Fetches an array of objects with a status and id for each batch
+        requested. There are for possible statuses with string values
+        `'COMMITTED'`, `'INVALID'`, `'PENDING'`, and `'UNKNOWN'`.
 
         The batch(es) you want to check can be specified using the `id` filter
         parameter. If a `wait` time is specified in the url, the API will wait
@@ -137,8 +136,9 @@ paths:
         it is set to any non-integer value other than `false`, the wait time
         will be just shy of the api's specified timeout (usually 300).
 
-        Note that as this route does not return a full resource, the response
-        body will _not_ include the `head` or `paging` properties.
+        Note that as this route does not return full resources, the response
+        will not be paginated, and there will be no `head` or `paging`
+        properties.
       parameters:
         - name: id
           in: query
@@ -504,15 +504,20 @@ definitions:
           Batches. You must submit at least one Batch.
 
   BatchStatuses:
-    properties:
-      "{batch_id}":
-        type: string
-        example: PENDING
-        enum:
-          - COMMITTED
-          - INVALID
-          - PENDING
-          - UNKNOWN
+    type: array
+    items:
+      properties:
+        id:
+          type: string
+          example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
+        status:
+          type: string
+          example: PENDING
+          enum:
+            - COMMITTED
+            - INVALID
+            - PENDING
+            - UNKNOWN
 
   Leaf:
     properties:

--- a/rest_api/sawtooth_rest_api/openapi.yaml
+++ b/rest_api/sawtooth_rest_api/openapi.yaml
@@ -126,7 +126,7 @@ paths:
       summary: Fetches the committed statuses for a set of batches
       description: |
         Fetches an array of objects with a status and id for each batch
-        requested. There are for possible statuses with string values
+        requested. There are four possible statuses with string values
         `'COMMITTED'`, `'INVALID'`, `'PENDING'`, and `'UNKNOWN'`.
 
         The batch(es) you want to check can be specified using the `id` filter
@@ -512,12 +512,26 @@ definitions:
           example: 89807bfc9089e37e00d87d97357de14cfbc455cd608438d426a625a30a0da9a31c406983803c4aa27e1f32a3ff61709e8ec4b56abbc553d7d330635b5d27029c
         status:
           type: string
-          example: PENDING
+          example: INVALID
           enum:
             - COMMITTED
             - INVALID
             - PENDING
             - UNKNOWN
+        invalid_transactions:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+                example: 540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a
+              message:
+                type: string
+                example: Verb is \"inc\" but name \"foo\" not in state
+              extended_data:
+                type: string
+                format: byte
+                example: ZXJyb3IgZGF0YQ==
 
   Leaf:
     properties:

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -301,14 +301,14 @@ class BaseApiTest(AioHTTPTestCase):
             self.assertEqual(pb_leaf.address, js_leaf['address'])
             self.assertEqual(pb_leaf.data, b64decode(js_leaf['data']))
 
-    def assert_statuses_match(self, enum_statuses, json_statuses):
+    def assert_statuses_match(self, proto_statuses, json_statuses):
         """Asserts that JSON statuses match the original enum statuses dict
         """
-        self.assertEqual(len(enum_statuses), len(json_statuses))
-        for batch_id, status_string in json_statuses.items():
-            self.assertIn(batch_id, enum_statuses)
-            status_enum = client_pb2.BatchStatus.Name(enum_statuses[batch_id])
-            self.assertEqual(status_string, status_enum)
+        self.assertEqual(len(proto_statuses), len(json_statuses))
+        for pb_status, js_status in zip(proto_statuses, json_statuses):
+            self.assertEqual(pb_status.batch_id, js_status['id'])
+            pb_enum_name = client_pb2.BatchStatus.Status.Name(pb_status.status)
+            self.assertEqual(pb_enum_name, js_status['status'])
 
     def assert_blocks_well_formed(self, blocks, *expected_ids):
         """Asserts a block dict or list of block dicts have expanded headers

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -310,6 +310,15 @@ class BaseApiTest(AioHTTPTestCase):
             pb_enum_name = client_pb2.BatchStatus.Status.Name(pb_status.status)
             self.assertEqual(pb_enum_name, js_status['status'])
 
+            if pb_status.invalid_transactions:
+                txn_info = zip(pb_status.invalid_transactions,
+                               js_status['invalid_transactions'])
+                for pb_txn, js_txn in txn_info:
+                    self.assertEqual(pb_txn.transaction_id, js_txn['id'])
+                    self.assertEqual(pb_txn.message, js_txn.get('message', ''))
+                    self.assertEqual(pb_txn.extended_data,
+                                     b64decode(js_txn.get('extended_data', b'')))
+
     def assert_blocks_well_formed(self, blocks, *expected_ids):
         """Asserts a block dict or list of block dicts have expanded headers
         and match the expected ids. Assumes each block contains one batch and

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -18,6 +18,7 @@ from aiohttp.test_utils import unittest_run_loop
 from tests.unit.components import Mocks, BaseApiTest
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_pb2
+from sawtooth_rest_api.protobuf.client_pb2 import BatchStatus
 
 
 class PostBatchTests(BaseApiTest):
@@ -172,7 +173,7 @@ class PostBatchTests(BaseApiTest):
             - a link property that ends in '/batches?id=a'
         """
         batches = Mocks.make_batches('a')
-        statuses = {'a': client_pb2.COMMITTED}
+        statuses = [BatchStatus(batch_id='a', status=BatchStatus.COMMITTED)]
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.post_batches(batches, wait=True)
@@ -204,7 +205,7 @@ class PostBatchTests(BaseApiTest):
             - a data property matching the batch statuses received
         """
         batches = Mocks.make_batches('pending')
-        statuses = {'pending': client_pb2.PENDING}
+        statuses = [BatchStatus(batch_id='pending', status=BatchStatus.PENDING)]
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.post_batches(batches, wait=True)
@@ -235,7 +236,7 @@ class BatchStatusTests(BaseApiTest):
         """Verifies a GET /batch_status with one id works properly.
 
         It will receive a Protobuf response with:
-            - batch statuses of {'pending': PENDING}
+            - batch statuses of {batch_id: 'pending',  status: PENDING}
 
         It should send a Protobuf request with:
             - a batch_ids property of ['pending']
@@ -245,7 +246,7 @@ class BatchStatusTests(BaseApiTest):
             - a link property that ends in '/batch_status?id=pending'
             - a data property matching the batch statuses received
         """
-        statuses = {'pending': client_pb2.PENDING}
+        statuses = [BatchStatus(batch_id='pending', status=BatchStatus.PENDING)]
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200('/batch_status?id=pending')
@@ -291,7 +292,7 @@ class BatchStatusTests(BaseApiTest):
         """Verifies a GET /batch_status with a wait set works properly.
 
         It will receive a Protobuf response with:
-            - batch statuses of {'pending': COMMITTED}
+            - batch statuses of {batch_id: 'pending', status: COMMITTED}
 
         It should send a Protobuf request with:
             - a batch_ids property of ['pending']
@@ -303,7 +304,7 @@ class BatchStatusTests(BaseApiTest):
             - a link property that ends in '/batch_status?id=pending&wait'
             - a data property matching the batch statuses received
         """
-        statuses = {'pending': client_pb2.COMMITTED}
+        statuses = [BatchStatus(batch_id='pending', status=BatchStatus.COMMITTED)]
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200('/batch_status?id=pending&wait')
@@ -333,10 +334,10 @@ class BatchStatusTests(BaseApiTest):
             - link property ending in '/batch_status?id=committed,unknown,bad'
             - a data property matching the batch statuses received
         """
-        statuses = {
-            'committed': client_pb2.COMMITTED,
-            'unknown': client_pb2.UNKNOWN,
-            'bad': client_pb2.UNKNOWN}
+        statuses = [
+            BatchStatus(batch_id='committed', status=BatchStatus.COMMITTED),
+            BatchStatus(batch_id='unknown', status=BatchStatus.UNKNOWN),
+            BatchStatus(batch_id='bad', status=BatchStatus.UNKNOWN)]
         self.stream.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200(
@@ -379,10 +380,10 @@ class BatchStatusTests(BaseApiTest):
             - an empty link property
             - a data property matching the batch statuses received
         """
-        statuses = {
-            'committed': client_pb2.COMMITTED,
-            'pending': client_pb2.PENDING,
-            'bad': client_pb2.UNKNOWN}
+        statuses = [
+            BatchStatus(batch_id='committed', status=BatchStatus.COMMITTED),
+            BatchStatus(batch_id='pending', status=BatchStatus.PENDING),
+            BatchStatus(batch_id='bad', status=BatchStatus.UNKNOWN)]
         self.stream.preset_response(batch_statuses=statuses)
 
         request = await self.client.post(

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -96,7 +96,7 @@ class XoClient:
                 'batch_status?id={}&wait={}'.format(batch_id, wait),
                 auth_user=auth_user,
                 auth_password=auth_password)
-            return yaml.safe_load(result)["data"]
+            return yaml.safe_load(result)['data'][0]['status']
         except BaseException as err:
             raise XoException(err)
 
@@ -194,7 +194,7 @@ class XoClient:
                 )
                 wait_time = time.time() - start_time
 
-                if status[batch_id] != 'PENDING':
+                if status != 'PENDING':
                     return response
 
             return response

--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -212,8 +212,7 @@ class WorkloadGenerator(object):
             result.raise_for_status()
 
             if code == 200 or code == 201 or code == 202:
-                status = list(json_result["data"].values())[0]
-                return status
+                return json_result['data'][0]['status']
             else:
                 if 'error' in json_result:
                     message = json_result['error']['message']

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -268,7 +268,7 @@ class Journal(object):
         """
         self._batch_queue.put(batch)
         for observer in self._batch_obs:
-            observer.notify_batch_pending(batch.header_signature)
+            observer.notify_batch_pending(batch)
 
 
 class PendingBatchObserver(metaclass=abc.ABCMeta):
@@ -276,12 +276,12 @@ class PendingBatchObserver(metaclass=abc.ABCMeta):
     has begun being processed.
     """
     @abc.abstractmethod
-    def notify_batch_pending(self, batch_id):
+    def notify_batch_pending(self, batch):
         """This method will be called when a Batch has passed initial
         validation and is queued to be processed by the Publisher.
 
         Args:
-            batch_id (str): The header signature of the batch
+            batch (Batch): The Batch that has been added to the Publisher
         """
         raise NotImplementedError('PendingBatchObservers must have a '
                                   '"notify_batch_pending" method')

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -166,7 +166,8 @@ class Validator(object):
             service=self._service,
             context_manager=context_manager,
             settings_view_factory=SettingsViewFactory(
-                StateViewFactory(merkle_db)))
+                StateViewFactory(merkle_db)),
+            invalid_observers=[batch_tracker])
         self._executor = executor
         self._service.set_check_connections(executor.check_connections)
 

--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -17,15 +17,18 @@ import abc
 from threading import RLock
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.journal.block_store import StoreUpdateObserver
+from sawtooth_validator.execution.executor import InvalidTransactionObserver
 from sawtooth_validator.journal.journal import PendingBatchObserver
 from sawtooth_validator.protobuf.client_pb2 import BatchStatus
 
 
-# By default pending batch ids will be kept for one hour
-PENDING_KEEP_TIME = 3600
+# By default invalid batch info will be kept for one hour
+CACHE_KEEP_TIME = 3600
 
 
-class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
+class BatchTracker(StoreUpdateObserver,
+                   InvalidTransactionObserver,
+                   PendingBatchObserver):
     """Tracks batch statuses for this local validator, allowing interested
     components to check where a batch is in the validation process. It should
     only be relied on for batches submitted locally, and is not persisted
@@ -40,7 +43,9 @@ class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
     """
     def __init__(self, block_store):
         self._block_store = block_store
-        self._pending = TimedCache(keep_time=PENDING_KEEP_TIME)
+        self._batch_info = TimedCache(keep_time=CACHE_KEEP_TIME)
+        self._invalid = TimedCache(keep_time=CACHE_KEEP_TIME)
+        self._pending = set()
 
         self._lock = RLock()
         self._observers = {}
@@ -50,20 +55,50 @@ class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
         and notifies any observers.
         """
         with self._lock:
-            for batch_id in set(self._pending):
+            for batch_id in self._pending.copy():
                 if self._block_store.has_batch(batch_id):
-                    self._pending.pop(batch_id)
+                    self._pending.remove(batch_id)
                     self._update_observers(batch_id, BatchStatus.COMMITTED)
 
-    def notify_batch_pending(self, batch_id):
-        """Adds a batch to the pending list.
+    def notify_txn_invalid(self, txn_id, message=None, extended_data=None):
+        """Adds a batch id to the invalid cache along with the id of the
+        transaction that was rejected and any error message or extended data.
+        Removes that batch id from the pending set. The cache is only
+        temporary, and the batch info will be purged after one hour.
 
         Args:
-            batch_id (str): The id of the pending batch
+            txn_id (str): The id of the invalid batch
+            message (str, optional): Message explaining why batch is invalid
+            extended_data (bytes, optional): Additional error data
         """
+        invalid_txn_info = {'id': txn_id}
+        if message is not None:
+            invalid_txn_info['message'] = message
+        if extended_data is not None:
+            invalid_txn_info['extended_data'] = extended_data
+
         with self._lock:
-            self._pending[batch_id] = True
-            self._update_observers(batch_id, BatchStatus.PENDING)
+            for batch_id, txn_ids in self._batch_info.items():
+                if txn_id in txn_ids:
+                    if batch_id not in self._invalid:
+                        self._invalid[batch_id] = [invalid_txn_info]
+                    else:
+                        self._invalid[batch_id].append(invalid_txn_info)
+                    self._pending.discard(batch_id)
+                    self._update_observers(batch_id, BatchStatus.INVALID)
+                    return
+
+    def notify_batch_pending(self, batch):
+        """Adds a Batch id to the pending cache, with its transaction ids.
+
+        Args:
+            batch (str): The id of the pending batch
+        """
+        txn_ids = {t.header_signature for t in batch.transactions}
+        with self._lock:
+            self._pending.add(batch.header_signature)
+            self._batch_info[batch.header_signature] = txn_ids
+            self._update_observers(batch.header_signature, BatchStatus.PENDING)
 
     def get_status(self, batch_id):
         """Returns the status enum for a batch.
@@ -77,6 +112,8 @@ class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
         with self._lock:
             if self._block_store.has_batch(batch_id):
                 return BatchStatus.COMMITTED
+            if batch_id in self._invalid:
+                return BatchStatus.INVALID
             if batch_id in self._pending:
                 return BatchStatus.PENDING
             return BatchStatus.UNKNOWN
@@ -92,6 +129,26 @@ class BatchTracker(StoreUpdateObserver, PendingBatchObserver):
         """
         with self._lock:
             return {b: self.get_status(b) for b in batch_ids}
+
+    def get_invalid_txn_info(self, batch_id):
+        """Fetches the id of the Transaction that failed within a particular
+        Batch, as well as any error message or other data about the failure.
+
+        Args:
+            batch_id (str): The id of the Batch containing an invalid txn
+
+        Returns:
+            list of dict: A list of dicts with three possible keys:
+                * 'id' - the header_signature of the invalid Transaction
+                * 'message' - the error message sent by the TP
+                * 'extended_data' - any additional data sent by the TP
+        """
+        try:
+            return self._invalid[batch_id]
+        except KeyError:
+            # If batch has been purged from the invalid cache before its txn
+            # info is fetched, return an empty array of txn info
+            return []
 
     def watch_statuses(self, observer, batch_ids):
         """Allows a component to register to be notified when a set of
@@ -138,7 +195,7 @@ class BatchFinishObserver(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def notify_batches_finished(self, statuses):
         """This method will be called when every Batch in a set of Batches is
-        no longer PENDING. Each should be committed or not found.
+        no longer PENDING. Each should be committed, invalid, or not found.
 
         Args:
             statuses (dict of int): A dict with keys of batch ids, and values

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -548,9 +548,15 @@ class _BatchWaiter(BatchFinishObserver):
 
         with self._wait_condition:
             while True:
-                if self._statuses or time() - start_time > timeout:
+                if self._statuses is not None:
                     return _format_batch_statuses(
                         self._statuses, batch_ids, self._batch_tracker)
+
+                if time() - start_time > timeout:
+                    statuses = self._batch_tracker.get_statuses(batch_ids)
+                    return _format_batch_statuses(
+                        statuses, batch_ids, self._batch_tracker)
+
                 self._wait_condition.wait(timeout - (time() - start_time))
 
 

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -148,6 +148,6 @@ def make_store_and_tracker(size=3):
     store = MockBlockStore(size=size)
     tracker = BatchTracker(store)
     store.add_update_observer(tracker)
-    tracker.notify_batch_pending('b-pending')
+    tracker.notify_batch_pending(make_mock_batch('pending'))
 
     return store, tracker

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -149,5 +149,7 @@ def make_store_and_tracker(size=3):
     tracker = BatchTracker(store)
     store.add_update_observer(tracker)
     tracker.notify_batch_pending(make_mock_batch('pending'))
+    tracker.notify_batch_pending(make_mock_batch('invalid'))
+    tracker.notify_txn_invalid('t-invalid', 'error message', b'error data')
 
     return store, tracker

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -68,7 +68,7 @@ class TestBatchSubmitFinisher(ClientHandlerTestCase):
             - a response status of OK
             - a status of COMMITTED at key 'b-new' in batch_statuses
         """
-        self._tracker.notify_batch_pending('b-new')
+        self._tracker.notify_batch_pending(make_mock_batch('new'))
         start_time = time()
         def delayed_add():
             sleep(1)
@@ -203,7 +203,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
             - a response status of OK
             - a status of COMMITTED at key 'b-new' in batch_statuses
         """
-        self._tracker.notify_batch_pending('b-new')
+        self._tracker.notify_batch_pending(make_mock_batch('new'))
         start_time = time()
         def delayed_add():
             sleep(1)

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -137,6 +137,34 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.batch_statuses)
 
+    def test_invalid_batch_status(self):
+        """Verifies batch status requests marked INVALID by the tracker work.
+
+        Queries the default mock batch tracker with invalid batch ids of:
+            - 'b-invalid'
+
+        Expects to find:
+            - a response status of OK
+            - a status of INVALID at key 'b-invalid' in batch_statuses
+            - an invalid_transaction with
+                * an 'id' of 't-invalid'
+                * a message of 'error message'
+                * extended_data of b'error data'
+        """
+        response = self.make_request(batch_ids=['b-invalid'])
+
+        self.assertEqual(self.status.OK, response.status)
+        status = response.batch_statuses[0]
+        self.assertEqual(status.batch_id, 'b-invalid')
+        self.assertEqual(status.status, BatchStatus.INVALID)
+        self.assertEqual(1, len(status.invalid_transactions))
+
+        invalid_txn = status.invalid_transactions[0]
+        self.assertEqual(invalid_txn.transaction_id, 't-invalid')
+        self.assertEqual(invalid_txn.message, 'error message')
+        self.assertEqual(invalid_txn.extended_data, b'error data')
+
+
     def test_pending_batch_status(self):
         """Verifies batch status requests marked PENDING by the tracker work.
 


### PR DESCRIPTION
This PR expands the BatchTracker to track invalid Batches, which transaction was rejected, and any data associated with the transaction. This data is then sent back through both the ZMQ and REST APIs with a more robust list of status objects, rather than a simple id to status hashmap.