### PR TITLE
Change PoET policy logging error messages to informational

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -617,7 +617,7 @@ class ConsensusState(object):
                 return False
 
             if utils.block_id_is_genesis(block.previous_block_id):
-                LOGGER.error(
+                LOGGER.info(
                     'Validator %s (ID=%s...%s): Signup committed block %s, '
                     'hit start of blockchain looking for block %s',
                     validator_info.name,
@@ -629,7 +629,7 @@ class ConsensusState(object):
 
             block = block_cache[block.previous_block_id]
 
-        LOGGER.error(
+        LOGGER.info(
             'Validator %s (ID=%s...%s): Signup committed block %s, failed to '
             'find block with ID ending in %s in %d previous block(s)',
             validator_info.name,
@@ -660,7 +660,7 @@ class ConsensusState(object):
         if validator_state.poet_public_key == \
                 validator_info.signup_info.poet_public_key:
             if validator_state.key_block_claim_count >= key_block_claim_limit:
-                LOGGER.error(
+                LOGGER.info(
                     'Validator %s (ID=%s...%s): Reached block claim limit '
                     'for PoET keys %d >= %d',
                     validator_info.name,
@@ -754,7 +754,7 @@ class ConsensusState(object):
             block_number - commit_block.block_num - 1
 
         if block_claim_delay > blocks_claimed_since_registration:
-            LOGGER.error(
+            LOGGER.info(
                 'Validator %s (ID=%s...%s): Committed in block %d, trying to '
                 'claim block %d, must wait until block %d',
                 validator_info.name,
@@ -865,7 +865,7 @@ class ConsensusState(object):
                         (observed_wins - expected_wins) / \
                         standard_deviation
                     if z_score > maximum_win_deviation:
-                        LOGGER.error(
+                        LOGGER.info(
                             'Validator %s (ID=%s...%s): zTest failed at depth '
                             '%d, z_score=%f, expected=%f, observed=%d',
                             validator_info.name,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -323,7 +323,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 validator_info=validator_info,
                 poet_settings_view=poet_settings_view,
                 block_cache=self._block_cache):
-            LOGGER.error(
+            LOGGER.info(
                 'Reject building on block %s: Validator signup information '
                 'not committed in a timely manner.',
                 block_header.previous_block_id[:8])
@@ -364,7 +364,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     block_header=block_header,
                     poet_enclave_module=poet_enclave_module)
 
-            LOGGER.error(
+            LOGGER.info(
                 'Reject building on block %s: Validator has reached maximum '
                 'number of blocks with key pair.',
                 block_header.previous_block_id[:8])
@@ -379,7 +379,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 validator_registry_view=validator_registry_view,
                 poet_settings_view=poet_settings_view,
                 block_store=self._block_cache.block_store):
-            LOGGER.error(
+            LOGGER.info(
                 'Reject building on block %s: Validator has not waited long '
                 'enough since registering validator information.',
                 block_header.previous_block_id[:8])
@@ -416,7 +416,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                     poet_settings_view=poet_settings_view),
                 block_cache=self._block_cache,
                 poet_enclave_module=poet_enclave_module):
-            LOGGER.error(
+            LOGGER.info(
                 'Reject building on block %s: Validator is claiming blocks '
                 'too frequently.',
                 block_header.previous_block_id[:8])

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -246,10 +246,11 @@ class TestPoetBlockPublisher(TestCase):
             # that this is fragile if the log message is changed, so would
             # accept any suggestions on a better way to verify that the
             # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.error.call_args
-            self.assertTrue('Validator signup information '
-                            'not committed in a timely manner.' in message)
+            self.assertTrue(
+                any(
+                    'Validator signup information not committed in a timely '
+                    'manner.' in call[0][0] for call in
+                    mock_logger.info.call_args_list))
 
             # check that create.signup_info() was called to create
             # the validator registry payload with new set of keys
@@ -354,7 +355,7 @@ class TestPoetBlockPublisher(TestCase):
             # accept any suggestions on a better way to verify that the
             # function fails for the reason we expect.
 
-            (message, *_), _ = mock_logger.error.call_args
+            (message, *_), _ = mock_logger.info.call_args
             self.assertTrue('Validator has reached maximum number of '
                             'blocks with key pair' in message)
 
@@ -461,7 +462,7 @@ class TestPoetBlockPublisher(TestCase):
             # accept any suggestions on a better way to verify that the
             # function fails for the reason we expect.
 
-            (message, *_), _ = mock_logger.error.call_args
+            (message, *_), _ = mock_logger.info.call_args
             self.assertTrue('Validator has not waited long enough '
                             'since registering validator '
                             'information' in message)
@@ -564,7 +565,7 @@ class TestPoetBlockPublisher(TestCase):
             # accept any suggestions on a better way to verify that the
             # function fails for the reason we expect.
 
-            (message, *_), _ = mock_logger.error.call_args
+            (message, *_), _ = mock_logger.info.call_args
             self.assertTrue('Validator is claiming blocks too '
                             'frequently' in message)
 


### PR DESCRIPTION
The consensus state and block publisher error messages when PoET policy will be violated have been demoted from error to informational logging messages.

Signed-off-by: Jamie Jason <jamie.jason@intel.com>