### PR TITLE
log readable namespaces

### DIFF
--- a/validator/sawtooth_validator/execution/processor_handlers.py
+++ b/validator/sawtooth_validator/execution/processor_handlers.py
@@ -41,7 +41,7 @@ class ProcessorRegisterHandler(Handler):
             request.family,
             request.version,
             request.encoding,
-            request.namespaces)
+            list(request.namespaces))
 
         processor_type = processor_iterator.ProcessorType(
             request.family,

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -159,7 +159,7 @@ class Processor(object):
 
     def __repr__(self):
         return "{}: {}".format(self.connection_id,
-                               self.namespaces)
+                               list(self.namespaces))
 
     def __eq__(self, other):
         return self.connection_id == other.connection_id


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Namespaces is a list type, so log it as a list type, not as a string type.