### PR TITLE
Yaml tester fixes, increase in yaml tests

### DIFF
--- a/validator/tests/test_scheduler/data/batch_fails_valid_txn.yaml
+++ b/validator/tests/test_scheduler/data/batch_fails_valid_txn.yaml
@@ -1,0 +1,106 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+---
+-  #------------------------- Batch 1
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+  -
+    inputs:
+      - b:sha
+    outputs:
+      - b:sha
+    addresses_to_set:
+      - b:sha :
+    valid: False
+- # ----------------------- Batch 2
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+  -
+    inputs:
+      - c:sha
+    outputs:
+      - c:sha
+    addresses_to_set:
+      - c:sha :
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+  -
+    inputs:
+      - e:sha
+    outputs:
+      - e:sha
+    addresses_to_set:
+      - e:sha :
+- #----------------------- Batch 3
+  -
+    inputs:
+      - t:sha
+    outputs:
+      - t:sha
+    addresses_to_set:
+      - t:sha :
+  -
+    inputs:
+      - g:sha
+    outputs:
+      - g:sha
+    addresses_to_set:
+      - g:sha :
+  -
+    inputs:
+      - e:sha
+    outputs:
+      - e:sha
+    addresses_to_set:
+      - e:sha :
+    valid: False
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+- #---------------------- Batch 4
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+  -
+    inputs:
+      - b:sha
+    outputs:
+      - b:sha
+    addresses_to_set:
+      - b:sha :

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -112,8 +112,8 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='intkey_small_batch.yaml')
 
     def test_serial_intkey_small_batch(self):
-        """Tests the parallel scheduler against the
-                test_scheduler/data/intkey_small_batch.yaml file.
+        """Tests the serial scheduler against the
+        test_scheduler/data/intkey_small_batch.yaml file.
 
         Notes:
             In general, there are 8 batches, all valid, with intkey style

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -61,6 +61,7 @@ class TestSchedulersWithYaml(unittest.TestCase):
                                       always_persist=False)
         return context_manager, scheduler
 
+    @unittest.skip("Skip until STL-476")
     def test_parallel_simple_scheduler_test(self):
         """Tests the parallel scheduler against the
         test_scheduler/data/simple_scheduler_test.yaml file.

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -127,6 +127,41 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='intkey_small_batch.yaml')
 
+    @unittest.skip("Skip until STL-485, STL-476")
+    def test_parallel_batch_fails_valid_txn(self):
+        """Tests the parallel scheduler against the
+        test_scheduler/data/batch_fails_valid_txn.yaml file.
+
+        Notes:
+            The yaml file has 4 batches, batches 1 and 3 are invalid, batch
+            2 has a txn that implicitly depends on batch 1.
+            Batch 4 has txns that implicitly depend on batch 2 and 1.
+            Batch 2 and Batch 4 are the only valid batches
+        """
+
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='batch_fails_valid_txn.yaml')
+
+    def test_serial_batch_fails_valid_txn(self):
+        """Tests the serial scheduler against the
+        test_scheduler/data/batch_fails_valid_txn.yaml file.
+
+        Notes:
+            The yaml file has 4 batches, batches 1 and 3 are invalid, batch
+            2 has a txn that implicitly depends on batch 1.
+            Batch 4 has txns that implicitly depend on batch 2 and 1.
+            Batch 2 and Batch 4 are the only valid batches
+        """
+
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='batch_fails_valid_txn.yaml')
+
     def _single_block_files_individually(self,
                                          scheduler,
                                          context_manager,

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -43,18 +43,14 @@ UnProcessedBatchInfo = namedtuple('UnprocessedBatchInfo',
 
 
 def create_transaction(payload, private_key, public_key, inputs=None,
-                        outputs=None, dependencies = None):
+                        outputs=None, dependencies=None):
     addr = '000000' + hashlib.sha512(payload).hexdigest()[:64]
 
     if inputs is None:
         inputs = [addr]
-    else:
-        inputs = inputs.copy().append(addr)
 
     if outputs is None:
         outputs = [addr]
-    else:
-        outputs.copy().append(addr)
 
     if dependencies is None:
         dependencies = []
@@ -295,7 +291,7 @@ class SchedulerTester(object):
         header = transaction_pb2.TransactionHeader()
         header.ParseFromString(txn.header)
 
-        return header.inputs, header.outputs
+        return list(header.inputs), list(header.outputs)
 
     def _bytes_if_none(self, value):
         if value is None:


### PR DESCRIPTION
The first three commits make the yaml testing framework better. The yaml test added in the last commit will be improved by a change to the yaml testing framework, in a future PR. It will also be able to be passed based on work done under issue STL-476, coming in a future PR. This PR is against the parallel-scheduler branch.