### PR TITLE
Add ability for yaml scheduler tester to calculate state for each transaction

### DIFF
--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -67,8 +67,8 @@ class StateContext(object):
         self._state_hash = state_hash
 
         # Create copies of the read and write lists
-        self._read_list = list(read_list)
-        self._write_list = list(write_list)
+        self._read_list = read_list.copy()
+        self._write_list = write_list.copy()
 
         self._state = {}
         self._lock = Lock()


### PR DESCRIPTION
This PR depends on #680 and is made against the parallel-scheduler branch. The first commit is unrelated to the second commit, but is a cleanup commit from a prior PR. The second commit implements the ability to assert that input addresses for a transaction have particular values in state.