### PR TITLE
Add Dockerfile for publishing JS SDK to NPM

### DIFF
--- a/ci/sawtooth-publish-js-sdk
+++ b/ci/sawtooth-publish-js-sdk
@@ -1,0 +1,74 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an environment to publish the Sawtooth JS SDK to NPM. Running it
+#   will update the version, install any NPM dependencies, and finally publish
+#   to the NPM registry. An NPM Auth Token must be set as an environment
+#   variable in the run command.
+#
+# Generating an npm auth token:
+#   $ npm adduser
+#       Username: hyperledger-sawtooth
+#       Password:
+#       Email: (this IS public) distributedledger@intel.com
+#   $ cat ~/.npmrc
+#       (copy the text after "authToken=" on the first line)
+#
+# Build:
+#   $ cd sawtooth-core
+#   $ docker build . -f ci/sawtooth-publish-js-sdk -t sawtooth-publish-js-sdk
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -v $(pwd):/project/sawtooth-core -e AUTH_TOKEN={npm auth token} sawtooth-publish-js-sdk
+
+FROM ubuntu:xenial
+
+# Add additional xenial repos
+RUN sh -c "echo deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse >> /etc/apt/sources.list" && \
+    sh -c "echo deb-src http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse >> /etc/apt/sources.list"
+
+# Create build directories
+RUN mkdir -p /home/build/packages && mkdir -p /home/build/projects
+ENV build_dir=/home/build/projects pkg_dir=/home/build/packages
+
+# Install build deps
+COPY ./bin/install_packaging_deps /home/build/install_packaging_deps
+RUN apt-get update \
+ && /home/build/install_packaging_deps \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Add sawtooth repo and dependencies
+RUN echo "deb http://repo.sawtooth.me/ubuntu/0.8/stable xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8AA7AF1F1091A5FD \
+ && apt-get update \
+ && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
+ && apt-get install -y -q \
+    nodejs \
+    python3-grpcio-tools=1.1.3-1 \
+    python3-grpcio=1.1.3-1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /project/sawtooth-core
+
+# Update version and publish JS SDK
+CMD cd /project/sawtooth-core/sdk/javascript \
+    && echo "//registry.npmjs.org/:_authToken=$AUTH_TOKEN" >> ~/.npmrc \
+    && VERSION=AUTO_STRICT ../../bin/get_version | xargs npm version \
+    && npm install \
+    && npm publish --unsafe-perm

--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -1,0 +1,11 @@
+![Hyperledger Sawtooth](https://raw.githubusercontent.com/hyperledger/sawtooth-core/master/images/sawtooth_logo_light_blue-small.png)
+
+# Hyperledger Sawtooth SDK
+
+*Hyperledger Sawtooth* is an enterprise solution for building, deploying, and running distributed ledgers (also called blockchains). It provides an extremely modular and flexible platform for implementing transaction-based updates to shared state between untrusted parties coordinated by consensus algorithms.
+
+The *Sawtooth SDK* provides a number of useful components that simplify developing JavaScript applications which interface with the Sawtooth platform. These include modules to create and sign Transactions, read state, and  create Transaction Processors. For full usage and installation instructions please reference the official Sawtooth documentation below:
+
+  * [Hyperledger Sawtooth Official Documentation](http://intelledger.github.io/)
+  * [Sawtooth Application Developer's Guide](http://intelledger.github.io/app_developers_guide.html)
+  * [Sawtooth JavaScript SDK Guide](http://intelledger.github.io/app_developers_guide/javascript_sdk.html)

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "standard && node_modules/mocha/bin/mocha --recursive spec",
-    "compile_protobuf": "node compile_protobuf.js > protobuf/protobuf_bundle.json"
+    "compile_protobuf": "node compile_protobuf.js > protobuf/protobuf_bundle.json",
+    "prepublish": "npm run compile_protobuf && npm test"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,7 +1,16 @@
 {
   "name": "sawtooth-sdk",
   "version": "0.0.0",
-  "description": "An SDK for interacting with the Sawtooth Lake distributed ledger",
+  "description": "An SDK for interacting with the Hyperledger Sawtooth distributed ledger.",
+  "keywords": [
+    "hyperledger",
+    "blockchain",
+    "signing",
+    "crypto",
+    "protobuf"
+  ],
+  "homepage": "https://www.hyperledger.org/projects/sawtooth",
+  "repository": "https://github.com/hyperledger/sawtooth-core.git",
   "main": "index.js",
   "scripts": {
     "test": "standard && node_modules/mocha/bin/mocha --recursive spec",

--- a/sdk/javascript/processor/index.js
+++ b/sdk/javascript/processor/index.js
@@ -52,7 +52,7 @@ class TransactionProcessor {
     this._stream.connect(() => {
       this._stream.onReceive(message => {
         if (message.messageType !== Message.MessageType.TP_PROCESS_REQUEST) {
-          if (message.messageType == Message.MessageType.TP_PING){
+          if (message.messageType === Message.MessageType.TP_PING) {
             console.log(`Received TpPing`)
             let pingResponse = TpPingResponse.create({status: TpPingResponse.Status.OK})
             this._stream.sendBack(Message.MessageType.TP_PING_RESPONSE,

--- a/sdk/javascript/protobuf/index.js
+++ b/sdk/javascript/protobuf/index.js
@@ -66,8 +66,7 @@ module.exports = {
 
   TpProcessResponse,
 
-  TpPingResponse:
-    root.lookup("TpProcessResponse"),
+  TpPingResponse,
 
   //
   // State


### PR DESCRIPTION
Also fixes some small typos that broke the JS SDK, and adds a prepublish hook to run tests and compile protobufs.

Note that this Docker will only run if you are in a clean tagged version of that Sawtooth repo.