### PR TITLE
Remove Block and Transaction completness checks from Journal

### DIFF
--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -24,6 +24,8 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 from sawtooth_validator.protobuf.block_pb2 import Block
 
+CHAIN_HEAD_KEY = "chain_head_id"
+
 
 class BlockStore(MutableMapping):
     """
@@ -98,7 +100,7 @@ class BlockStore(MutableMapping):
         if old_chain is not None:
             for blkw in old_chain:
                 del_keys = del_keys + self._build_remove_block_ops(blkw)
-        add_pairs.append(("chain_head_id", new_chain[0].identifier))
+        add_pairs.append((CHAIN_HEAD_KEY, new_chain[0].identifier))
 
         self._block_store.set_batch(add_pairs, del_keys)
         for observer in self._update_obs:
@@ -114,10 +116,10 @@ class BlockStore(MutableMapping):
         """
         Return the head block of the current chain.
         """
-        if "chain_head_id" not in self._block_store:
+        if CHAIN_HEAD_KEY not in self._block_store:
             return None
-        if self._block_store["chain_head_id"] in self._block_store:
-            return self.__getitem__(self._block_store["chain_head_id"])
+        if self._block_store[CHAIN_HEAD_KEY] in self._block_store:
+            return self.__getitem__(self._block_store[CHAIN_HEAD_KEY])
         return None
 
     @property

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -109,26 +109,6 @@ class BlockValidator(object):
 
         return self._block_cache[blkw.previous_block_id].state_root_hash
 
-    def _is_block_complete(self, blkw):
-        """
-        Check that the block is formally complete.
-        - all batches are present and in the correct order
-        :param blkw: the block to verify
-        :return: Boolean - True on success.
-        """
-
-        batch_ids = blkw.header.batch_ids
-        batches = blkw.batches
-
-        if len(batch_ids) != len(batches):
-            return False
-
-        for i in range(0, len(batch_ids)):
-            if batch_ids[i] != batches[i].header_signature:
-                return False
-
-        return True
-
     def _verify_batches_dependencies(self, batch, committed_txn):
         """Verify that all transactions dependencies in this batch have been
         satisfied, ie already committed by this block or prior block in the
@@ -205,9 +185,6 @@ class BlockValidator(object):
                                   data_dir=self._data_dir,
                                   config_dir=self._config_dir,
                                   validator_id=self._identity_public_key)
-
-                if valid:
-                    valid = self._is_block_complete(blkw)
 
                 if valid:
                     valid = self._verify_block_batches(blkw, committed_txn)

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 import hashlib
+import logging
 import pprint
 import random
 import string
@@ -44,7 +45,25 @@ from test_journal.mock import MockBlockSender
 from test_journal.mock import MockStateViewFactory
 from test_journal.mock import MockTransactionExecutor
 
+
 pp = pprint.PrettyPrinter(indent=4)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def dumps_batch(batch):
+    out = '\tbatch: {}\n'.format(batch.header_signature[:8])
+    for txn in batch.transactions:
+        out += '\ttxn: {}\n'.format(txn.header_signature[:8])
+    return out
+
+
+def dumps_block(block):
+    out = 'block: {}\n'.format(block)
+    for batch in block.batches:
+        out += dumps_batch(batch)
+    return out
 
 
 def _generate_id(length=16):
@@ -154,6 +173,7 @@ class BlockTreeManager(object):
         if add_to_store:
             self.block_store[block_wrapper.identifier] = block_wrapper
 
+        LOGGER.debug("Generated %s", dumps_block(block_wrapper))
         return block_wrapper
 
     def generate_chain(self, root_block, blocks, params=None):
@@ -197,7 +217,9 @@ class BlockTreeManager(object):
         signature = signing.sign(header_bytes, self.identity_signing_key)
         block_builder.set_signature(signature)
 
-        return BlockWrapper(block_builder.build_block())
+        block_wrapper = BlockWrapper(block_builder.build_block())
+        LOGGER.debug("Generated %s", dumps_block(block_wrapper))
+        return block_wrapper
 
     def generate_genesis_block(self):
         return self._generate_block(
@@ -274,6 +296,8 @@ class BlockTreeManager(object):
             header_signature=self._signed_header(batch_header),
             transactions=txns)
 
+        LOGGER.debug("Generated %s", dumps_batch(batch))
+
         return batch
 
     def generate_transaction(self, payload='txn', deps=None):
@@ -311,7 +335,7 @@ class BlockTreeManager(object):
             header=batch_header,
             header_signature=self._signed_header(batch_header),
             transactions=[txn])
-
+        LOGGER.debug("Generated %s", dumps_batch(batch))
         return batch
 
     def _signed_header(self, header):

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -89,8 +89,17 @@ class MockScheduler(Scheduler):
         self.batches[batch.header_signature] = batch
 
     def get_batch_execution_result(self, batch_signature):
+        result = True
+        if self.batch_execution_result is None:
+            batch = self.batches[batch_signature]
+            for txn in batch.transactions:
+                if txn.payload == b'BAD':
+                    result = False
+        else:
+            result = self.batch_execution_result
+
         return BatchExecutionResult(
-            is_valid=self.batch_execution_result,
+            is_valid=result,
             state_hash="0000000000")
 
     def set_transaction_execution_result(

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -426,8 +426,7 @@ class TestBlockValidator(unittest.TestCase):
         """
 
         new_block = self.block_tree_manager.generate_block(
-            previous_block=self.root,
-            add_to_store=True)
+            previous_block=self.root)
 
         self.validate_block(new_block)
 
@@ -613,7 +612,7 @@ class TestBlockValidator(unittest.TestCase):
             state_view_factory=self.state_view_factory,
             block_cache=self.block_tree_manager.block_cache,
             done_cb=on_block_validated,
-            executor=MockTransactionExecutor(),
+            executor=MockTransactionExecutor(batch_execution_result=None),
             squash_handler=None,
             identity_signing_key=self.block_tree_manager.identity_signing_key,
             data_dir=None,
@@ -662,7 +661,8 @@ class TestChainController(unittest.TestCase):
                 self.block_tree_manager.state_db),
             block_sender=self.block_sender,
             executor=self.executor,
-            transaction_executor=MockTransactionExecutor(),
+            transaction_executor=MockTransactionExecutor(
+                batch_execution_result=None),
             chain_head_lock=self._chain_head_lock,
             on_chain_updated=chain_updated,
             squash_handler=None,

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -560,24 +560,6 @@ class TestBlockValidator(unittest.TestCase):
         self.assert_invalid_block(new_block)
         self.assert_new_block_not_committed()
 
-    def test_block_missing_batch(self):
-        """
-        Test the case where the new block is missing a batch.
-        """
-        pass
-
-    def test_block_extra_batch(self):
-        """
-        Test the case where the new block has an extra batch.
-        """
-        pass
-
-    def test_block_batches_order(self):
-        """
-        Test the case where the new block has batches that are
-        out of order.
-        """
-        pass
 
     def test_block_missing_batch_dependency(self):
         """


### PR DESCRIPTION
Block and Transaction completness is already enforced by the completer. The duplicate checks are removed from the BlockValidator. 

Journal unit test enhancements to allow for BadTransaction simulation and remove unimplemented test. 


