### PR TITLE
Add version option for rest api and validator

### DIFF
--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -44,6 +44,9 @@ from sawtooth_cli.cluster import add_cluster_parser
 from sawtooth_cli.cluster import do_cluster
 
 
+DISTRIBUTION_NAME = 'sawtooth-cli'
+
+
 def create_console_handler(verbose_level):
     clog = logging.StreamHandler()
     formatter = ColoredFormatter(
@@ -85,15 +88,15 @@ def create_parent_parser(prog_name):
         help='enable more verbose output')
 
     try:
-        version = pkg_resources.get_distribution('sawtooth-cli').version
+        version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
     except pkg_resources.DistributionNotFound:
         version = 'UNKNOWN'
 
     parent_parser.add_argument(
         '-V', '--version',
         action='version',
-        version='sawtooth-cli (Hyperledger Sawtooth) version {}'
-                .format(version),
+        version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
+        .format(version),
         help='print version information')
 
     return parent_parser

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -18,6 +18,7 @@ import sys
 import logging
 import asyncio
 import argparse
+import pkg_resources
 from aiohttp import web
 
 from zmq.asyncio import ZMQEventLoop
@@ -36,6 +37,7 @@ from sawtooth_rest_api.config import RestApiConfig
 
 
 LOGGER = logging.getLogger(__name__)
+DISTRIBUTION_NAME = 'sawtooth-rest-api'
 
 
 def parse_args(args):
@@ -53,6 +55,18 @@ def parse_args(args):
                         action='count',
                         default=0,
                         help='Increase level of output sent to stderr')
+
+    try:
+        version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
+    except pkg_resources.DistributionNotFound:
+        version = 'UNKNOWN'
+
+    parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
+        .format(version),
+        help='print version information')
 
     return parser.parse_args(args)
 

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -17,6 +17,7 @@ import logging
 import sys
 import argparse
 import os
+import pkg_resources
 import netifaces
 
 import sawtooth_signing as signing
@@ -36,6 +37,7 @@ from sawtooth_validator.exceptions import LocalConfigurationError
 
 
 LOGGER = logging.getLogger(__name__)
+DISTRIBUTION_NAME = 'sawtooth-validator'
 
 
 def parse_args(args):
@@ -89,6 +91,18 @@ def parse_args(args):
                         action='count',
                         default=0,
                         help='Increase output sent to stderr')
+
+    try:
+        version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
+    except pkg_resources.DistributionNotFound:
+        version = 'UNKNOWN'
+
+    parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
+        .format(version),
+        help='print version information')
 
     return parser.parse_args(args)
 


### PR DESCRIPTION
Signed-off-by: feihujiang <jiangfeihu@huawei.com>

Implement a "--version, -V" argument for the rest api and validator commands.