### PR TITLE
Provide State Delta Events via Web Socket

### DIFF
--- a/docs/source/rest_api.rst
+++ b/docs/source/rest_api.rst
@@ -7,3 +7,4 @@ REST API Reference
 
    rest_api/endpoint_specs
    rest_api/error_codes
+   rest_api/state_delta_websockets

--- a/docs/source/rest_api/state_delta_websockets.rst
+++ b/docs/source/rest_api/state_delta_websockets.rst
@@ -1,0 +1,155 @@
+*****************************************
+State Delta Subscriptions via Web Sockets
+*****************************************
+
+As transactions are committed to the block chain, an app developer may be
+interested in receiving events related to the changes in state that result.
+These events, `StateDeltaEvents`, include information about the advance of the
+block chain, as well as state changes that can be limited to specific address
+spaces in the global state.
+
+An application can subscribe to receive these events via a web socket, provided
+by the REST API component.  For example, a single-page JavaScript application may
+open a web socket connection and subscribe to a particular transaction family's
+state values, using the incoming events to re-render portions of the display.
+
+.. note::
+
+   All examples here are written in JavaScript, and assumes the Sawtooth REST
+   API is reachable at `localhost`.
+
+Opening a Web Socket
+====================
+
+The application developer must first open a web socket. This is accomplished
+by using standard means.  In the case of in-browser JavaScript:
+
+.. code-block:: javascript
+
+   let ws = new WebSocket('ws:localhost:8080/subscriptions')
+
+If the REST API is running, it should trigger an event on the web socket's
+`onopen` handler.
+
+Subscribing to State Changes
+============================
+
+In order to subscribe to an address space in the global state, first a message
+needs to be sent on the socket with the list of prefixes. It is a best-practice
+to send this message as part of the web socket's `onopen` handler.
+
+In the following example, we'll subscribe to changes in the XO family:
+
+.. code-block:: javascript
+
+  ws.onopen = () => {
+    ws.send(JSON.stringify({
+      'action': 'subscribe',
+      'address_prefixes': ['5b7349']
+    }))
+  }
+
+This message will begin the subscription of events as of the current block.  If
+you are interested in the state prior to the point of subscription, you should
+fetch the values of state via the REST API's `/state` endpoint.
+
+Subscriptions may be changed by sending a subscribe message at later time while
+the websocket is open.  It is up to the client to maintain the list of address
+prefixes of interest.  Any subsequent subscriptions will overwrite this list.
+
+
+Events
+======
+
+Once subscribed, events will be received via the web socket's `onmessage`
+handler. The event data is a JSON string, which looks like the following:
+
+.. code-block:: javascript
+
+  {
+    "block_num": 8,
+    "block_id": "ab7cbc7a...",
+    "previous_block_id": "d4b46c1c...",
+    "state_changes": [
+      {
+        "type": "SET",
+        "value": "oWZQdmxqcmsZU4w"=,
+        "address": "1cf126613a..."
+      },
+      ...
+    ]
+  }
+
+There is an entry in the `state_changes` array for each address that matches the
+`address_prefixes` provided during the subscribe action.  The type is either
+"SET" or "DELETE".  In the case of "SET" the value is base-64 encoded (like the
+`/state` endpoint's response).  In the case of "DELETE", only the address is
+provided. If you are using a transaction family that supports deletes, you'll
+need to keep track of values via address, as well.
+
+Missed Events
+-------------
+
+In the case where you have missed an event, a request can be sent via the web
+socket for a particular block's changes.  You can use the `previous_block_id`
+from the current event to request the previous block's events, for example.
+Send the following message:
+
+.. code-block:: javascript
+
+  ws.send(JSON.stringify({
+    'action': 'get_block_deltas',
+    'block_id': 'd4b46c1c...',
+    'address_prefixes': ['5b7349']
+  }))
+
+The event will be returned in the same manner as any other event, so it is
+recommended that you push the events on to a stack before processing them.
+
+If the block id does not exist, the following error will be returned:
+
+.. code-block:: javascript
+
+  {
+    "error": "Must specify a block id"
+  }
+
+Unsubscribing
+=============
+
+To unsubscribe, you can either close the web socket, or if you want to
+unsubscribe temporarily, you can send an unsubscribe action:
+
+.. code-block:: javascript
+
+  ws.send(JSON.stringify({
+    'action': 'unsubscribe'
+  }))
+
+
+Errors and Warnings
+===================
+
+An open, subscribed web socket may receive the following errors and warnings:
+
+* the validator is unavailable
+* an unknown action was requested
+
+If the validator is unavailable to the REST API process, a warning will be sent
+in lieu of a state delta event:
+
+.. code-block:: javascript
+
+  {
+    "warning": "Validator unavailable"
+  }
+
+If an unrecognized action is sent on to the server via the websocket, an error
+message will be sent back:
+
+.. code-block:: javascript
+
+  {
+    "error": "Unknown action \"bad_action\""
+  }
+

--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -60,7 +60,7 @@ message StateDeltaEvent {
 // Registers a subscriber for StateDeltaEvent objects.  The
 // identity of the subscriber will be based on the ZMQ connection
 // id. This is an idempotent request.
-message RegisterStateDeltaSubscriberRequest {
+message StateDeltaSubscribeRequest {
     // The block id (or ids, if trying to walk back a fork) the
     // subscriber last received deltas on.  It can be set to empty
     // if it has not yet received the genesis block.
@@ -71,8 +71,8 @@ message RegisterStateDeltaSubscriberRequest {
     repeated string address_prefixes = 2;
 }
 
-// The response to a RegisterStateDeltaSubscriberRequest
-message RegisterStateDeltaSubscriberResponse {
+// The response to a StateDeltaSubscribeRequest
+message StateDeltaSubscribeResponse {
     enum Status {
         // returned on successful registration
         OK = 0;
@@ -92,11 +92,11 @@ message RegisterStateDeltaSubscriberResponse {
 // Unregisters a subscriber for StateDeltaEvent objects.  The
 // identity of the subscriber will be based on the ZMQ connection
 // id.  This is an idempotent request.
-message UnregisterStateDeltaSubscriberRequest {
+message StateDeltaUnsubscribeRequest {
     // No data
 }
 
-message UnregisterStateDeltaSubscriberResponse {
+message StateDeltaUnsubscribeResponse {
     enum Status {
         // returned on successful registration
         OK = 0;
@@ -110,7 +110,7 @@ message UnregisterStateDeltaSubscriberResponse {
 // Request message for a set of StateDeltaEvent objects, based on a given list
 // of block_ids and a known filter.  The result will include a set of
 // StateDeltaEvent objects.
-message GetStateDeltaEventsRequest {
+message StateDeltaGetEventsRequest {
     // The block ids to query
     repeated string block_ids = 1;
 
@@ -123,7 +123,7 @@ message GetStateDeltaEventsRequest {
 // Response message for a GetStateDeltasRequest.  Returns a list of
 // StateDeltaEvent objects for the block_ids requested.  Only block_ids known
 // to the validator will result in events.
-message GetStateDeltaEventsResponse {
+message StateDeltaGetEventsResponse {
     enum Status {
         // returned on a successful request
         OK = 0;

--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -1,0 +1,293 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import asyncio
+import logging
+import json
+import aiohttp
+from aiohttp import web
+
+from google.protobuf.json_format import MessageToDict
+
+from sawtooth_rest_api.protobuf.validator_pb2 import Message
+
+from sawtooth_rest_api.protobuf import client_pb2
+from sawtooth_rest_api.protobuf import state_delta_pb2
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class StateDeltaSubscriberHandler:
+    """
+    Handles websocket connections and negotiates their subscriptions for state
+    deltas.
+
+    This handler acts as a subscriber on behalf of all incoming websocket
+    connections.  The handler subscribes to all state delta changes when the
+    first websocket client requests a subscription, regardless of the client's
+    own address prefix filters of interest. Subsequent websocket subscribers
+    all are fed state deltas from the incoming complete stream, filtered by
+    this handler according to their preferred filters.
+    """
+    def __init__(self, connection):
+        """
+        Constructs this handler on a given validator connection.
+
+        Args:
+            connection (messaging.Connection): the validator connection
+        """
+        self._connection = connection
+
+        self._latest_state_delta_event = None
+        self._subscribers = []
+        self._subscriber_lock = asyncio.Lock()
+        self._delta_task = None
+        self._listening = False
+
+    async def on_shutdown(self):
+        """
+        Cleans up any outstanding subscriptions.
+        """
+        await self._unregister_subscriptions()
+
+    async def subscriptions(self, request):
+        """
+        Handles requests for new subscription websockets.
+
+        Args:
+            request (aiohttp.Request): the incoming request
+
+        Returns:
+            aiohttp.web.WebSocketResponse: the websocket response, when the
+                resulting websocket is closed
+        """
+        web_sock = web.WebSocketResponse()
+        await web_sock.prepare(request)
+
+        async for msg in web_sock:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                await self._handle_message(web_sock, msg.data)
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                LOGGER.warning(
+                    'Web socket connection closed with exception %s',
+                    web_sock.exception())
+                await web_sock.close()
+
+        await self._handle_unsubscribe(web_sock)
+
+        return web_sock
+
+    async def _handle_message(self, web_sock, message_content):
+        try:
+            incoming_message = json.loads(message_content)
+        except json.decoder.JSONDecodeError:
+            await web_sock.send_str(json.dumps({
+                'error': 'Invalid input: "{}"'.format(message_content)
+            }))
+            return
+
+        action = incoming_message.get('action', '')
+        if action == 'subscribe':
+            await self._handle_subscribe(web_sock, incoming_message)
+        elif action == 'unsubscribe':
+            await self._handle_unsubscribe(web_sock)
+        elif action == 'get_block_deltas':
+            await self._handle_get_block_deltas(web_sock, incoming_message)
+        else:
+            await web_sock.send_str(json.dumps({
+                'error': 'Unknown action "{}"'.format(action)
+            }))
+
+    async def _handle_subscribe(self, web_sock, subscription_message):
+        if not self._subscribers:
+            last_known_block_id = await self._get_latest_block_id()
+            self._latest_state_delta_event = \
+                await self._get_block_deltas(last_known_block_id)
+
+            LOGGER.debug('Starting subscriber from %s',
+                         last_known_block_id[:8])
+
+            resp = await self._connection.send(
+                Message.STATE_DELTA_SUBSCRIBE_REQUEST,
+                state_delta_pb2.RegisterStateDeltaSubscriberRequest(
+                    last_known_block_ids=[last_known_block_id]
+                ).SerializeToString())
+
+            subscription = state_delta_pb2.\
+                RegisterStateDeltaSubscriberResponse()
+            subscription.ParseFromString(resp.content)
+
+            if subscription.status != \
+                    state_delta_pb2.RegisterStateDeltaSubscriberResponse.OK:
+                LOGGER.error('unable to subscribe!')
+
+            self._listening = True
+            self._delta_task = asyncio.ensure_future(self._listen_for_events())
+
+        LOGGER.debug('Sending initial most recent event to new subscriber')
+
+        addr_prefixes = subscription_message.get('address_prefixes', [])
+        with await self._subscriber_lock:
+            self._subscribers.append((web_sock, addr_prefixes))
+
+        event = self._latest_state_delta_event
+        await web_sock.send_str(json.dumps({
+            'block_id': event.block_id,
+            'block_num': event.block_num,
+            'previous_block_id': event.previous_block_id,
+            'state_changes': StateDeltaSubscriberHandler._client_deltas(
+                event.state_changes, addr_prefixes)
+        }))
+
+    async def _handle_unsubscribe(self, web_sock):
+        index = None
+
+        with await self._subscriber_lock:
+            for i, (subscriber_web_sock, _) in enumerate(self._subscribers):
+                if subscriber_web_sock == web_sock:
+                    index = i
+                    break
+
+            if index is not None:
+                del self._subscribers[index]
+
+            if not self._subscribers:
+                await self._unregister_subscriptions()
+
+    async def _unregister_subscriptions(self):
+        if self._delta_task:
+            self._listening = False
+            self._delta_task.cancel()
+            self._delta_task = None
+
+            LOGGER.info('Unsubscribing for state delta events')
+            req = state_delta_pb2.UnregisterStateDeltaSubscriberRequest()
+            await self._connection.send(
+                Message.STATE_DELTA_UNSUBSCRIBE_REQUEST,
+                req.SerializeToString(),
+                timeout=30)
+
+    async def _handle_get_block_deltas(self, web_sock, get_block_message):
+        if 'block_id' not in get_block_message:
+            await web_sock.send_str(json.dumps({
+                'error': 'Must specify a block id'
+            }))
+            return
+
+        block_id = get_block_message['block_id']
+        addr_prefixes = get_block_message.get('address_prefixes', [])
+
+        event = await self._get_block_deltas(block_id)
+        await web_sock.send_str(json.dumps({
+            'block_id': event.block_id,
+            'block_num': event.block_num,
+            'previous_block_id': event.previous_block_id,
+            'state_changes': StateDeltaSubscriberHandler._client_deltas(
+                event.state_changes, addr_prefixes)
+        }))
+
+    async def _get_block_deltas(self, block_id):
+        resp = await self._connection.send(
+            Message.STATE_DELTA_GET_EVENTS_REQUEST,
+            state_delta_pb2.GetStateDeltaEventsRequest(
+                block_ids=[block_id]).SerializeToString())
+
+        state_deltas_resp = state_delta_pb2.GetStateDeltaEventsResponse()
+        state_deltas_resp.ParseFromString(resp.content)
+
+        if state_deltas_resp.status == \
+                state_delta_pb2.GetStateDeltaEventsResponse.OK:
+            return state_deltas_resp.events[0]
+
+        return None
+
+    async def _get_latest_block_id(self):
+        resp = await self._connection.send(
+            Message.CLIENT_BLOCK_LIST_REQUEST,
+            client_pb2.ClientBlockListRequest(
+                paging=client_pb2.PagingControls(count=1)).SerializeToString())
+
+        block_list_resp = client_pb2.ClientBlockListResponse()
+        block_list_resp.ParseFromString(resp.content)
+
+        if block_list_resp.status != client_pb2.ClientBlockListResponse.OK:
+            LOGGER.error('Unable to fetch latest block id')
+
+        return block_list_resp.head_id
+
+    async def _listen_for_events(self):
+        LOGGER.debug('Subscribing to state delta events')
+        while self._listening:
+            try:
+                msg = await self._connection.receive()
+            except asyncio.CancelledError:
+                return
+
+            # Note: if there are other messages that the REST API will listen
+            # for, a way of splitting the incoming messages will be needed.
+            if msg.message_type == Message.STATE_DELTA_EVENT:
+                state_delta_event = state_delta_pb2.StateDeltaEvent()
+                state_delta_event.ParseFromString(msg.content)
+
+                LOGGER.debug('Received event %s: %s changes',
+                             state_delta_event.block_id[:8],
+                             len(state_delta_event.state_changes))
+
+                base_event = {
+                    'block_id': state_delta_event.block_id,
+                    'block_num': state_delta_event.block_num,
+                    'previous_block_id': state_delta_event.previous_block_id,
+                }
+
+                LOGGER.debug('Updating %s subscribers', len(self._subscribers))
+
+                for (web_sock, addr_prefixes) in self._subscribers:
+                    base_event['state_changes'] = \
+                        StateDeltaSubscriberHandler._client_deltas(
+                            state_delta_event.state_changes, addr_prefixes)
+                    try:
+                        await web_sock.send_str(json.dumps(base_event))
+                    except asyncio.CancelledError:
+                        return
+
+                self._latest_state_delta_event = state_delta_event
+
+    @staticmethod
+    def _client_deltas(state_changes, addr_prefixes):
+        return [_message_to_dict(change)
+                for change in state_changes
+                if StateDeltaSubscriberHandler._matches_prefixes(
+                    change, addr_prefixes)]
+
+    @staticmethod
+    def _matches_prefixes(state_change, addr_prefixes):
+        if not addr_prefixes:
+            return True
+
+        for prefix in addr_prefixes:
+            if state_change.address.startswith(prefix):
+                return True
+
+        return False
+
+
+def _message_to_dict(message):
+    """Converts a Protobuf object to a python dict with desired settings.
+    """
+    return MessageToDict(
+        message,
+        including_default_value_fields=True,
+        preserving_proto_field_name=True)

--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -252,6 +252,10 @@ class StateDeltaSubscriberHandler:
                     'previous_block_id': state_delta_event.previous_block_id,
                 }
 
+                if state_delta_event.block_num <= \
+                        self._latest_state_delta_event.block_num:
+                    base_event['fork_detected'] = True
+
                 LOGGER.debug('Updating %s subscribers', len(self._subscribers))
 
                 for (web_sock, addr_prefixes) in self._subscribers:

--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -197,16 +197,16 @@ class StateDeltaSubscriberHandler:
 
             resp = await self._connection.send(
                 Message.STATE_DELTA_SUBSCRIBE_REQUEST,
-                state_delta_pb2.RegisterStateDeltaSubscriberRequest(
+                state_delta_pb2.StateDeltaSubscribeRequest(
                     last_known_block_ids=[last_known_block_id]
                 ).SerializeToString())
 
             subscription = state_delta_pb2.\
-                RegisterStateDeltaSubscriberResponse()
+                StateDeltaSubscribeResponse()
             subscription.ParseFromString(resp.content)
 
             if subscription.status != \
-                    state_delta_pb2.RegisterStateDeltaSubscriberResponse.OK:
+                    state_delta_pb2.StateDeltaSubscribeResponse.OK:
                 LOGGER.error('unable to subscribe!')
 
             self._listening = True
@@ -222,7 +222,7 @@ class StateDeltaSubscriberHandler:
             self._delta_task = None
 
             LOGGER.info('Unsubscribing for state delta events')
-            req = state_delta_pb2.UnregisterStateDeltaSubscriberRequest()
+            req = state_delta_pb2.StateDeltaUnsubscribeRequest()
             await self._connection.send(
                 Message.STATE_DELTA_UNSUBSCRIBE_REQUEST,
                 req.SerializeToString(),
@@ -250,15 +250,15 @@ class StateDeltaSubscriberHandler:
     async def _get_block_deltas(self, block_id):
         resp = await self._connection.send(
             Message.STATE_DELTA_GET_EVENTS_REQUEST,
-            state_delta_pb2.GetStateDeltaEventsRequest(
+            state_delta_pb2.StateDeltaGetEventsRequest(
                 block_ids=[block_id]).SerializeToString(),
             timeout=DEFAULT_TIMEOUT)
 
-        state_deltas_resp = state_delta_pb2.GetStateDeltaEventsResponse()
+        state_deltas_resp = state_delta_pb2.StateDeltaGetEventsResponse()
         state_deltas_resp.ParseFromString(resp.content)
 
         if state_deltas_resp.status == \
-                state_delta_pb2.GetStateDeltaEventsResponse.OK:
+                state_delta_pb2.StateDeltaGetEventsResponse.OK:
             return state_deltas_resp.events[0]
 
         return None

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -121,12 +121,24 @@ def do_workload(args):
     generator and run.
     """
     try:
+        args.auth_info = _get_auth_info(args.auth_user, args.auth_password)
         generator = WorkloadGenerator(args)
         workload = NoopWorkload(generator, args)
         generator.set_workload(workload)
         generator.run()
     except KeyboardInterrupt:
         generator.stop()
+
+
+def _get_auth_info(auth_user, auth_password):
+    if auth_user is not None:
+        if auth_password is None:
+            auth_password = getpass.getpass(prompt="Auth Password: ")
+        auth_string = "{}:{}".format(auth_user, auth_password)
+        b64_string = b64encode(auth_string.encode()).decode()
+        return b64_string
+    else:
+        return None
 
 
 def add_workload_parser(subparsers, parent_parser):
@@ -149,3 +161,12 @@ def add_workload_parser(subparsers, parent_parser):
                         help='comma separated urls of the REST API to connect '
                         'to.',
                         default="http://127.0.0.1:8080")
+    parser.add_argument('--auth-user',
+                        type=str,
+                        help='username for authentication '
+                             'if REST API is using Basic Auth')
+
+    parser.add_argument('--auth-password',
+                        type=str,
+                        help='password for authentication '
+                             'if REST API is using Basic Auth')

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -61,7 +61,7 @@ from sawtooth_validator.state.state_delta_processor import \
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
 from sawtooth_validator.state.state_delta_processor import \
-    GetStateDeltaEventsHandler
+    StateDeltaGetEventsHandler
 from sawtooth_validator.state.state_delta_store import StateDeltaStore
 from sawtooth_validator.state.state_view import StateViewFactory
 from sawtooth_validator.gossip import signature_verifier
@@ -524,7 +524,7 @@ class Validator(object):
 
         self._dispatcher.add_handler(
             validator_pb2.Message.STATE_DELTA_GET_EVENTS_REQUEST,
-            GetStateDeltaEventsHandler(block_store, state_delta_store),
+            StateDeltaGetEventsHandler(block_store, state_delta_store),
             thread_pool)
 
     def start(self):

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -53,6 +53,10 @@ class _DeltaSubscriber(object):
         return [delta for delta in deltas if self._match(delta.address)]
 
     def _match(self, address):
+        # Match all if there are no prefixes
+        if not self.address_prefixes:
+            return True
+
         for prefix in self.address_prefixes:
             if address.startswith(prefix):
                 return True

--- a/validator/sawtooth_validator/state/state_delta_processor.py
+++ b/validator/sawtooth_validator/state/state_delta_processor.py
@@ -23,17 +23,17 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.protobuf.state_delta_pb2 import StateDeltaEvent
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    RegisterStateDeltaSubscriberRequest
+    StateDeltaSubscribeRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    RegisterStateDeltaSubscriberResponse
+    StateDeltaSubscribeResponse
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    UnregisterStateDeltaSubscriberRequest
+    StateDeltaUnsubscribeRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    UnregisterStateDeltaSubscriberResponse
+    StateDeltaUnsubscribeResponse
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    GetStateDeltaEventsRequest
+    StateDeltaGetEventsRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    GetStateDeltaEventsResponse
+    StateDeltaGetEventsResponse
 
 LOGGER = logging.getLogger(__name__)
 
@@ -242,10 +242,10 @@ class StateDeltaSubscriberValidationHandler(Handler):
         self._delta_processor = delta_processor
 
     def handle(self, connection_id, message_content):
-        request = RegisterStateDeltaSubscriberRequest()
+        request = StateDeltaSubscribeRequest()
         request.ParseFromString(message_content)
 
-        ack = RegisterStateDeltaSubscriberResponse()
+        ack = StateDeltaSubscribeResponse()
         if self._delta_processor.is_valid_subscription(
                 request.last_known_block_ids):
             ack.status = ack.OK
@@ -269,7 +269,7 @@ class StateDeltaAddSubscriberHandler(Handler):
         self._delta_processor = delta_processor
 
     def handle(self, connection_id, message_content):
-        request = RegisterStateDeltaSubscriberRequest()
+        request = StateDeltaSubscribeRequest()
         request.ParseFromString(message_content)
 
         try:
@@ -295,10 +295,10 @@ class StateDeltaUnsubscriberHandler(Handler):
         self._delta_processor = delta_processor
 
     def handle(self, connection_id, message_content):
-        request = UnregisterStateDeltaSubscriberRequest()
+        request = StateDeltaUnsubscribeRequest()
         request.ParseFromString(message_content)
 
-        ack = UnregisterStateDeltaSubscriberResponse()
+        ack = StateDeltaUnsubscribeResponse()
         self._delta_processor.remove_subscriber(connection_id)
         ack.status = ack.OK
 
@@ -308,7 +308,7 @@ class StateDeltaUnsubscriberHandler(Handler):
             message_type=self._msg_type)
 
 
-class GetStateDeltaEventsHandler(Handler):
+class StateDeltaGetEventsHandler(Handler):
     """Handles receiving messages for getting state delta events based on block
     ids.
     """
@@ -319,7 +319,7 @@ class GetStateDeltaEventsHandler(Handler):
         self._state_delta_store = state_delta_store
 
     def handle(self, connection_id, message_content):
-        request = GetStateDeltaEventsRequest()
+        request = StateDeltaGetEventsRequest()
         request.ParseFromString(message_content)
 
         # Create a temporary subscriber for this response
@@ -349,10 +349,10 @@ class GetStateDeltaEventsHandler(Handler):
 
             events.append(event)
 
-        status = GetStateDeltaEventsResponse.OK if events else \
-            GetStateDeltaEventsResponse.NO_VALID_BLOCKS_SPECIFIED
+        status = StateDeltaGetEventsResponse.OK if events else \
+            StateDeltaGetEventsResponse.NO_VALID_BLOCKS_SPECIFIED
 
-        ack = GetStateDeltaEventsResponse(status=status, events=events)
+        ack = StateDeltaGetEventsResponse(status=status, events=events)
 
         return HandlerResult(
             HandlerStatus.RETURN,

--- a/validator/tests/test_state_delta_processor/tests.py
+++ b/validator/tests/test_state_delta_processor/tests.py
@@ -33,22 +33,22 @@ from sawtooth_validator.state.state_delta_processor import \
 from sawtooth_validator.state.state_delta_processor import \
     StateDeltaUnsubscriberHandler
 from sawtooth_validator.state.state_delta_processor import \
-    GetStateDeltaEventsHandler
+    StateDeltaGetEventsHandler
 
 from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
 from sawtooth_validator.protobuf.state_delta_pb2 import StateDeltaEvent
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    RegisterStateDeltaSubscriberRequest
+    StateDeltaSubscribeRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    RegisterStateDeltaSubscriberResponse
+    StateDeltaSubscribeResponse
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    UnregisterStateDeltaSubscriberRequest
+    StateDeltaUnsubscribeRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    UnregisterStateDeltaSubscriberResponse
+    StateDeltaUnsubscribeResponse
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    GetStateDeltaEventsRequest
+    StateDeltaGetEventsRequest
 from sawtooth_validator.protobuf.state_delta_pb2 import \
-    GetStateDeltaEventsResponse
+    StateDeltaGetEventsResponse
 from sawtooth_validator.protobuf import validator_pb2
 
 from test_journal.block_tree_manager import BlockTreeManager
@@ -69,7 +69,7 @@ class StateDeltaSubscriberValidationHandlerTest(unittest.TestCase):
 
         handler = StateDeltaSubscriberValidationHandler(delta_processor)
 
-        request = RegisterStateDeltaSubscriberRequest(
+        request = StateDeltaSubscribeRequest(
             last_known_block_ids=[block_tree_manager.chain_head.identifier],
             address_prefixes=['000000']).SerializeToString()
 
@@ -77,7 +77,7 @@ class StateDeltaSubscriberValidationHandlerTest(unittest.TestCase):
 
         self.assertEqual(HandlerStatus.RETURN_AND_PASS, response.status)
 
-        self.assertEqual(RegisterStateDeltaSubscriberResponse.OK,
+        self.assertEqual(StateDeltaSubscribeResponse.OK,
                          response.message_out.status)
 
     def test_register_with_uknown_block_ids(self):
@@ -94,7 +94,7 @@ class StateDeltaSubscriberValidationHandlerTest(unittest.TestCase):
 
         handler = StateDeltaSubscriberValidationHandler(delta_processor)
 
-        request = RegisterStateDeltaSubscriberRequest(
+        request = StateDeltaSubscribeRequest(
             last_known_block_ids=['a'],
             address_prefixes=['000000']).SerializeToString()
 
@@ -103,7 +103,7 @@ class StateDeltaSubscriberValidationHandlerTest(unittest.TestCase):
         self.assertEqual(HandlerStatus.RETURN, response.status)
 
         self.assertEqual(
-            RegisterStateDeltaSubscriberResponse.UNKNOWN_BLOCK,
+            StateDeltaSubscribeResponse.UNKNOWN_BLOCK,
             response.message_out.status)
 
 
@@ -120,7 +120,7 @@ class StateDeltaAddSubscriberHandlerTest(unittest.TestCase):
 
         handler = StateDeltaAddSubscriberHandler(delta_processor)
 
-        request = RegisterStateDeltaSubscriberRequest(
+        request = StateDeltaSubscribeRequest(
             last_known_block_ids=[block_tree_manager.chain_head.identifier],
             address_prefixes=['0123456']).SerializeToString()
 
@@ -144,7 +144,7 @@ class StateDeltaAddSubscriberHandlerTest(unittest.TestCase):
 
         handler = StateDeltaAddSubscriberHandler(delta_processor)
 
-        request = RegisterStateDeltaSubscriberRequest(
+        request = StateDeltaSubscribeRequest(
             last_known_block_ids=['a'],
             address_prefixes=['000000']).SerializeToString()
 
@@ -163,7 +163,7 @@ class StateDeltaUnregisterSubscriberHandlerTest(unittest.TestCase):
         mock_delta_processor = Mock()
         handler = StateDeltaUnsubscriberHandler(mock_delta_processor)
 
-        request = UnregisterStateDeltaSubscriberRequest().SerializeToString()
+        request = StateDeltaUnsubscribeRequest().SerializeToString()
 
         response = handler.handle('test_conn_id', request)
 
@@ -171,13 +171,13 @@ class StateDeltaUnregisterSubscriberHandlerTest(unittest.TestCase):
             'test_conn_id')
 
         self.assertEqual(HandlerStatus.RETURN, response.status)
-        self.assertEqual(UnregisterStateDeltaSubscriberResponse.OK,
+        self.assertEqual(StateDeltaUnsubscribeResponse.OK,
                          response.message_out.status)
 
 
-class GetStateDeltaEventsHandlerTest(unittest.TestCase):
+class StateDeltaGetEventsHandlerTest(unittest.TestCase):
     def test_get_events(self):
-        """Tests that the GetStateDeltaEventsHandler will return a response
+        """Tests that the StateDeltaGetEventsHandler will return a response
         with the state event for the block requested.
         """
         block_tree_manager = BlockTreeManager()
@@ -193,16 +193,16 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
                          value='some other state value'.encode(),
                          type=StateChange.SET)])
 
-        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+        handler = StateDeltaGetEventsHandler(block_tree_manager.block_store,
                                              delta_store)
 
-        request = GetStateDeltaEventsRequest(
+        request = StateDeltaGetEventsRequest(
             block_ids=[block_tree_manager.chain_head.identifier],
             address_prefixes=['deadbeef']).SerializeToString()
 
         response = handler.handle('test_conn_id', request)
         self.assertEqual(HandlerStatus.RETURN, response.status)
-        self.assertEqual(GetStateDeltaEventsResponse.OK,
+        self.assertEqual(StateDeltaGetEventsResponse.OK,
                          response.message_out.status)
 
         chain_head = block_tree_manager.chain_head
@@ -218,7 +218,7 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
             [event for event in response.message_out.events])
 
     def test_get_events_ignore_bad_blocks(self):
-        """Tests that the GetStateDeltaEventsHandler will return a response
+        """Tests that the StateDeltaGetEventsHandler will return a response
         containing only the events for blocks that exists.
         """
         block_tree_manager = BlockTreeManager()
@@ -234,17 +234,17 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
                          value='some other state value'.encode(),
                          type=StateChange.SET)])
 
-        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+        handler = StateDeltaGetEventsHandler(block_tree_manager.block_store,
                                              delta_store)
 
-        request = GetStateDeltaEventsRequest(
+        request = StateDeltaGetEventsRequest(
             block_ids=[block_tree_manager.chain_head.identifier,
                        'somebadblockid'],
             address_prefixes=['deadbeef']).SerializeToString()
 
         response = handler.handle('test_conn_id', request)
         self.assertEqual(HandlerStatus.RETURN, response.status)
-        self.assertEqual(GetStateDeltaEventsResponse.OK,
+        self.assertEqual(StateDeltaGetEventsResponse.OK,
                          response.message_out.status)
 
         chain_head = block_tree_manager.chain_head
@@ -260,7 +260,7 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
             [event for event in response.message_out.events])
 
     def test_get_events_no_valid_block_ids(self):
-        """Tests that the GetStateDeltaEventsHandler will return a response
+        """Tests that the StateDeltaGetEventsHandler will return a response
         with NO_VALID_BLOCKS_SPECIFIED error when no valid blocks are
         specified in the request.
         """
@@ -268,17 +268,17 @@ class GetStateDeltaEventsHandlerTest(unittest.TestCase):
 
         delta_store = StateDeltaStore(DictDatabase())
 
-        handler = GetStateDeltaEventsHandler(block_tree_manager.block_store,
+        handler = StateDeltaGetEventsHandler(block_tree_manager.block_store,
                                              delta_store)
 
-        request = GetStateDeltaEventsRequest(
+        request = StateDeltaGetEventsRequest(
             block_ids=['somebadblockid'],
             address_prefixes=['deadbeef']).SerializeToString()
 
         response = handler.handle('test_conn_id', request)
 
         self.assertEqual(HandlerStatus.RETURN, response.status)
-        self.assertEqual(GetStateDeltaEventsResponse.NO_VALID_BLOCKS_SPECIFIED,
+        self.assertEqual(StateDeltaGetEventsResponse.NO_VALID_BLOCKS_SPECIFIED,
                          response.message_out.status)
 
 


### PR DESCRIPTION
Provide state delta events over a web socket connection.  

Subscriptions are limited to only starting at the current block.  Web socket-based subscribers cannot specify the block they start with, unlike ZMQ subscribers (the REST API doesn't maintain a cache of the state changes). 

Users of the web socket may request specific events by block id, to get missed events if necessary, but the expectation is that they will have queried the state directly for the current value, and then subscribe to future events.