### PR TITLE
Fix typos and inaccuracies in Supply Chain documentation

### DIFF
--- a/docs/source/examples/supplychain/supplychain_transaction_family.rst
+++ b/docs/source/examples/supplychain/supplychain_transaction_family.rst
@@ -1,39 +1,39 @@
-***************************************
+*******************************
 Supply Chain Transaction Family
-***************************************
+*******************************
 
 Overview
 =========
 
-The Supplychain Transaction Processor (SCTP) provides a mechanism for
+The Supply Chain Transaction Processor (SCTP) provides a mechanism for
 storing records of asset ownership. The SCTP tracks records, which correlate
-to a real world item. Every Record has an owner and a custodaian, which can
+to a real world item. Every Record has an owner and a custodian, which can
 be the same Agent. The owner is the Agent the legally owns the good. The
-custodian is the Agent that is in possesion of the good, which may be a
+custodian is the Agent that is in possession of the good, which may be a
 warehousing service, transportation service, etc. Agents are actors in the
-system that are can manupulate the Records by updating them or transfering
+system that can manipulate the Records by updating them or transferring
 their role to other Agents. Agents are identified by their public key and
 authenticated by the signature on the transactions they submit. Transfer of
-roles (Owner, Custodian) betweeen Agents is done via an Application process,
-Where the Agent wishing to assume the role Applies for the new role and the
-Agent in the role currently can either accept or reject that applicaiton.
+roles (Owner, Custodian) between Agents is done via an Application process,
+where the Agent wishing to assume the role applies for the new role and the
+Agent in the role currently can either accept or reject that Application.
 
-This is an proof of concept Transaction Processor that is actively being
-developed. As such it has not been thoughly tested and there will be
-protentially breaking changes made to it.
+This is a proof of concept Transaction Processor that is actively being
+developed. As such it has not been thoroughly tested and there will potentially
+be breaking changes made to it.
 
 State
 =====
 
 This section describes in detail how SCTP objects are stored and addressed in
-the global state. All objects in state are stored as encoded protobufs. Each
-type of object below is stored in containers at nodes in the Merkle Trie. The
+the global state. All objects in state are stored as encoded Protobufs. Each
+type of object below is stored in containers at nodes in the Merkle trie. The
 address of the Merkle nodes is detailed below in the addressing section. The
 entry at the nodes is a container object that allows for multiple items to be
 stored at that node if there is an address collision. All items stored in state
-are include their natural key. When an address collision occurs the item stored
-at the address are searched to find the item with the natural key that matches
-the key being searched for.
+include their natural key. When an address collision occurs the items stored at
+the address are searched to find the item with the natural key that matches the
+key being searched for.
 
 SCTP stores the following data objects:
 
@@ -71,33 +71,34 @@ Addressing
 When a setting is read or changed, it is accessed by addressing it using the
 following algorithm:
 
-The SCTP uses the 3 namespaces, to store the corresponding objects:
+The SCTP uses these three namespaces to store the corresponding objects:
     - supplychain.agent
     - supplychain.application
     - supplychain.record
 
 The strings are converted to a Merkle prefix by taking the first 6 characters
-of the hex encoded sha512 hash of the string.
+of the hex encoded SHA-512 hash of the string.
 
-Agent addresses are generated sha512(agent_pub_key), prepended with the
-supplychain.agent namespace.
+Agent addresses are generated with ``sha512(agent_pub_key)``, and prepended
+with the ``supplychain.agent`` namespace.
 
 .. code-block:: python
 
     address = hashlib.sha512(public_key.encode()).hexdigest()[0:64]
 
 
-Application are stored using the Record address and the supplychain.application
-namespace. This stores all application for a record at the same address.
-The correct Application must be searched for useing the public_key of the
-applicant, the Application type, and the Application status.
+Applications are stored using the Record address and the
+``supplychain.application`` namespace. This stores all applications for a
+record at the same address. The correct Application must be searched for using
+the ``public_key`` of the applicant, the Application type, and the Application
+status.
 
 .. code-block:: python
 
     address_addr = namespace + sha512(record_identifier)).hexdigest()[0:64]
 
-Record addresses are generated sha512 of the records natural key., prepended
-with the supplychain.record namespace.
+Record addresses are a generated SHA-512 hash of the record's natural key
+prepended with the ``supplychain.record`` namespace.
 
 .. code-block:: python
 
@@ -110,7 +111,7 @@ Transactions
 Transaction Headers
 -------------------
 
-The settings for the common Sawtooth Transaction header fields.
+The settings for the common Sawtooth transaction header fields.
 
 .. code-block:: javascript
 
@@ -122,12 +123,13 @@ The settings for the common Sawtooth Transaction header fields.
 
 Inputs and Outputs
 ++++++++++++++++++
-The inputs for Supplychain family transactions must include:
-- the address of the object the transaction is operating on if it is a record
+
+The inputs for Supply Chain family transactions must include:
+- The address of the object the transaction is operating on if it is a Record
 operation
 - Any Agents involved in the operation
 
-The outputs for Supplychain family transactions must include:
+The outputs for Supply Chain family transactions must include:
 - The address of the object the transaction is operating on if it is a Record
 operation
 - Any Agents involved in the operation
@@ -136,14 +138,14 @@ Dependencies
 ++++++++++++
 
 Transactions should be batched and specify any transactions that they expect
-to be commited as dependencies.
+to be committed as dependencies.
 
 
 Transaction Payload
 ===================
 
 All SCTP transactions are wrapped in a payload object that allows for the items
-to be dispatch to the correct handling logic.
+to be dispatched to the correct handling logic.
 
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
@@ -157,8 +159,9 @@ Agent Transactions
 Create Agent
 ++++++++++++
 
-Create an agent record, the signer_pubkey in the transaction header will
-be used as the agent's public key.
+Register a signing participant that can update Records and Applications. The
+``signer_pubkey`` in the transaction header will be used as the Agent's public
+key.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -181,7 +184,7 @@ set to the signer of this transaction.
 Create Application
 ++++++++++++++++++
 
-Create an application for transfer of ownership or custodianship of the record.
+Create a request for transfer of ownership or custodianship of the record.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -191,8 +194,8 @@ Create an application for transfer of ownership or custodianship of the record.
 Accept Application
 ++++++++++++++++++
 
-Accept an application for transfer of ownership or custodianship of the record.
-Must be submitted by the current owner or custodian.
+Accept an Application for transfer of ownership or custodianship of a Record.
+Must be submitted by the current Owner or Custodian.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -201,9 +204,9 @@ Must be submitted by the current owner or custodian.
 Reject Application
 ++++++++++++++++++
 
-Reject an application for transfer of ownership or custodianship of the
-record. Must be submitted by the current owner or custodian depending on
-application type.
+Reject an Application for transfer of ownership or custodianship of the
+record. Must be submitted by the current Owner or Custodian depending on
+Application type.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -212,8 +215,8 @@ application type.
 Cancel Application
 ++++++++++++++++++
 
-Cancel an application for transfer of ownership or custodianship of the record.
-Must be submitted by the Applicant.
+Cancel an Application for transfer of ownership or custodianship of the record.
+Must be submitted by the applicant.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -223,8 +226,8 @@ Must be submitted by the Applicant.
 Finalize Record
 +++++++++++++++
 
-Mark the record as final (no longer able to be updated). The owner must be
-the current custodian and this transaction must be signed by the owner.
+Mark the record as final (no longer able to be updated). The Owner must be
+the current Custodian and this transaction must be signed by the Owner.
 
 .. literalinclude:: ../../../../families/supplychain/protos/payload.proto
     :language: protobuf
@@ -235,12 +238,12 @@ Execution
 
 Agents can only be created by transactions signed with their private key.
 
-Records exist in a active modifiable state until they are finalized. Once a
-Record is finalized it can be thought of as destroyed, the item it represents
-has either consumed in manufacturing, lost, or the victim of an
+Records exist in an active modifiable state until they are finalized. Once a
+Record is finalized, it can be thought of as destroyed. A finalized item
+has either been consumed in manufacturing, lost, or the victim of an
 unfortunate accident.
 
-Applications can only be created by the applicant agent and then transitioned
-to either an Accepted state which means the proposal has been executed and the
-role on the Record has been updated or a closed state (rejected/canceled) if
+Applications can only be created by the applying Agent and then transitioned
+to either an Accepted state, which means the proposal has been executed and the
+role on the Record has been updated, or a closed state (Rejected/Canceled) if
 either of the Agents involved do not want the application.

--- a/families/supplychain/protos/agent.proto
+++ b/families/supplychain/protos/agent.proto
@@ -18,15 +18,19 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "sawtooth.supplychain.protobuf";
 
-// Agent State Representation
+// The representation of an Agent to store in state.
+// Agents are essentially public keys registered with a human readable name on
+// the chain. They will be able to create Records and submit Applications for
+// ownership or custodianship.
 message Agent {
-    string identifier = 1; // the hex encoded public key of the agent
-    string name = 2; // the agent name
+    string identifier = 1; // the hex-encoded public key of the Agent
+    string name = 2; // a human readable name
 }
 
-// Agent Container for storage in global state
+// Container for on-chain Agents.
+// Allows multiple to be saved at a single address in case of hash collision.
 message AgentContainer {
-    // List of agents entries - more than one implies a state key collision
+    // List of Agents - more than one implies a state address collision
     repeated Agent entries = 1;
 }
 

--- a/families/supplychain/protos/application.proto
+++ b/families/supplychain/protos/application.proto
@@ -18,22 +18,22 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "sawtooth.supplychain.protobuf";
 
-// Application State Representation
-// application for change in ownership of the record
+// The representation of an Application to store in state.
+// Applications are a request for ownership or custodianship of a Record.
 message Application {
 
     string record_identifier = 1; // the natural key of the record
     string applicant = 2; // public key of the applicant
     int64 creation_time = 3;
 
-    // The Type indicates the type of this Application
+    // Whether this Application is a request for ownership or custodianship
     enum Type {
         OWNER = 0;
         CUSTODIAN = 1;
     }
     Type type = 4;
 
-    // The Status indicates the type of this Application
+    // The current acceptance status
     enum Status {
         OPEN = 0;
         CANCELED = 1;
@@ -41,12 +41,14 @@ message Application {
         ACCEPTED = 3;
     }
     Status status = 5;
-    string terms = 6; // the terms of the application. Human readable.
+
+    string terms = 6; // human readable terms
 }
 
-// Setting Container for on-chain configuration key/value pairs
+// Container for on-chain Applications.
+// Allows multiple to be saved at a single address in case of hash collision.
 message ApplicationContainer {
-    // List of Application entries - more than one implies a state key collision
+    // List of Applications - more than one implies a state address collision
     repeated Application entries = 1;
 }
 

--- a/families/supplychain/protos/payload.proto
+++ b/families/supplychain/protos/payload.proto
@@ -19,9 +19,10 @@ import "application.proto";
 option java_multiple_files = true;
 option java_package = "sawtooth.supplychain.protobuf";
 
-// Supplychain Transaction Setting Payload
+// Wrapper for Transaction payloads for the Supply Chain Transaction Family
 message SupplyChainPayload {
-    // The action indicates data is contained within this payload
+    // Describes the action this payload is initiating.
+    // Used to "route" the data to the proper handler.
     enum Action {
         AGENT_CREATE = 0;
         APPLICATION_CREATE = 1;
@@ -32,10 +33,8 @@ message SupplyChainPayload {
         RECORD_FINALIZE = 6;
     }
 
-    // The action of this payload
     Action action = 1;
 
-    // The content of this payload
     bytes data = 2;
 }
 

--- a/families/supplychain/protos/record.proto
+++ b/families/supplychain/protos/record.proto
@@ -18,8 +18,8 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "sawtooth.supplychain.protobuf";
 
-// Record State Representation
-// represents an item being tracked
+// The representation of a Record to store in state.
+// A Record tracks a physical item with a history of its owners and custodians.
 message Record {
     string identifier = 1; // the natural key of the record, serial number or
     // attached sensor identifier
@@ -30,20 +30,20 @@ message Record {
         string agent_identifier = 1; // the public key of the agent
         int64 start_time = 2; // the time the agent started in the role
     }
-    repeated AgentRecord owners = 3; // ordered list of the owners, current
-    // owner is first in the list. List is ordered in chronological order oldest
-    // to most recent. The first by definition is the creator of the record.
+    repeated AgentRecord owners = 3; // list of the owners, ordered from oldest
+    // to newest. The first by definition is the creator of the record.
     // The last is the current owner of the record.
     repeated AgentRecord custodians = 4; // ordered list of custodians.
-    // current owner is first in the list. Same ordering as the owners list.
+    // Same ordering as the owners list.
 
     bool final = 5; // is the record finalized, finalized records cannot be
     // changed.
 }
 
-// Setting Container for on-chain configuration key/value pairs
+// Container for on-chain Records.
+// Allows multiple to be saved at a single address in case of hash collision.
 message RecordContainer {
-    // List of Record entries - more than one implies a state key collision
+    // List of Records - more than one implies a state address collision
     repeated Record entries = 1;
 }
 


### PR DESCRIPTION
This PR fixes spelling/grammar errors and misaligned code blocks in the Supply Chain Transaction Family document. It does not alter the wording or flow of this document.

It also addresses some inaccurate and unclear docstrings in the Supply Chain proto-files. These have been reworded somewhat more heavily than the Transaction Family document.

This PR does not alter any functionality.