### PR TITLE
STL-461 Java SDK transaction signing

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -78,5 +78,16 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.bitcoinj</groupId>
+            <artifactId>bitcoinj-core</artifactId>
+            <version>0.14.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.lambdaworks</groupId>  <!-- Exclude invalid, unneeded signed jar -->
+                    <artifactId>scrypt</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/sdk/java/src/main/java/sawtooth/sdk/client/sawtooth/sdk/client/Signing.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/client/sawtooth/sdk/client/Signing.java
@@ -1,0 +1,45 @@
+package sawtooth.sdk.client.sawtooth.sdk.client;
+
+import org.bitcoinj.core.DumpedPrivateKey;
+import org.bitcoinj.core.ECKey;
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Utils;
+
+import java.security.SecureRandom;
+
+
+public class Signing {
+
+  private static final NetworkParameters MAINNET = org.bitcoinj.params.MainNetParams.get();
+
+  public static ECKey readWif(String wif) {
+    return DumpedPrivateKey.fromBase58(MAINNET, wif).getKey();
+  }
+
+  public static ECKey generatePrivateKey(SecureRandom random) {
+    return new ECKey(random);
+  }
+
+  public static String getPublicKey(ECKey privateKey) {
+    return "03" + privateKey.getPublicKeyAsHex();
+  }
+
+  /**
+   * Returns a bitcoin-style 64-byte compact signature.
+   * @param privateKey the private key with which to sign
+   * @param data the data to sign
+   * @return String the signature
+   */
+  public static String sign(ECKey privateKey, byte[] data) {
+    Sha256Hash hash = Sha256Hash.of(data);
+    ECKey.ECDSASignature sig = privateKey.sign(hash);
+
+    byte[] csig = new byte[64];
+
+    System.arraycopy(Utils.bigIntegerToBytes(sig.r, 32), 0, csig, 0, 32);
+    System.arraycopy(Utils.bigIntegerToBytes(sig.s, 32), 0, csig, 32, 32);
+
+    return Utils.HEX.encode(csig);
+  }
+}


### PR DESCRIPTION
*Includes*

- wif reading
- public key derivation from the private key
- transaction signing using the 'compact signature' scheme

*Does not cover*
- payload verification

This has been verified by signing a payload in Java, then verifying it in Python.

I had to exclude a transitive scrypt lib inclusion, as it had a signed but invalid jar.