### PR TITLE
Remove redundant "sawtooth" from REST API log name

### DIFF
--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -158,7 +158,7 @@ def main():
             log_configuration(log_config=log_config)
         else:
             log_dir = get_log_dir()
-            log_configuration(log_dir=log_dir, name="sawtooth_rest_api")
+            log_configuration(log_dir=log_dir, name="rest_api")
         init_console_logging(verbose_level=opts.verbose)
 
         try:


### PR DESCRIPTION
As logs are stored in a "sawtooth" directory, labeling the REST API's
log file "sawtooth_rest_api" is redundant, and does not match the pattern
used by other log files. Renamed to "rest_api".