### PR TITLE
Minor doc updates. 

### DIFF
--- a/docs/source/architecture/validator_network.rst
+++ b/docs/source/architecture/validator_network.rst
@@ -196,10 +196,11 @@ Network Layer Security
 
 0MQ includes a TLS [#f3]_ like certificate exchange mechanism and protocol
 encryption capability which is transparent to the socket implementation.
-Support for socket level encryption is currently implemented with hardcoded
-server keys, to avoid needing separate identities for each validator's server
-socket. This is appropriate for a public network. For each client, ephemeral
-certificates are generated on connect.
+Support for socket level encryption is currently implemented with
+server keys being read from the validator.toml config file. For each client,
+ephemeral certificates are generated on connect. If the server key pair is not
+configured, network communications between validators will not be authenticated
+or encrypted.
 
 .. rubric:: Footnotes
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -9,36 +9,10 @@ Validators
 How do I change the validator configuration?
 --------------------------------------------
 
-An example configuration file is at  `sawtooth-core/validator/etc/txnvalidator.js.example`. 
-Copy that file to a new file in
-the same directory and make changes to the new file. When starting the
-txnvalidator, use the `--config` argument to reference the configuration file,
-In this example, we have copied the `txnvalidator.js.example` file to `single-
-node.js` and modified it:
+An example configuration file is at `sawtooth-core/packaging/validator.toml.example`.
+Copy that file to a new file named validator.toml. The new file should be
+placed into the config directory declared by path.toml. Edit the validator.toml
+file to configure the validator to your needs. When starting sawtooth-validator,
+the config file will automatically be found and applied.
 
-.. code-block:: console
-
-    $ cd /project/sawtooth-core
-    $ ./bin/txnvalidator -v --config validator/etc/single-node.js
-
-Multiple config files can be overlaid, and all of the settings in the
-config file can be overridden on the command line, but that's beyond the
-scope of this answer.
-
-What configuration changes should I make to run a single validator?
--------------------------------------------------------------------
-
-Copy the file `sawtooth-core/validator/etc/txnvalidator.js.example` to `single-node.js` and
-make the following changes:
-
-
-`TargetWaitTime`
-The desired mean inter-block commit time across the network.
-While the default is 30 seconds, we recommend 5 seconds for
-development and experimenting.
-
-`InitialWaitTime`
-This is only important when starting the first node which
-will initialize the ledger (i.e. `GenesisLedger` is true).
-This will often be the case when testing. We recommend setting
-it to the same value as `TargetWaitTime`.
+Most of the settings in the config file can be overridden on the command line.


### PR DESCRIPTION
Removes outdated reference to hard coded zmq server keys.
Updates the FAQ to no long reference 0.7 and correctly explains how to configure the validator in 0.8. 