### PR TITLE
Add docker-compose files for stat collection

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -25,6 +25,9 @@
 - name: Nicholas Drozd
   user: nick-drozd
 
+- name: Joel Dudley
+  user: joeldudleyr3
+
 - name: Mark Ford
   user: mfford
 
@@ -49,6 +52,9 @@
 - name: Ry Jones
   user: ryjones
 
+- name: Chris Khan
+  user: ckr3
+ 
 - name: Adam Ludvik
   user: aludvik
 

--- a/COMMITTERS
+++ b/COMMITTERS
@@ -16,6 +16,9 @@
 - name: Jordan Byrd
   user: jabyrd3
 
+- name: James Carlyle
+  user: jamescarlyle
+
 - name: Naissa Conde
   user: nconde
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
@@ -33,7 +33,7 @@ def create_console_handler(verbose_level):
     formatter = ColoredFormatter(
         "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
         "%(white)s%(message)s",
-        datefmt="%H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S",
         reset=True,
         log_colors={
             'DEBUG': 'cyan',

--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_enclave/poet_state.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_enclave/poet_state.cpp
@@ -198,7 +198,7 @@ void PoetState::SetCurrentWaitTimer(
     sp::ThrowIfNull(waitTimerSignature, "Wait timer signature is NULL");
 
     // Copy the wait timer signature and set the valid flag to indicate that
-    // there is a currently wait timer.
+    // there is currently a wait timer.
     memcpy(
         &this->state->currentWaitTimerSignature,
         waitTimerSignature,

--- a/docker/compose/sawtooth-local.yaml
+++ b/docker/compose/sawtooth-local.yaml
@@ -1,0 +1,106 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-settings-tp-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-intkey-tp-python-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: intkey-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  xo-tp-python:
+    image: sawtooth-xo-tp-python:latest
+    container_name: sawtooth-xo-tp-python-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: xo-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-validator-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        sawtooth-validator -vv \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-rest-api-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    stop_signal: SIGKILL
+
+  client:
+    image: sawtooth-dev-python:latest
+    container_name: sawtooth-client-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 8080
+      - 4004
+    depends_on:
+      - rest-api
+    entrypoint: "bash -c \"\
+        sawtooth keygen && \
+        tail -f /dev/null \
+        \""
+
+networks:
+  default:
+    external:
+      name: sawtooth_stats

--- a/docs/source/architecture/validator_network.rst
+++ b/docs/source/architecture/validator_network.rst
@@ -196,10 +196,11 @@ Network Layer Security
 
 0MQ includes a TLS [#f3]_ like certificate exchange mechanism and protocol
 encryption capability which is transparent to the socket implementation.
-Support for socket level encryption is currently implemented with hardcoded
-server keys, to avoid needing separate identities for each validator's server
-socket. This is appropriate for a public network. For each client, ephemeral
-certificates are generated on connect.
+Support for socket level encryption is currently implemented with
+server keys being read from the validator.toml config file. For each client,
+ephemeral certificates are generated on connect. If the server key pair is not
+configured, network communications between validators will not be authenticated
+or encrypted.
 
 .. rubric:: Footnotes
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -6,3 +6,4 @@ Examples
    :maxdepth: 2
 
    examples/supplychain/overview
+   examples/private_utxo/overview

--- a/docs/source/examples/private_utxo/overview.rst
+++ b/docs/source/examples/private_utxo/overview.rst
@@ -1,0 +1,229 @@
+********************
+Private UTXO Example
+********************
+
+This example shows how assets may be created and traded on the Sawtooth Ledger
+and how SGX may be utilized to allow for assets to be transfered off ledger and
+traded in private between parties with only the trading parties knowing the
+details of the transaction.
+
+
+Private UTXO Overview
+=====================
+
+The Private UTXO example allows for assets to be tracked and traded on the
+Ledger. These assets can also be held off the Ledger and still traded in a
+manner that enforces the Ledger rules governing the Asset and allows
+transactional privacy for the owner of the asset. Assets in this system can
+exist in two states; on-Ledger and off-Ledger. When assets are on-Ledger, they
+are held in "Holdings" associated with the owner’s public key. In this state
+the balances and trades of and trades between participants are visible to all
+who can see the Ledger.
+
+Assets in the off-Ledger state are unspent transaction outputs (UTXO) stored on
+the Ledger with a matching document held by the owner off-Ledger describing the
+Asset represented by the UTXO. Trusted Execution Environments(TEE) are used to
+validate and process off-Ledger transactions. Once validated by the TEE, a
+proof of the transaction is submitted to the Ledger recording the UTXO consumed
+and the new UTXO produced.
+
+Assets represent something of value. In order to preserve this value, it is
+important that the rules governing that asset are preserved. In this system,
+users can issue assets, but only the original issuer can create more. All other
+transactions for these Assets can not change the amount of these Assets in
+circulation.
+
+In this example, Assets are represented as positive whole numbers. Fractional
+asset representations are not supported.
+
+The Private UTXO example manages three stores of information: the Asset Types,
+Holdings, and UTXO. Participants may act on these stores according to their
+permissions. Participants are identified by their public key. A Participant's
+signature on a transaction is their authorization of the transaction.
+
+Asset Types
++++++++++++
+
+The Asset Type is the definition of what exists, who created it, and how much
+of that asset is in circulation. The creator of the Asset Type may create more
+of that asset at any time to increase the amount in circulation.
+
+Holdings
+++++++++
+
+Holdings keep a record of which participants hold how much of which Assets.
+Holdings can be thought of as on-Ledger wallets or bank accounts where the
+balance of each Asset is held.
+
+Unspent Transaction Output (UTXO)
++++++++++++++++++++++++++++++++++
+
+When off-Ledger, the assets are represented as a document. This document
+holds the details of the assets. The sha512 hash of this document is the UTXO
+handle. In this case, the document is in a very real sense the asset that is
+being represented. Having access to the document will provide the details of
+the asset and who owns it. As such, it is important that the document is kept
+secret and protected.  UTXODocument is considered valid when there is a
+matching UTXO record in the DLT. If there is not a matching entry in the DLT
+then the Asset has either been consumed or has not yet be recorded with
+**Convert to UTXO** or **Transfer UTXO** transactions.
+
+
+.. literalinclude:: ../../../../families/private_utxo/protos/utxo_document.proto
+    :language: protobuf
+    :lines: 18-25
+
+Trading and Transactions
+=========================
+
+Private UTXO Transaction Family
++++++++++++++++++++++++++++++++
+
+The Private UTXO Transaction Family is implemented by a Transaction Processor
+that manages representation in the Ledger.
+
+.. toctree::
+   :maxdepth: 2
+
+   private_utxo_transaction_family.rst
+
+
+Off-Ledger Trading
+++++++++++++++++++
+
+This section describes how off-Ledger Assets, stored in UTXODocuments,
+are traded.
+
+UTXO processing Trusted Execution Environment (UTEE) are reponsible for
+validating and signing all off-Ledger transactions. UTEE's will be provided as
+signed binaries from the operators of the Ledger. The initial versions of the
+UTEE will support operation on clients enabled with SGX technology. The UTEE
+will utilize an IAS Proxy service to allow for generation of the Attestation
+Verification Reports(AVRs).
+
+The UTEE is responsible for enforcing the Asset semantic rules. This
+implementation only enforces the constant supply of Assets (Transfers neither
+create nor destroy assets). Other semantics are possible but would require a
+different UTEE implementation to enforce those rules.
+
+The flow of an off-Ledger trade happens as follows:
+
+First, the UTXODocument owner creates a set of Output documents that they wish
+to transform their document into. For example, if Alice has a UTXODocument for
+100 units and wishes to give 10 to Bob, she would generate two output
+UTXODocuments, one with Bob as the owner with the amount of 10 and the other
+with her as the owner and the amount of 90.
+
+Next, Alice will produce a signature of her input UTXODocument using her
+private key. This signature acts as her authorization to consume the document.
+
+The Input UTXODocument, the signature, and the output UTXODocuments are all
+submitted to the UTEE for verification. When the verification finishes, a Quote
+is generated by the UTEE. A Quote contains the details of the UTEE environment,
+the enclave, and the transaction. The Quote is used by the Attestation service
+to verify that this is a valid UTEE environment.
+
+Alice then submits the Quote to the Intel Attestation Service for verification.
+When the verification succeeds, an Attestation Verification Report(AVR) is
+generated.
+
+Alice will then generate a Transfer UTXO transaction with the addresses of the
+input UTXODocument, the addresses of the output UTXODocuments, and the AVR. She
+will sign this with a randomly generated key and submit it to any validator on
+the network. A random signing key is used on these transactions so that the
+transaction can not be traced back to the sender directly, providing anonymity
+of who is participating in the transaction.
+
+Once the Transfer UTXO transaction has been validated and is included in the
+Ledger (added to a block in the block chain), the input UTXODocument is now
+consumed and no longer valid, and the two output UTXODocuments are now valid.
+Alice can now send the Output document to Bob and Bob can verify that they are
+valid by seeing that the address of the document appears on the Ledger.
+
+UTEE Enclave Operations
++++++++++++++++++++++++
+
+The UTEE provides functionality to generate an Attestation for UTXO transfers.
+
+Generate Transfer UTXO Quote
+-----------------------------
+
+Given a set of Input and Output UTXODocuments, validate the Inputs are
+authorized to be spent and the Outputs conform to the asset rules. Then
+generate a Quote attesting to the transfer's correctness.
+
+Inputs:
+
+* List of (UTXODocument, signature) pairs, specifying the UTXO inputs to spend
+  and the authorization to spend them. The signatures are ECDSA signatures
+  of UTXODocument, produced using the document owner's private key.
+* List of Output UTXODocument.
+
+Outputs:
+
+* An Enclave quote (sgx_quote_t) with the report data set to
+  (sgx_report_data_t) sha512(input UTXOs|output UTXOs)
+
+Enclave Execution:
+
+The enclave validates the following cases:
+
+* The Input documents are validly formatted.
+* The Output documents are validly formatted.
+* All Inputs and outputs are of the same AssetType.
+* The signatures match the owner in the corresponding Input UTXODocument.
+* The sum of the outputs amounts equal the sum of the Input amounts.
+
+If any of these cases are not true, the enclave stops processing and returns an
+error.
+
+If all the validation passes, then an enclave quote is generated. The report
+data field of the quote (sgx_report_data_t) set to the sha512(input
+addresses|output addresses). This provides linkage between the transaction and
+the SGX Attestation. The input and output addresses are generated UTXO
+address as described in the :doc:`private_utxo_transaction_family`
+
+IAS Proxy
+---------
+
+Once the Enclave Quote is generated, it must be passed to the Intel Attestation
+Service (IAS) for verification and signing. A proxy interface to IAS is
+provided to allow the connection to IAS to be authenticated with the Software
+provider Id. The proxy accepts the Enclave quotes and returns Attestation
+Verification Reports (AVRS) singed by IAS.
+
+Transfer UTXO Transaction
+-------------------------
+
+Once the Transfer AVR is created, a Transfer UTXO transaction can be created
+and submitted for validation. This transaction must contain the input and
+output document addresses in the order of the documents we submitted to the
+UTEE. This transaction should be signed with a randomly generated key, so that
+the identity of the UTXO can be hidden.
+
+UTEE Authorization
+-----------------------------------
+
+A Ledger setting in the settings namespace is used to hold the list of enclave
+builds that are authorized to operate on this network. The setting
+`sawtooth.private_utxo.valid_enclave_measurements` holds a comma separated list
+of the measurements of enclaves that are allowed to attest for Transfer UTXO
+transactions.
+
+Best Practices
+==============
+
+The conversion of assets to and from the Ledger are visible and the spending
+DAG of the off-Ledger UTXO is visible (note: the contents of the UTXO are
+not visible). The UTXO DAG can provide an inadvertent source of information for
+those interested in the trading behavior.
+
+It is recommended that Participants in the system manage multiple private keys
+for holding off-Ledger UTXO. Only use a primary key for trading on-Ledger and
+have a set of keys for off-Ledger trading. When an asset is converted to UTXO,
+it should be transferred among these keys several times in a random order to
+hide the ownership of the asset. Furthermore, when an asset is transferred off-
+Ledger, it should receive the same mixing behavior both before and after the
+trade by both the sender and receiver. In addition, the off-Ledger keys should
+regularly be regenerated so that the public keys cannot be associated with a
+particular participant over time from observing the behavior of the trading.

--- a/docs/source/examples/private_utxo/private_utxo_transaction_family.rst
+++ b/docs/source/examples/private_utxo/private_utxo_transaction_family.rst
@@ -1,0 +1,410 @@
+***************************************
+Private UTXO Transaction Family
+***************************************
+
+Overview
+========
+
+This document describes a Transaction Family that allows for assets to be
+tracked and traded on the Ledger as well as to be held off the Ledger. This
+off-Ledger processing allows assets to be traded in a a  manner that enforces
+the Ledger rules governing the Asset and allows transactional privacy for the
+owner of the asset.
+
+When assets are on-Ledger they are held in buckets associated with the owner’s
+public key. In this state the balances and trades of and trades between
+participants are visible to all who can see the Ledger. The second state of
+assets is off-Ledger, as unspent transaction outputs (UTXO). In this form the
+assets are represented as documents stored off-Ledger and the UTXO are opaque
+identifiers of these documents stored in the Ledger. Trusted Execution
+Environments(TEE) are used to validate and process off Ledger transactions.
+Once validated by the TEE, the transaction is submitted to the Ledger recording
+the UTXO consumed and the new UTXO produced.
+
+State
+=====
+
+This section describes in detail how Private UTXO Transaction Processor (PUTP)
+objects are stored and addressed in the global state. All objects in state are
+stored as encoded protobufs. The address of the Merkle nodes is detailed below
+in the addressing section.
+
+AssetType
+---------
+
+AssetTypes represent types of assets being tracked and traded on the Ledger.
+
+.. literalinclude:: ../../../../families/private_utxo/protos/asset_type.proto
+    :language: protobuf
+    :lines: 18-
+
+Holding
+-------
+
+Holdings represent the amount of an assets a participant possesses on the
+Ledger. This handles the unlikely case of collisions due to the transformation
+of multiple public keys to the same address in global state.
+
+The state entry for holdings is a container that allows the holdings of
+multiple participants to be stored at the same address. This handles the
+unlikely case of collisions due to the transformation of multiple public keys
+to the same address in global state. The Holding container is a list of
+participant holdings. Each holding is identified by the participant's public
+key.
+
+The participant Holding is a list of key value pairs, with the key being the
+AssetType address and the value being the amount of the asset the participant
+has.
+
+.. literalinclude:: ../../../../families/private_utxo/protos/holding.proto
+    :language: protobuf
+    :lines: 22-
+
+UTXO
+----
+
+UTXO are stored in the state, The key uniquely identifies the UTXO. Since there
+is no value associated with UTXO, the Key is stored as the value. The value and
+details of the UTXO are described by the UtxoDocument held off chain.
+
+
+Addressing
+----------
+
+The PUTP uses the standard Sawtooth Merkle Addressing scheme a of 70 byte hex
+encoded string, consisting of 6 characters of namespace and 64 characters of
+key.
+
+Asset Type Addresses
+++++++++++++++++++++
+
+AssetTypes are stored in the address type namespace: '4251e9', which is derived
+by hex encoding the first 3 bytes of the sha512 hash of the string
+'private_utxo.asset_types'.
+
+.. code-block:: python
+
+    >>> asset_namespace = hashlib.sha512("private_utxo.asset_types".encode())\
+    ... .hexdigest()[0:6]
+    >>> asset_namespace
+    '4251e9'
+
+AssetType addresses are derived from the contents of the create transaction.
+The name, issuer's hex encoded public key, and the nonce are concatenated and
+the sha512 hash is taken. The result is hex encoded and the first 64 bytes of
+the result are taken as the address.
+
+.. code-block:: python
+
+    >>> raw_key = name + issuer_public_key + nonce
+    >>> address = hashlib.sha512(raw_key.encode()).hexdigest()[0:64]
+
+
+Holding Addresses
++++++++++++++++++
+
+Holdings are stored in the address type namespace: 'f1fc42', which is derived
+by hex encoding the first 3 bytes of the sha512 hash of the string
+'private_utxo.holdings'.
+
+.. code-block:: python
+
+    >>> holdings_namespace = hashlib.sha512("private_utxo.holdings".encode())\
+    ... .hexdigest()[0:6]
+    >>> holdings_namespace
+    'f1fc42'
+
+Holding addresses are derived from the participant's public key. The sha512
+hash is taken of the participants hex encoded public key. The result is hex
+encoded and the first 64 bytes of the result are taken as the address.
+
+.. code-block:: python
+
+    >>> address = hashlib.sha512(public_key.encode()).hexdigest()[0:64]
+
+.. _utxo_addresses:
+
+UTXO Addresses
+++++++++++++++
+
+UTXOs are stored in the address type namespace: 'cbefaf', which is derived by
+hex encoding the first 3 bytes of the sha512 hash of the string
+'private_utxo.utxo'.
+
+.. code-block:: python
+
+    >>> utxo_namespace = hashlib.sha512("private_utxo.utxo".encode())\
+    ... .hexdigest()[0:6]
+    >>> utxo_namespace
+    'cbefaf'
+
+UTXOs addresses are derived from the UtxoDocument. The sha512 hash is taken of
+the UtxoDocument. The result is hex encoded and the first 64 bytes of the
+result are taken as the address.
+
+.. code-block:: python
+
+    >>> address = hashlib.sha512(utxo_document).hexdigest()[0:64]
+
+
+Transactions
+============
+
+Transaction Headers
+-------------------
+
+The settings for the common Sawtooth Transaction header fields:
+
+.. code-block:: javascript
+
+    {
+        family_name: "sawtooth_private_utxo"
+        family_version: "1.0"
+        encoding: "application/protobuf"
+    }
+
+Inputs and Outputs
+------------------
+
+Issue Asset
++++++++++++
+
+    Inputs:
+
+    * AssetType Address of the asset being issued
+
+    Outputs:
+
+    * AssetType Address of the asset being issued
+    * Holding Address of the transaction signer
+
+Transfer Asset
+++++++++++++++
+
+    Inputs:
+
+    * AssetType Address of the asset being transfered
+    * Holding Address of the transaction signer
+    * Holding Address of the recipient
+
+    Outputs:
+
+    * Holding Address of the transaction signer
+    * Holding Address of the recipient
+
+Convert To UTXO
++++++++++++++++
+
+    Inputs:
+
+    * AssetType Address of the asset being converted
+    * Holding Address of the transaction signer
+
+    Outputs:
+
+    * Holding Address of the transaction signer
+    * The output UTXO address
+
+Convert From UTXO
++++++++++++++++++
+
+    Inputs:
+
+    * AssetType Address of the asset being converted
+    * Holding Address of the transaction signer
+    * The UTXO address of the UtxoDocument
+
+    Outputs:
+
+    * Holding Address of the transaction signer
+    * The UTXO address of the UtxoDocument
+
+Transfer UTXO
++++++++++++++++++
+
+    Inputs:
+
+    * Settings address for `sawtooth.private_utxo.valid_enclave_measurements`
+    * The all of the input and output UTXO addresses
+
+    Outputs:
+
+    * The all of the input and output UTXO addresses
+
+Dependencies
+++++++++++++
+
+Transactions should be batched and should specify any transactions that they
+expect to be committed to the ledger prior to execution as dependencies.
+
+Transaction Payload
+===================
+
+All Private UTXO transactions are wrapped in a payload object that allows for
+the items to be dispatched to the correct handling logic.
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 19-36
+
+Issue Asset
+-----------
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 37-43
+
+Transfer Asset
+--------------
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 44-50
+
+Convert To UTXO
+---------------
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 51-57
+
+Convert From UTXO
+-----------------
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 59-63
+
+Transfer UTXO
+-------------
+
+.. literalinclude:: ../../../../families/private_utxo/protos/payload.proto
+    :language: protobuf
+    :lines: 64-70
+
+
+Execution
+=========
+
+Holdings
+--------
+
+Participant Holdings are created when written to. If a Participants holdings
+are being read and the Holding for that participant does not exist, the
+particpant's holding of that asset are zero.
+
+Issue Asset
+-----------
+
+**Issue Asset** transactions create new assets for trading. This can either be
+in the form of creating a new AssetType entry or adding to the amount of an
+existing asset in circulation.
+
+**Issue Asset** transactions are validated as follows:
+
+The address of the AssetType and the signer of the transaction are calculated.
+
+If the AssetType exists and the AssetType issuer is the signer, then the
+amount of the AssetType and the signers holdings for that AssetType are
+increased by the transaction amount.
+
+If the AssetType exists but the signer is not the issuer of the AssetType, the
+transaction is invalid. These failures may be caused by collisions in the
+AssetType address. If a transaction creates an AssetType that already exists
+then it is an invalid transaction. In this case, the create AssetType
+transactions should be recreated with a new nonce and resubmitted.
+
+If the AssetType does not exist, then the AssetType is created with the Amount
+from the transaction and the signers holdings for that AssetType are set to
+the transaction amount.
+
+
+Transfer Asset
+--------------
+
+**Transfer Asset** transactions are used to move assets from one participant's
+holdings to another participant's holdings.
+
+**Transfer Asset** transactions are validated as follows:
+
+The signer of the transaction is calculated.
+
+If the `asset_type` of the transaction does not exist, the transaction fails.
+If the signer's holdings of the asset type are less than the transaction
+amount, the transaction fails.
+
+If the above validation steps pass, then the transaction amount is removed from
+the signers holdings and added to the transaction recipients holdings.
+
+
+Convert To UTXO
+---------------
+
+**Convert To UTXO** transactions are used to move assets from ledger holdings
+to an off-Ledger UtxoDocument for private trading.
+
+**Convert To UTXO** transactions are validated as follows:
+
+The signer of the transaction is calculated.
+
+If the `asset_type` of the transaction does not exist, the transaction fails.
+
+If the signer's holdings of the `asset_type` are less than the transaction
+amount the transaction fails.
+
+The UtxoDocument is created with the signer as the document owner, and
+the asset_type, amount, and nonce from the transaction. The UtxoDocument
+address is computed and compared to the transactions output_utxo field. If
+the addresses do not match, the transaction fails. UTXO collisions are not
+allowed. If a transaction on UTXO creates a UTXO that already exists, it is an
+invalid transaction. In this case the UtxoDocument should be recreated with a
+new nonce and the transaction should be recreated.
+
+If the above validation steps pass, then the transaction amount is removed from
+the signer's holdings and the transaction `output_utxo` address is added
+to the UTXO store.
+
+Convert From UTXO
+-----------------
+
+**Convert From UTXO** transactions are used to move off-Ledger assets held in
+UtxoDocuments to on-Ledger holdings.
+
+**Convert From UTXO** transactions are validated as follows:
+
+The signer of the transaction is calculated. The transaction document is
+unpacked. The UtxoDocument address of the transaction document is calculated.
+
+If the UtxoDocument address does not exist, the transaction fails.
+
+If the `asset_type` of the document does not exist, the transaction fails. This
+is done to ensure system consistency.
+
+If the above validation steps pass, then the document amount is added to
+the signer's holdings and the UtxoDocument address is removed
+from the UTXO store.
+
+Transfer UTXO
+-----------------
+
+**Transfer UTXO** transactions to facilitate off-Ledger trading.
+
+**Transfer UTXO** transactions are validated as follows:
+
+The transaction `attestation` is validated:
+
+* If the attestation is not signed by IAS, the transaction fails
+* If the attestation's `mr_enclave` is not the
+  `sawtooth.private_utxo.valid_enclave_measurements`, the transaction fails.
+* The attestation's report data (`sgx_report_data_t`) does not match the
+  sha512(input|output), the transaction fails.
+
+All input UTXO in the transaction must exist in the UTXO Store or the
+transaction fails.
+
+UTXO collisions are not allowed. If any of the UTXO outputs exist, then the
+transaction fails. In this case, the output UtxoDocument should be recreated
+with a new nonce and the transaction should be recreated.
+
+If the above validation steps pass, then the transaction inputs are removed
+from the UTXO store and the transaction outputs are added to the UTXO store.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -9,36 +9,10 @@ Validators
 How do I change the validator configuration?
 --------------------------------------------
 
-An example configuration file is at  `sawtooth-core/validator/etc/txnvalidator.js.example`. 
-Copy that file to a new file in
-the same directory and make changes to the new file. When starting the
-txnvalidator, use the `--config` argument to reference the configuration file,
-In this example, we have copied the `txnvalidator.js.example` file to `single-
-node.js` and modified it:
+An example configuration file is at `sawtooth-core/packaging/validator.toml.example`.
+Copy that file to a new file named validator.toml. The new file should be
+placed into the config directory declared by path.toml. Edit the validator.toml
+file to configure the validator to your needs. When starting sawtooth-validator,
+the config file will automatically be found and applied.
 
-.. code-block:: console
-
-    $ cd /project/sawtooth-core
-    $ ./bin/txnvalidator -v --config validator/etc/single-node.js
-
-Multiple config files can be overlaid, and all of the settings in the
-config file can be overridden on the command line, but that's beyond the
-scope of this answer.
-
-What configuration changes should I make to run a single validator?
--------------------------------------------------------------------
-
-Copy the file `sawtooth-core/validator/etc/txnvalidator.js.example` to `single-node.js` and
-make the following changes:
-
-
-`TargetWaitTime`
-The desired mean inter-block commit time across the network.
-While the default is 30 seconds, we recommend 5 seconds for
-development and experimenting.
-
-`InitialWaitTime`
-This is only important when starting the first node which
-will initialize the ledger (i.e. `GenesisLedger` is true).
-This will often be the case when testing. We recommend setting
-it to the same value as `TargetWaitTime`.
+Most of the settings in the config file can be overridden on the command line.

--- a/families/private_utxo/protos/asset_type.proto
+++ b/families/private_utxo/protos/asset_type.proto
@@ -1,0 +1,24 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// AssetType State Representation
+message AssetType {
+    string name = 1; // the name of the asset type
+    string issuer = 2; // the hex encoded public key of the issuer
+    string nonce = 3; // random vaue
+    int64 amount = 4; // Total amount of the asset issued.
+}

--- a/families/private_utxo/protos/holding.proto
+++ b/families/private_utxo/protos/holding.proto
@@ -1,0 +1,35 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// Participant holdings of a single asset type
+message AssetHolding {
+    string asset_type = 1; // the AssetType address
+    int64 amount = 2; // the amount of the asset held
+}
+
+// Participant holdings state representation
+message Holdings {
+    string identifier = 1; // the hex encoded public key of the participant
+    repeated AssetHolding asset_holdings = 2; // unordered list of holdings.
+}
+
+// Participant holdings container for storage in global state
+message HoldingContainer {
+    // List of Participant entries - more than one implies a collision
+    // when hashing agent public key to the Merkle Address
+    repeated Holdings entries = 1;
+}

--- a/families/private_utxo/protos/payload.proto
+++ b/families/private_utxo/protos/payload.proto
@@ -1,0 +1,69 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// Private UTXO Transaction Payload
+message PrivateUtxoPayload {
+    // The action indicates data is contained within this payload
+    enum Action {
+        ISSUE_ASSET = 0;
+        TRANSFER_ASSET = 1;
+        CONVERT_TO_UTXO = 2;
+        CONVERT_FROM_ASSET = 3;
+        UTXO_TRANSFER = 4;
+    }
+
+    // The action of this payload
+    Action action = 1;
+
+    // The content of this payload
+    bytes data = 2;
+}
+
+// Payload for Asset issuance
+message IssueAssetPayload {
+    string name = 1; // The name of the asset
+    int64 amount = 2; // The amount of the asset to issue
+    string nonce = 3; // A random value to ensure AssetType uniqueness
+}
+
+// Payload for transfering Assets
+message TransferAssetPayload {
+    string recipient = 1; // The public key of the recepient
+    string asset_type = 2; // The address of the AssetType to transfer
+    int64 amount = 3; // the amount to send to the recipient
+}
+
+// Payload to converting on chain asset holdings to UTXO
+message ConvertToUtxoPayload {
+    string asset_type = 1; // The address of the AssetType to transfer
+    int64 amount = 2; // The amount of the asset to to convert
+    string nonce = 3;  // A random value to ensure AssetType uniqueness
+    string output_utxo = 4; // The UTXO address of the resulting UtxoDocument
+}
+
+// Payload to convert UTXO to an on ledger asset
+message ConvertFromUtxoPayload {
+    string document = 1; // the UtxoDocument being converted
+}
+
+// Transfer UTXO ownership off ledger
+message UtxoTransferPayload {
+    repeated string inputs = 1; // the UTXO to be consumed
+    repeated string outputs = 2; // the UTXO to be produced
+    string attestation = 3; // the Attestation Verification Report signed by
+    // IAS
+}

--- a/families/private_utxo/protos/utxo_document.proto
+++ b/families/private_utxo/protos/utxo_document.proto
@@ -1,0 +1,24 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// Utxo off-Ledger Representation
+message UtxoDocument {
+    string owner = 1; // The hex encoded public key of the owner
+    string asset_type = 2; // The identifier of the asset type
+    int64 amount = 3; // The amount of the Asset stored in this UTXO
+    string nonce = 4; // A random vaue to guarentee uniqness
+}

--- a/families/settings/sawtooth_settings/processor/main.py
+++ b/families/settings/sawtooth_settings/processor/main.py
@@ -33,7 +33,7 @@ def create_console_handler(verbose_level):
     formatter = ColoredFormatter(
         "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
         "%(white)s%(message)s",
-        datefmt="%H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S",
         reset=True,
         log_colors={
             'DEBUG': 'cyan',

--- a/families/supplychain/python/sawtooth_supplychain/processor/main.py
+++ b/families/supplychain/python/sawtooth_supplychain/processor/main.py
@@ -67,6 +67,11 @@ def main(args=None):
 
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="supplychain_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="supplychain_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -129,7 +129,7 @@ message Message {
     // content.
     MessageType message_type = 1;
 
-    // The identifier used to coorelate response messages to their related
+    // The identifier used to correlate response messages to their related
     // request messages.  correlation_id should be set to a random string
     // for messages which are not responses to previously sent messages.  For
     // response messages, correlation_id should be set to the same string as

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -98,7 +98,7 @@ message Message {
         CLIENT_BATCH_STATUS_RESPONSE = 121;
         // Further messages from the stats client through the web api
 
-        // Temp message types until a discusion can be had about gossip msg
+        // Temp message types until a discussion can be had about gossip msg
         GOSSIP_MESSAGE = 200;
         GOSSIP_REGISTER = 201;
         GOSSIP_UNREGISTER = 202;

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -154,6 +154,11 @@ def main():
         connection = Connection(url)
 
         log_config = get_log_config(filename="rest_api_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="rest_api_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
@@ -64,6 +64,11 @@ def main(args=None):
     try:
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="intkey_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="intkey_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -51,7 +51,7 @@ class XoTransactionHandler:
 
         # 2. Retrieve the game data from state storage
         board, state, player1, player2, game_list = \
-            _get_state_data(state_store, name)
+            _get_state_data(state_store, self._namespace_prefix, name)
 
         # 3. Validate the game data
         _validate_game_data(
@@ -76,7 +76,8 @@ class XoTransactionHandler:
 
         # 6. Put the game data back in state storage
         _store_state_data(
-            state_store, game_list, name,
+            state_store, game_list,
+            self._namespace_prefix, name,
             upd_board, upd_state,
             upd_player1, upd_player2)
 
@@ -147,13 +148,15 @@ def _validate_game_data(action, space, signer, board, state, player1, player2):
                 'Invalid Action: space {} already taken'.format(space))
 
 
-def _make_xo_address(name):
-    return '5b7349' + hashlib.sha512(name.encode('utf-8')).hexdigest()[:64]
+def _make_xo_address(namespace_prefix, name):
+    return namespace_prefix + \
+        hashlib.sha512(name.encode('utf-8')).hexdigest()[:64]
 
 
-def _get_state_data(state_store, name):
+def _get_state_data(state_store, namespace_prefix, name):
     # Get data from address
-    state_entries = state_store.get([_make_xo_address(name)])
+    state_entries = \
+        state_store.get([_make_xo_address(namespace_prefix, name)])
 
     # state_store.get() returns a list. If no data has been stored yet
     # at the given address, it will be empty.
@@ -182,7 +185,8 @@ def _get_state_data(state_store, name):
 
 
 def _store_state_data(
-        state_store, game_list, name,
+        state_store, game_list,
+        namespace_prefix, name,
         board, state, player1, player2):
 
     game_list[name] = board, state, player1, player2
@@ -194,7 +198,7 @@ def _store_state_data(
 
     addresses = state_store.set([
         StateEntry(
-            address=_make_xo_address(name),
+            address=_make_xo_address(namespace_prefix, name),
             data=state_data
         )
     ])

--- a/sdk/examples/xo_python/sawtooth_xo/processor/main.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/main.py
@@ -65,6 +65,11 @@ def main(args=None):
     try:
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="xo_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="xo_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/python/sawtooth_sdk/client/config.py
+++ b/sdk/python/sawtooth_sdk/client/config.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import toml
+import yaml
 
 
 def get_config_dir():
@@ -82,12 +83,16 @@ def _get_log_config(filename=None):
         log_config (dict): The dictionary to pass to logging.config.dictConfig
     """
     if filename is not None:
+
         conf_file = os.path.join(get_config_dir(), filename)
-    if os.path.exists(conf_file):
-        with open(conf_file) as fd:
-            raw_config = fd.read()
-        log_config = toml.loads(raw_config)
-        return log_config
+        if os.path.exists(conf_file):
+            with open(conf_file) as fd:
+                raw_config = fd.read()
+            if filename.endswith(".yaml"):
+                log_config = yaml.safe_load(raw_config)
+            else:
+                log_config = toml.loads(raw_config)
+            return log_config
     return None
 
 

--- a/sdk/python/sawtooth_sdk/client/log.py
+++ b/sdk/python/sawtooth_sdk/client/log.py
@@ -26,7 +26,7 @@ def create_console_handler(verbose_level):
         "%(log_color)s[%(asctime)s.%(msecs)03d "
         "%(levelname)-8s %(module)s]%(reset)s "
         "%(white)s%(message)s",
-        datefmt="%H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S",
         reset=True,
         log_colors={
             'DEBUG': 'cyan',

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -52,4 +52,5 @@ setup(name='sawtooth-sdk',
           "protobuf",
           "pyzmq",
           "toml",
+          "PyYAML",
       ])

--- a/stat_collection/docker/grafana/datasources/influxdb.json
+++ b/stat_collection/docker/grafana/datasources/influxdb.json
@@ -1,0 +1,8 @@
+{
+  "name":"metrics",
+  "type":"influxdb",
+  "url":"http://influxdb:8086",
+  "access":"proxy",
+  "database":"metrics",
+  "basicauth":false
+}

--- a/stat_collection/docker/grafana/grafana_entrypoint.sh
+++ b/stat_collection/docker/grafana/grafana_entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+url="http://admin:admin@localhost:3000"
+
+post() {
+    curl -s -X POST -d "$1" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        "$url$2" 2> /dev/null
+}
+
+if [ ! -f "/var/lib/grafana/.init" ]; then
+    exec /run.sh $@ &
+
+    until curl -s "$url/api/datasources" 2> /dev/null; do
+        sleep 1
+    done
+
+    for datasource in /etc/grafana/datasources/*; do
+        post "$(cat $datasource)" "/api/datasources"
+    done
+
+    for dashboard in /etc/grafana/dashboards/*; do
+        post "$(cat $dashboard)" "/api/dashboards/db"
+    done
+
+    touch "/var/lib/grafana/.init"
+
+    kill $(pgrep grafana)
+fi
+
+exec /run.sh $@

--- a/stat_collection/docker/grafana/sawtooth-stats-grafana
+++ b/stat_collection/docker/grafana/sawtooth-stats-grafana
@@ -1,0 +1,30 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM grafana/grafana:latest
+
+RUN apt-get update && \
+    apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY dashboards /etc/grafana/dashboards
+COPY datasources /etc/grafana/datasources
+
+WORKDIR /app  
+COPY grafana_entrypoint.sh ./  
+RUN chmod u+x grafana_entrypoint.sh
+
+ENTRYPOINT ["/app/grafana_entrypoint.sh"]

--- a/stat_collection/docker/influxdb/influxdb_entrypoint.sh
+++ b/stat_collection/docker/influxdb/influxdb_entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+if [ ! -f "/var/lib/influxdb/.init" ]; then  
+  exec influxd $@ &
+
+  until wget -q "http://localhost:8086/ping" 2> /dev/null; do
+    sleep 1
+  done
+
+  curl -i -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE DATABASE metrics"
+
+  touch "/var/lib/influxdb/.init"
+
+  kill -s TERM %1
+fi
+
+exec influxd $@

--- a/stat_collection/docker/influxdb/sawtooth-stats-influxdb
+++ b/stat_collection/docker/influxdb/sawtooth-stats-influxdb
@@ -1,0 +1,25 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM influxdb:alpine
+
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+    
+WORKDIR /app
+COPY influxdb_entrypoint.sh ./
+RUN chmod u+x influxdb_entrypoint.sh
+
+ENTRYPOINT ["/app/influxdb_entrypoint.sh"]

--- a/stat_collection/docker/metrics.yaml
+++ b/stat_collection/docker/metrics.yaml
@@ -1,0 +1,51 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  influxdb:
+    container_name: influxdb
+    build:
+      context: ./influxdb
+      dockerfile: sawtooth-stats-influxdb
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb_data:/var/lib/influxdb
+    stop_signal: SIGKILL
+
+  grafana:
+    container_name: grafana
+    build:
+      context: ./grafana
+      dockerfile: sawtooth-stats-grafana
+    links:
+      - influxdb
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    stop_signal: SIGKILL
+
+volumes:
+  grafana_data: {}
+  influxdb_data: {}
+
+networks:
+  default:
+    external:
+      name: sawtooth_stats

--- a/validator/sawtooth_validator/config/logs.py
+++ b/validator/sawtooth_validator/config/logs.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import toml
+import yaml
 
 
 def _get_config_dir():
@@ -45,6 +46,14 @@ def _get_config():
             raw_config = fd.read()
         log_config = toml.loads(raw_config)
         return log_config
+
+    conf_file = os.path.join(_get_config_dir(), 'log_config.yaml')
+    if os.path.exists(conf_file):
+        with open(conf_file) as fd:
+            raw_config = fd.read()
+        log_config = yaml.safe_load(raw_config)
+        return log_config
+
     return None
 
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -284,11 +284,10 @@ class BlockValidator(object):
                         self._block_cache[
                             new_blkw.previous_block_id]
                 except KeyError:
-                    LOGGER.debug("Block rejected due missing" +
+                    LOGGER.debug("Block rejected due to missing" +
                                  " predecessor: %s", new_blkw)
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
-                    self._done_cb(False, self._result)
                     raise BlockValidationAborted()
         elif new_blkw.block_num < cur_blkw.block_num:
             # current chain is longer
@@ -320,9 +319,16 @@ class BlockValidator(object):
                 self._done_cb(False, self._result)
                 raise BlockValidationAborted()
             new_chain.append(new_blkw)
-            new_blkw = \
-                self._block_cache[
-                    new_blkw.previous_block_id]
+            try:
+                new_blkw = \
+                    self._block_cache[
+                        new_blkw.previous_block_id]
+            except KeyError:
+                LOGGER.debug("Block rejected due to missing" +
+                             " predecessor: %s", new_blkw)
+                for b in new_chain:
+                    b.status = BlockStatus.Invalid
+                raise BlockValidationAborted()
 
             cur_chain.append(cur_blkw)
             cur_blkw = \

--- a/validator/sawtooth_validator/server/log.py
+++ b/validator/sawtooth_validator/server/log.py
@@ -37,7 +37,7 @@ def create_console_handler(verbose_level):
         "%(log_color)s[%(asctime)s.%(msecs)03d "
         "%(levelname)-8s %(module)s]%(reset)s "
         "%(white)s%(message)s",
-        datefmt="%H:%M:%S",
+        datefmt="%Y-%m-%d %H:%M:%S",
         reset=True,
         log_colors={
             'DEBUG': 'cyan',

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -58,6 +58,7 @@ setup(
         "requests",
         "sawtooth-signing",
         "toml",
+        "PyYAML",
         "pyzmq",
         "netifaces"
     ],


### PR DESCRIPTION
This PR adds docker-compose files that build containers containing InfluxDB, Grafana, and local Sawtooth files. 

_Note: Prior to running either docker-compose file, a user must create the `sawtooth_stats` Docker network with the command: `$ docker network create sawtooth_stats`. This allows communication between the containers._

The metrics.yaml docker compose file automatically run scripts that will set up a framework for stat collection:

- After InfluxDB is started, a post to the InfluxDB HTTP API is made that creates a database called "metrics"

- After Grafana is started, a post to the Grafana HTTP API is made that establishes a connection between the InfluxDB "metrics" database. Other datasources and dashboards can be added by adding json files to the `stat_collection/docker/grafana/datasources` or `stat_collection/docker/grafana/dashboards` directories