### PR TITLE
Support YAML format for logging config

### DIFF
--- a/families/supplychain/python/sawtooth_supplychain/processor/main.py
+++ b/families/supplychain/python/sawtooth_supplychain/processor/main.py
@@ -67,6 +67,11 @@ def main(args=None):
 
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="supplychain_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="supplychain_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -154,6 +154,11 @@ def main():
         connection = Connection(url)
 
         log_config = get_log_config(filename="rest_api_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="rest_api_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/main.py
@@ -64,6 +64,11 @@ def main(args=None):
     try:
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="intkey_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="intkey_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/examples/xo_python/sawtooth_xo/processor/main.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/main.py
@@ -65,6 +65,11 @@ def main(args=None):
     try:
         processor = TransactionProcessor(url=opts.endpoint)
         log_config = get_log_config(filename="xo_log_config.toml")
+
+        # If no toml, try loading yaml
+        if log_config is None:
+            log_config = get_log_config(filename="xo_log_config.yaml")
+
         if log_config is not None:
             log_configuration(log_config=log_config)
         else:

--- a/sdk/python/sawtooth_sdk/client/config.py
+++ b/sdk/python/sawtooth_sdk/client/config.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import toml
+import yaml
 
 
 def get_config_dir():
@@ -82,12 +83,16 @@ def _get_log_config(filename=None):
         log_config (dict): The dictionary to pass to logging.config.dictConfig
     """
     if filename is not None:
+
         conf_file = os.path.join(get_config_dir(), filename)
-    if os.path.exists(conf_file):
-        with open(conf_file) as fd:
-            raw_config = fd.read()
-        log_config = toml.loads(raw_config)
-        return log_config
+        if os.path.exists(conf_file):
+            with open(conf_file) as fd:
+                raw_config = fd.read()
+            if filename.endswith(".yaml"):
+                log_config = yaml.safe_load(raw_config)
+            else:
+                log_config = toml.loads(raw_config)
+            return log_config
     return None
 
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -52,4 +52,5 @@ setup(name='sawtooth-sdk',
           "protobuf",
           "pyzmq",
           "toml",
+          "PyYAML",
       ])

--- a/validator/sawtooth_validator/config/logs.py
+++ b/validator/sawtooth_validator/config/logs.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import toml
+import yaml
 
 
 def _get_config_dir():
@@ -45,6 +46,14 @@ def _get_config():
             raw_config = fd.read()
         log_config = toml.loads(raw_config)
         return log_config
+
+    conf_file = os.path.join(_get_config_dir(), 'log_config.yaml')
+    if os.path.exists(conf_file):
+        with open(conf_file) as fd:
+            raw_config = fd.read()
+        log_config = yaml.safe_load(raw_config)
+        return log_config
+
     return None
 
 

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -58,6 +58,7 @@ setup(
         "requests",
         "sawtooth-signing",
         "toml",
+        "PyYAML",
         "pyzmq",
         "netifaces"
     ],


### PR DESCRIPTION
TOML does not support enough data types to support the SysLog handler type in
python logging. YAML does.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>