### PR TITLE
Add Rust SDK with compiled Protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@
 /sdk/go/src/gopkg.in/
 /families/burrow_evm/bin/
 /families/burrow_evm/src/sawtooth_burrow_evm/protobuf/
+/sdk/rust/target
+/sdk/rust/src/messages/*.rs
+!/sdk/rust/src/messages/mod.rs
 
 /signing/build/
 /signing/sawtooth_signing.egg-info/

--- a/bin/build_all
+++ b/bin/build_all
@@ -90,6 +90,7 @@ then
         java
         javascript
         python
+        rust
 "
 fi
 
@@ -145,9 +146,11 @@ main() {
                 python)
                     build_python
                     ;;
-
+                rust)
+                    build_rust
+                    ;;
                 *)
-                    echo "Module '$language' not found."
+                    warn "Module '$language' not found."
                     ;;
             esac
         fi
@@ -258,6 +261,11 @@ then
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-validator
         docker_run sawtooth-dev-python
     }
+
+    build_rust() {
+        docker_build docker/sawtooth-dev-rust docker/ sawtooth-dev-rust
+        docker_run sawtooth-dev-rust
+    }
 fi
 
 if [[ $BUILD_MODE == $INSTALLED ]]
@@ -345,6 +353,11 @@ then
             $build_dir/ sawtooth-validator
     }
 
+    build_rust() {
+        cp $top_dir/docker/sawtooth-dev-rust $build_dir
+        docker_build $build_dir/sawtooth-dev-rust $build_dir/ sawtooth-dev-rust
+        docker_run sawtooth-dev-rust
+    }
 fi
 
 main

--- a/bin/build_rust
+++ b/bin/build_rust
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+set -e
+
+top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+
+echo -e "\033[0;32m--- Running protogen rust ---\n\033[0m"
+$top_dir/bin/protogen rust
+
+echo -e "\033[0;32m--- Building Rust SDK ---\n\033[0m"
+cd $top_dir/sdk/rust/
+cargo build
+
+# echo -e "\033[0;32m--- Building intkey-tp-rust ---\n\033[0m"
+
+# echo -e "\033[0;32m--- Building xo-tp-rust ---\n\033[0m"
+
+# echo -e "\033[0;32m--- Building noop-tp-rust ---\n\033[0m"

--- a/bin/protogen
+++ b/bin/protogen
@@ -52,6 +52,9 @@ def main(args=None):
     if "go" in args:
         protoc(proto_dir, "sdk/go/src", "sawtooth_sdk/protobuf", "go")
 
+    if "rust" in args:
+        protoc(proto_dir, "sdk/rust", "src/messages", "rust")
+
     # 2. Generate config protos
     proto_dir = JOIN(TOP_DIR, "families/settings/protos")
     protoc(proto_dir, "families/settings", "sawtooth_settings/protobuf")
@@ -81,6 +84,8 @@ def protoc(src_dir, base_dir, pkg, language="python"):
         protoc_go(src_dir, base_dir, pkg)
     elif language == "javascript":
         protoc_javascript(src_dir, base_dir, pkg)
+    elif language == "rust":
+        protoc_rust(src_dir, base_dir, pkg)
 
 
 def protoc_python(src_dir, base_dir, pkg):
@@ -178,6 +183,40 @@ def protoc_go(src_dir, base_dir, pkg):
 
         for args in defer:
             _protoc(args)
+
+
+def protoc_rust(src_dir, base_dir, pkg):
+    # 1. Create output package directory
+    pkg_dir = JOIN(TOP_DIR, base_dir, pkg)
+    os.makedirs(pkg_dir, exist_ok=True)
+
+    # 2. Create a temp directory for building
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_pkg_dir = JOIN(tmp_dir, pkg)
+        os.makedirs(tmp_pkg_dir)
+
+        # 3. Get a list of all .proto files to build
+        cwd = os.getcwd()
+        os.chdir(src_dir)
+        proto_files = glob("*.proto")
+        os.chdir(cwd)
+
+        # 4. Copy protos to temp dir and fix imports
+        for proto in proto_files:
+            src = JOIN(src_dir, proto)
+            dst = JOIN(tmp_pkg_dir, proto)
+            with open(src, encoding='utf-8') as fin:
+                with open(dst, "w", encoding='utf-8') as fout:
+                    src_contents = fin.read()
+                    fixed_contents = fix_import(src_contents, pkg)
+                    fout.write(fixed_contents)
+
+        # 5. Compile protobuf files
+        _protoc([
+            __file__,
+            "-I=%s" % tmp_dir,
+            "--rust_out=%s" % JOIN(TOP_DIR, base_dir, pkg),
+        ] + glob("%s/*.proto" % tmp_pkg_dir))
 
 
 def fix_import(contents, pkg, sub_dir=False):

--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -1,0 +1,63 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image to be used when developing in Rust. The default CMD is to run
+#   build_rust.
+#
+# Build:
+#   $ cd sawtooth-core/docker
+#   $ docker build . -f sawtooth-dev-rust -t sawtooth-dev-rust
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -v $(pwd):/project/sawtooth-core sawtooth-dev-rust
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="mounted"
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8AA7AF1F1091A5FD \
+ && apt-get update \
+ && apt-get install -y -q --allow-downgrades \
+    curl \
+    libzmq3-dev \
+    gcc \
+    pkg-config \
+    python3-grpcio-tools=1.1.3-1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+EXPOSE 4004/tcp
+
+ENV PATH=$PATH:/project/sawtooth-core/bin:/root/.cargo/bin
+
+RUN cargo install protobuf
+
+RUN mkdir -p /project/sawtooth-core/ \
+ && mkdir -p /var/log/sawtooth \
+ && mkdir -p /var/lib/sawtooth \
+ && mkdir -p /etc/sawtooth \
+ && mkdir -p /etc/sawtooth/keys
+
+WORKDIR /
+
+CMD build_rust
+

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,0 +1,22 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+[package]
+name = "sawtooth_sdk"
+version = "0.1.0"
+authors = ["sawtooth"]
+
+[dependencies]
+protobuf="1.4.1"

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate protobuf;
+
+pub mod messages;

--- a/sdk/rust/src/messages/mod.rs
+++ b/sdk/rust/src/messages/mod.rs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+pub mod validator;
+pub mod transaction;
+pub mod batch;
+pub mod block;
+pub mod setting;
+pub mod state_delta;
+pub mod state_context;
+pub mod processor;
+pub mod genesis;
+pub mod client;
+pub mod network;


### PR DESCRIPTION
Add the tools necessary to compile a Sawtooth Rust SDK, including the
core protobuf messages. This includes a docker container for doing rust
development.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>