### PR TITLE
Invalidate block on cache miss

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -284,11 +284,10 @@ class BlockValidator(object):
                         self._block_cache[
                             new_blkw.previous_block_id]
                 except KeyError:
-                    LOGGER.debug("Block rejected due missing" +
+                    LOGGER.debug("Block rejected due to missing" +
                                  " predecessor: %s", new_blkw)
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
-                    self._done_cb(False, self._result)
                     raise BlockValidationAborted()
         elif new_blkw.block_num < cur_blkw.block_num:
             # current chain is longer
@@ -320,9 +319,16 @@ class BlockValidator(object):
                 self._done_cb(False, self._result)
                 raise BlockValidationAborted()
             new_chain.append(new_blkw)
-            new_blkw = \
-                self._block_cache[
-                    new_blkw.previous_block_id]
+            try:
+                new_blkw = \
+                    self._block_cache[
+                        new_blkw.previous_block_id]
+            except KeyError:
+                LOGGER.debug("Block rejected due to missing" +
+                             " predecessor: %s", new_blkw)
+                for b in new_chain:
+                    b.status = BlockStatus.Invalid
+                raise BlockValidationAborted()
 
             cur_chain.append(cur_blkw)
             cur_blkw = \


### PR DESCRIPTION
During fork resolution, when finding a common ancestor, a miss to the block cache will cause an exception.  While the callback is notified that block validation has failed, the blocks in the new chain are not marked as invalid.  This commit corrects the issue.

Additionally, it removes the calling of the callback from `_find_common_height`, since it raise an error that is caught by its calling function that results in the callback being executed.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>