### PR TITLE
Initial Batch Generation Tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@
 /validator/**/__pycache__/
 
 /sdk/cxx/build/
+
+/perf/sawtooth/sawtooth_workload/Cargo.lock
+/perf/sawtooth/sawtooth_workload/target/

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -324,6 +324,7 @@ test_python_sdk() {
 
 test_rust_sdk() {
     run_docker_test ./sdk/rust/unit_rust_sdk.yaml
+    run_docker_test ./perf/sawtooth/sawtooth_workload/unit_perf_workload.yaml
 }
 
 test_burrow_evm() {

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -29,6 +29,7 @@ MODULE_LIST="
     java_sdk
     javascript_sdk
     python_sdk
+    rust_sdk
     burrow_evm
     integration
 "
@@ -180,6 +181,9 @@ main() {
                 python_sdk)
                     test_python_sdk
                     ;;
+                rust_sdk)
+                    test_rust_sdk
+                    ;;
                 integration)
                     test_integration
                     ;;
@@ -316,6 +320,10 @@ test_python_sdk() {
     copy_coverage .coverage.test_xo_smoke_python
     run_docker_test test_two_families
     copy_coverage .coverage.two_families
+}
+
+test_rust_sdk() {
+    run_docker_test ./sdk/rust/unit_rust_sdk.yaml
 }
 
 test_burrow_evm() {

--- a/perf/sawtooth/sawtooth_workload/Cargo.toml
+++ b/perf/sawtooth/sawtooth_workload/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sawtooth_workload"
+version = "0.1.0"
+
+[dependencies]
+sawtooth_sdk = { path = "../../../sdk/rust" }
+protobuf = "1.4.1"
+clap = "2.26.0"

--- a/perf/sawtooth/sawtooth_workload/src/batch_gen.rs
+++ b/perf/sawtooth/sawtooth_workload/src/batch_gen.rs
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate protobuf;
+
+use std::error;
+use std::fmt;
+use std::io::Read;
+use std::io::Write;
+
+use sawtooth_sdk::messages::transaction::Transaction;
+use sawtooth_sdk::messages::batch::Batch;
+use sawtooth_sdk::messages::batch::BatchHeader;
+use self::protobuf::Message;
+
+pub fn generate_signed_batches<'a>(reader: &'a mut Read, writer: &'a mut Write, max_batch_size: usize)
+    -> Result<(), BatchingError>
+{
+    let mut producer = SignedBatchProducer::new(reader, max_batch_size);
+    loop {
+        match producer.next() {
+            Ok(Some(batch)) => {
+                if let Err(err) = batch.write_length_delimited_to_writer(writer) {
+                    return Err(BatchingError::MessageError(err));
+                }
+            },
+            Ok(None) => break,
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(())
+}
+
+struct TransactionSource<'a> {
+    source: protobuf::CodedInputStream<'a>,
+}
+
+impl<'a> TransactionSource<'a> {
+    pub fn new(source: &'a mut Read) -> Self {
+        let source = protobuf::CodedInputStream::new(source);
+        TransactionSource {
+            source,
+        }
+    }
+
+    pub fn next(&mut self, max_txns: usize)
+        -> Result<Vec<Transaction>, protobuf::ProtobufError>
+    {
+        let mut results = Vec::with_capacity(max_txns);
+        for _ in 0..max_txns {
+            if self.source.eof()? {
+                break;
+            }
+
+            // read the delimited length
+            let next_len = self.source.read_raw_varint32()?;
+            let buf =  self.source.read_raw_bytes(next_len)?;
+            
+            let txn = try!(protobuf::parse_from_bytes(&buf));
+            results.push(txn);
+        }
+        Ok(results)
+    }
+}
+
+#[derive(Debug)]
+pub enum BatchingError {
+    MessageError(protobuf::ProtobufError),
+    SigningError,
+}
+
+impl fmt::Display for BatchingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchingError::MessageError(ref err) =>
+                write!(f, "Error occurred reading messages: {}", err),
+            BatchingError::SigningError => write!(f, "Unable to sign batch"),
+        }
+    }
+}
+
+impl error::Error for BatchingError {
+    fn description(&self) -> &str {
+        match *self {
+            BatchingError::MessageError(ref err) => err.description(),
+            BatchingError::SigningError => "Unable to sign batch",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            BatchingError::MessageError(ref err) => Some(err),
+            BatchingError::SigningError => None,
+        }
+    }
+}
+
+pub struct SignedBatchProducer<'a> {
+    transaction_source: TransactionSource<'a>,
+    max_batch_size: usize,
+}
+
+pub type BatchResult = Result<Option<Batch>, BatchingError>;
+
+impl<'a> SignedBatchProducer<'a> {
+    pub fn new(source: &'a mut Read, max_batch_size: usize) -> Self {
+        let transaction_source = TransactionSource::new(source);
+        SignedBatchProducer {
+            transaction_source,
+            max_batch_size,
+        }
+    }
+
+    pub fn next(&mut self) -> BatchResult {
+        let txns = match self.transaction_source.next(self.max_batch_size) {
+            Ok(txns) => txns,
+            Err(err) => return Err(BatchingError::MessageError(err)),
+        };
+
+        if txns.len() == 0 {
+            return Ok(None);
+        }
+
+        let mut batch_header = BatchHeader::new();
+
+        // set signer_pubkey
+        let txn_ids = txns.iter().cloned().map(|mut txn| txn.take_header_signature()).collect();
+        batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(txn_ids));
+
+        let mut batch = Batch::new();
+        batch.set_header(batch_header.write_to_bytes().unwrap());
+        batch.set_transactions(protobuf::RepeatedField::from_vec(txns));
+            
+        Ok(Some(batch))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::TransactionSource;
+    use super::SignedBatchProducer;
+    use std::io::{Cursor, Write};
+    use sawtooth_sdk::messages::transaction::{Transaction, TransactionHeader};
+    use sawtooth_sdk::messages::batch::BatchHeader;
+    use super::protobuf;
+    use super::protobuf::Message;
+
+    #[test]
+    fn empty_transaction_source() {
+        let encoded_bytes: Vec<u8> = Vec::new();
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut txn_stream = TransactionSource::new(&mut source);
+        let txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 0);
+    }
+
+    #[test]
+    fn next_transactions() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+        write_txn_with_sig("sig2", &mut encoded_bytes);
+        write_txn_with_sig("sig3", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut txn_stream = TransactionSource::new(&mut source);
+
+        let mut txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 2);
+
+        // ensure that it is exhausted, even when more are requested
+        txns = txn_stream.next(2).unwrap();
+        assert_eq!(txns.len(), 1);
+    }
+
+    #[test]
+    fn signed_batches_empty_transactions() {
+        let encoded_bytes: Vec<u8> = Vec::new();
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2);
+        let batch_result = producer.next().unwrap();
+        
+        assert_eq!(batch_result, None);
+    }
+
+    #[test]
+    fn signed_batches_single_transaction() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2);
+        let mut batch_result = producer.next().unwrap();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap();
+
+        let batch_header: BatchHeader = protobuf::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 1);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig1"));
+
+        // test exhaustion
+        batch_result = producer.next().unwrap();
+        assert_eq!(batch_result, None);
+    }
+
+    #[test]
+    fn signed_batches_multiple_batches() {
+        let mut encoded_bytes: Vec<u8> = Vec::new();
+
+        write_txn_with_sig("sig1", &mut encoded_bytes);
+        write_txn_with_sig("sig2", &mut encoded_bytes);
+        write_txn_with_sig("sig3", &mut encoded_bytes);
+
+        let mut source = Cursor::new(encoded_bytes);
+
+        let mut producer = SignedBatchProducer::new(&mut source, 2);
+        let mut batch_result = producer.next().unwrap();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap();
+
+        let batch_header: BatchHeader = protobuf::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 2);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig1"));
+        assert_eq!(batch_header.transaction_ids[1], String::from("sig2"));
+
+        // pull the next batch
+        batch_result = producer.next().unwrap();
+        assert!(batch_result.is_some());
+
+        let batch = batch_result.unwrap();
+
+        let batch_header: BatchHeader = protobuf::parse_from_bytes(&batch.header).unwrap();
+        assert_eq!(batch_header.transaction_ids.len(), 1);
+        assert_eq!(batch_header.transaction_ids[0], String::from("sig3"));
+
+        // test exhaustion
+        batch_result = producer.next().unwrap();
+        assert_eq!(batch_result, None);
+    }
+
+    fn make_txn(sig: &str) -> Transaction {
+        let mut txn_header = TransactionHeader::new();
+
+        txn_header.set_batcher_pubkey(String::from("some_pubkey"));
+        txn_header.set_family_name(String::from("test_family"));
+        txn_header.set_family_version(String::from("1.0"));
+        txn_header.set_signer_pubkey(String::from("some_pubkey"));
+        txn_header.set_payload_encoding(String::from("text/string"));
+        txn_header.set_payload_sha512(String::from("some_sha512_hash"));
+
+        let mut txn = Transaction::new();
+        txn.set_header(txn_header.write_to_bytes().unwrap());
+        txn.set_header_signature(String::from(sig));
+        txn.set_payload(sig.as_bytes().to_vec());
+
+        txn
+    }
+
+    fn write_txn_with_sig(sig: &str, out: &mut Write) {
+        let txn = make_txn(sig);
+        txn.write_length_delimited_to_writer(out).expect("Unable to write delimiter");
+    }
+}

--- a/perf/sawtooth/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth/sawtooth_workload/src/main.rs
@@ -1,0 +1,113 @@
+extern crate clap;
+extern crate sawtooth_sdk;
+
+mod batch_gen;
+
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+use std::error::Error;
+
+use batch_gen::generate_signed_batches;
+use clap::{App, ArgMatches, AppSettings, Arg, SubCommand};
+
+const APP_NAME: &'static str = env!("CARGO_PKG_NAME");
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    let arg_matches = 
+        App::new(APP_NAME)
+            .version(VERSION)
+            .setting(AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(SubCommand::with_name("batch")
+                        .about("Generates signed batches from transaction input.\n \
+                        The transaction input is expected to be length-delimited protobuf \
+                        Transaction messages, which should also be pre-signed for \
+                        submission to the validator.")
+                        .arg(Arg::with_name("input")
+                             .short("i")
+                             .long("input")
+                             .value_name("FILE")
+                             .required(true)
+                             .help("The source of input transactions"))
+                        .arg(Arg::with_name("output")
+                             .short("o")
+                             .long("output")
+                             .value_name("FILE")
+                             .required(true)
+                             .help("The target for the signed batches"))
+                        .arg(Arg::with_name("max-batch-size")
+                             .short("n")
+                             .long("max-batch-size")
+                             .value_name("NUMBER")
+                             .help("The maximum number of transactions to include in a batch; \
+                             Defaults to 100.")))
+            .get_matches();
+
+    let result = match arg_matches.subcommand() {
+        ("batch", Some(args)) => run_batch_command(args),
+        _ => panic!("Should have processed a subcommand or exited before here")
+    };
+
+    std::process::exit(match result {
+        Ok(_) => 0,
+        Err(err) => {
+            writeln!(io::stderr(), "Error: {}", err).unwrap();
+            1
+        }
+    });
+}
+
+macro_rules! arg_error {
+    ($msg:expr) => (Err(Box::new(CliError::ArgumentError(String::from($msg)))));
+}
+
+fn run_batch_command(args: &ArgMatches) -> Result<(), Box<Error>> {
+    let max_txns: usize = match args.value_of("max-batch-size")
+        .unwrap_or("100")
+        .parse() {
+            Ok(n) => n,
+            Err(_) => 0
+        };
+
+    if max_txns == 0 {
+        return arg_error!("max-batch-size must be a number greater than 0");
+    }
+
+    let mut in_file = File::open(args.value_of("input").unwrap())?;
+    let mut out_file = File::create(args.value_of("output").unwrap())?;
+
+    if let Err(err) = generate_signed_batches(&mut in_file, &mut out_file, max_txns) {
+        return Err(Box::new(err));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+enum CliError {
+    ArgumentError(String),
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            CliError::ArgumentError(ref msg) =>
+                write!(f, "ArgumentError: {}",  msg)
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn description(&self) -> &str {
+        match *self {
+            CliError::ArgumentError(ref msg) => msg
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match * self {
+            CliError::ArgumentError(_) => None
+        }
+    }
+}

--- a/perf/sawtooth/sawtooth_workload/unit_perf_workload.yaml
+++ b/perf/sawtooth/sawtooth_workload/unit_perf_workload.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  unit-perf-workload:
+    image: sawtooth-dev-rust:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/perf/sawtooth/sawtooth_workload
+    command: cargo test

--- a/sdk/rust/unit_rust_sdk.yaml
+++ b/sdk/rust/unit_rust_sdk.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  unit-rust-sdk:
+    image: sawtooth-dev-rust:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/sdk/rust
+    command: cargo test


### PR DESCRIPTION
Initial tool for generating batches from a length-delimited source of transactions.  

The batches produced are not yet signed.  