### PR TITLE
Add influx and grafana docker files for stat collection

### DIFF
--- a/docker/compose/sawtooth-local.yaml
+++ b/docker/compose/sawtooth-local.yaml
@@ -1,0 +1,106 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-settings-tp-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-intkey-tp-python-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: intkey-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  xo-tp-python:
+    image: sawtooth-xo-tp-python:latest
+    container_name: sawtooth-xo-tp-python-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: xo-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-validator-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        sawtooth-validator -vv \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-rest-api-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    stop_signal: SIGKILL
+
+  client:
+    image: sawtooth-dev-python:latest
+    container_name: sawtooth-client-local
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 8080
+      - 4004
+    depends_on:
+      - rest-api
+    entrypoint: "bash -c \"\
+        sawtooth keygen && \
+        tail -f /dev/null \
+        \""
+
+networks:
+  default:
+    external:
+      name: sawtooth_stats

--- a/stat_collection/docker/grafana/datasources/influxdb.json
+++ b/stat_collection/docker/grafana/datasources/influxdb.json
@@ -1,0 +1,8 @@
+{
+  "name":"metrics",
+  "type":"influxdb",
+  "url":"http://influxdb:8086",
+  "access":"proxy",
+  "database":"metrics",
+  "basicauth":false
+}

--- a/stat_collection/docker/grafana/grafana_entrypoint.sh
+++ b/stat_collection/docker/grafana/grafana_entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+url="http://admin:admin@localhost:3000"
+
+post() {
+    curl -s -X POST -d "$1" \
+        -H 'Content-Type: application/json;charset=UTF-8' \
+        "$url$2" 2> /dev/null
+}
+
+if [ ! -f "/var/lib/grafana/.init" ]; then
+    exec /run.sh $@ &
+
+    until curl -s "$url/api/datasources" 2> /dev/null; do
+        sleep 1
+    done
+
+    for datasource in /etc/grafana/datasources/*; do
+        post "$(cat $datasource)" "/api/datasources"
+    done
+
+    for dashboard in /etc/grafana/dashboards/*; do
+        post "$(cat $dashboard)" "/api/dashboards/db"
+    done
+
+    touch "/var/lib/grafana/.init"
+
+    kill $(pgrep grafana)
+fi
+
+exec /run.sh $@

--- a/stat_collection/docker/grafana/sawtooth-stats-grafana
+++ b/stat_collection/docker/grafana/sawtooth-stats-grafana
@@ -1,0 +1,30 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM grafana/grafana:latest
+
+RUN apt-get update && \
+    apt-get install -y \
+        curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY dashboards /etc/grafana/dashboards
+COPY datasources /etc/grafana/datasources
+
+WORKDIR /app  
+COPY grafana_entrypoint.sh ./  
+RUN chmod u+x grafana_entrypoint.sh
+
+ENTRYPOINT ["/app/grafana_entrypoint.sh"]

--- a/stat_collection/docker/influxdb/influxdb_entrypoint.sh
+++ b/stat_collection/docker/influxdb/influxdb_entrypoint.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+if [ ! -f "/var/lib/influxdb/.init" ]; then  
+  exec influxd $@ &
+
+  until wget -q "http://localhost:8086/ping" 2> /dev/null; do
+    sleep 1
+  done
+
+  curl -i -XPOST "http://localhost:8086/query" --data-urlencode "q=CREATE DATABASE metrics"
+
+  touch "/var/lib/influxdb/.init"
+
+  kill -s TERM %1
+fi
+
+exec influxd $@

--- a/stat_collection/docker/influxdb/sawtooth-stats-influxdb
+++ b/stat_collection/docker/influxdb/sawtooth-stats-influxdb
@@ -1,0 +1,25 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM influxdb:alpine
+
+RUN apk add --update curl && \
+    rm -rf /var/cache/apk/*
+    
+WORKDIR /app
+COPY influxdb_entrypoint.sh ./
+RUN chmod u+x influxdb_entrypoint.sh
+
+ENTRYPOINT ["/app/influxdb_entrypoint.sh"]

--- a/stat_collection/docker/metrics.yaml
+++ b/stat_collection/docker/metrics.yaml
@@ -1,0 +1,51 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  influxdb:
+    container_name: influxdb
+    build:
+      context: ./influxdb
+      dockerfile: sawtooth-stats-influxdb
+    ports:
+      - "8086:8086"
+    volumes:
+      - influxdb_data:/var/lib/influxdb
+    stop_signal: SIGKILL
+
+  grafana:
+    container_name: grafana
+    build:
+      context: ./grafana
+      dockerfile: sawtooth-stats-grafana
+    links:
+      - influxdb
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    stop_signal: SIGKILL
+
+volumes:
+  grafana_data: {}
+  influxdb_data: {}
+
+networks:
+  default:
+    external:
+      name: sawtooth_stats


### PR DESCRIPTION
This PR adds docker-compose files that build containers containing InfluxDB, Grafana, and local Sawtooth files.

_Note: Prior to running either docker-compose file, a user must create the sawtooth_stats Docker network with the command: `$ docker network create sawtooth_stats`. This allows communication between the containers._

The metrics.yaml docker compose file automatically run scripts that will set up a framework for
stat collection:

- After InfluxDB is started, a post to the InfluxDB HTTP API is made that creates a database called "metrics"

- After Grafana is started, a JSON file is read from the `stat_collection/docker/grafana/datasources` directory, which is posted to the Grafana HTTP API. This request establishes a connection between the InfluxDB "metrics" database.

Note: other datasources and dashboards can be added by adding json files to the `stat_collection/docker/grafana/datasources` or `stat_collection/docker/grafana/dashboards` directories