### PR TITLE
Initial implementation of workload batch submission

### DIFF
--- a/perf/sawtooth/sawtooth_workload/Cargo.toml
+++ b/perf/sawtooth/sawtooth_workload/Cargo.toml
@@ -6,3 +6,7 @@ version = "0.1.0"
 sawtooth_sdk = { path = "../../../sdk/rust" }
 protobuf = "1.4.1"
 clap = "2.26.0"
+futures = "0.1"
+hyper = "0.11"
+tokio-core = "0.1"
+tokio-timer = "0.1"

--- a/perf/sawtooth/sawtooth_workload/src/batch_submit.rs
+++ b/perf/sawtooth/sawtooth_workload/src/batch_submit.rs
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Tools for submitting batch lists of signed batches to Sawtooth endpoints
+
+extern crate protobuf;
+extern crate hyper;
+extern crate tokio_core;
+extern crate tokio_timer;
+extern crate futures;
+
+use std::error;
+use std::fmt;
+use std::io::Read;
+use std::thread;
+use std::time;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::marker::PhantomData;
+
+use self::tokio_core::reactor::Core;
+use self::hyper::Method;
+use self::hyper::client::{HttpConnector, Client, Request};
+use self::hyper::header::{ContentType, ContentLength};
+use self::futures::Future;
+
+use sawtooth_sdk::messages::batch::Batch;
+use sawtooth_sdk::messages::batch::BatchList;
+use self::protobuf::Message;
+use self::protobuf::MessageStatic;
+
+
+/// Populates a channel from a stream of length-delimited batches.
+/// Starts one workload submitter of the appropriate type (http, zmq)
+/// per target. Workload submitters consume from the channel at
+/// the configured rate until the channel is exhausted.
+pub fn submit_signed_batches<'a>(reader: &'a mut Read, target: String, rate: usize)
+    -> Result<(), BatchReadingError>
+{
+    let (sender, receiver) = mpsc::channel();
+    let receiver = Arc::new(Mutex::new(receiver));
+
+    let submit_thread = thread::spawn(move || {
+        http_submitter(target, rate as u64, receiver);
+    });
+
+    let mut feeder = BatchListFeeder::new(reader);
+
+    loop {
+        match feeder.next_batch_list() {
+            Ok(Some(batch_list)) => {
+                sender.send(Some(batch_list)).unwrap();
+            },
+            Ok(None) => {
+                sender.send(None).unwrap();
+                break;
+            },
+            Err(err) => return Err(err),
+        }
+    }
+
+    submit_thread.join().unwrap();
+
+    Ok(())
+}
+
+pub fn http_submitter(target: String, rate: u64, receiver: Arc<Mutex<mpsc::Receiver<Option<BatchList>>>>)
+{
+    let mut core = Core::new().unwrap();
+
+    let client = Client::configure()
+                     .connector(HttpConnector::new(1, &core.handle()))
+                     .keep_alive(true)
+                     .build(&core.handle());
+
+    let timer = tokio_timer::wheel()
+                    .tick_duration(time::Duration::new(0, 1000000))
+                    .build();
+
+    /// Define a target timeslice (how often to submit batches) based
+    /// on number of nanoseconds in a second divided by rate
+    let timeslice = time::Duration::new(0, 1000000000/rate as u32);
+
+    let mut uri = target.clone();
+    uri.push_str("/batches");
+
+    let mut count = 0;
+    let mut last_count = 0;
+    let mut last_time = time::Instant::now();
+
+    loop {
+        match receiver.lock().unwrap().recv().unwrap() {
+            Some(batch_list) => {
+                let bytes = batch_list.write_to_bytes().unwrap();
+
+                let mut req = Request::new(Method::Post, uri.parse().unwrap());
+                req.headers_mut().set(ContentType::octet_stream());
+                req.headers_mut().set(ContentLength(bytes.len() as u64));
+                req.set_body(bytes);
+
+                let work = client.request(req).and_then(|_| {
+                    count = count + 1;
+
+                    if count % rate == 0 {
+                        let log_duration = time::Instant::now() - last_time;
+                        let log_duration_flt = log_duration.as_secs() as f64 + log_duration.subsec_nanos() as f64 * 1e-9;
+
+                        println!("target: {} target rate: {} count: {} effective rate: {} per sec",
+                                 target,
+                                 rate,
+                                 count,
+                                 (count - last_count) as f64/log_duration_flt);
+
+                        last_count = count;
+                        last_time = time::Instant::now();
+                    }
+
+                    Ok(())
+                });
+
+                let request_time = time::Instant::now();
+                core.run(work).unwrap();
+                let runtime = time::Instant::now() - request_time;
+
+                if let Some(sleep_duration) = timeslice.checked_sub(runtime) {
+                    let sleep = timer.sleep(sleep_duration);
+                    sleep.wait().unwrap();
+                }
+            },
+            None => break
+        }
+    }
+}
+
+/// Decodes Protocol Buffer messages from a length-delimited input reader.
+struct LengthDelimitedMessageSource<'a, T: 'a> {
+    source: protobuf::CodedInputStream<'a>,
+    phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T> LengthDelimitedMessageSource<'a, T>
+    where T: Message + MessageStatic
+{
+    /// Creates a new `LengthDelimitedMessageSource` from a given reader.
+    pub fn new(source: &'a mut Read) -> Self {
+        let source = protobuf::CodedInputStream::new(source);
+        LengthDelimitedMessageSource {
+            source,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns the next set of messages.
+    /// The vector of messages will contain up to `max_msgs` number of
+    /// messages.  An empty vector indicates that the source has been consumed.
+    pub fn next(&mut self, max_msgs: usize)
+        -> Result<Vec<T>, protobuf::ProtobufError>
+    {
+        let mut results = Vec::with_capacity(max_msgs);
+        for _ in 0..max_msgs {
+            if self.source.eof()? {
+                break;
+            }
+
+            // read the delimited length
+            let next_len = try!(self.source.read_raw_varint32());
+            let buf = try!(self.source.read_raw_bytes(next_len));
+
+            let msg = try!(protobuf::parse_from_bytes(&buf));
+            results.push(msg);
+        }
+        Ok(results)
+    }
+}
+
+type BatchSource<'a> = LengthDelimitedMessageSource<'a, Batch>;
+
+/// Errors that may occur during the reading of batches.
+#[derive(Debug)]
+pub enum BatchReadingError {
+    MessageError(protobuf::ProtobufError),
+}
+
+impl fmt::Display for BatchReadingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            BatchReadingError::MessageError(ref err) =>
+                write!(f, "Error occurred reading messages: {}", err),
+        }
+    }
+}
+
+impl error::Error for BatchReadingError {
+    fn description(&self) -> &str {
+        match *self {
+            BatchReadingError::MessageError(ref err) => err.description(),
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            BatchReadingError::MessageError(ref err) => Some(err),
+        }
+    }
+}
+
+/// Produces signed batches from a length-delimited source of Transactions.
+pub struct BatchListFeeder<'a> {
+    batch_source: BatchSource<'a>,
+}
+
+/// Resulting BatchList or error.
+pub type BatchListResult = Result<Option<BatchList>, BatchReadingError>;
+
+impl<'a> BatchListFeeder<'a> {
+
+    /// Creates a new `BatchListFeeder` with a given Batch source
+    /// TODO put channel here?
+    pub fn new(source: &'a mut Read) -> Self {
+        let batch_source = LengthDelimitedMessageSource::new(source);
+        BatchListFeeder {
+            batch_source,
+        }
+    }
+
+    /// Gets the next Batch.
+    /// `Ok(None)` indicates that the underlying source has been consumed.
+    pub fn next_batch_list(&mut self) -> BatchListResult {
+        let batches = match self.batch_source.next(1) {
+            Ok(batches) => batches,
+            Err(err) => return Err(BatchReadingError::MessageError(err)),
+        };
+
+        if batches.len() == 0 {
+            return Ok(None);
+        }
+
+        /// Construct a BatchList out of the read batches
+        let mut batch_list = BatchList::new();
+        batch_list.set_batches(protobuf::RepeatedField::from_vec(batches));
+
+        Ok(Some(batch_list))
+    }
+}

--- a/perf/sawtooth/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth/sawtooth_workload/src/main.rs
@@ -2,6 +2,7 @@ extern crate clap;
 extern crate sawtooth_sdk;
 
 mod batch_gen;
+mod batch_submit;
 
 use std::fs::File;
 use std::io;
@@ -9,13 +10,14 @@ use std::io::prelude::*;
 use std::error::Error;
 
 use batch_gen::generate_signed_batches;
+use batch_submit::submit_signed_batches;
 use clap::{App, ArgMatches, AppSettings, Arg, SubCommand};
 
 const APP_NAME: &'static str = env!("CARGO_PKG_NAME");
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let arg_matches = 
+    let arg_matches =
         App::new(APP_NAME)
             .version(VERSION)
             .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -42,10 +44,31 @@ fn main() {
                              .value_name("NUMBER")
                              .help("The maximum number of transactions to include in a batch; \
                              Defaults to 100.")))
+            .subcommand(SubCommand::with_name("submit")
+                        .about("Submits signed batches to one or more targets from batch input.\n \
+                        The batch input is expected to be length-delimited protobuf \
+                        Batch messages, which should also be pre-signed for \
+                        submission to the validator.")
+                        .arg(Arg::with_name("input")
+                            .short("i")
+                            .long("input")
+                            .value_name("FILE")
+                            .help("The source of batch transactions"))
+                        .arg(Arg::with_name("target")
+                            .short("t")
+                            .long("target")
+                            .value_name("TARGET")
+                            .help("A Sawtooth REST API endpoint"))
+                        .arg(Arg::with_name("rate")
+                            .short("r")
+                            .long("rate")
+                            .value_name("RATE")
+                            .help("The number of batches per second to submit to the target")))
             .get_matches();
 
     let result = match arg_matches.subcommand() {
         ("batch", Some(args)) => run_batch_command(args),
+        ("submit", Some(args)) => run_submit_command(args),
         _ => panic!("Should have processed a subcommand or exited before here")
     };
 
@@ -83,6 +106,52 @@ fn run_batch_command(args: &ArgMatches) -> Result<(), Box<Error>> {
 
     Ok(())
 }
+
+fn run_submit_command(args: &ArgMatches) -> Result<(), Box<Error>> {
+    let rate: usize = match args.value_of("rate")
+        .unwrap_or("1")
+        .parse() {
+            Ok(n) => n,
+            Err(_) => 0
+        };
+
+    if rate == 0 {
+        return arg_error!("rate must be a number greater than 0");
+    }
+
+    let target: String = match args.value_of("target")
+        .unwrap_or("http://localhost:8080")
+        .parse() {
+            Ok(s) => s,
+            Err(_) => String::new()
+        };
+
+    if target == "" {
+        return arg_error!("target must be a valid http uri");
+    }
+
+    let input: String = match args.value_of("input")
+        .unwrap_or("")
+        .parse() {
+            Ok(s) => s,
+            Err(_) => String::new()
+        };
+
+    if input == "" {
+       return arg_error!("an input file must be specified");
+    }
+
+    let mut in_file = File::open(args.value_of("input").unwrap())?;
+
+    println!("Input: {} Target: {} Rate: {}", input, target, rate);
+
+    if let Err(err) = submit_signed_batches(&mut in_file, target, rate) {
+        return Err(Box::new(err));
+    }
+
+    Ok(())
+}
+
 
 #[derive(Debug)]
 enum CliError {


### PR DESCRIPTION
This consumes length delimited signed Batches from an input file
and posts BatchLists at a single Sawtooth REST API endpoint at
the specified rate.

Open items:
- Define format for combined target/rate argument
- Support multiple target rates
- Support direct ZMQ target

Signed-off-by: James Mitchell <mitchell@bitwise.io>