### PR TITLE
Fix HW Counter management. Release old signups.

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/signup_info.py
@@ -126,6 +126,27 @@ class SignupInfo(object):
         """
         return poet_enclave_module.unseal_signup_data(sealed_signup_data)
 
+    @classmethod
+    def release_signup_data(cls,
+                            poet_enclave_module,
+                            sealed_signup_data):
+        """
+        Takes sealed data from a previous call to create_signup_info and
+        releases enclave resources invalidating this data for future use.
+
+        Args:
+            poet_enclave_module (module): The module that implements the
+                underlying PoET enclave.
+            sealed_signup_data: The sealed signup data that was previously
+                returned as part of the signup info returned from
+                create_signup_info.
+
+        Returns:
+            The encoded PoET public key corresponding to private key used by
+            PoET to sign wait certificates.
+        """
+        return poet_enclave_module.release_signup_data(sealed_signup_data)
+
     def __init__(self, enclave_signup_info):
         self.poet_public_key = enclave_signup_info.poet_public_key
         self.proof_data = enclave_signup_info.proof_data

--- a/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.h
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.h
@@ -43,7 +43,9 @@ public:
     static std::string UnsealSignupData(
         const std::string& sealedSignupData
         );
-
+    static void ReleaseSignupData(
+        const std::string& sealedSignupData
+        );
     // Signup data properties
     std::string poet_public_key;
     std::string pse_manifest;
@@ -61,6 +63,10 @@ _SignupData* _create_signup_data(
     );
 
 std::string unseal_signup_data(
+    const std::string& sealed_signup_data
+    );
+
+void release_signup_data(
     const std::string& sealed_signup_data
     );
 

--- a/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/signup_data.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/signup_data.cpp
@@ -82,6 +82,18 @@ std::string _SignupData::UnsealSignupData(
 } // _SignupData::UnsealSignupData
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+void _SignupData::ReleaseSignupData(
+    const std::string& sealedSignupData
+    )
+{
+    // Unseal the signup data
+    poet_err_t result =
+        Poet_ReleaseSignupData(
+            sealedSignupData.c_str());
+    ThrowPoetError(result);
+} // _SignupData::UnsealSignupData
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 _SignupData* _create_signup_data(
     const std::string& originator_public_key_hash
     )
@@ -96,4 +108,12 @@ std::string unseal_signup_data(
     )
 {
     return _SignupData::UnsealSignupData(sealed_signup_data);
+} // _unseal_signup_data
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+void release_signup_data(
+    const std::string& sealed_signup_data
+    )
+{
+    _SignupData::ReleaseSignupData(sealed_signup_data);
 } // _unseal_signup_data

--- a/consensus/poet/sgx/tests/test_sgx/test_poet_enclave_signup_info.py
+++ b/consensus/poet/sgx/tests/test_sgx/test_poet_enclave_signup_info.py
@@ -99,3 +99,11 @@ class TestPoetEnclaveSignupInfo(TestCase):
         self.assertEqual(
             signup_info.poet_public_key,
             poet.unseal_signup_data(signup_info.sealed_signup_data))
+
+    def test_release_signup_data(self):
+        signup_info = self._create_signup_info()
+
+        poet.release_signup_data(signup_info.sealed_signup_data)
+
+        with self.assertRaises(SystemError):
+            poet.unseal_signup_data(signup_info.sealed_signup_data)

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -294,6 +294,20 @@ class _PoetEnclaveSimulator(object):
         return signup_data.get('poet_public_key')
 
     @classmethod
+    def release_signup_data(cls, sealed_signup_data):
+        """
+
+        Args:
+            sealed_signup_data: Sealed signup data that was returned
+                previously in a EnclaveSignupInfo object from a call to
+                create_signup_info
+        """
+        # This is a standin method to release enclave resources associated
+        # with this signup. This is not currently relevant to the simulator
+        # but it must match the interface with the HW enclave.
+        pass
+
+    @classmethod
     def create_wait_timer(cls,
                           sealed_signup_data,
                           validator_address,


### PR DESCRIPTION
Hardware counters must be released when no longer needed.
This change adds a simple policy to poet to release counters
after a validator registration has exhausted its allowed
number of blocks published (k test).

The SGX enclave is also updated to throw an error if PoET
attempts to unseal signup data that references a defunct counter.

The block publisher now traps for that event to no longer use
that signup data and puts it into the condition where it seeks
to sign up again.

See Also STL-642 to add HW Counter simulation to poet simulator.
Broader poet core tests will be appropriate when that feature is added.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>