### PR TITLE
Ensure different ids

### DIFF
--- a/perf/sawtooth/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth/sawtooth_workload/src/main.rs
@@ -264,8 +264,8 @@ fn run_playlist_create_command(args: &ArgMatches) -> Result<(), Box<Error>> {
         Err(_) => 0
     };
 
-    if num_accounts == 0 {
-        return arg_error("'accounts' must be a number greater than 0");
+    if num_accounts < 2 {
+        return arg_error("'accounts' must be a number greater than 2");
     }
 
     let num_transactions = match args.value_of("transactions").unwrap().parse() {

--- a/perf/sawtooth/sawtooth_workload/src/playlist.rs
+++ b/perf/sawtooth/sawtooth_workload/src/playlist.rs
@@ -475,8 +475,10 @@ fn make_smallbank_send_payment_txn(rng: &mut StdRng, num_accounts: usize)
 {
     let mut payload =
         smallbank::SmallbankTransactionPayload_SendPaymentTransactionData::new();
-    payload.set_source_customer_id(rng.gen_range(0, num_accounts as u32));
-    payload.set_dest_customer_id(rng.gen_range(0, num_accounts as u32));
+    let source_id = rng.gen_range(0, num_accounts as u32);
+    let dest_id = next_non_matching_in_range(rng, num_accounts as u32, source_id);
+    payload.set_source_customer_id(source_id);
+    payload.set_dest_customer_id(dest_id);
     payload.set_amount(rng.gen_range(10, 200));
 
     payload
@@ -487,10 +489,20 @@ fn make_smallbank_amalgamate_txn(rng: &mut StdRng, num_accounts: usize)
 {
     let mut payload =
         smallbank::SmallbankTransactionPayload_AmalgamateTransactionData::new();
-    payload.set_source_customer_id(rng.gen_range(0, num_accounts as u32));
-    payload.set_dest_customer_id(rng.gen_range(0, num_accounts as u32));
+    let source_id = rng.gen_range(0, num_accounts as u32);
+    let dest_id = next_non_matching_in_range(rng, num_accounts as u32, source_id);
+    payload.set_source_customer_id(source_id);
+    payload.set_dest_customer_id(dest_id);
 
     payload
+}
+
+fn next_non_matching_in_range(rng: &mut StdRng, max: u32, exclude: u32) -> u32 {
+    let mut selected = exclude;
+    while selected == exclude {
+        selected = rng.gen_range(0, max)
+    }
+    selected
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Ensure source and dest ids are different

For transactions that require two customer ids, ensure that the randomly selected keys are different. This requires that the CLI needs a minimum of 2 accounts to properly generate accounts.