### PR TITLE
Create Transaction Receipt Store and Handlers

### DIFF
--- a/protos/events.proto
+++ b/protos/events.proto
@@ -1,0 +1,35 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "events_pb2";
+
+message Event {
+  // Determines how to deserialize event_data, what pairs to expect in Meta, and
+  // is used to subscribe to a class of events.
+  string event_type = 1;
+  // Opaque data defined by the event_type.
+  bytes  event_data = 2;
+  message Meta {
+    string key = 1;
+    string value = 2;
+}
+  // Transparent data defined by the event_type. Events of a given type can be
+  // filtered by key­value pairs in meta_data when subscribing.
+  repeated Meta meta_data = 3;
+}

--- a/protos/txn_receipt.proto
+++ b/protos/txn_receipt.proto
@@ -1,0 +1,60 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "txn_receipt_pb2";
+
+import "state_delta.proto";
+import "events.proto";
+
+message TransactionReceipt {
+  message Data {
+    // Interpretation left to transaction family
+    string data_type = 1;
+    bytes data = 2;
+  }
+  // State changes made by this transaction
+  // StateChange is already defined in protos/state_delta.proto
+  repeated StateChange state_changes = 1;
+  // Events fired by this transaction
+  repeated Event events = 2;
+  // Transaction family defined data
+  repeated Data data = 3;
+}
+
+// Fetches a specific txn by its id (header_signature) from the blockchain.
+message ClientReceiptGetRequest {
+    repeated string transaction_ids = 1;
+}
+
+// A response that returns the txn receipt specified by a
+// ClientTransactionReceiptGetRequest.
+//
+// Statuses:
+//   * OK - everything worked as expected, txn receipt has been fetched
+//   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
+//   * NO_RESOURCE - no receipt exists for the transaction id specified
+message ClientReceiptGetResponse {
+    enum Status {
+        OK = 0;
+        INTERNAL_ERROR = 1;
+        NO_RESOURCE = 4;
+    }
+    Status status = 1;
+    repeated TransactionReceipt receipts = 2;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -96,6 +96,10 @@ message Message {
         CLIENT_BATCH_STATUS_REQUEST = 120;
         // A response with the batch statuses
         CLIENT_BATCH_STATUS_RESPONSE = 121;
+        // A request for one or more transaction receipts
+        CLIENT_RECEIPT_GET_REQUEST= 122;
+        // A response with the receipts
+        CLIENT_RECEIPT_GET_RESPONSE= 123;
         // Further messages from the stats client through the web api
 
         // Temp message types until a discussion can be had about gossip msg

--- a/validator/sawtooth_validator/journal/receipt_store.py
+++ b/validator/sawtooth_validator/journal/receipt_store.py
@@ -1,0 +1,101 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+from sawtooth_validator.protobuf.txn_receipt_pb2 import TransactionReceipt
+from sawtooth_validator.protobuf.txn_receipt_pb2 import \
+    ClientReceiptGetRequest
+from sawtooth_validator.protobuf.txn_receipt_pb2 import \
+    ClientReceiptGetResponse
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.protobuf import validator_pb2
+
+
+class TransactionReceiptStore:
+    """A TransactionReceiptStore persists TransactionReceipt records to a
+    provided database implementation.
+    """
+
+    def __init__(self, receipt_db):
+        """Constructs a TransactionReceiptStore, backed by a given database
+        implementation.
+
+        Args:
+            receipt_db (:obj:sawtooth_validator.database.database.Database): A
+                database implementation that backs this store.
+        """
+        self._receipt_db = receipt_db
+
+    def put(self, txn_id, txn_receipt):
+        """Add the given transaction receipt to the store. Does not guarantee
+           it has been written to the backing store.
+
+        Args:
+            txn_id (str): the id of the transaction being stored.
+            receipt (TransactionReceipt): the receipt object to store.
+        """
+        self._receipt_db[txn_id] = txn_receipt.SerializeToString()
+
+    def get(self, txn_id):
+        """Returns the TransactionReceipt
+
+        Args:
+            txn_id (str): the id of the transaction for which the receipt
+                should be retrieved.
+
+        Returns:
+            TransactionReceipt: The receipt for the given transaction id.
+
+        Raises:
+            KeyError: if the transaction id is unknown.
+        """
+        if txn_id not in self._receipt_db:
+            raise KeyError(
+                'Unknown transaction id {}'.format(txn_id))
+
+        txn_receipt_bytes = self._receipt_db[txn_id]
+        txn_receipt = TransactionReceipt()
+        txn_receipt.ParseFromString(txn_receipt_bytes)
+        return txn_receipt
+
+
+class ClientReceiptGetRequestHandler(Handler):
+    """Handles receiving messages for getting transactionreceipts."""
+    _msg_type = validator_pb2.Message.CLIENT_RECEIPT_GET_RESPONSE
+
+    def __init__(self, txn_receipt_store):
+        self._txn_receipt_store = txn_receipt_store
+
+    def handle(self, connection_id, message_content):
+        request = ClientReceiptGetRequest()
+        request.ParseFromString(message_content)
+
+        try:
+            response = ClientReceiptGetResponse(
+                receipts=[
+                    self._txn_receipt_store.get(txn_id)
+                    for txn_id in request.transaction_ids
+                ],
+                status=ClientReceiptGetResponse.OK)
+
+        except KeyError:
+            response = ClientReceiptGetResponse(
+                status=ClientReceiptGetResponse.NO_RESOURCE)
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=response,
+            message_type=self._msg_type)

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -1,0 +1,121 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.journal.receipt_store import TransactionReceiptStore
+from sawtooth_validator.journal.receipt_store import \
+    ClientReceiptGetRequestHandler
+
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.protobuf.txn_receipt_pb2 import TransactionReceipt
+from sawtooth_validator.protobuf.txn_receipt_pb2 import \
+    ClientReceiptGetRequest
+from sawtooth_validator.protobuf.txn_receipt_pb2 import \
+    ClientReceiptGetResponse
+from sawtooth_validator.protobuf.state_delta_pb2 import StateChange
+from sawtooth_validator.protobuf.events_pb2 import Event
+
+
+class ReceiptStoreTest(unittest.TestCase):
+    def test_receipt_store_get_and_set(self):
+        """Tests that we correctly get and set state changes to a ReceiptStore.
+
+        This test sets a list of receipts and then gets them back, ensuring that
+        the data is the same.
+        """
+
+        receipt_store = TransactionReceiptStore(DictDatabase())
+
+        receipts = []
+        for i in range(10):
+            state_changes = []
+            events = []
+            data = []
+
+            for j in range(10):
+                string = str(j)
+                byte = string.encode()
+
+                state_changes.append(StateChange(
+                    address='a100000' + string,
+                    value=byte,
+                    type=StateChange.SET))
+                events.append(Event(
+                    event_type="test",
+                    event_data=byte,
+                    meta_data=[Event.Meta(key=string, value=string)]))
+                data.append(TransactionReceipt.Data(
+                    data_type="test",
+                    data=byte))
+
+            receipts.append(TransactionReceipt(
+                state_changes=state_changes,
+                events=events,
+                data=data))
+
+        for i in range(len(receipts)):
+            receipt_store.put(str(i), receipts[i])
+
+        for i in range(len(receipts)):
+            stored_receipt = receipt_store.get(str(i))
+
+            self.assertEqual(stored_receipt.state_changes, receipts[i].state_changes)
+            self.assertEqual(stored_receipt.events, receipts[i].events)
+            self.assertEqual(stored_receipt.data, receipts[i].data)
+
+    def test_raise_key_error_on_missing_receipt(self):
+        """Tests that we correctly raise key error on a missing receipt
+        """
+        receipt_store = TransactionReceiptStore(DictDatabase())
+
+        with self.assertRaises(KeyError):
+            receipt_store.get('unknown')
+
+class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
+    def test_get_receipts(self):
+        """Tests that the TransactionReceiptGetRequestHandler will return a
+        response with the receipt for the transaction requested.
+        """
+        receipt_store = TransactionReceiptStore(DictDatabase())
+
+        receipt = TransactionReceipt(
+            data=[TransactionReceipt.Data(
+                data_type="dead", data="beef".encode())])
+
+        receipt_store.put("deadbeef", receipt)
+
+        handler = ClientReceiptGetRequestHandler(receipt_store)
+
+        request = ClientReceiptGetRequest(
+            transaction_ids=['deadbeef']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(ClientReceiptGetResponse.OK,
+                         response.message_out.status)
+
+        self.assertEqual([receipt], [r for r in response.message_out.receipts])
+
+
+        request = ClientReceiptGetRequest(
+            transaction_ids=['unknown']).SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(ClientReceiptGetResponse.NO_RESOURCE,
+                         response.message_out.status)


### PR DESCRIPTION
This PR adds a receipt store object, transaction receipt protobuf messages, message handlers, and tests that they all function. The receipt store will be used once the transaction execution results are returned from the executor.