### PR TITLE
Track and Trade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,14 +27,16 @@
 /consensus/poet/sgx/**/poet_enclave_wrap.cpp
 
 /core/sawtooth_core.egg-info/
-/families/settings/sawtooth_settings/protobuf/
-/families/supplychain/python/sawtooth_supplychain/protobuf
-/families/supplychain/python/build/
+
 /families/**/__pycache__/
-/families/track_and_trade/client/public/dist
-/families/track_and_trade/server/rethinkdb_data
+/families/settings/sawtooth_settings/protobuf/
 /families/identity/sawtooth_identity/protobuf
 /families/block_info/sawtooth_block_info/protobuf
+/families/supplychain/python/sawtooth_supplychain/protobuf
+/families/supplychain/python/build/
+/families/track_and_trade/sawtooth_track_and_trade/protobuf
+/families/track_and_trade/client/public/dist
+/families/track_and_trade/server/rethinkdb_data
 
 /coverage
 /coverage/html

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@
 /families/block_info/sawtooth_block_info/protobuf
 /families/supplychain/python/sawtooth_supplychain/protobuf
 /families/supplychain/python/build/
-/families/track_and_trade/sawtooth_track_and_trade/protobuf
+/families/track_and_trade/processor/sawtooth_track_and_trade/protobuf
 /families/track_and_trade/client/public/dist
 /families/track_and_trade/server/rethinkdb_data
 

--- a/bin/build_all
+++ b/bin/build_all
@@ -255,6 +255,7 @@ then
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-block-info-tp
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-intkey-tp-python
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-supplychain-tp
+	docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-track-and-trade-tp
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-poet-validator-registry-tp
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-xo-tp-python
         docker_build $top_dir/docker/sawtooth-dev-python docker/ sawtooth-validator

--- a/bin/protogen
+++ b/bin/protogen
@@ -83,7 +83,7 @@ def main(args=None):
     # 7. Generate Track and Trade protos
     protoc(
         JOIN(TOP_DIR, "families/track_and_trade/protos"),
-        "families/track_and_trade",
+        "families/track_and_trade/processor",
         "sawtooth_track_and_trade/protobuf")
 
     if "go" in args:

--- a/bin/protogen
+++ b/bin/protogen
@@ -76,10 +76,15 @@ def main(args=None):
     protoc(proto_dir, "families/identity", "sawtooth_identity/protobuf")
     protoc(proto_dir, "cli", "sawtooth_cli/protobuf")
 
-    # 5. Generate block info protos
+    # 6. Generate block info protos
     proto_dir = JOIN(TOP_DIR, "families/block_info/protos")
     protoc(proto_dir, "families/block_info", "sawtooth_block_info/protobuf")
 
+    # 7. Generate Track and Trade protos
+    protoc(
+        JOIN(TOP_DIR, "families/track_and_trade/protos"),
+        "families/track_and_trade",
+        "sawtooth_track_and_trade/protobuf")
 
     if "go" in args:
         proto_dir = JOIN(TOP_DIR, "families/seth/src/protos")

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -171,6 +171,7 @@ lint families/identity "$SINCE" || retval=1
 lint families/block_info "$SINCE" || retval=1
 lint families/supplychain/python "$SINCE" || retval=1
 lint families/track_and_trade/processor/sawtooth_track_and_trade/ "$SINCE" || retval=1
+lint families/track_and_trade/tests/sawtooth_tt_test "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/validator

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -163,12 +163,14 @@ PYTHONPATH=$top_dir/families/identity
 PYTHONPATH=$top_dir/families/block_info
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/families/supplychain/python
+PYTHONPATH=$PYTHONPATH:$top_dir/families/track_and_trade/processor
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
 export PYTHONPATH
 lint families/settings "$SINCE" || retval=1
 lint families/identity "$SINCE" || retval=1
 lint families/block_info "$SINCE" || retval=1
 lint families/supplychain/python "$SINCE" || retval=1
+lint families/track_and_trade/processor/sawtooth_track_and_trade/ "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/validator

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -169,6 +169,9 @@ main() {
                 supplychain)
                     test_supplychain
                     ;;
+		track_and_trade)
+		    test_track_and_trade
+		    ;;
                 validator)
                     test_validator
                     ;;
@@ -270,6 +273,11 @@ test_supplychain() {
     copy_coverage .coverage.config
     run_docker_test ./families/supplychain/python/tests/int_supplychain_python.yaml
     copy_coverage .coverage.config
+}
+
+test_track_and_trade() {
+    run_docker_test test_track_and_trade
+    copy_coverage .coverage.track_and_trade
 }
 
 test_validator() {

--- a/bin/track-and-trade-tp
+++ b/bin/track-and-trade-tp
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import sys
+import sysconfig
+
+build_str = "lib.{}-{}.{}".format(
+    sysconfig.get_platform(),
+    sys.version_info.major, sys.version_info.minor)
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'families', 'track_and_trade', 'processor'))
+
+from sawtooth_track_and_trade.processor.main import main
+
+if __name__ == '__main__':
+    main()

--- a/families/track_and_trade/nose2.cfg
+++ b/families/track_and_trade/nose2.cfg
@@ -1,0 +1,8 @@
+[unittest]
+start-dir = tests
+code-directories = ..
+test-file-pattern = test*.py
+plugins = nose2.plugins.coverage
+
+[coverage]
+always-on = True

--- a/families/track_and_trade/processor/sawtooth_track_and_trade/addressing.py
+++ b/families/track_and_trade/processor/sawtooth_track_and_trade/addressing.py
@@ -1,0 +1,89 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import hashlib
+
+
+def _hash(string):
+    return hashlib.sha512(string.encode('utf-8')).hexdigest()
+
+
+# The first six characters of a T&T address are the first six
+# characters of the hash of the T&T family name. The next two
+# characters depend on the type of object being stored. There is no
+# formula for deriving these infixes.
+
+FAMILY_NAME = 'track_and_trade'
+
+NAMESPACE = _hash(FAMILY_NAME)[:6]
+
+AGENT = 'ae'
+PROPERTY = 'ea'
+PROPOSAL = 'aa'
+RECORD = 'ec'
+RECORD_TYPE = 'ee'
+
+
+def make_agent_address(identifier):
+    return (
+        NAMESPACE
+        + AGENT
+        + _hash(identifier)[:62]
+    )
+
+
+def make_record_address(record_id):
+    return (
+        NAMESPACE
+        + RECORD
+        + _hash(record_id)[:62]
+    )
+
+
+def make_record_type_address(type_name):
+    return (
+        NAMESPACE
+        + RECORD_TYPE
+        + _hash(type_name)[:62]
+    )
+
+
+def make_property_address(record_id, property_name, page=0):
+    return (
+        make_property_address_range(record_id)
+        + _hash(property_name)[:22]
+        + _num_to_page_number(page)
+    )
+
+
+def _num_to_page_number(num):
+    return hex(num)[2:].zfill(4)
+
+
+def make_property_address_range(record_id):
+    return (
+        NAMESPACE
+        + PROPERTY
+        + _hash(record_id)[:36]
+    )
+
+
+def make_proposal_address(record_id, agent_id):
+    return (
+        NAMESPACE
+        + PROPOSAL
+        + _hash(record_id)[:36]
+        + _hash(agent_id)[:26]
+    )

--- a/families/track_and_trade/processor/sawtooth_track_and_trade/processor/handler.py
+++ b/families/track_and_trade/processor/sawtooth_track_and_trade/processor/handler.py
@@ -1,0 +1,796 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+import time
+
+from sawtooth_sdk.processor.state import StateEntry
+from sawtooth_sdk.processor.exceptions import InvalidTransaction
+from sawtooth_sdk.processor.exceptions import InternalError
+from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
+
+from sawtooth_track_and_trade.protobuf.agent_pb2 import Agent
+from sawtooth_track_and_trade.protobuf.agent_pb2 import AgentContainer
+
+from sawtooth_track_and_trade.protobuf.property_pb2 import Property
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertyContainer
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertySchema
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertyPage
+from sawtooth_track_and_trade.protobuf.property_pb2 import \
+    PropertyPageContainer
+
+from sawtooth_track_and_trade.protobuf.proposal_pb2 import Proposal
+from sawtooth_track_and_trade.protobuf.proposal_pb2 import ProposalContainer
+
+from sawtooth_track_and_trade.protobuf.record_pb2 import Record
+from sawtooth_track_and_trade.protobuf.record_pb2 import RecordContainer
+from sawtooth_track_and_trade.protobuf.record_pb2 import RecordType
+from sawtooth_track_and_trade.protobuf.record_pb2 import RecordTypeContainer
+
+from sawtooth_track_and_trade.protobuf.payload_pb2 import TTPayload
+from sawtooth_track_and_trade.protobuf.payload_pb2 import AnswerProposalAction
+
+import sawtooth_track_and_trade.addressing as addressing
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+
+PROPERTY_PAGE_MAX_LENGTH = 256
+TOTAL_PROPERTY_PAGE_MAX = 16 ** 4
+
+
+class TTTransactionHandler:
+    @property
+    def family_name(self):
+        return addressing.FAMILY_NAME
+
+    @property
+    def family_versions(self):
+        return ['1.0']
+
+    @property
+    def encodings(self):
+        return ['application/protobuf']
+
+    @property
+    def namespaces(self):
+        return [addressing.NAMESPACE]
+
+    def apply(self, transaction, state):
+        '''
+        A TTPayload consists of a timestamp, an action tag, and
+        attributes corresponding to various actions (create_agent,
+        create_record, etc). The appropriate attribute will be
+        selected depending on the action tag, and that information
+        plus the timestamp and the public key with which the
+        transaction was signed will be passed on to the appropriate
+        handler function (_create_agent, _create_record, etc).
+        _unpack_transaction gets the signing key, the timestamp, and
+        the action tag out of the transaction, then returns the
+        signing key, the timestamp, and the appropriate TTPayload
+        attribute and handler function.
+
+        Besides this, the transaction's timestamp is verified, since
+        that validation is common to all transactions.
+        '''
+        signer, timestamp, payload, handler = _unpack_transaction(transaction)
+
+        _verify_timestamp(timestamp)
+
+        handler(payload, signer, timestamp, state)
+
+
+# handlers
+
+def _create_agent(payload, signer, timestamp, state):
+    name = payload.name
+
+    address = addressing.make_agent_address(signer)
+    container = _get_container(state, address)
+
+    for agent in container.entries:
+        if agent.public_key == signer:
+            raise InvalidTransaction(
+                'Agent already exists')
+
+    agent = Agent(
+        public_key=signer,
+        name=name,
+        timestamp=timestamp,
+    )
+
+    container.entries.extend([agent])
+    container.entries.sort(key=lambda ag: ag.public_key)
+
+    _set_container(state, address, container)
+
+
+def _create_record(payload, signer, timestamp, state):
+    '''
+    * Check that the signer is registered.
+    * Check that the record doesn't already exist.
+    * Check that the record type exists.
+    * Check that the required properties have been provided.
+    * Create the record (and record container if needed).
+    * Create the associated properties.
+    * Post the provided property values.
+    '''
+
+    # Check that the signer is registered.
+    _verify_agent(state, signer)
+
+    # Check that the record doesn't already exist
+    record_id = payload.record_id
+
+    record_address = addressing.make_record_address(record_id)
+    record_container = _get_container(state, record_address)
+
+    if any(rec.record_id == record_id for rec in record_container.entries):
+        raise InvalidTransaction(
+            'Record {} already exists'.format(record_id))
+
+    # Check that the record type exists.
+    type_name = payload.record_type
+    record_type, _, _ = _get_record_type(state, type_name)
+
+    type_schemata = {
+        prop.name: prop
+        for prop in record_type.properties
+    }
+
+    required_properties = {
+        name: prop
+        for name, prop in type_schemata.items()
+        if prop.required
+    }
+
+    provided_properties = {
+        prop.name: prop
+        for prop in payload.properties
+    }
+
+    # Make sure the required properties are all provided
+    for name in required_properties:
+        if name not in provided_properties:
+            raise InvalidTransaction(
+                'Required property {} not provided'.format(
+                    name))
+
+    # Make sure the provided properties have the right type
+    for provided_name in provided_properties:
+        required_type = required_properties[provided_name].data_type
+        provided_type = provided_properties[provided_name].data_type
+        if required_type != provided_type:
+            raise InvalidTransaction(
+                'Value provided for {} is the wrong type'.format(
+                    provided_name))
+
+    # Create the record
+    record = Record(
+        record_id=record_id,
+        record_type=type_name,
+        final=False,
+    )
+
+    record.owners.extend([
+        Record.AssociatedAgent(
+            agent_id=signer,
+            timestamp=timestamp,
+        )
+    ])
+
+    record.custodians.extend([
+        Record.AssociatedAgent(
+            agent_id=signer,
+            timestamp=timestamp,
+        )
+    ])
+
+    record_container.entries.extend([record])
+    record_container.entries.sort(key=lambda rec: rec.record_id)
+
+    _set_container(state, record_address, record_container)
+
+    # Create the associated properties
+    for property_name, prop in type_schemata.items():
+        _make_new_property(
+            state=state,
+            record_id=record_id,
+            property_name=property_name,
+            data_type=prop.data_type,
+            signer=signer,
+        )
+
+        _make_new_property_page(
+            state=state,
+            timestamp=timestamp,
+            record_id=record_id,
+            property_name=property_name,
+            value=(
+                None if property_name not in provided_properties
+                else provided_properties[property_name]
+            ),
+            page_number=1,
+        )
+
+
+def _finalize_record(payload, signer, timestamp, state):
+    '''
+    * Check that the signer is both the owner and custodian
+    * Check that the record is not already final
+    '''
+    record_id = payload.record_id
+
+    record, container, address = _get_record(state, record_id)
+
+    if not _is_owner(record, signer) or not _is_custodian(record, signer):
+        raise InvalidTransaction(
+            'Must be owner and custodian to finalize record')
+
+    if record.final:
+        raise InvalidTransaction(
+            'Record is already final')
+
+    record.final = True
+
+    _set_container(state, address, container)
+
+
+def _create_record_type(payload, signer, timestamp, state):
+    _verify_agent(state, signer)
+
+    name, properties = payload.name, payload.properties
+
+    address = addressing.make_record_type_address(name)
+
+    container = _get_container(state, address)
+
+    for rec_type in container.entries:
+        if name == rec_type.name:
+            raise InvalidTransaction(
+                'Record type `{}` already exists'.format(name))
+
+    record_type = RecordType(
+        name=name,
+        properties=properties,
+    )
+
+    container.entries.extend([record_type])
+    container.entries.sort(key=lambda rec_type: rec_type.name)
+
+    _set_container(state, address, container)
+
+
+def _update_properties(payload, signer, timestamp, state):
+    '''
+    * Check that the record is not final
+    * Check that the signer is an authorized reporter
+    * Check that the types are correct
+    '''
+    # Check that the record is not final
+    record_id = payload.record_id
+    record, _, _ = _get_record(state, record_id)
+
+    if record.final:
+        raise InvalidTransaction(
+            'Record is final')
+
+    updates = payload.properties
+
+    for update in updates:
+        name, data_type = update.name, update.data_type
+        property_address = addressing.make_property_address(record_id, name)
+        property_container = _get_container(state, property_address)
+
+        try:
+            prop = next(
+                prop
+                for prop in property_container.entries
+                if prop.name == name
+            )
+        except StopIteration:
+            raise InvalidTransaction(
+                'Record does not have property')
+
+        try:
+            reporter_index = next(
+                reporter.index
+                for reporter in prop.reporters
+                if reporter.public_key == signer and reporter.authorized
+            )
+        except StopIteration:
+            raise InvalidTransaction(
+                'Reporter is not authorized')
+
+        if data_type != prop.data_type:
+            raise InvalidTransaction(
+                'Update has wrong type')
+
+        page_number = prop.current_page
+        page_address = addressing.make_property_address(
+            record_id, name, page_number)
+        page_container = _get_container(state, page_address)
+
+        try:
+            page = next(
+                page
+                for page in page_container.entries
+                if page.name == name
+            )
+        except StopIteration:
+            raise InternalError(
+                'Property page does not exists')
+
+        reported_value = _make_new_reported_value(
+            reporter_index=reporter_index,
+            timestamp=timestamp,
+            prop=update,
+        )
+
+        page.reported_values.extend([reported_value])
+        page.reported_values.sort(
+            key=lambda val: (val.timestamp, val.reporter_index))
+
+        page_container.entries.extend([page])
+        page_container.entries.sort(key=lambda page: page.name)
+
+        _set_container(state, page_address, page_container)
+
+
+def _create_proposal(payload, signer, timestamp, state):
+    record_id, receiving_agent, role, properties = \
+        payload.record_id, payload.receiving_agent, \
+        payload.role, payload.properties
+
+    # Verify both agents
+    _verify_agent(state, signer)
+    _verify_agent(state, receiving_agent)
+
+    proposal_address = addressing.make_proposal_address(
+        record_id, receiving_agent)
+    proposal_container = _get_container(state, proposal_address)
+
+    open_proposals = [
+        proposal
+        for proposal in proposal_container.entries
+        if proposal.status == Proposal.OPEN
+    ]
+
+    for proposal in open_proposals:
+        if (proposal.receiving_agent == receiving_agent
+                and proposal.role == role
+                and proposal.timestamp == timestamp
+                and proposal.record_id == record_id):
+            raise InvalidTransaction(
+                'Proposal already exists')
+
+    record, _, _ = _get_record(state, record_id)
+
+    if record.final:
+        raise InvalidTransaction(
+            'Record is final')
+
+    if role == Proposal.OWNER or role == Proposal.REPORTER:
+        if not _is_owner(record, signer):
+            raise InvalidTransaction(
+                'Must be owner')
+
+    if role == Proposal.CUSTODIAN:
+        if not _is_custodian(record, signer):
+            raise InvalidTransaction(
+                'Must be custodian')
+
+    proposal = Proposal(
+        record_id=record_id,
+        timestamp=timestamp,
+        issuing_agent=signer,
+        receiving_agent=receiving_agent,
+        role=role,
+        properties=properties,
+        status=Proposal.OPEN,
+    )
+
+    proposal_container.entries.extend([proposal])
+    proposal_container.entries.sort(
+        key=lambda prop: (
+            prop.record_id,
+            prop.receiving_agent,
+            prop.timestamp,
+        )
+    )
+
+    _set_container(state, proposal_address, proposal_container)
+
+
+def _answer_proposal(payload, signer, timestamp, state):
+    record_id, receiving_agent, role, response = \
+        payload.record_id, payload.receiving_agent, \
+        payload.role, payload.response
+
+    proposal_address = addressing.make_proposal_address(
+        record_id, receiving_agent)
+    proposal_container = _get_container(state, proposal_address)
+
+    try:
+        proposal = next(
+            proposal
+            for proposal in proposal_container.entries
+            if (proposal.status == Proposal.OPEN
+                and proposal.receiving_agent == receiving_agent
+                and proposal.role == role)
+        )
+    except StopIteration:
+        raise InvalidTransaction(
+            'No such open proposal')
+
+    if response == AnswerProposalAction.CANCEL:
+        if proposal.issuing_agent != signer:
+            raise InvalidTransaction(
+                'Only the issuing agent can cancel')
+
+        proposal.status = Proposal.CANCELLED
+
+    elif response == AnswerProposalAction.REJECT:
+        if proposal.receiving_agent != signer:
+            raise InvalidTransaction(
+                'Only the receiving agent can reject')
+
+        proposal.status = Proposal.REJECTED
+
+    elif response == AnswerProposalAction.ACCEPT:
+        if proposal.receiving_agent != signer:
+            raise InvalidTransaction(
+                'Only the receiving agent can accept')
+
+        proposal.status = _accept_proposal(state, signer, proposal, timestamp)
+
+    _set_container(state, proposal_address, proposal_container)
+
+
+def _accept_proposal(state, signer, proposal, timestamp):
+    record_id, issuing_agent, receiving_agent, role, properties = \
+        proposal.record_id, proposal.issuing_agent, \
+        proposal.receiving_agent, proposal.role, proposal.properties
+
+    record, record_container, record_address = _get_record(state, record_id)
+
+    if role == Proposal.OWNER:
+        if not _is_owner(record, issuing_agent):
+            LOGGER.info('Issuing agent is not owner')
+            return Proposal.CANCELLED
+
+        record.owners.extend([
+            Record.AssociatedAgent(
+                agent_id=receiving_agent,
+                timestamp=timestamp)
+        ])
+
+        record.owners.sort(key=lambda agent: agent.timestamp)
+
+        _set_container(state, record_address, record_container)
+
+        return Proposal.ACCEPTED
+
+    elif role == Proposal.CUSTODIAN:
+        if not _is_custodian(record, issuing_agent):
+            LOGGER.info('Issuing agent is not custodian')
+            return Proposal.CANCELLED
+
+        record.custodians.extend([
+            Record.AssociatedAgent(
+                agent_id=receiving_agent,
+                timestamp=timestamp)
+        ])
+
+        record.custodians.sort(key=lambda agent: agent.timestamp)
+
+        _set_container(state, record_address, record_container)
+
+        return Proposal.ACCEPTED
+
+    elif role == Proposal.REPORTER:
+        if not _is_owner(record, issuing_agent):
+            LOGGER.info('Issuing agent is not owner')
+            return Proposal.CANCELLED
+
+        for prop_name in properties:
+            prop, container, address = _get_property(
+                state, record_id, prop_name)
+
+            prop.reporters.extend([
+                Property.Reporter(
+                    public_key=signer,
+                    authorized=True,
+                    index=len(prop.reporters),
+                )
+            ])
+
+            _set_container(state, address, container)
+
+        return Proposal.ACCEPTED
+
+
+def _revoke_reporter(payload, signer, timestamp, state):
+    '''
+    * Check that the signer is the owner
+    * Check that the reporter is actually a reporter
+    * Does it matter if the record is finalized?
+    '''
+    record_id, reporter_id, properties = \
+        payload.record_id, payload.reporter_id, payload.properties
+
+    record, _, _ = _get_record(state, record_id)
+
+    if not _is_owner(record, signer):
+        raise InvalidTransaction(
+            'Must be owner to revoke reporters')
+
+    if record.final:
+        raise InvalidTransaction(
+            'Record is final')
+
+    for property_name in properties:
+        property_container, property_address, prop = \
+            _get_property(state, record_id, property_name)
+
+        if reporter_id not in prop.reporters:
+            raise InvalidTransaction(
+                'Reporter is not authorized')
+
+        for reporter in prop.reporters:
+            if reporter.public_key == reporter_id:
+                reporter.authorization = False
+
+        _set_container(state, property_address, property_container)
+
+
+# helpers
+
+def _get_container(state, address):
+    # Get the appropriate container type based on the address
+    namespace = address[6:8]
+
+    containers = {
+        addressing.AGENT: AgentContainer,
+        addressing.PROPERTY: (PropertyContainer
+                              if address[-4:] == '0000'
+                              else PropertyPageContainer),
+        addressing.PROPOSAL: ProposalContainer,
+        addressing.RECORD: RecordContainer,
+        addressing.RECORD_TYPE: RecordTypeContainer,
+    }
+
+    container = containers[namespace]()
+
+    # Get data from state
+    entries = state.get([address])
+
+    if entries:
+        data = entries[0].data
+        container.ParseFromString(data)
+
+    return container
+
+
+def _set_container(state, address, container):
+    addresses = state.set([
+        StateEntry(
+            address=address,
+            data=container.SerializeToString(),
+        )
+    ])
+
+    if not addresses:
+        raise InternalError(
+            'State error -- failed to set state entries')
+
+
+def _verify_agent(state, public_key):
+    ''' Verify that public_key has been registered as an agent '''
+    address = addressing.make_agent_address(public_key)
+    container = _get_container(state, address)
+
+    if all(agent.public_key != public_key for agent in container.entries):
+        raise InvalidTransaction(
+            'Agent must be registered to perform this action')
+
+
+def _is_owner(record, agent_id):
+    return record.owners[-1].agent_id == agent_id
+
+
+def _is_custodian(record, agent_id):
+    return record.custodians[-1].agent_id == agent_id
+
+
+def _get_record(state, record_id):
+    ''' Return record, record_container, record_address '''
+    record_address = addressing.make_record_address(record_id)
+    record_container = _get_container(state, record_address)
+
+    try:
+        record = next(
+            record
+            for record in record_container.entries
+            if record.record_id == record_id
+        )
+    except StopIteration:
+        raise InvalidTransaction(
+            'Record does not exist')
+
+    return record, record_container, record_address
+
+
+def _get_record_type(state, type_name):
+    type_address = addressing.make_record_type_address(type_name)
+    type_container = _get_container(state, type_address)
+
+    try:
+        record_type = next(
+            rec_type
+            for rec_type in type_container.entries
+            if rec_type.name == type_name
+        )
+    except StopIteration:
+        raise InvalidTransaction(
+            'No record type {} exists'.format(type_name))
+
+    return record_type, type_container, type_address
+
+
+def _get_property(state, record_id, property_name):
+    ''' Return property, property_container, property_address '''
+    property_address = addressing.make_property_address(
+        record_id, property_name)
+
+    property_container = _get_container(state, property_address)
+
+    try:
+        prop = next(
+            prop
+            for prop in property_container.entries
+            if prop.name == property_name
+        )
+    except StopIteration:
+        raise InvalidTransaction(
+            'Property does not exist')
+
+    return prop, property_container, property_address
+
+
+def _make_new_property(state, record_id, property_name, data_type, signer):
+    property_address = addressing.make_property_address(
+        record_id, property_name, 0)
+
+    property_container = _get_container(state, property_address)
+
+    new_prop = Property(
+        name=property_name,
+        record_id=record_id,
+        data_type=data_type,
+        reporters=[Property.Reporter(
+            public_key=signer,
+            authorized=True,
+            index=0,
+        )],
+        current_page=1,
+        wrapped=False,
+    )
+
+    property_container.entries.extend([new_prop])
+    property_container.entries.sort(key=lambda prop: prop.name)
+
+    _set_container(state, property_address, property_container)
+
+
+def _make_new_property_page(
+        state, timestamp, record_id,
+        property_name, value, page_number):
+    page_address = addressing.make_property_address(
+        record_id, property_name, page_number)
+
+    page_container = _get_container(state, page_address)
+
+    page = PropertyPage(name=property_name)
+
+    if value:
+        page.reported_values.extend([
+            _make_new_reported_value(
+                reporter_index=0,
+                timestamp=timestamp,
+                prop=value,
+            )
+        ])
+
+    page_container.entries.extend([page])
+    page_container.entries.sort(key=lambda page: page.name)
+
+    _set_container(state, page_address, page_container)
+
+
+def _make_new_reported_value(reporter_index, timestamp, prop):
+    reported_value = PropertyPage.ReportedValue(
+        reporter_index=reporter_index,
+        timestamp=timestamp,
+    )
+
+    attribute = DATA_TYPE_TO_ATTRIBUTE[prop.data_type]
+
+    setattr(
+        reported_value,
+        attribute,
+        getattr(prop, attribute))
+
+    return reported_value
+
+
+DATA_TYPE_TO_ATTRIBUTE = {
+    PropertySchema.BYTES: 'bytes_value',
+    PropertySchema.STRING: 'string_value',
+    PropertySchema.INT: 'int_value',
+    PropertySchema.FLOAT: 'float_value',
+    PropertySchema.LOCATION: 'location_value',
+}
+
+
+def _verify_timestamp(timestamp):
+    '''Verify that the timestamp is not greater than the system time.'''
+    system_time = round(time.time())
+
+    if timestamp > system_time:
+        raise InvalidTransaction(
+            'Timestamp must be less than system time')
+
+
+def _unpack_transaction(transaction):
+    '''Return the transaction signing key, the TTPayload timestamp, the
+    appropriate TTPayload action attribute, and the appropriate
+    handler function (with the latter two determined by the constant
+    TYPE_TO_ACTION_HANDLER table.
+    '''
+    header = TransactionHeader()
+    header.ParseFromString(transaction.header)
+
+    signer = header.signer_pubkey
+
+    payload = TTPayload()
+    payload.ParseFromString(transaction.payload)
+
+    action = payload.action
+    timestamp = payload.timestamp
+
+    try:
+        attribute, handler = TYPE_TO_ACTION_HANDLER[action]
+    except KeyError:
+        raise Exception('Specified action is invalid')
+
+    payload = getattr(payload, attribute)
+
+    return signer, timestamp, payload, handler
+
+
+TYPE_TO_ACTION_HANDLER = {
+    TTPayload.CREATE_AGENT: ('create_agent', _create_agent),
+    TTPayload.CREATE_RECORD: ('create_record', _create_record),
+    TTPayload.FINALIZE_RECORD: ('finalize_record', _finalize_record),
+    TTPayload.CREATE_RECORD_TYPE: ('create_record_type',
+                                   _create_record_type),
+    TTPayload.UPDATE_PROPERTIES: ('update_properties', _update_properties),
+    TTPayload.CREATE_PROPOSAL: ('create_proposal', _create_proposal),
+    TTPayload.ANSWER_PROPOSAL: ('answer_proposal', _answer_proposal),
+    TTPayload.REVOKE_REPORTER: ('revoke_reporter', _revoke_reporter),
+}

--- a/families/track_and_trade/processor/sawtooth_track_and_trade/processor/main.py
+++ b/families/track_and_trade/processor/sawtooth_track_and_trade/processor/main.py
@@ -1,0 +1,120 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import argparse
+import logging
+import os
+import sys
+import pkg_resources
+
+from colorlog import ColoredFormatter
+
+from sawtooth_sdk.processor.core import TransactionProcessor
+from sawtooth_track_and_trade.processor.handler import TTTransactionHandler
+
+
+DISTRIBUTION_NAME = 'sawtooth-track-and-trade'
+
+
+def create_console_handler(verbose_level):
+    clog = logging.StreamHandler()
+    formatter = ColoredFormatter(
+        "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
+        "%(white)s%(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        reset=True,
+        log_colors={
+            'DEBUG': 'cyan',
+            'INFO': 'green',
+            'WARNING': 'yellow',
+            'ERROR': 'red',
+            'CRITICAL': 'red',
+        })
+
+    clog.setFormatter(formatter)
+
+    if verbose_level == 0:
+        clog.setLevel(logging.WARN)
+    elif verbose_level == 1:
+        clog.setLevel(logging.INFO)
+    else:
+        clog.setLevel(logging.DEBUG)
+
+    return clog
+
+
+def setup_loggers(verbose_level):
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(create_console_handler(verbose_level))
+
+
+def create_parser(prog_name):
+    parser = argparse.ArgumentParser(
+        prog=prog_name,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument('endpoint',
+                        nargs='?',
+                        default='tcp://localhost:4004',
+                        help='Endpoint for the validator connection')
+
+    parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        default=0,
+        help='Increase output sent to stderr')
+
+    try:
+        version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
+    except pkg_resources.DistributionNotFound:
+        version = 'UNKNOWN'
+
+    parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
+        .format(version),
+        help='print version information')
+
+    return parser
+
+
+def main(prog_name=os.path.basename(sys.argv[0]), args=None,
+         with_loggers=True):
+    if args is None:
+        args = sys.argv[1:]
+    parser = create_parser(prog_name)
+    args = parser.parse_args(args)
+
+    if with_loggers is True:
+        if args.verbose is None:
+            verbose_level = 0
+        else:
+            verbose_level = args.verbose
+        setup_loggers(verbose_level=verbose_level)
+
+    processor = TransactionProcessor(url=args.endpoint)
+
+    handler = TTTransactionHandler()
+
+    processor.add_handler(handler)
+
+    try:
+        processor.start()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        processor.stop()

--- a/families/track_and_trade/protos/agent.proto
+++ b/families/track_and_trade/protos/agent.proto
@@ -1,0 +1,32 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+
+message Agent {
+  string public_key = 1;
+
+  // A human readable name identifying the Agent
+  string name = 2;
+
+  // Unix UTC timestamp of approximately when this agent was registered
+  uint64 timestamp = 3;
+}
+
+
+message AgentContainer {
+  repeated Agent entries = 1;
+}

--- a/families/track_and_trade/protos/payload.proto
+++ b/families/track_and_trade/protos/payload.proto
@@ -1,0 +1,137 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "property.proto";
+import "proposal.proto";
+
+
+message TTPayload {
+  enum Action {
+    CREATE_AGENT = 0;
+    CREATE_RECORD = 1;
+    FINALIZE_RECORD = 2;
+    CREATE_RECORD_TYPE = 3;
+    UPDATE_PROPERTIES = 4;
+    CREATE_PROPOSAL = 5;
+    ANSWER_PROPOSAL = 6;
+    REVOKE_REPORTER = 7;
+  }
+
+  Action action = 1;
+
+  // Approximately when transaction was submitted, as a Unix UTC
+  // timestamp
+  uint64 timestamp = 2;
+
+  // The transaction handler will read from just one of these fields
+  // according to the Action.
+  CreateAgentAction create_agent = 3;
+  CreateRecordAction create_record = 4;
+  FinalizeRecordAction finalize_record = 5;
+  CreateRecordTypeAction create_record_type = 6;
+  UpdatePropertiesAction update_properties = 7;
+  CreateProposalAction create_proposal = 8;
+  AnswerProposalAction answer_proposal = 9;
+  RevokeReporterAction revoke_reporter = 10;
+}
+
+
+message CreateAgentAction {
+  // The human-readable name of the Agent. This does not need to be
+  // unique.
+  string name = 1;
+}
+
+
+message CreateRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The name of the RecordType this Record belongs to
+  string record_type = 2;
+
+  repeated PropertyValue properties = 3;
+}
+
+
+message FinalizeRecordAction {
+  // The natural key of the Record
+  string record_id = 1;
+}
+
+
+message CreateRecordTypeAction {
+  string name = 1;
+
+  repeated PropertySchema properties = 2;
+}
+
+
+message UpdatePropertiesAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  repeated PropertyValue properties = 2;
+}
+
+
+message CreateProposalAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // the public key of the Agent to whom the Proposal is sent
+  // (must be different from the Agent creating the Proposal)
+  string receiving_agent = 2;
+
+  Proposal.Role role = 3;
+
+  repeated string properties = 4;
+}
+
+
+message AnswerProposalAction {
+  enum Response {
+    ACCEPT = 0;
+    REJECT = 1;
+    CANCEL = 2;
+  }
+
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The public key of the Agent to whom the proposal is sent
+  string receiving_agent = 2;
+
+  // The role being proposed (owner, custodian, or reporter)
+  Proposal.Role role = 3;
+
+  // The respose to the Proposal (accept, reject, or cancel)
+  Response response = 4;
+}
+
+
+message RevokeReporterAction {
+  // The natural key of the Record
+  string record_id = 1;
+
+  // The reporter's public key
+  string reporter_id = 2;
+
+  // The names of the Properties for which the reporter's
+  // authorization is revoked
+  repeated string properties = 3;
+}

--- a/families/track_and_trade/protos/property.proto
+++ b/families/track_and_trade/protos/property.proto
@@ -1,0 +1,134 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+
+message Property {
+  message Reporter {
+    // The public key of the Agent authorized to report updates.
+    string public_key = 1;
+    bool authorized = 2;
+    // An update must be stored with some way of identifying which
+    // Agent sent it. Storing a full public key for each update would
+    // be wasteful, so instead Reporters are identified by their index
+    // in the `reporters` field.
+    uint32 index = 3;
+  }
+
+  // The name of the Property, e.g. "temperature". This must be unique
+  // among Properties.
+  string name = 1;
+
+  // The natural key of the Property's associated Record.
+  string record_id = 2;
+
+  PropertySchema.DataType data_type = 3;
+
+  // The Reporters authorized to send updates, sorted by index. New
+  // Reporters should be given an index equal to the number of
+  // Reporters already authorized.
+  repeated Reporter reporters = 4;
+
+  // The page to which new updates are added. This number represents
+  // the last 4 hex characters of the page's address. Consequently,
+  // it should not exceed 16^4 = 65536.
+  uint32 current_page = 5;
+
+  // A flag indicating whether the first 16^4 pages have been filled.
+  // This is used to calculate the last four hex characters of the
+  // address of the page containing the earliest updates. When it is
+  // false, the earliest page's address will end in "0001". When it is
+  // true, the earliest page's address will be one more than the
+  // current_page, or "0001" if the current_page is "ffff".
+  bool wrapped = 6;
+}
+
+
+message PropertyContainer {
+  repeated Property entries = 1;
+}
+
+
+message PropertySchema {
+  enum DataType {
+    BYTES = 0;
+    STRING = 1;
+    INT = 2;
+    FLOAT = 3;
+    LOCATION = 4;
+  }
+
+  // The name of the property, e.g. "temperature"
+  string name = 1;
+  DataType data_type = 2;
+  bool required = 3;
+}
+
+
+message PropertyValue {
+  // The name of the property being set
+  string name = 1;
+  PropertySchema.DataType data_type = 2;
+
+  // The type-specific value to initialize or update a Property. Only
+  // one of these fields should be used, and it should match the type
+  // specified for this Property in the RecordType.
+  bytes bytes_value = 11;
+  string string_value = 12;
+  sint64 int_value = 13;
+  float float_value = 14;
+  Location location_value = 15;
+}
+
+
+message PropertyPage {
+  message ReportedValue {
+    // The index of the reporter id in reporters field
+    uint32 reporter_index = 1;
+    // Approximately when this value was reported, as a Unix UTC
+    // timestamp
+    uint64 timestamp = 2;
+
+    // The type-specific value of the update. Only one of these
+    // fields should be used, and it should match the type
+    // specified for this Property in the RecordType.
+    bytes bytes_value = 11;
+    string string_value = 12;
+    sint64 int_value = 13;
+    float float_value = 14;
+    Location location_value = 15;
+  }
+
+  // The name of the page's associated Property. This is required to
+  // distinguish pages with colliding addresses.
+  string name = 1;
+
+  // ReportedValues are sorted first by timestamp, then by
+  // reporter_index
+  repeated ReportedValue reported_values = 2;
+}
+
+
+message PropertyPageContainer {
+  repeated PropertyPage entries = 1;
+}
+
+
+message Location {
+  // Coordinates are expected to be in millionths of a degree
+  sint64 latitude = 1;
+  sint64 longitude = 2;
+}

--- a/families/track_and_trade/protos/proposal.proto
+++ b/families/track_and_trade/protos/proposal.proto
@@ -1,0 +1,66 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+
+message Proposal {
+  enum Role {
+    OWNER = 0;
+    CUSTODIAN = 1;
+    REPORTER = 2;
+  }
+
+  enum Status {
+    OPEN = 0;
+    ACCEPTED = 1;
+    REJECTED = 2;
+    CANCELLED = 3;
+  }
+
+  string record_id = 1;
+
+  // The time at which the Proposal was created
+  uint64 timestamp = 2;
+
+  // The public key of the Agent sending the Proposal. This Agent must
+  // be the owner of the Record (or the custodian, if the Proposal is
+  // to transfer custodianship).
+  string issuing_agent = 3;
+
+  // The public key of the Agent to whom the Proposal is sent.
+  string receiving_agent = 4;
+
+  // What the Proposal is for -- transferring ownership, transferring
+  // custodianship, or authorizing a reporter.
+  Role role = 5;
+
+  // The names of properties for which the reporter is being authorized
+  // (empty for owner or custodian transfers)
+  repeated string properties = 6;
+
+  // The status of the Proposal. For a given Record and receiving
+  // Agent, there can be only one open Proposal at a time for each
+  // role.
+  Status status = 7;
+
+  // The human-readable terms of transfer.
+  string terms = 8;
+}
+
+
+message ProposalContainer {
+  repeated Proposal entries = 1;
+}

--- a/families/track_and_trade/protos/record.proto
+++ b/families/track_and_trade/protos/record.proto
@@ -1,0 +1,59 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+import "property.proto";
+
+
+message Record {
+  message AssociatedAgent {
+    string agent_id = 1;
+    uint64 timestamp = 2;
+  }
+
+  // The user-defined natural key which identifies the object in the
+  // real world (for example a serial number)
+  string record_id = 1;
+
+  string record_type = 2;
+
+  // Ordered oldest to newest by timestamp
+  repeated AssociatedAgent owners = 3;
+  repeated AssociatedAgent custodians = 4;
+
+  // Flag indicating whether the Record can be updated. If it is set
+  // to true, then the record has been finalized and no further
+  // changes can be made to it or its Properties.
+  bool final = 5;
+}
+
+
+message RecordContainer {
+  repeated Record entries = 1;
+}
+
+
+message RecordType {
+  // A unique human-readable designation for the RecordType
+  string name = 1;
+
+  repeated PropertySchema properties = 2;
+}
+
+
+message RecordTypeContainer {
+  repeated RecordType entries = 1;
+}

--- a/families/track_and_trade/tests/sawtooth_tt_test/track_and_trade_message_factory.py
+++ b/families/track_and_trade/tests/sawtooth_tt_test/track_and_trade_message_factory.py
@@ -1,0 +1,270 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import time
+
+from sawtooth_processor_test.message_factory import MessageFactory
+
+from sawtooth_track_and_trade.protobuf.payload_pb2 import TTPayload
+from sawtooth_track_and_trade.protobuf.payload_pb2 import CreateAgentAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import CreateProposalAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import AnswerProposalAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import CreateRecordAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import \
+    CreateRecordTypeAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import FinalizeRecordAction
+from sawtooth_track_and_trade.protobuf.payload_pb2 import \
+    UpdatePropertiesAction
+
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertySchema
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertyValue
+
+import sawtooth_track_and_trade.addressing as addressing
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+
+class TrackAndTradeMessageFactory:
+    def __init__(self, private=None, public=None):
+        self._factory = MessageFactory(
+            encoding='application/protobuf',
+            family_name=addressing.FAMILY_NAME,
+            family_version='1.0',
+            namespace=addressing.NAMESPACE,
+            private=private,
+            public=public)
+
+        self.public_key = self._factory.get_public_key()
+        self.signer_address = addressing.make_agent_address(self.public_key)
+
+    def create_agent(self, name):
+        payload = _make_tt_payload(
+            action=TTPayload.CREATE_AGENT,
+            create_agent=CreateAgentAction(name=name))
+
+        return self._create_transaction(
+            payload,
+            [self.signer_address],
+            [self.signer_address],
+        )
+
+    def create_record_type(self, name, *properties):
+        payload = _make_tt_payload(
+            action=TTPayload.CREATE_RECORD_TYPE,
+            create_record_type=CreateRecordTypeAction(
+                name=name,
+                properties=[
+                    PropertySchema(
+                        name=name,
+                        data_type=data_type,
+                        required=required)
+                    for (name, data_type, required) in properties
+                ]
+            )
+        )
+
+        record_type_address = addressing.make_record_type_address(name)
+
+        return self._create_transaction(
+            payload,
+            inputs=[record_type_address, self.signer_address],
+            outputs=[record_type_address],
+        )
+
+    def create_record(self, record_id, record_type, properties_dict):
+        payload = _make_tt_payload(
+            action=TTPayload.CREATE_RECORD,
+            create_record=CreateRecordAction(
+                record_id=record_id,
+                record_type=record_type,
+                properties=[
+                    _make_property_value(name, value)
+                    for name, value in properties_dict.items()
+                ]
+            )
+        )
+
+        record_address = addressing.make_record_address(record_id)
+        record_type_address = addressing.make_record_type_address(record_type)
+        property_address_range = \
+            addressing.make_property_address_range(record_id)
+
+        inputs = [
+            record_address,
+            record_type_address,
+            property_address_range,
+            self.signer_address,
+        ]
+
+        return self._create_transaction(
+            payload,
+            inputs=inputs,
+            outputs=[
+                record_address,
+                property_address_range,
+            ]
+        )
+
+    def finalize_record(self, record_id):
+        payload = _make_tt_payload(
+            action=TTPayload.FINALIZE_RECORD,
+            finalize_record=FinalizeRecordAction(
+                record_id=record_id))
+
+        record_address = addressing.make_record_address(record_id)
+
+        return self._create_transaction(
+            payload,
+            [record_address],
+            [record_address]
+        )
+
+    def update_properties(self, record_id, properties_dict):
+        payload = _make_tt_payload(
+            action=TTPayload.UPDATE_PROPERTIES,
+            update_properties=UpdatePropertiesAction(
+                record_id=record_id,
+                properties=[
+                    _make_property_value(name, value)
+                    for name, value in properties_dict.items()
+                ]
+            )
+        )
+
+        record_address = addressing.make_record_address(record_id)
+        property_address_range = \
+            addressing.make_property_address_range(record_id)
+
+        inputs = [
+            record_address,
+            property_address_range,
+        ]
+
+        return self._create_transaction(
+            payload,
+            inputs=inputs,
+            outputs=[property_address_range]
+        )
+
+    def create_proposal(self, record_id, receiving_agent,
+                        role, properties=None):
+        if properties is None:
+            properties = []
+
+        payload = _make_tt_payload(
+            action=TTPayload.CREATE_PROPOSAL,
+            create_proposal=CreateProposalAction(
+                record_id=record_id,
+                receiving_agent=receiving_agent,
+                role=role,
+                properties=properties))
+
+        proposal_address = addressing.make_proposal_address(
+            record_id,
+            receiving_agent)
+
+        receiving_address = addressing.make_agent_address(receiving_agent)
+
+        record_address = addressing.make_record_address(record_id)
+
+        return self._create_transaction(
+            payload,
+            inputs=[
+                proposal_address,
+                record_address,
+                receiving_address,
+                self.signer_address,
+            ],
+            outputs=[proposal_address],
+        )
+
+    def answer_proposal(self, record_id, receiving_agent, role, response):
+        payload = _make_tt_payload(
+            action=TTPayload.ANSWER_PROPOSAL,
+            answer_proposal=AnswerProposalAction(
+                record_id=record_id,
+                receiving_agent=receiving_agent,
+                role=role,
+                response=response))
+
+        proposal_address = addressing.make_proposal_address(
+            record_id,
+            receiving_agent)
+
+        record_address = addressing.make_record_address(record_id)
+
+        property_address_range = addressing.make_property_address_range(
+            record_id)
+
+        return self._create_transaction(
+            payload,
+            inputs=[
+                proposal_address,
+                record_address,
+                property_address_range,
+            ],
+            outputs=[
+                proposal_address,
+                record_address,
+                property_address_range,
+            ],
+        )
+
+    def _create_transaction(self, payload, inputs, outputs):
+        return self._factory.create_transaction(
+            payload, inputs, outputs, [])
+
+    def create_batch(self, transaction):
+        return self._factory.create_batch([transaction])
+
+
+def _make_tt_payload(**kwargs):
+    return TTPayload(
+        timestamp=round(time.time()),
+        **kwargs
+    ).SerializeToString()
+
+
+def _make_property_value(name, value):
+    property_value = PropertyValue(name=name)
+
+    type_slots = {
+        int: 'int_value',
+        str: 'string_value',
+        bytes: 'bytes_value',
+        float: 'float_value',
+    }
+
+    type_tags = {
+        int: PropertySchema.INT,
+        str: PropertySchema.STRING,
+        bytes: PropertySchema.BYTES,
+        float: PropertySchema.FLOAT,
+    }
+
+    try:
+        value_type = type(value)
+        slot = type_slots[value_type]
+        type_tag = type_tags[value_type]
+    except KeyError:
+        raise Exception('Unsupported type')
+
+    setattr(property_value, slot, value)
+    property_value.data_type = type_tag
+
+    return property_value

--- a/integration/sawtooth_integration/docker/test_track_and_trade.yaml
+++ b/integration/sawtooth_integration/docker/test_track_and_trade.yaml
@@ -1,0 +1,83 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  track-and-trade-tp:
+    image: sawtooth-track-and-trade-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: track-and-trade-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        sawtooth-validator -vv \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api -vv --connect tcp://validator:4004 --bind rest-api:8080
+    stop_signal: SIGKILL
+
+  test-track-and-trade:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_track_and_trade.TestTrackAndTrade
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/families/track_and_trade/processor:\
+        /project/sawtooth-core/families/track_and_trade/tests:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/tests/integration_tools.py
+++ b/integration/sawtooth_integration/tests/integration_tools.py
@@ -63,7 +63,7 @@ class RestClient:
             dict: the json result data, as a dict
         """
 
-        return self._post('/batches', batch_list)
+        return self._post('/batches?wait', batch_list)
 
     def _get(self, path, **queries):
         code, json_result = self._submit_request(

--- a/integration/sawtooth_integration/tests/test_track_and_trade.py
+++ b/integration/sawtooth_integration/tests/test_track_and_trade.py
@@ -1,0 +1,484 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import unittest
+
+from sawtooth_integration.tests.integration_tools import RestClient
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
+
+from sawtooth_tt_test.track_and_trade_message_factory import \
+    TrackAndTradeMessageFactory
+
+import sawtooth_track_and_trade.addressing as addressing
+from sawtooth_track_and_trade.protobuf.property_pb2 import PropertySchema
+from sawtooth_track_and_trade.protobuf.proposal_pb2 import Proposal
+from sawtooth_track_and_trade.protobuf.payload_pb2 import AnswerProposalAction
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+
+REST_API = 'rest-api:8080'
+URL = 'http://' + REST_API
+
+
+NARRATION = False
+
+
+class TTClient(RestClient):
+    def __init__(self, url=URL):
+        self.factory = TrackAndTradeMessageFactory()
+        self.public_key = self.factory.public_key
+        super().__init__(
+            url=url,
+            namespace=addressing.NAMESPACE)
+
+    def _post_tt_transaction(self, transaction):
+        return self.send_batches(
+            self.factory.create_batch(
+                transaction))
+
+    def create_agent(self, name):
+        return self._post_tt_transaction(
+            self.factory.create_agent(
+                name))
+
+    def create_record_type(self, name, *properties):
+        return self._post_tt_transaction(
+            self.factory.create_record_type(
+                name, *properties))
+
+    def create_record(self, record_id, record_type, properties_dict):
+        return self._post_tt_transaction(
+            self.factory.create_record(
+                record_id, record_type, properties_dict))
+
+    def finalize_record(self, record_id):
+        return self._post_tt_transaction(
+            self.factory.finalize_record(
+                record_id))
+
+    def update_properties(self, record_id, properties_dict):
+        return self._post_tt_transaction(
+            self.factory.update_properties(
+                record_id, properties_dict))
+
+    def create_proposal(self, record_id, receiving_agent,
+                        role, properties=None):
+        if properties is None:
+            properties = []
+
+        return self._post_tt_transaction(
+            self.factory.create_proposal(
+                record_id, receiving_agent, role, properties))
+
+    def answer_proposal(self, record_id, role, response, receiving_agent=None):
+        if receiving_agent is None:
+            receiving_agent = self.public_key
+
+        return self._post_tt_transaction(
+            self.factory.answer_proposal(
+                record_id=record_id,
+                receiving_agent=receiving_agent,
+                role=role,
+                response=response))
+
+
+class TestTrackAndTrade(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        wait_for_rest_apis([REST_API])
+
+    def assert_valid(self, result):
+        try:
+            self.assertEqual(1, len(result))
+            self.assertIn('link', result)
+        except AssertionError:
+            raise AssertionError(
+                'Transaction is unexpectedly invalid -- {}'.format(
+                    result['data'][0]['invalid_transactions'][0]['message']))
+
+    def assert_invalid(self, result):
+        self.narrate('{}', result)
+        try:
+            self.assertEqual(
+                'INVALID',
+                result['data'][0]['status'])
+        except (KeyError, IndexError):
+            raise AssertionError(
+                'Transaction is unexpectedly valid')
+
+    def narrate(self, message, *interpolations):
+        if NARRATION:
+            LOGGER.info(
+                message.format(
+                    *interpolations))
+
+    def test_track_and_trade(self):
+        jin = TTClient()
+
+        self.narrate(
+            '''
+            Jin tries to create a record for a fish with label `fish-456`.
+            ''')
+
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {}))
+
+        self.narrate(
+            '''
+            Only registered agents can create records, so
+            Jin registers as an agent with public key {}.
+            ''',
+            jin.public_key[:6])
+
+        self.assert_valid(
+            jin.create_agent('Jin Kwon'))
+
+        self.narrate(
+            '''
+            He can't register as an agent again because there is already an
+            agent registerd with his key (namely, himself).
+            ''')
+
+        self.assert_invalid(
+            jin.create_agent('Jin Kwon'))
+
+        self.narrate(
+            '''
+            Jin tries to create a record for a fish with label `fish-456`.
+            ''')
+
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {}))
+
+        self.narrate(
+            '''
+            He said his fish record should have type `fish`, but that
+            type doesn't exist yet. He needs to create the `fish`
+            record type first.
+            ''')
+
+        self.narrate(
+            '''
+            Jin creates the record type `fish` with properties {}.
+            Subsequent attempts to create a type with that name will
+            fail.
+            ''',
+            ['species', 'weight', 'temperature', 'latitude', 'longitude'])
+
+        self.assert_valid(
+            jin.create_record_type(
+                'fish',
+                ('species', PropertySchema.STRING, True),
+                ('weight', PropertySchema.INT, True),
+                ('temperature', PropertySchema.INT, False),
+                ('latitude', PropertySchema.INT, False),
+                ('longitude', PropertySchema.INT, False),
+            ))
+
+        self.assert_invalid(
+            jin.create_record_type(
+                'fish',
+                ('blarg', PropertySchema.FLOAT, True),
+            ))
+
+        self.narrate(
+            '''
+            Now that the `fish` record type is created, Jin can create
+            his fish record.
+            ''')
+
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {}))
+
+        self.narrate(
+            '''
+            This time, Jin's attempt to create a record failed because
+            he neglected to include initial property values for the
+            record type's require properties. In this case, a `fish`
+            record cannot be created without value for the properties
+            `species` and `weight`.
+            ''')
+
+        self.assert_invalid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {'species': 'trout', 'weight': 5.1}))
+
+        self.narrate(
+            '''
+            Jin gave the value 5.1 for the property `weight`, but the
+            type for that property is required to be int. When he
+            provides a string value for `species` and an int value for
+            `weight`, the record can be successfully created.
+            ''')
+
+        self.assert_valid(
+            jin.create_record(
+                'fish-456',
+                'fish',
+                {'species': 'trout', 'weight': 5}))
+
+        self.narrate(
+            '''
+            Jin updates the fish record's temperature. Updates, of
+            course, can only be made to the type-specified properties
+            of existing records, and the type of the update value must
+            match the type-specified type.
+            ''')
+
+        self.assert_valid(
+            jin.update_properties(
+                'fish-456',
+                {'temperature': 4}))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'temperature': '4'}))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'splecies': 'tluna'}))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-???',
+                {'species': 'flounder'}))
+
+        self.narrate(
+            '''
+            Jin updates the temperature again.
+            ''')
+
+        self.assert_valid(
+            jin.update_properties(
+                'fish-456',
+                {'temperature': 3}))
+
+        self.narrate(
+            '''
+            Jin gets tired of sending fish updates himself, so he decides to
+            get an autonomous IoT sensor to do it for him.
+            ''')
+
+        sensor_stark = TTClient()
+
+        self.assert_invalid(
+            sensor_stark.update_properties(
+                'fish-456',
+                {'temperature': 3}))
+
+        self.narrate(
+            '''
+            To get his sensor to be able to send updates, Jin has to send it a
+            proposal to authorize it as a reporter for some properties
+            for his record.
+            ''')
+
+        self.assert_invalid(
+            jin.create_proposal(
+                record_id='fish-456',
+                receiving_agent=sensor_stark.public_key,
+                role=Proposal.REPORTER,
+                properties=['temperature'],
+            ))
+
+        self.narrate(
+            '''
+            This requires that the sensor be registered as an agent,
+            just like Jin.
+            ''')
+
+        self.assert_valid(
+            sensor_stark.create_agent(
+                'sensor-stark'))
+
+        self.assert_valid(
+            jin.create_proposal(
+                record_id='fish-456',
+                receiving_agent=sensor_stark.public_key,
+                role=Proposal.REPORTER,
+                properties=['temperature'],
+            ))
+
+        self.assert_invalid(
+            sensor_stark.update_properties(
+                'fish-456',
+                {'temperature': 3}))
+
+        self.narrate(
+            '''
+            There's one last step before the sensor can send updates:
+            it has to "accept" the proposal.
+            ''')
+
+        self.assert_valid(
+            sensor_stark.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.REPORTER,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.assert_invalid(
+            sensor_stark.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.REPORTER,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.narrate(
+            '''
+            Now that it is an authorized reporter, the sensor can
+            start sending updates.
+            ''')
+
+        for i in range(5):
+            self.assert_valid(
+                sensor_stark.update_properties(
+                    'fish-456',
+                    {'temperature': i}))
+
+        self.narrate(
+            '''
+            Jin would like to sell his fish to Sun, a fish dealer. Of
+            course, Sun must also be registered as an agent. After she
+            registers, Jin can propose to transfer ownership to her
+            (with payment made off-chain).
+            ''')
+
+        sun = TTClient()
+
+        self.assert_invalid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.assert_valid(
+            sun.create_agent(name='Sun Kwon'))
+
+        self.assert_valid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.narrate(
+            '''
+            Jin has second thoughts and cancels his proposal. Sun and
+            her lawyers convince him to change his mind back, so he
+            opens a new proposal.
+            ''')
+
+        self.assert_valid(
+            jin.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                response=AnswerProposalAction.CANCEL,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.assert_invalid(
+            sun.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.assert_valid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.assert_valid(
+            sun.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.assert_invalid(
+            sun.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.assert_invalid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.OWNER,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.narrate(
+            '''
+            Sun wants to finalize the record to prevent any further updates.
+            ''')
+
+        self.assert_invalid(
+            sun.finalize_record('fish-456'))
+
+        self.narrate(
+            '''
+            In order to finalize a record, the owner and the custodian
+            must be the same person. Sun is the owner of the fish in a
+            legal sense, but Jin is still the custodian (that is, he
+            has physical custody of it). Jin hands over the fish.
+            ''')
+
+        self.assert_valid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.CUSTODIAN,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.assert_valid(
+            sun.answer_proposal(
+                record_id='fish-456',
+                role=Proposal.CUSTODIAN,
+                response=AnswerProposalAction.ACCEPT,
+            ))
+
+        self.assert_valid(
+            sun.finalize_record('fish-456'))
+
+        self.assert_invalid(
+            sun.finalize_record('fish-456'))
+
+        self.assert_invalid(
+            jin.update_properties(
+                'fish-456',
+                {'temperature': 2}))


### PR DESCRIPTION
Implemented:
* Agents
* Records
* Record types
* Properties
* Property updates
* Proposals for ownership and custodianship transfers

Implemented, but not working:
* Reporter authorization proposals. Something is going wrong in `_answer_proposal` and the updates aren't getting written to state properly. It's currently not possible to authorize reporters, and consequently nobody can report updates except the record's creator.

Not implemented:
* Real property paging. I'll worry about this when reporter authorization gets figured out.

I've included an integration test but not a unit TP test. Currently the TP test framework is fairly implementation-dependent, and this implementation is not yet stable, so I will a TP test at a later stage. I'm experimenting with a more "narrative" approach to the integration test. I can change that if nobody likes it.

To run the integration test, `run_docker_test test_track_and_trade`.