### PR TITLE
Fix connection status delete

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -433,7 +433,7 @@ class Topology(Thread):
 
                 self._gossip.unregister_peer(conn_id)
                 if conn_id in self._connection_statuses:
-                    del self.connections[conn_id]
+                    del self._connection_statuses[conn_id]
 
     def _refresh_connection_list(self):
         with self._condition:


### PR DESCRIPTION
Attempts to cleanup the connection status using an old field name.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>