### PR TITLE
Rust sdk fix secp256k1 context handling

### DIFF
--- a/sdk/rust/src/signing/mod.rs
+++ b/sdk/rust/src/signing/mod.rs
@@ -63,7 +63,7 @@ pub trait Algorithm {
 
 pub fn create_algorithm(name: &str) -> Result<Box<Algorithm>, Error> {
     match name {
-        "secp256k1" => Ok(Box::new(secp256k1::Secp256k1Algorithm{})),
+        "secp256k1" => Ok(Box::new(secp256k1::Secp256k1Algorithm::new())),
         _ => Err(Error::NoSuchAlgorithm(format!("no such algorithm: {}", name)))
     }
 }


### PR DESCRIPTION
This stores the secp256k1 context in the Secp256k1Algorithm struct
as was the original intent, avoiding the recreation of the context
on each signing/verification/key call.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>