### PR TITLE
Add requests dependency to sawtooth-cli package

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -34,6 +34,7 @@ setup(name='sawtooth-cli',
           'sawtooth-signing',
           'toml',
           'PyYAML',
+          'requests'
           ],
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
Without this dependency, the resulting deb package fails to pull
in the requests package and will fail on the requests import.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>