### PR TITLE
Update Identity Transaction Processor to accept transaction from allowed signers

### DIFF
--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -611,3 +611,7 @@ def _key_to_address(key):
     key_parts.extend([''] * (_MAX_KEY_PARTS - len(key_parts)))
 
     return SETTINGS_NAMESPACE + ''.join(_short_hash(x) for x in key_parts)
+
+
+def setting_key_to_address(key):
+    return _key_to_address(key)

--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -37,6 +37,7 @@ from sawtooth_cli.protobuf.transaction_pb2 import Transaction
 from sawtooth_cli.protobuf.batch_pb2 import BatchHeader
 from sawtooth_cli.protobuf.batch_pb2 import Batch
 from sawtooth_cli.protobuf.batch_pb2 import BatchList
+from sawtooth_cli.config import setting_key_to_address
 
 import sawtooth_signing as signing
 
@@ -50,6 +51,7 @@ _ADDRESS_PART_SIZE = 16
 _POLICY_PREFIX = "00"
 _ROLE_PREFIX = "01"
 _EMPTY_PART = hashlib.sha256("".encode()).hexdigest()[:_ADDRESS_PART_SIZE]
+_REQUIRED_INPUT = setting_key_to_address("sawtooth.identity.allowed_keys")
 
 
 def add_identity_parser(subparsers, parent_parser):
@@ -82,7 +84,7 @@ def add_identity_parser(subparsers, parent_parser):
     create_target_group.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to ouput the resulting batches')
+        help='the name of the file to output the resulting batches')
 
     create_target_group.add_argument(
         '--url',
@@ -138,7 +140,7 @@ def add_identity_parser(subparsers, parent_parser):
     create_target_group.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to ouput the resulting batches')
+        help='the name of the file to output the resulting batches')
 
     create_target_group.add_argument(
         '--url',
@@ -385,7 +387,7 @@ def _create_policy_txn(pubkey, signing_key, policy_name, rules):
         signer_pubkey=pubkey,
         family_name='sawtooth_identity',
         family_version='1.0',
-        inputs=[policy_address],
+        inputs=[_REQUIRED_INPUT, policy_address],
         outputs=[policy_address],
         dependencies=[],
         payload_encoding="application/protobuf",
@@ -418,7 +420,7 @@ def _create_role_txn(pubkey, signing_key, role_name, policy_name):
         signer_pubkey=pubkey,
         family_name='sawtooth_identity',
         family_version='1.0',
-        inputs=[policy_address, role_address],
+        inputs=[_REQUIRED_INPUT, policy_address, role_address],
         outputs=[role_address],
         dependencies=[],
         payload_encoding="application/protobuf",

--- a/families/identity/sawtooth_identity/processor/handler.py
+++ b/families/identity/sawtooth_identity/processor/handler.py
@@ -20,6 +20,8 @@ from sawtooth_sdk.processor.state import StateEntry
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
+from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
+from sawtooth_sdk.protobuf.setting_pb2 import Setting
 
 from sawtooth_identity.protobuf.identity_pb2 import Policy
 from sawtooth_identity.protobuf.identity_pb2 import PolicyList
@@ -27,16 +29,60 @@ from sawtooth_identity.protobuf.identity_pb2 import Role
 from sawtooth_identity.protobuf.identity_pb2 import RoleList
 from sawtooth_identity.protobuf.identities_pb2 import IdentityPayload
 
-
 LOGGER = logging.getLogger(__name__)
 
 # The identity namespace is special: it is not derived from a hash.
 IDENTITY_NAMESPACE = '00001d'
 POLICY_PREFIX = '00'
 ROLE_PREFIX = '01'
+ALLOWED_SIGNER_SETTING = "sawtooth.identity.allowed_keys"
 
+# Constants to be used when constructing config namespace addresses
+_SETTING_NAMESPACE = '000000'
+_SETTING_MAX_KEY_PARTS = 4
+_SETTING_ADDRESS_PART_SIZE = 16
 # Number of seconds to wait for state operations to succeed
 STATE_TIMEOUT_SEC = 10
+
+
+def _setting_key_to_address(key):
+    """Computes the address for the given setting key.
+
+     Keys are broken into four parts, based on the dots in the string. For
+     example, the key `a.b.c` address is computed based on `a`, `b`, `c` and
+     padding. A longer key, for example `a.b.c.d.e`, is still
+     broken into four parts, but the remaining pieces are in the last part:
+     `a`, `b`, `c` and `d.e`.
+
+     Each of these pieces has a short hash computed (the first
+     _SETTING_ADDRESS_PART_SIZE characters of its SHA256 hash in hex), and is
+     joined into a single address, with the config namespace
+     (_SETTING_NAMESPACE) added at the beginning.
+
+     Args:
+         key (str): the setting key
+     Returns:
+         str: the computed address
+     """
+    # Split the key into _SETTING_MAX_KEY_PARTS parts, maximum, compute the
+    # short hash of each, and then pad if necessary
+    key_parts = key.split('.', maxsplit=_SETTING_MAX_KEY_PARTS - 1)
+    addr_parts = [_setting_short_hash(byte_str=x.encode()) for x in key_parts]
+    addr_parts.extend(
+        [_SETTING_ADDRESS_PADDING] * (_SETTING_MAX_KEY_PARTS - len(addr_parts))
+    )
+    return _SETTING_NAMESPACE + ''.join(addr_parts)
+
+
+def _setting_short_hash(byte_str):
+    # Computes the SHA 256 hash and truncates to be the length
+    # of an address part (see _config_key_to_address for information on
+    return hashlib.sha256(byte_str).hexdigest()[:_SETTING_ADDRESS_PART_SIZE]
+
+
+_SETTING_ADDRESS_PADDING = _setting_short_hash(byte_str=b'')
+ALLOWED_SIGNER_ADDRESS = _setting_key_to_address(
+    "sawtooth.identity.allowed_keys")
 
 
 class IdentityTransactionHandler(object):
@@ -57,6 +103,8 @@ class IdentityTransactionHandler(object):
         return [IDENTITY_NAMESPACE]
 
     def apply(self, transaction, state):
+        _check_allowed_transactor(transaction, state)
+
         payload = IdentityPayload()
         payload.ParseFromString(transaction.payload)
 
@@ -72,6 +120,29 @@ class IdentityTransactionHandler(object):
         else:
             raise InvalidTransaction("The IdentityType must be either a"
                                      " ROLE or a POLICY")
+
+
+def _check_allowed_transactor(transaction, state):
+    header = TransactionHeader()
+    header.ParseFromString(transaction.header)
+
+    entries_list = _get_data(ALLOWED_SIGNER_ADDRESS, state)
+    if not entries_list:
+        raise InvalidTransaction(
+            "The transaction signer is not authorized to submit transactions: "
+            "{}".format(header.signer_pubkey))
+
+    setting = Setting()
+    setting.ParseFromString(entries_list[0].data)
+    for entry in setting.entries:
+        if entry.key == "sawtooth.identity.allowed_keys":
+            allowed_signer = entry.value.split(",")
+            if header.signer_pubkey in allowed_signer:
+                return
+
+    raise InvalidTransaction(
+        "The transction signer is not authorized to submit transactions: "
+        "{}".format(header.signer_pubkey))
 
 
 def _set_policy(data, state):

--- a/families/identity/tests/sawtooth_identity_test/identity_message_factory.py
+++ b/families/identity/tests/sawtooth_identity_test/identity_message_factory.py
@@ -20,6 +20,7 @@ from sawtooth_identity.protobuf.identity_pb2 import Policy
 from sawtooth_identity.protobuf.identity_pb2 import PolicyList
 from sawtooth_identity.protobuf.identity_pb2 import Role
 from sawtooth_identity.protobuf.identity_pb2 import RoleList
+from sawtooth_identity.protobuf.setting_pb2 import Setting
 
 _MAX_KEY_PARTS = 4
 _FIRST_ADDRESS_PART_SIZE = 14
@@ -186,3 +187,21 @@ class IdentityMessageFactory(object):
     def create_set_role_response(self, name):
         addresses = [self._role_to_address(name)]
         return self._factory.create_set_response(addresses)
+
+    def create_get_setting_request(self, key):
+        addresses = [key]
+        return self._factory.create_get_request(addresses)
+
+    def create_get_setting_response(self, key, allowed):
+        if allowed:
+            entry = Setting.Entry(
+                key="sawtooth.identity.allowed_keys",
+                value=self.public_key)
+            data = Setting(entries=[entry]).SerializeToString()
+        else:
+            entry = Setting.Entry(
+                key="sawtooth.identity.allowed_keys",
+                value="")
+            data = Setting(entries=[entry]).SerializeToString()
+
+        return self._factory.create_get_response({key: data})


### PR DESCRIPTION
Only those pub keys that are in the setting sawtooth.identity.allowed_keys should be allowed to sign identity transactions. If an identity transaction is received signed by someone else, the transaction is deemed invalid. 

This PR is build on top of #766 Implement Off-Chain Transactor Permissioning. This Pr will be rebased once that PR is merged. 