### PR TITLE
Increase block_num size from int32 to uint64

### DIFF
--- a/protos/block.proto
+++ b/protos/block.proto
@@ -22,7 +22,7 @@ import "batch.proto";
 
 message BlockHeader {
     // Block number in the chain
-    int32 block_num = 1;
+    uint64 block_num = 1;
 
     // The header_signature of the previous block that was added to the chain.
     string previous_block_id = 2;

--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -46,7 +46,7 @@ message StateDeltaEvent {
     // The block id associated with the changes.
     string block_id = 1;
     // The block number associated with the changes
-    int32 block_num = 2;
+    uint64 block_num = 2;
     // The state root hash which resulted from the changes.
     string state_root_hash = 3;
 


### PR DESCRIPTION
int32 for block num size is too small for long-term deployments.  Increasing this to uint64 should avoid any size constraints in the long term.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>