### PR TITLE
Fix gossip error

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -545,7 +545,7 @@ class Topology(Thread):
             self._network.send(validator_pb2.Message.NETWORK_DISCONNECT,
                                msg.SerializeToString(),
                                connection_id)
-            del self._connection[connection_id]
+            del self._connection_statuses[connection_id]
             self._network.remove_connection(connection_id)
         elif status == "peer":
             LOGGER.debug("Connection is a peer, do not close.")

--- a/validator/sawtooth_validator/networking/future.py
+++ b/validator/sawtooth_validator/networking/future.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import logging
 from concurrent.futures import ThreadPoolExecutor
 from threading import Condition
 from threading import RLock
 import time
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class FutureResult(object):
@@ -72,7 +76,11 @@ class Future(object):
         if self._has_callback:
             if self._callback_func is None:
                 self._condition.wait()
-            self._callback_func(self._request, self._result)
+            try:
+                self._callback_func(self._request, self._result)
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception('An unhandled error occurred while running '
+                                 'future callback')
 
     def add_callback(self, callback_func):
         """Add a callback to be executed on set_result.


### PR DESCRIPTION
**Fix invalid field access**

Correct an error caused by accessing the incorrect (and non-existent) _connections field of the Topology class. This error caused the connection status/known connections to be left in an incorrect state, which effects peering.

Additionally:

**Capture unhandled exceptions on future callbacks** 

Callbacks in futures that throw exceptions get swallowed when executing in the thread pool.  This commit adds a try/except block around the callback to trap and log those exceptions.

