### PR TITLE
Update serial scheduler to fail fast on invalid batch

### DIFF
--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -186,7 +186,10 @@ class SchedulerTester(object):
         while not scheduler.complete(block=False):
             stop = False
             while not stop:
-                txn_info = scheduler.next_transaction()
+                try:
+                    txn_info = scheduler.next_transaction()
+                except StopIteration:
+                    break
                 if txn_info is not None:
                     txns_to_process.append(txn_info)
                     LOGGER.debug("Transaction %s scheduled",


### PR DESCRIPTION
This commit also updates tests and testing framework to not set an
invalid transaction result and expect further transactions within
a batch.

STL-579

Signed-off-by: Boyd Johnson <boydx.johnson@intel.com>