### PR TITLE
Restrict smoke tests to appropriate namespaces

### DIFF
--- a/integration/sawtooth_integration/docker/seth_intkey_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_intkey_test.yaml
@@ -17,6 +17,17 @@ version: "2.1"
 
 services:
 
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
   seth-tp:
     image: sawtooth-seth-tp:$ISOLATION_ID
     volumes:

--- a/integration/sawtooth_integration/docker/seth_intkey_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_intkey_test.yaml
@@ -46,10 +46,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/seth_perm_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_perm_test.yaml
@@ -17,6 +17,17 @@ version: "2.1"
 
 services:
 
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
   seth-tp:
     image: sawtooth-seth-tp:$ISOLATION_ID
     volumes:

--- a/integration/sawtooth_integration/docker/seth_perm_test.yaml
+++ b/integration/sawtooth_integration/docker/seth_perm_test.yaml
@@ -46,10 +46,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
@@ -35,10 +35,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
@@ -17,6 +17,17 @@ version: "2.1"
 
 services:
 
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
   validator:
     image: sawtooth-validator:$ISOLATION_ID
     volumes:

--- a/integration/sawtooth_integration/docker/test_config_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_config_smoke.yaml
@@ -35,7 +35,6 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
         sawtooth admin keygen && \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_go.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_go.yaml
@@ -45,10 +45,12 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_java.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_java.yaml
@@ -45,10 +45,12 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_javascript.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_javascript.yaml
@@ -45,10 +45,12 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
@@ -46,10 +46,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_permission.yaml
+++ b/integration/sawtooth_integration/docker/test_permission.yaml
@@ -35,7 +35,6 @@ services:
     expose:
       - 40000
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
         sawtooth admin keygen && \

--- a/integration/sawtooth_integration/docker/test_two_families.yaml
+++ b/integration/sawtooth_integration/docker/test_two_families.yaml
@@ -57,10 +57,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -vv \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_workload.yaml
+++ b/integration/sawtooth_integration/docker/test_workload.yaml
@@ -46,10 +46,12 @@ services:
     expose:
       - 4004
       - 8800
-    # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_all.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_all.yaml
@@ -70,7 +70,10 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
@@ -48,7 +48,10 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_java.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_java.yaml
@@ -48,7 +48,10 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
@@ -48,7 +48,10 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
@@ -48,7 +48,10 @@ services:
       - 8800
     command: "bash -c \"\
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -33,6 +33,8 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
 
+INTKEY_PREFIX = '1cf126'
+
 class TestIntkeySmoke(unittest.TestCase):
 
     @classmethod
@@ -133,7 +135,7 @@ def _get_data():
     return data
 
 def _get_state():
-    response = _query_rest_api('/state')
+    response = _query_rest_api('/state?address={}'.format(INTKEY_PREFIX))
     return response['data']
 
 def _query_rest_api(suffix='', data=None, headers={}):

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -90,14 +90,19 @@ class TestTwoFamilies(unittest.TestCase):
                 how_many_updates += 1
 
             self.verify_state_after_n_updates(how_many_updates)
-            self.verify_all_state_xo_or_intkey()
 
     def verify_empty_state(self):
         LOGGER.debug('Verifying empty state')
+
         self.assertEqual(
             [],
-            _get_state(),
-            'Empty state error')
+            _get_intkey_state(),
+            'Expected intkey state to be empty')
+
+        self.assertEqual(
+            [],
+            _get_xo_state(),
+            'Expected xo state to be empty')
 
     def verify_state_after_n_updates(self, num):
         LOGGER.debug('Verifying state after {} updates'.format(num))
@@ -116,18 +121,6 @@ class TestTwoFamilies(unittest.TestCase):
             xo_data,
             self.xo_verifier.state_after_n_updates(num),
             'Wrong xo state')
-
-    def verify_all_state_xo_or_intkey(self):
-        state = _get_state()
-        xo_state = _get_xo_state()
-        intkey_state = _get_intkey_state()
-
-        for entry in state:
-            if entry not in intkey_state:
-                self.assertIn(
-                    entry,
-                    xo_state,
-                    'Unknown state entry')
 
 
 # sending commands
@@ -176,10 +169,6 @@ def _get_xo_state():
 
 def _get_state_prefix(prefix):
     response = _query_rest_api('/state?address=' + prefix)
-    return response['data']
-
-def _get_state():
-    response = _query_rest_api('/state')
     return response['data']
 
 def _query_rest_api(suffix='', data=None, headers={}):


### PR DESCRIPTION
Currently the intkey smoke and two-family tests verify that the entire
state is initially empty. This will work if the validator is started
with an empty genesis batch, as it is in these tests' compose files:

        sawtooth admin keygen && \
        sawtooth admin genesis && \
        sawtooth-validator -v \
            --endpoint tcp://validator:8800 \
            --bind component:tcp://eth0:4004 \
            --bind network:tcp://eth0:8800 \

However, if the genesis batch is non-empty, then state won't be empty,
and the tests will fail:

        sawtooth admin keygen && \
        sawtooth keygen my_key && \
        sawtooth config genesis -k /root/.sawtooth/keys/my_key.priv && \
        sawtooth admin genesis config-genesis.batch && \
        sawtooth-validator -vv \
          --endpoint tcp://validator:8800 \
          --bind component:tcp://eth0:4004 \
          --bind network:tcp://eth0:8800 \

This commit fixes the tests to only check their specific namespaces so
that the tests will pass regardless of what the genesis batch is.

The fix here is quick and dirty. A more elegant approach would be to refactor both tests using the `RestClient` at `integration/sawtooth_integration/tests/integration_tools.py`.