### PR TITLE
Gossip and Poet Simulator Fixes

### DIFF
--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -521,6 +521,10 @@ def unseal_signup_data(sealed_signup_data):
     return _PoetEnclaveSimulator.unseal_signup_data(sealed_signup_data)
 
 
+def release_signup_data(sealed_signup_data):
+    return _PoetEnclaveSimulator.release_signup_data(sealed_signup_data)
+
+
 def create_wait_timer(sealed_signup_data,
                       validator_address,
                       previous_certificate_id,

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -575,11 +575,14 @@ class Topology(Thread):
         self._connection_statuses[connection_id] = "temp"
         get_peers_request = GetPeersRequest()
 
+        def callback(request, result):
+            # request, result are ignored, but required by the callback
+            self._remove_temporary_connection(connection_id)
+
         self._network.send(validator_pb2.Message.GOSSIP_GET_PEERS_REQUEST,
                            get_peers_request.SerializeToString(),
                            connection_id,
-                           callback=partial(self._remove_temporary_connection,
-                                            connection_id))
+                           callback=callback)
 
     def _connect_failure_topology_callback(self, connection_id):
         LOGGER.debug("Connection to %s failed for topology request",


### PR DESCRIPTION
From recent long-running instances:

- Fix remove temporary connection callback
    Using partial with this function caused it to receive too many arguments. Wrapping it in a function that takes the correct number of arguments to act as a future callback.
- Add release_signup_data to the PoET simulator module
    Add the release_signup_data function at the module level.  This was missing from the simulator vs the SGX implementation.