### PR TITLE
Implement Batch Injection - Phase 1/3

### DIFF
--- a/bin/run_lint
+++ b/bin/run_lint
@@ -160,15 +160,20 @@ lint rest_api/sawtooth_rest_api "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/families/settings
 PYTHONPATH=$top_dir/families/identity
-PYTHONPATH=$top_dir/families/block_info
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/families/supplychain/python
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
 export PYTHONPATH
 lint families/settings "$SINCE" || retval=1
 lint families/identity "$SINCE" || retval=1
-lint families/block_info "$SINCE" || retval=1
 lint families/supplychain/python "$SINCE" || retval=1
+
+PYTHONPATH=$top_dir/families/block_info
+PYTHONPATH=$PYTHONPATH:$top_dir/signing
+PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
+PYTHONPATH=$PYTHONPATH:$top_dir/validator
+export PYTHONPATH
+lint families/block_info "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/validator

--- a/docker/compose/sawtooth-seth.yaml
+++ b/docker/compose/sawtooth-seth.yaml
@@ -36,6 +36,27 @@ services:
     command: seth-tp -vv tcp://validator:4004
     stop_signal: SIGKILL
 
+  block-info-tp:
+    image: sawtooth-block-info-tp:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: block-info-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  settings-tp:
+    image: sawtooth-settings-tp:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    entrypoint: settings-tp -vv tcp://validator:4004
+
   validator:
     image: sawtooth-validator:latest
     volumes:
@@ -49,11 +70,21 @@ services:
     command: "bash -c \"\
         if [ ! -f sawtooth.priv ]; then sawtooth keygen --key-dir /project/sawtooth-core sawtooth; fi && \
         sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth config proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.validator.batch_injectors=block_info \
+          -o config.batch && \
+        sawtooth admin genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
     \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   rest-api:

--- a/docker/compose/sawtooth-seth.yaml
+++ b/docker/compose/sawtooth-seth.yaml
@@ -43,6 +43,9 @@ services:
     expose:
       - 4004
       - 8800
+    ports:
+      - 4004
+      - 8800
     command: "bash -c \"\
         sawtooth keygen --key-dir /project/sawtooth-core sawtooth && \
         sawtooth admin keygen && \
@@ -59,6 +62,8 @@ services:
       - ../../:/project/sawtooth-core
     expose:
       - 4004
+      - 8080
+    ports:
       - 8080
     depends_on:
      - validator

--- a/docker/compose/sawtooth-seth.yaml
+++ b/docker/compose/sawtooth-seth.yaml
@@ -47,7 +47,7 @@ services:
       - 4004
       - 8800
     command: "bash -c \"\
-        sawtooth keygen --key-dir /project/sawtooth-core sawtooth && \
+        if [ ! -f sawtooth.priv ]; then sawtooth keygen --key-dir /project/sawtooth-core sawtooth; fi && \
         sawtooth admin keygen && \
         sawtooth admin genesis && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \

--- a/docker/compose/sawtooth-xo.yaml
+++ b/docker/compose/sawtooth-xo.yaml
@@ -77,6 +77,8 @@ services:
     expose:
       - 4004
       - 8800
+    ports:
+      - 4004
     command: "bash -c \"\
         sawtooth admin keygen && \
         sawtooth admin genesis && \
@@ -92,6 +94,8 @@ services:
       - ../../:/project/sawtooth-core
     expose:
       - 4004
+      - 8080
+    ports:
       - 8080
     depends_on:
      - validator

--- a/families/block_info/sawtooth_block_info/injector.py
+++ b/families/block_info/sawtooth_block_info/injector.py
@@ -1,0 +1,112 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import hashlib
+import time
+
+import sawtooth_signing.secp256k1_signer as signing
+
+from sawtooth_validator.journal.batch_injector import BatchInjector
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
+from sawtooth_validator.protobuf.transaction_pb2 import Transaction
+from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
+from sawtooth_validator.protobuf.batch_pb2 import Batch
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+
+from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfoTxn
+from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfo
+
+from sawtooth_block_info.common import FAMILY_NAME
+from sawtooth_block_info.common import FAMILY_VERSION
+from sawtooth_block_info.common import ENCODING
+from sawtooth_block_info.common import CONFIG_ADDRESS
+from sawtooth_block_info.common import BLOCK_INFO_NAMESPACE
+
+
+class BlockInfoInjector(BatchInjector):
+    """Inject BlockInfo transactions at the beginning of blocks."""
+    def __init__(self, block_store, state_view_factory, signing_key,
+                 public_key):
+        self._block_store = block_store
+        self._state_view_factory = state_view_factory
+        self._signing_key = signing_key
+        self._public_key = public_key
+
+    def create_batch(self, block_info):
+        payload = BlockInfoTxn(block=block_info).SerializeToString()
+        header = TransactionHeader(
+            signer_pubkey=self._public_key,
+            family_name=FAMILY_NAME,
+            family_version=FAMILY_VERSION,
+            inputs=[CONFIG_ADDRESS, BLOCK_INFO_NAMESPACE],
+            outputs=[CONFIG_ADDRESS, BLOCK_INFO_NAMESPACE],
+            dependencies=[],
+            payload_encoding=ENCODING,
+            payload_sha512=hashlib.sha512(payload).hexdigest(),
+            batcher_pubkey=self._public_key,
+        ).SerializeToString()
+
+        transaction_signature = signing.sign(header, self._signing_key)
+
+        transaction = Transaction(
+            header=header,
+            payload=payload,
+            header_signature=transaction_signature,
+        )
+
+        header = BatchHeader(
+            signer_pubkey=self._public_key,
+            transaction_ids=[transaction_signature],
+        ).SerializeToString()
+
+        batch_signature = signing.sign(header, self._signing_key)
+
+        return Batch(
+            header=header,
+            transactions=[transaction],
+            header_signature=batch_signature,
+        )
+
+    def block_start(self, previous_block_id):
+        """Returns an ordered list of batches to inject at the beginning of the
+        block. Can also return None if no batches should be injected.
+
+        Args:
+            previous_block_id (str): The signature of the previous block.
+
+        Returns:
+            A list of batches to inject.
+        """
+        previous_block = self._block_store[previous_block_id].get_block()
+        previous_header = BlockHeader()
+        previous_header.ParseFromString(previous_block.header)
+
+        block_info = BlockInfo(
+            block_num=previous_header.block_num,
+            previous_block_id=previous_header.previous_block_id,
+            signer_pubkey=previous_header.signer_pubkey,
+            header_signature=previous_block.header_signature,
+            timestamp=int(time.time()))
+
+        return [self.create_batch(block_info)]
+
+    def before_batch(self, previous_block_id, batch):
+        return None
+
+    def after_batch(self, previous_block_id, batch):
+        return None
+
+    def block_end(self, previous_block_id, batches):
+        return None

--- a/families/block_info/sawtooth_block_info/processor/handler.py
+++ b/families/block_info/sawtooth_block_info/processor/handler.py
@@ -167,7 +167,7 @@ class BlockInfoTransactionHandler(object):
                         next_block.previous_block_id,
                         prev_block.header_signature))
 
-            if next_block.timestamp <= prev_block.timestamp:
+            if next_block.timestamp < prev_block.timestamp:
                 raise InvalidTransaction(
                     "Timestamp must be greater than previous block's."
                     " Got {}, expected >{}".format(

--- a/integration/sawtooth_integration/docker/test_block_info_injector.yaml
+++ b/integration/sawtooth_integration/docker/test_block_info_injector.yaml
@@ -1,0 +1,112 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: intkey-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  block-info-tp:
+    image: sawtooth-block-info-tp:latest
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: block-info-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth config proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.validator.batch_injectors=block_info \
+          -o config.batch && \
+        sawtooth admin genesis \
+          config-genesis.batch config.batch && \
+        sawtooth-validator --endpoint tcp://validator:8800 -v \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/families/block_info"
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    stop_signal: SIGKILL
+
+  test-block-info-injector:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    depends_on:
+      - validator
+      - rest-api
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_block_info_injector.TestBlockInfoInjector
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/sdk/examples/intkey_python:\
+        /project/sawtooth-core/families/block_info:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/tests/test_block_info_injector.py
+++ b/integration/sawtooth_integration/tests/test_block_info_injector.py
@@ -1,0 +1,102 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import time
+import unittest
+import logging
+import json
+import urllib.request
+import urllib.error
+import base64
+
+from sawtooth_block_info.common import CONFIG_ADDRESS
+from sawtooth_block_info.common import create_block_address
+from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfoConfig
+from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfo
+
+from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+def get_blocks():
+    response = query_rest_api('/blocks')
+    return response['data']
+
+
+def get_block_info_config():
+    bic = BlockInfoConfig()
+    bic.ParseFromString(get_state(CONFIG_ADDRESS))
+    return bic
+
+
+def get_block_info(block_num):
+    bi = BlockInfo()
+    bi.ParseFromString(get_state(create_block_address(block_num)))
+    return bi
+
+
+def get_state(address):
+    response = query_rest_api('/state/%s' % address)
+    return base64.b64decode(response['data'])
+
+
+def post_batch(batch):
+    headers = {'Content-Type': 'application/octet-stream'}
+    response = query_rest_api('/batches', data=batch, headers=headers)
+    return response
+
+
+def query_rest_api(suffix='', data=None, headers={}):
+    url = 'http://rest-api:8080' + suffix
+    request = urllib.request.Request(url, data, headers)
+    response = urllib.request.urlopen(request).read().decode('utf-8')
+    return json.loads(response)
+
+
+def make_batches(keys):
+    imf = IntkeyMessageFactory()
+    return [imf.create_batch([('set', k, 0)]) for k in keys]
+
+
+class TestBlockInfoInjector(unittest.TestCase):
+    def test_block_info_injector(self):
+        """Tests that BlockInfo transactions are injected and committed for
+        each block that is created by submitting intkey batches and then
+        confirming that block info batches are in the final state.
+        """
+        batches = make_batches('abcd')
+
+        # Assert all block info transactions are committed
+        for i in range(len(batches)):
+            post_batch(batches[i])
+            time.sleep(0.5)
+            block_info = get_block_info(i)
+            self.assertEqual(block_info.block_num, i)
+
+        # Assert config is set correctly
+        config = get_block_info_config()
+        self.assertEqual(config.latest_block, len(batches) - 1)
+        self.assertEqual(config.oldest_block, 0)
+        self.assertEqual(config.sync_tolerance, 300)
+        self.assertEqual(config.target_count, 256)
+
+        # Assert block info batches are first in the block
+        for block in get_blocks()[:-1]:
+            print(block['header']['block_num'])
+            family_name = \
+                block['batches'][0]['transactions'][0]['header']['family_name']
+            self.assertEqual(family_name, 'block_info')

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -87,4 +87,12 @@ class DefaultBatchInjectorFactory:
 
     def _create_injector(self, injector):
         """Returns a new batch injector"""
+        if injector == "block_info":
+            block_info_injector = importlib.import_module(
+                "sawtooth_block_info.injector")
+
+            return block_info_injector.BlockInfoInjector(
+                self._block_store, self._state_view_factory, self._signing_key,
+                self._public_key)
+
         raise UnknownBatchInjectorError(injector)

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -1,0 +1,90 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import abc
+import importlib
+
+from sawtooth_validator.state.settings_view import SettingsView
+import sawtooth_signing as signing
+
+
+class BatchInjectorFactory(object, metaclass=abc.ABCMeta):
+    """The interface to implement for constructing batch injectors"""
+    @abc.abstractmethod
+    def create_injectors(self, previous_block_id):
+        """
+        Instantiate all batch injectors that are enabled.
+
+        Returns:
+            A list of BatchInjectors.
+        """
+        raise NotImplementedError()
+
+
+class BatchInjector(object, metaclass=abc.ABCMeta):
+    """The interface to implement for injecting batches during block
+    publishing."""
+
+    @abc.abstractmethod
+    def block_start(self, previous_block_id):
+        """Returns an ordered list of batches to inject at the beginning of the
+        block. Can also return None if no batches should be injected.
+
+        Args:
+            previous_block_id (str): The signature of the previous block.
+
+        Returns:
+            A list of batches to inject.
+        """
+        raise NotImplementedError()
+
+
+class UnknownBatchInjectorError(Exception):
+    def __init__(self, injector_name):
+        super().__init__("Unknown injector: %s" % injector_name)
+
+
+class DefaultBatchInjectorFactory:
+    def __init__(self, block_store, state_view_factory, signing_key):
+        """
+        Args:
+            block_store (:obj:`BlockStore`): The block store, for passing to
+                batch injectors that require it.
+            state_view_factory (:obj:`StateViewFactory`): The state view
+                factory, for passing to injectors that require it.
+            signing_key (str): The signing key of the validator.
+            public_key (str): The public key of the validator.
+        """
+        self._block_store = block_store
+        self._state_view_factory = state_view_factory
+        self._signing_key = signing_key
+        self._public_key = signing.generate_pubkey(signing_key)
+
+    def _read_injector_setting(self, block_id):
+        state_view = self._state_view_factory.create_view(
+            self._block_store[block_id].state_root_hash)
+        settings_view = SettingsView(state_view)
+        batch_injector_setting = settings_view.get_setting(
+            "sawtooth.validator.batch_injectors")
+        return [] if not batch_injector_setting \
+            else batch_injector_setting.split(',')
+
+    def create_injectors(self, chain_head_id):
+        injectors = self._read_injector_setting(chain_head_id)
+        return [self._create_injector(i) for i in injectors]
+
+    def _create_injector(self, injector):
+        """Returns a new batch injector"""
+        raise UnknownBatchInjectorError(injector)

--- a/validator/sawtooth_validator/journal/journal.py
+++ b/validator/sawtooth_validator/journal/journal.py
@@ -23,6 +23,8 @@ import time
 from sawtooth_validator.journal.publisher import BlockPublisher
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.block_cache import BlockCache
+from sawtooth_validator.journal.batch_injector import \
+    DefaultBatchInjectorFactory
 
 
 LOGGER = logging.getLogger(__name__)
@@ -190,6 +192,11 @@ class Journal(object):
         self._permission_verifier = permission_verifier
 
     def _init_subprocesses(self):
+        batch_injector_factory = DefaultBatchInjectorFactory(
+            block_store=self._block_store,
+            state_view_factory=self._state_view_factory,
+            signing_key=self._identity_signing_key,
+        )
         self._block_publisher = BlockPublisher(
             transaction_executor=self._transaction_executor,
             block_cache=self._block_cache,
@@ -201,7 +208,8 @@ class Journal(object):
             identity_signing_key=self._identity_signing_key,
             data_dir=self._data_dir,
             config_dir=self._config_dir,
-            permission_verifier=self._permission_verifier
+            permission_verifier=self._permission_verifier,
+            batch_injector_factory=batch_injector_factory,
         )
         self._publisher_thread = self._PublisherThread(
             block_publisher=self._block_publisher,

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -19,6 +19,8 @@ from sawtooth_validator.execution.scheduler import BatchExecutionResult
 
 from sawtooth_validator.journal.batch_sender import BatchSender
 from sawtooth_validator.journal.block_sender import BlockSender
+from sawtooth_validator.journal.batch_injector import BatchInjectorFactory
+from sawtooth_validator.journal.batch_injector import BatchInjector
 
 from sawtooth_validator.protobuf import batch_pb2
 from sawtooth_validator.protobuf import block_pb2
@@ -267,3 +269,19 @@ class MockStateDeltaProcessor(object):
 class MockPermissionVerifier(object):
     def is_batch_signer_authorized(self, batch, state_root=None):
         return True
+
+
+class MockBatchInjectorFactory(BatchInjectorFactory):
+    def __init__(self, batch):
+        self._batch = batch
+
+    def create_injectors(self, previous_block_id):
+        return [MockBatchInjector(self._batch)]
+
+
+class MockBatchInjector(BatchInjector):
+    def __init__(self, batch):
+        self._batch = batch
+
+    def block_start(self, previous_block_id):
+        return [self._batch]


### PR DESCRIPTION
Add feature to inject batches into the beginning of a block and create a new BlockInfoInjector which utilizes this feature. Also add tests.

This is an incremental PR towards the completion of STL-567. It implements the portion of the task that is required by the Solidity Developer Compatibility epic and unblocks STL-495.

This PR also depends on the context manager fix @boydjohnson has up.

Phase 2 - Injection before and after a batch
Phase 3 - Injection at the end of a block