### PR TITLE
Update serial scheduler to fail fast on invalid batch

### DIFF
--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -15,6 +15,7 @@
 
 import unittest
 from unittest.mock import Mock
+from collections import deque
 import hashlib
 import threading
 import time
@@ -233,6 +234,90 @@ class TestSchedulers(unittest.TestCase):
                     i + 1,
                     'valid' if result.is_valid else 'invalid',
                     'valid' if validity else 'invalid'))
+
+    def test_serial_fail_fast(self):
+        """Tests that transactions that are already determined to be in an
+        invalid batch due to a prior transaction being invalid, won't run.
+        """
+
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._fail_fast(scheduler)
+
+    def _fail_fast(self, scheduler):
+        """Tests that transactions that are already determined to be in an
+        invalid batch due to a prior transaction being invalid, won't run.
+          x
+        [ A B ] [ C D ]
+                  B
+        Notes:
+             1. Create an invalid transaction, txn A, and put it in a batch
+                with txn B. Create a transaction, txn C, that depends on txn B
+                and put it in a batch with txn D.
+
+             2. Add the batches to the scheduler and call finalize.
+
+             3. Assert that only txn A is run.
+        """
+
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+
+        transaction_validity = {}
+
+        txn_a, _ = create_transaction(
+            payload='A'.encode(),
+            private_key=private_key,
+            public_key=public_key)
+
+        transaction_validity[txn_a.header_signature] = False
+
+        txn_b, _ = create_transaction(
+            payload='B'.encode(),
+            private_key=private_key,
+            public_key=public_key)
+
+        batch_1 = create_batch(transactions=[txn_a, txn_b],
+                               private_key=private_key,
+                               public_key=public_key)
+
+        txn_c, _ = create_transaction(
+            payload='C'.encode(),
+            private_key=private_key,
+            public_key=public_key,
+            dependencies=[txn_b.header_signature])
+
+        txn_d, _ = create_transaction(
+            payload='D'.encode(),
+            private_key=private_key,
+            public_key=public_key)
+
+        batch_2 = create_batch(
+            transactions=[txn_c, txn_d],
+            private_key=private_key,
+            public_key=public_key)
+
+        scheduler.add_batch(batch_1)
+        scheduler.add_batch(batch_2)
+        scheduler.finalize()
+
+        scheduler_iter = iter(scheduler)
+        while not scheduler.complete(block=False):
+            try:
+                txn_from_scheduler = next(scheduler_iter)
+            except StopIteration:
+                break
+            txn_id = txn_from_scheduler.txn.header_signature
+
+            self.assertEqual(txn_id,
+                             txn_a.header_signature,
+                             "Only Transaction A is run, not txn {}"
+                             "".format(txn_from_scheduler.txn.payload))
+
+            validity = transaction_validity[txn_id]
+            scheduler.set_transaction_execution_result(
+                txn_signature=txn_id,
+                is_valid=validity,
+                context_id=None)
 
     def test_serial_completion_on_finalize(self):
         """Tests that iteration will stop when finalized is called on an
@@ -472,6 +557,7 @@ class TestSchedulers(unittest.TestCase):
         context_manager, scheduler = self._setup_serial_scheduler()
         self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
+    @unittest.skip("STL-486 Parallel-fail fast")
     def test_parallel_add_valid_batch_invalid_batch(self):
         """Tests the squash function. That the correct state hash is found
         at the end of valid and invalid batches, similar to block publishing.
@@ -523,7 +609,10 @@ class TestSchedulers(unittest.TestCase):
         sched1 = iter(scheduler)
         invalid_payload = hashlib.sha512('invalid'.encode()).hexdigest()
         while not scheduler.complete(block=False):
-            txn_info = next(sched1)
+            try:
+                txn_info = next(sched1)
+            except StopIteration:
+                break
             txn_header = transaction_pb2.TransactionHeader()
             txn_header.ParseFromString(txn_info.txn.header)
             inputs_or_outputs = list(txn_header.inputs)
@@ -552,7 +641,6 @@ class TestSchedulers(unittest.TestCase):
         address_b = _get_address_from_txn(txn_info_b)
 
         txn_infoInvalid = next(sched2)
-        txn_info_c = next(sched2)
 
         txn_info_d = next(sched2)
         address_d = _get_address_from_txn(txn_info_d)
@@ -759,8 +847,13 @@ class TestSerialScheduler(unittest.TestCase):
             self.assertEqual(scheduled_txn_info, next(iterable2))
             self.assertIsNotNone(scheduled_txn_info)
             self.assertEqual(txn.payload, scheduled_txn_info.txn.payload)
+            c_id = self.context_manager.create_context(
+                self.first_state_root,
+                base_contexts=scheduled_txn_info.base_context_ids,
+                inputs=[],
+                outputs=[])
             self.scheduler.set_transaction_execution_result(
-                txn.header_signature, False, None)
+                txn.header_signature, True, c_id)
 
         with self.assertRaises(StopIteration):
             next(iterable1)
@@ -805,8 +898,14 @@ class TestSerialScheduler(unittest.TestCase):
         for txn in txns:
             scheduled_txn_info = next(iterable1)
             self.assertFalse(self.scheduler.complete(block=False))
+
+            c_id = self.context_manager.create_context(
+                self.first_state_root,
+                base_contexts=scheduled_txn_info.base_context_ids,
+                inputs=[],
+                outputs=[])
             self.scheduler.set_transaction_execution_result(
-                txn.header_signature, False, None)
+                txn.header_signature, True, c_id)
 
         self.assertTrue(self.scheduler.complete(block=False))
 
@@ -856,11 +955,16 @@ class TestSerialScheduler(unittest.TestCase):
         self.assertEqual('a', scheduled_txn_info.txn.payload.decode())
 
         self.assertIsNone(self.scheduler.next_transaction())
+        c_id = self.context_manager.create_context(
+            self.first_state_root,
+            base_contexts=scheduled_txn_info.base_context_ids,
+            inputs=[],
+            outputs=[])
 
         self.scheduler.set_transaction_execution_result(
             scheduled_txn_info.txn.header_signature,
-            is_valid=False,
-            context_id=None)
+            is_valid=True,
+            context_id=c_id)
 
         scheduled_txn_info = self.scheduler.next_transaction()
         self.assertIsNotNone(scheduled_txn_info)

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -186,7 +186,10 @@ class SchedulerTester(object):
         while not scheduler.complete(block=False):
             stop = False
             while not stop:
-                txn_info = scheduler.next_transaction()
+                try:
+                    txn_info = scheduler.next_transaction()
+                except StopIteration:
+                    break
                 if txn_info is not None:
                     txns_to_process.append(txn_info)
                     LOGGER.debug("Transaction %s scheduled",


### PR DESCRIPTION
This commit also updates tests and testing framework to not set an
invalid transaction result and expect further transactions within
a batch.

STL-579

Signed-off-by: Boyd Johnson <boydx.johnson@intel.com>