### PR TITLE
Move Future Callback Threadpool Up to Interconnect 

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -164,7 +164,8 @@ class Validator(object):
                                      secured=False,
                                      heartbeat=False,
                                      max_incoming_connections=20,
-                                     monitor=True)
+                                     monitor=True,
+                                     max_future_callback_workers=10)
 
         executor = TransactionExecutor(
             service=self._service,
@@ -203,7 +204,8 @@ class Validator(object):
             heartbeat=True,
             public_endpoint=endpoint,
             connection_timeout=30,
-            max_incoming_connections=100)
+            max_incoming_connections=100,
+            max_future_callback_workers=10)
 
         self._gossip = Gossip(self._network,
                               endpoint=endpoint,


### PR DESCRIPTION
Move the future callback threadpool up to the Interconnect. This fixes an issue caused by the future callback pool being shutdown from a thread in the same pool.  With `wait=True`, the caller of shutdown calls `join()` on all the threads in the pool.  If the calling thread is in the same pool, it fails due to not being able to join with itself.

By pulling this threadpool up to the Interconnect level allows the pool to be shutdown when the interconnect is stopped.