### PR TITLE
Create core event system and block commit events

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -277,6 +277,7 @@ test_validator() {
     copy_coverage .coverage.validator
     run_docker_test test_shutdown_smoke.yaml
     copy_coverage .coverage.test_shutdown_smoke
+    run_docker_test test_event_broadcaster
 }
 
 test_go_sdk() {

--- a/integration/sawtooth_integration/docker/test_event_broadcaster.yaml
+++ b/integration/sawtooth_integration/docker/test_event_broadcaster.yaml
@@ -1,0 +1,91 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: intkey-tp-python -vv tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawtooth admin keygen && \
+        sawtooth admin genesis && \
+        sawtooth-validator --endpoint tcp://validator:8800 -v \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    stop_signal: SIGKILL
+
+  test-event-broadcaster:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    depends_on:
+      - validator
+      - rest-api
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_event_broadcaster.TestEventBroadcaster
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/sdk/examples/intkey_python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/validator:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/tests/test_event_broadcaster.py
+++ b/integration/sawtooth_integration/tests/test_event_broadcaster.py
@@ -1,0 +1,155 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import time
+import unittest
+import logging
+import json
+import urllib.request
+import urllib.error
+import base64
+import sys
+
+from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+from sawtooth_sdk.messaging.stream import Stream
+
+from sawtooth_validator.protobuf import events_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+class TestEventBroadcaster(unittest.TestCase):
+    def test_subscribe_and_unsubscribe(self):
+        """Tests that a client can subscribe and unsubscribe from events."""
+        response = self._subscribe()
+        self.assert_subscribe_response(response)
+
+        response = self._unsubscribe()
+        self.assert_unsubscribe_response(response)
+
+    def test_block_commit_event_received(self):
+        """Tests that block commit events are properly received on block
+        boundaries."""
+        self._subscribe()
+
+        for i in range(1, 5):
+            self.batch_submitter.submit_next_batch()
+            msg = self.stream.receive().result()
+            self.assertEqual(
+                msg.message_type,
+                validator_pb2.Message.CLIENT_EVENTS)
+            event_list = events_pb2.EventList()
+            event_list.ParseFromString(msg.content)
+            events = event_list.events
+            self.assertEqual(len(events), 1)
+            self.assert_block_commit_event(events[0], i)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.batch_submitter = BatchSubmitter()
+
+    def setUp(self):
+        self.url = "tcp://validator:4004"
+        self.stream = Stream(self.url)
+
+    def tearDown(self):
+        if self.stream is not None:
+            self.stream.close()
+
+    def _subscribe(self, subscriptions=None):
+        if subscriptions is None:
+            subscriptions = [
+                events_pb2.EventSubscription(event_type="block_commit"),
+            ]
+        request = events_pb2.ClientEventsSubscribeRequest(
+            subscriptions=subscriptions)
+        response = self.stream.send(
+            validator_pb2.Message.CLIENT_EVENTS_SUBSCRIBE_REQUEST,
+            request.SerializeToString()).result()
+        return response
+
+    def _unsubscribe(self):
+        request = events_pb2.ClientEventsUnsubscribeRequest()
+        response = self.stream.send(
+            validator_pb2.Message.CLIENT_EVENTS_UNSUBSCRIBE_REQUEST,
+            request.SerializeToString()).result()
+        return response
+
+    def assert_block_commit_event(self, event, block_num):
+        self.assertEqual(event.event_type, "block_commit")
+        self.assertTrue(all([
+            any(attribute.key == "block_id" for attribute in event.attributes),
+            any(attribute.key == "block_num"
+                for attribute in event.attributes),
+            any(attribute.key == "previous_block_id"
+                for attribute in event.attributes),
+            any(attribute.key == "state_root_hash"
+                for attribute in event.attributes),
+        ]))
+        for attribute in event.attributes:
+            if attribute.key == "block_num":
+                self.assertEqual(attribute.value, str(block_num))
+
+
+    def assert_subscribe_response(self, msg):
+        self.assertEqual(
+            msg.message_type,
+            validator_pb2.Message.CLIENT_EVENTS_SUBSCRIBE_RESPONSE)
+
+        subscription_response = events_pb2.ClientEventsSubscribeResponse()
+        subscription_response.ParseFromString(msg.content)
+
+        self.assertEqual(
+            subscription_response.status,
+            events_pb2.ClientEventsSubscribeResponse.OK)
+
+    def assert_unsubscribe_response(self, msg):
+        self.assertEqual(
+            msg.message_type,
+            validator_pb2.Message.CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE)
+
+        subscription_response = events_pb2.ClientEventsUnsubscribeResponse()
+        subscription_response.ParseFromString(msg.content)
+
+        self.assertEqual(
+            subscription_response.status,
+            events_pb2.ClientEventsUnsubscribeResponse.OK)
+
+class BatchSubmitter:
+    def __init__(self):
+        self.n = 0
+        self.imf = IntkeyMessageFactory()
+
+    def _post_batch(self, batch):
+        headers = {'Content-Type': 'application/octet-stream'}
+        response = self._query_rest_api('/batches', data=batch, headers=headers)
+        return response
+
+    def _query_rest_api(self, suffix='', data=None, headers={}):
+        url = 'http://rest-api:8080' + suffix
+        request = urllib.request.Request(url, data, headers)
+        response = urllib.request.urlopen(request).read().decode('utf-8')
+        return json.loads(response)
+
+    def make_batch(self, n):
+        return self.imf.create_batch([('set', str(n), 0)])
+
+    def submit_next_batch(self):
+        batch = self.make_batch(self.n)
+        self.n += 1
+        self._post_batch(batch)
+        time.sleep(0.5)

--- a/protos/events.proto
+++ b/protos/events.proto
@@ -20,16 +20,74 @@ option java_package = "sawtooth.sdk.protobuf";
 option go_package = "events_pb2";
 
 message Event {
-  // Determines how to deserialize event_data, what pairs to expect in Meta, and
-  // is used to subscribe to a class of events.
+  // Used to subscribe to events and servers as a hint for how to deserialize
+  // event_data and what pairs to expect in attributes.
   string event_type = 1;
-  // Opaque data defined by the event_type.
-  bytes  event_data = 2;
-  message Meta {
+
+  // Transparent data defined by the event_type.
+  message Attribute {
     string key = 1;
     string value = 2;
+  }
+  repeated Attribute attributes = 2;
+
+  // Opaque data defined by the event_type.
+  bytes  data = 3;
 }
-  // Transparent data defined by the event_type. Events of a given type can be
-  // filtered by key­value pairs in meta_data when subscribing.
-  repeated Meta meta_data = 3;
+
+message EventList {
+    repeated Event events = 1;
+}
+
+message EventFilter {
+    // EventFilter is used when subscribing to events to limit the events
+    // received within a given event type. See
+    // validator/server/events/subscription.py for further explanation.
+    string key = 1;
+    string match_string = 2;
+
+    enum FilterType {
+      SIMPLE_ANY = 0;
+      SIMPLE_ALL = 1;
+      REGEX_ANY  = 2;
+      REGEX_ALL  = 3;
+    }
+    FilterType filter_type = 3;
+}
+
+message EventSubscription {
+    // EventSubscription is used when subscribing to events to specify the type
+    // of events being subscribed to, along with any additional filters. See
+    // validator/server/events/subscription.py for further explanation.
+    string event_type = 1;
+    repeated EventFilter filters = 2;
+}
+
+message ClientEventsSubscribeRequest {
+    repeated EventSubscription subscriptions = 1;
+    // The block id (or ids, if trying to walk back a fork) the subscriber last
+    // received events on. It can be set to empty if it has not yet received the
+    // genesis block.
+    repeated string last_known_block_ids = 2;
+}
+
+message ClientEventsSubscribeResponse {
+    enum Status {
+         OK = 0;
+         INVALID_FILTER = 1;
+         UNKNOWN_BLOCK = 2;
+    }
+    Status status = 1;
+    // Additional information about the response status
+    string response_message = 2;
+}
+
+message ClientEventsUnsubscribeRequest {}
+
+message ClientEventsUnsubscribeResponse {
+    enum Status {
+         OK = 0;
+         INTERNAL_ERROR = 1;
+    }
+    Status status = 1;
 }

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -100,7 +100,13 @@ message Message {
         CLIENT_RECEIPT_GET_REQUEST= 122;
         // A response with the receipts
         CLIENT_RECEIPT_GET_RESPONSE= 123;
-        // Further messages from the stats client through the web api
+
+        // Message types for events
+        CLIENT_EVENTS_SUBSCRIBE_REQUEST = 500;
+        CLIENT_EVENTS_SUBSCRIBE_RESPONSE = 501;
+        CLIENT_EVENTS_UNSUBSCRIBE_REQUEST = 502;
+        CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE = 503;
+        CLIENT_EVENTS = 504;
 
         // Temp message types until a discussion can be had about gossip msg
         GOSSIP_MESSAGE = 200;

--- a/validator/sawtooth_validator/journal/block_event_extractor.py
+++ b/validator/sawtooth_validator/journal/block_event_extractor.py
@@ -1,0 +1,39 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_validator.server.events.extractor import EventExtractor
+from sawtooth_validator.protobuf.events_pb2 import Event
+
+
+class BlockEventExtractor(EventExtractor):
+    def __init__(self, block):
+        self._block = block
+
+    def _make_event(self):
+        block = self._block
+        attributes = [
+            Event.Attribute(key="block_id", value=block.identifier),
+            Event.Attribute(key="block_num", value=str(block.block_num)),
+            Event.Attribute(
+                key="state_root_hash", value=block.state_root_hash),
+            Event.Attribute(
+                key="previous_block_id", value=block.previous_block_id)]
+        return Event(event_type="block_commit", attributes=attributes)
+
+    def extract(self, subscriptions):
+        if subscriptions:
+            for sub in subscriptions:
+                if sub.event_type == "block_commit":
+                    return [self._make_event()]

--- a/validator/sawtooth_validator/server/events/__init__.py
+++ b/validator/sawtooth_validator/server/events/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/sawtooth_validator/server/events/broadcaster.py
+++ b/validator/sawtooth_validator/server/events/broadcaster.py
@@ -1,0 +1,130 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+from threading import Condition
+
+from sawtooth_validator.protobuf.events_pb2 import EventList
+from sawtooth_validator.protobuf import validator_pb2
+
+from sawtooth_validator.journal.chain import ChainObserver
+from sawtooth_validator.journal.block_event_extractor \
+    import BlockEventExtractor
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EventBroadcaster(ChainObserver):
+    def __init__(self, service):
+        self._subscribers = {}
+        self._subscribers_cv = Condition()
+        self._service = service
+
+    def add_subscriber(self, connection_id, subscriptions,
+                       last_known_block_ids):
+        """Register the subscriber for the given event subscriptions.
+
+        Raises an exception if:
+        1. The subscription is unsuccessful.
+        2. None of the block ids in last_known_block_ids are part of the
+           current chain.
+        """
+        with self._subscribers_cv:
+            self._subscribers[connection_id] = \
+                EventSubscriber(
+                    connection_id, subscriptions, last_known_block_ids)
+
+    def enable_subscriber(self, connection_id):
+        """Start sending events to the subscriber.
+
+        If any of the block ids in last_known_block_ids are part of the current
+        chain, the observer will be notified of all events that it would have
+        received based on its subscriptions for each block in the chain since
+        the most recent block in last_known_block_ids.
+        """
+        with self._subscribers_cv:
+            self._subscribers[connection_id].start_listening()
+
+    def disable_subscriber(self, connection_id):
+        with self._subscribers_cv:
+            self._subscribers[connection_id].stop_listening()
+
+    def remove_subscriber(self, connection_id):
+        with self._subscribers_cv:
+            if connection_id in self._subscribers:
+                del self._subscribers[connection_id]
+
+    def chain_update(self, block, receipts):
+        extractors = [
+            BlockEventExtractor(block),
+        ]
+
+        subscriptions = []
+        for subscriber in self._subscribers.values():
+            for subscription in subscriber.subscriptions:
+                if subscription not in subscriptions:
+                    subscriptions.append(subscription)
+
+        events = []
+        for extractor in extractors:
+            extracted_events = extractor.extract(subscriptions)
+            if extracted_events:
+                events.extend(extracted_events)
+
+        if events:
+            self.broadcast_events(events)
+
+    def broadcast_events(self, events):
+        LOGGER.debug("Broadcasting events: %s", events)
+        if self._subscribers:
+            for connection_id, subscriber in self._subscribers.items():
+                if subscriber.is_listening():
+                    subscriber_events = [event for event in events
+                                         if subscriber.is_subscribed(event)]
+                    event_list = EventList(events=subscriber_events)
+                    self._send(connection_id, event_list.SerializeToString())
+
+    def _send(self, connection_id, message_bytes):
+        self._service.send(validator_pb2.Message.CLIENT_EVENTS,
+                           message_bytes,
+                           connection_id=connection_id)
+
+
+class EventSubscriber:
+    def __init__(self, connection_id, subscriptions, last_known_block_ids):
+        self._connection_id = connection_id
+        self._subscriptions = subscriptions
+        self._listening = False
+        self._last_known_block_ids = last_known_block_ids
+
+    def start_listening(self):
+        self._listening = True
+
+    def stop_listening(self):
+        self._listening = False
+
+    def is_listening(self):
+        return self._listening
+
+    def is_subscribed(self, event):
+        for sub in self._subscriptions:
+            if event in sub:
+                return True
+
+        return False
+
+    @property
+    def subscriptions(self):
+        return self._subscriptions.copy()

--- a/validator/sawtooth_validator/server/events/extractor.py
+++ b/validator/sawtooth_validator/server/events/extractor.py
@@ -1,0 +1,38 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from abc import ABCMeta
+from abc import abstractmethod
+
+
+class EventExtractor(object, metaclass=ABCMeta):
+    """Construct all the events of interest by taking the union of all
+    subscriptions. One extractor should be created for each input source that
+    events can be extracted from. This input source should be passed to the
+    implementation through the constructor.
+    """
+
+    @abstractmethod
+    def extract(self, subscriptions):
+        """Produce events for the given subscriptions.
+
+        Args:
+            subscriptions (list of :obj:`EventSubscription`): The subscriptions
+            to return events for.
+
+        Returns:
+            A list of protobuf Events.
+        """
+        raise NotImplementedError()

--- a/validator/sawtooth_validator/server/events/handlers.py
+++ b/validator/sawtooth_validator/server/events/handlers.py
@@ -1,0 +1,120 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+
+from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.protobuf.events_pb2 \
+    import ClientEventsSubscribeRequest
+from sawtooth_validator.protobuf.events_pb2 \
+    import ClientEventsSubscribeResponse
+from sawtooth_validator.protobuf.events_pb2 \
+    import ClientEventsUnsubscribeRequest
+from sawtooth_validator.protobuf.events_pb2 \
+    import ClientEventsUnsubscribeResponse
+
+from sawtooth_validator.server.events.subscription import EventSubscription
+from sawtooth_validator.server.events.subscription import EventFilterFactory
+from sawtooth_validator.server.events.subscription import InvalidFilterError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ClientEventsSubscribeValidationHandler(Handler):
+    """Handles validating an EventSubscriptionRequest. This must be done
+    separately from adding the subscriber to the EventBroadcaster so that the
+    subscriber does not receive events before the EventSubscribeResponse.
+    """
+
+    _msg_type = validator_pb2.Message.CLIENT_EVENTS_SUBSCRIBE_RESPONSE
+
+    def __init__(self, event_broadcaster):
+        self._event_broadcaster = event_broadcaster
+        self._filter_factory = EventFilterFactory()
+
+    def handle(self, connection_id, message_content):
+        request = ClientEventsSubscribeRequest()
+        request.ParseFromString(message_content)
+
+        ack = ClientEventsSubscribeResponse()
+        try:
+            subscriptions = [
+                EventSubscription(
+                    event_type=sub.event_type,
+                    filters=[
+                        self._filter_factory.create(
+                            f.key, f.match_string, f.filter_type)
+                        for f in sub.filters
+                    ],
+                )
+                for sub in request.subscriptions
+            ]
+        except InvalidFilterError as err:
+            LOGGER.warning("Invalid Filter Error: %s", err)
+            ack.status = ack.INVALID_FILTER
+            ack.response_message = str(err)
+            return HandlerResult(
+                HandlerStatus.RETURN,
+                message_out=ack,
+                message_type=self._msg_type)
+
+        self._event_broadcaster.add_subscriber(
+            connection_id, subscriptions, request.last_known_block_ids)
+
+        ack.status = ack.OK
+        return HandlerResult(
+            HandlerStatus.RETURN_AND_PASS,
+            message_out=ack,
+            message_type=self._msg_type)
+
+
+class ClientEventsSubscribeHandler(Handler):
+    """Tells the EventBroadcaster to actually start sending the subscriber
+    events. This is separate from validation and acknowledgement in order to
+    ensure the correct message ordering.
+    """
+
+    def __init__(self, event_broadcaster):
+        self._event_broadcaster = event_broadcaster
+
+    def handle(self, connection_id, message_content):
+        self._event_broadcaster.enable_subscriber(connection_id)
+        return HandlerResult(HandlerStatus.PASS)
+
+
+class ClientEventsUnsubscribeHandler(Handler):
+    _msg_type = validator_pb2.Message.CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE
+
+    def __init__(self, event_broadcaster):
+        self._event_broadcaster = event_broadcaster
+
+    def handle(self, connection_id, message_content):
+        request = ClientEventsUnsubscribeRequest()
+        request.ParseFromString(message_content)
+
+        ack = ClientEventsUnsubscribeResponse()
+        self._event_broadcaster.disable_subscriber(connection_id)
+        self._event_broadcaster.remove_subscriber(connection_id)
+
+        ack.status = ack.OK
+
+        return HandlerResult(
+            HandlerStatus.RETURN,
+            message_out=ack,
+            message_type=self._msg_type)

--- a/validator/sawtooth_validator/server/events/subscription.py
+++ b/validator/sawtooth_validator/server/events/subscription.py
@@ -1,0 +1,192 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from abc import ABCMeta
+from abc import abstractmethod
+import re
+
+
+class EventSubscription:
+    """Represents a subscription to events. An event is part of a subscription
+    if its type matches the type of the subscription and, if any filters are
+    included in the subscription, it passes all filters.
+    """
+    def __init__(self, event_type, filters=None):
+        self.event_type = event_type
+        if filters:
+            self.filters = filters
+        else:
+            self.filters = []
+
+    def __eq__(self, other):
+        if self.event_type != other.event_type:
+            return False
+
+        for f in self.filters:
+            if f not in other.filters:
+                return False
+
+        return True
+
+    def __contains__(self, event):
+        """Returns whether this events belongs within this subscriptions."""
+        if event.event_type == self.event_type:
+            for sub_filter in self.filters:
+                if event not in sub_filter:
+                    return False
+            return True
+
+        return False
+
+
+class InvalidFilterError(Exception):
+    pass
+
+
+class EventFilterType:
+    # Not using Enum here because we want compatibility with the protobuf
+    # filter types, which are just integers
+    simple_any = 0
+    simple_all = 1
+    regex_any = 2
+    regex_all = 3
+
+
+class EventFilterFactory:
+    def __init__(self):
+        self.filter_types = {
+            EventFilterType.simple_any: SimpleAnyFilter,
+            EventFilterType.simple_all: SimpleAllFilter,
+            EventFilterType.regex_any: RegexAnyFilter,
+            EventFilterType.regex_all: RegexAllFilter,
+        }
+
+    def create(self, key, match_string,
+               filter_type=EventFilterType.simple_any):
+        try:
+            return self.filter_types[filter_type](key, match_string)
+        except KeyError:
+            raise InvalidFilterError(
+                "Unknown filter type: {}".format(filter_type))
+
+
+class EventFilter(object, metaclass=ABCMeta):
+    """Represents a subset of events within an event type."""
+
+    def __init__(self, key, match_string):
+        self.match_string = match_string
+        self.key = key
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.key == other.key \
+            and self.match_string == other.match_string
+
+    def __contains__(self, event):
+        return self.matches(event)
+
+    @abstractmethod
+    def matches(self, event):
+        """Returns whether the event passes this filter."""
+        raise NotImplementedError()
+
+
+class SimpleAnyFilter(EventFilter):
+    def matches(self, event):
+        for attribute in event.attributes:
+            if self.key == attribute.key:
+                if self.match_string == attribute.value:
+                    return True
+        return False
+
+
+class SimpleAllFilter(EventFilter):
+    def matches(self, event):
+        for attribute in event.attributes:
+            if self.key == attribute.key:
+                if self.match_string != attribute.value:
+                    return False
+        return True
+
+
+class RegexAnyFilter(EventFilter):
+    """Represents a subset of events within an event type. Pattern must be a
+    valid regular expression that can be compiled by the re module.
+
+    Since multiple event attributes with the same key can be present in an
+    event, an event is considered part of this filter if its pattern matches
+    the value of ANY attribute with the filter's key.
+
+    For example, if an event has the following attributes:
+
+        - Attribute(key="address", value="abc")
+        - Attribute(key="address", value="def")
+
+    it will pass the following filter:
+
+        AnyRegexFilter(key="address", value="abc")
+
+    Because it matches one of the two attributes with the key "address".
+    """
+    def __init__(self, key, match_string):
+        super().__init__(key, match_string)
+        try:
+            self.regex = re.compile(match_string)
+        except:
+            raise InvalidFilterError(
+                "Invalid regular expression: {}".format(match_string))
+
+    def matches(self, event):
+        for attribute in event.attributes:
+            if self.key == attribute.key:
+                if self.regex.search(attribute.value):
+                    return True
+        return False
+
+
+class RegexAllFilter(EventFilter):
+    """Represents a subset of events within an event type. Pattern must be a
+    valid regular expression that can be compiled by the re module.
+
+    Since multiple event attributes with the same key can be present in an
+    event, an event is considered part of this filter if its pattern matches
+    the value of ALL attribute with the filter's key.
+
+    For example, if an event has the following attributes:
+
+        - Attribute(key="address", value="abc")
+        - Attribute(key="address", value="def")
+
+    it will NOT pass this filter:
+
+        AllRegexFilter(key="address", value="abc")
+
+    Because it does not match all attributes with the key "address".
+    """
+    def __init__(self, key, match_string):
+        super().__init__(key, match_string)
+        try:
+            self.regex = re.compile(match_string)
+        except:
+            raise InvalidFilterError(
+                "Invalid regular expression: {}".format(match_string))
+
+    def matches(self, event):
+        for attribute in event.attributes:
+            if self.key == attribute.key:
+                if not self.regex.search(attribute.value):
+                    return False
+        return True

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -1,0 +1,228 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.server.events.broadcaster import EventBroadcaster
+from sawtooth_validator.server.events.handlers \
+    import ClientEventsSubscribeValidationHandler
+from sawtooth_validator.server.events.handlers \
+    import ClientEventsSubscribeHandler
+from sawtooth_validator.server.events.handlers \
+    import ClientEventsUnsubscribeHandler
+from sawtooth_validator.server.events.subscription import EventSubscription
+from sawtooth_validator.server.events.subscription import EventFilterFactory
+from sawtooth_validator.server.events.subscription import EventFilterType
+
+from sawtooth_validator.protobuf import events_pb2
+from sawtooth_validator.protobuf import block_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
+from sawtooth_validator.journal.block_event_extractor \
+    import BlockEventExtractor
+
+
+def create_block():
+    block_header = block_pb2.BlockHeader(
+        block_num=85,
+        state_root_hash="0987654321fedcba",
+        previous_block_id="0000000000000000")
+    block = BlockWrapper(block_pb2.Block(
+        header_signature="abcdef1234567890",
+        header=block_header.SerializeToString()))
+    return block
+
+
+def create_block_commit_subscription():
+    return EventSubscription(event_type="block_commit")
+
+
+FILTER_FACTORY = EventFilterFactory()
+
+
+class EventSubscriptionTest(unittest.TestCase):
+    def test_filter(self):
+        """Test that a regex filter matches properly against an event."""
+        self.assertIn(
+            events_pb2.Event(attributes=[
+                events_pb2.Event.Attribute(
+                    key="address", value="000000" + "f" * 64)]),
+            FILTER_FACTORY.create(key="address", match_string="000000.*",
+                filter_type=EventFilterType.regex_any))
+
+        self.assertIn(
+            events_pb2.Event(attributes=[
+                events_pb2.Event.Attribute(key="abc", value="123")]),
+            FILTER_FACTORY.create(key="abc", match_string="123"))
+
+    def test_subscription(self):
+        """Test that an event correctly matches against a subscription."""
+        self.assertIn(
+            events_pb2.Event(event_type="test", attributes=[
+                events_pb2.Event.Attribute(key="test", value="test")]),
+            EventSubscription(
+                event_type="test",
+                filters=[FILTER_FACTORY.create(key="test", match_string="test")]))
+
+
+class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
+    def test_subscribe(self):
+        """Test that a subscriber is successfully validated and added to the
+        event broadcaster.
+        """
+
+        mock_event_broadcaster = Mock()
+        handler = \
+            ClientEventsSubscribeValidationHandler(mock_event_broadcaster)
+        request = events_pb2.ClientEventsSubscribeRequest(
+            subscriptions=[events_pb2.EventSubscription(
+                event_type="test_event",
+                filters=[
+                    events_pb2.EventFilter(key="test", match_string="test")],
+            )],
+            last_known_block_ids=["0" * 128]).SerializeToString()
+
+        response = handler.handle("test_conn_id", request)
+
+        mock_event_broadcaster.add_subscriber.assert_called_with(
+            "test_conn_id",
+            [EventSubscription(
+                event_type="test_event",
+                filters=[
+                    FILTER_FACTORY.create(key="test", match_string="test")])],
+            ["0" * 128])
+        self.assertEqual(HandlerStatus.RETURN_AND_PASS, response.status)
+        self.assertEqual(events_pb2.ClientEventsSubscribeResponse.OK,
+                         response.message_out.status)
+
+    def test_subscribe_bad_filter(self):
+        """Tests that the handler will respond with an INVALID_FILTER
+        when a subscriber provides an invalid filter.
+        """
+        mock_event_broadcaster = Mock()
+        handler = \
+            ClientEventsSubscribeValidationHandler(mock_event_broadcaster)
+        request = events_pb2.ClientEventsSubscribeRequest(
+            subscriptions=[events_pb2.EventSubscription(
+                event_type="test_event",
+                filters=[events_pb2.EventFilter(
+                    key="test", match_string="???",
+                    filter_type=events_pb2.EventFilter.REGEX_ANY)],
+            )],
+            last_known_block_ids=["0" * 128]).SerializeToString()
+
+        response = handler.handle("test_conn_id", request)
+
+        mock_event_broadcaster.add_subscriber.assert_not_called()
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(
+            events_pb2.ClientEventsSubscribeResponse.INVALID_FILTER,
+             response.message_out.status)
+
+
+class ClientEventsSubscribeHandlersTest(unittest.TestCase):
+
+    def test_subscribe(self):
+        """Tests that the handler turns on the subscriber."""
+        mock_event_broadcaster = Mock()
+        handler = ClientEventsSubscribeHandler(mock_event_broadcaster)
+        request = events_pb2.ClientEventsSubscribeRequest()
+
+        response = handler.handle("test_conn_id", request)
+
+        mock_event_broadcaster.enable_subscriber.assert_called_with(
+            "test_conn_id")
+        self.assertEqual(HandlerStatus.PASS, response.status)
+
+
+class ClientEventsUnsubscribeHandlerTest(unittest.TestCase):
+    def test_unsubscribe(self):
+        """Test that a handler will unregister a subscriber via a requestor's
+        connection id.
+        """
+        mock_event_broadcaster = Mock()
+        handler = ClientEventsUnsubscribeHandler(mock_event_broadcaster)
+
+        request = \
+            events_pb2.ClientEventsUnsubscribeRequest().SerializeToString()
+
+        response = handler.handle('test_conn_id', request)
+
+        mock_event_broadcaster.disable_subscriber.assert_called_with(
+            'test_conn_id')
+        mock_event_broadcaster.remove_subscriber.assert_called_with(
+            'test_conn_id')
+
+        self.assertEqual(HandlerStatus.RETURN, response.status)
+        self.assertEqual(events_pb2.ClientEventsUnsubscribeResponse.OK,
+                         response.message_out.status)
+
+
+class EventBroadcasterTest(unittest.TestCase):
+    def test_add_remove_subscriber(self):
+        """Test adding and removing a subscriber."""
+        mock_service = Mock()
+        event_broadcaster = EventBroadcaster(mock_service)
+        subscriptions = [EventSubscription(
+            event_type="test_event",
+            filters=[FILTER_FACTORY.create(key="test", match_string="test")],
+        )]
+        event_broadcaster.add_subscriber("test_conn_id", subscriptions, [])
+
+        self.assertTrue(
+            "test_conn_id" in event_broadcaster._subscribers.keys())
+        self.assertEqual(
+            event_broadcaster._subscribers["test_conn_id"].subscriptions,
+            subscriptions)
+
+        event_broadcaster.remove_subscriber("test_conn_id")
+
+        self.assertTrue(
+            "test_conn_id" not in event_broadcaster._subscribers.keys())
+
+    def test_broadcast_events(self):
+        """Test that broadcast_events works with a single subscriber to the
+        block_commit event type and that the subscriber does not receive events
+        until it is enabled.
+        """
+        mock_service = Mock()
+        event_broadcaster = EventBroadcaster(mock_service)
+        block = create_block()
+
+        event_broadcaster.chain_update(block, [])
+        mock_service.send.assert_not_called()
+
+        event_broadcaster.add_subscriber(
+            "test_conn_id", [create_block_commit_subscription()], [])
+
+        event_broadcaster.chain_update(block, [])
+        mock_service.send.assert_not_called()
+
+        event_broadcaster.enable_subscriber("test_conn_id")
+        event_broadcaster.chain_update(block, [])
+
+        event_list = events_pb2.EventList(
+            events=BlockEventExtractor(block).extract(
+                [create_block_commit_subscription()])).SerializeToString()
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.CLIENT_EVENTS,
+            event_list, connection_id="test_conn_id")

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -57,8 +57,8 @@ class ReceiptStoreTest(unittest.TestCase):
                     type=StateChange.SET))
                 events.append(Event(
                     event_type="test",
-                    event_data=byte,
-                    meta_data=[Event.Meta(key=string, value=string)]))
+                    data=byte,
+                    attributes=[Event.Attribute(key=string, value=string)]))
                 data.append(TransactionReceipt.Data(
                     data_type="test",
                     data=byte))


### PR DESCRIPTION
Creates the core components of the event subscription system within sawtooth and creates a BlockEventExtractor for generating block_commit events.

A couple things are missing:
1. Event catch-up
2. A "pull" system with supporting messages and handlers (similar to `StateDeltaGetEventsRequest`)

I will circle back and add these once transaction execution results exist.