### PR TITLE
Capture Unhandled Exceptions in Executor

### DIFF
--- a/rest_api/sawtooth_rest_api/messaging.py
+++ b/rest_api/sawtooth_rest_api/messaging.py
@@ -151,7 +151,7 @@ class _Sender:
         try:
             await self._socket.send_multipart([message.SerializeToString()])
         except asyncio.CancelledError:
-            return None
+            raise
 
         return await self._msg_router.await_reply(correlation_id,
                                                   timeout=timeout)


### PR DESCRIPTION
Catch and log any unhandled exceptions in the various threads of the executor.

Also, correct a cancelled error usage in the rest api