### PR TITLE
Remove callback used for Gossip Peering

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -321,14 +321,17 @@ class Validator(object):
 
         self._network_dispatcher.add_handler(
             validator_pb2.Message.AUTHORIZATION_VIOLATION,
-            AuthorizationViolationHandler(network=self._network),
+            AuthorizationViolationHandler(
+                network=self._network,
+                gossip=self._gossip),
             network_thread_pool)
 
         self._network_dispatcher.add_handler(
             validator_pb2.Message.AUTHORIZATION_TRUST_REQUEST,
             AuthorizationTrustRequestHandler(
                 network=self._network,
-                permission_verifier=permission_verifier),
+                permission_verifier=permission_verifier,
+                gossip=self._gossip),
             network_thread_pool)
 
         # Set up gossip handlers


### PR DESCRIPTION
Instead the Authorization handler will notify gossip that a connection it initialized has been authorized in both directions. At that point gossip can either try to peer or request the peers of that connection depending on the temp stored endpoints. 

This fixes the timing issue where one validator sends a gossip messages before both directions are authorized causing an AuthorizationViolation to be sent and the connection to be closed. 