### PR TITLE
Make TimedCaches self-purging, and improve BatchTracker's cache usage

### DIFF
--- a/validator/sawtooth_validator/journal/block_cache.py
+++ b/validator/sawtooth_validator/journal/block_cache.py
@@ -20,8 +20,8 @@ class BlockCache(TimedCache):
     """
     A dict like interface to access blocks. Stores BlockState objects.
     """
-    def __init__(self, block_store=None, keep_time=10):
-        super(BlockCache, self).__init__(keep_time)
+    def __init__(self, block_store=None, keep_time=10, purge_frequency=10):
+        super(BlockCache, self).__init__(keep_time, purge_frequency)
         self._block_store = block_store if block_store is not None else {}
 
     def __getitem__(self, key):

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -14,7 +14,6 @@
 # ------------------------------------------------------------------------------
 
 import logging
-import time
 from threading import RLock
 from collections import deque
 
@@ -45,30 +44,42 @@ class Completer(object):
     have their dependencies satisifed, otherwise it will request the batch that
     has the missing transaction.
     """
-    def __init__(self, block_store, gossip, cache_purge_frequency=30,
-                 requested_purge_frequency=1200):
+    def __init__(self,
+                 block_store,
+                 gossip,
+                 cache_keep_time=30,
+                 cache_purge_frequency=30,
+                 requested_keep_time=1200):
         """
         :param block_store (dictionary) The block store shared with the journal
         :param gossip (gossip.Gossip) Broadcasts block and batch request to
                 peers
-        :param cache_purge_frequency (int) The time between purging the
-                TimedCaches.
+        :param cache_keep_time (float) Time in seconds to keep values in
+            TimedCaches.
+        :param cache_purge_frequency (float) Time between purging the
+            TimedCaches.
         """
         self.gossip = gossip
-        self.batch_cache = TimedCache(cache_purge_frequency)
-        self.block_cache = BlockCache(block_store, cache_purge_frequency)
+        self.batch_cache = TimedCache(cache_keep_time, cache_purge_frequency)
+        self.block_cache = BlockCache(block_store,
+                                      cache_keep_time,
+                                      cache_purge_frequency)
         self._block_store = block_store
         # avoid throwing away the genesis block
         self.block_cache[NULL_BLOCK_IDENTIFIER] = None
         self._seen_txns = TimedCache(cache_purge_frequency)
         self._incomplete_batches = TimedCache(cache_purge_frequency)
         self._incomplete_blocks = TimedCache(cache_purge_frequency)
-        self._requested = TimedCache(requested_purge_frequency)
+        self._seen_txns = TimedCache(cache_keep_time, cache_purge_frequency)
+        self._incomplete_batches = TimedCache(cache_keep_time,
+                                              cache_purge_frequency)
+        self._incomplete_blocks = TimedCache(cache_keep_time,
+                                             cache_purge_frequency)
+        self._requested = TimedCache(requested_keep_time,
+                                     cache_purge_frequency)
         self._on_block_received = None
         self._on_batch_received = None
         self.lock = RLock()
-        self._cache_purge_frequency = cache_purge_frequency
-        self._purge_time = time.time() + self._cache_purge_frequency
 
     def _complete_block(self, block):
         """ Check the block to see if it is complete and if it can be passed to
@@ -261,17 +272,6 @@ class Completer(object):
                             to_complete.append(inc_block.header_signature)
                     del self._incomplete_blocks[my_key]
 
-    def _purge_caches(self):
-        if self._purge_time < time.time():
-            LOGGER.debug("Purges caches of expired entries.")
-            self._seen_txns.purge_expired()
-            self._incomplete_batches.purge_expired()
-            self._incomplete_blocks.purge_expired()
-            self.batch_cache.purge_expired()
-            self.block_cache.purge_expired()
-            self._requested.purge_expired()
-            self._purge_time = time.time() + self._cache_purge_frequency
-
     def set_on_block_received(self, on_block_received_func):
         self._on_block_received = on_block_received_func
 
@@ -286,7 +286,6 @@ class Completer(object):
                 self.block_cache[block.header_signature] = blkw
                 self._on_block_received(blkw)
                 self._process_incomplete_blocks(block.header_signature)
-                self._purge_caches()
 
     def add_batch(self, batch):
         with self.lock:

--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -22,10 +22,6 @@ from sawtooth_validator.journal.journal import PendingBatchObserver
 from sawtooth_validator.protobuf.client_pb2 import BatchStatus
 
 
-# By default invalid batch info will be kept for one hour
-CACHE_KEEP_TIME = 3600
-
-
 class BatchTracker(StoreUpdateObserver,
                    InvalidTransactionObserver,
                    PendingBatchObserver):
@@ -40,11 +36,16 @@ class BatchTracker(StoreUpdateObserver,
 
     Args:
         block_store (BlockStore): For querying if a batch is committed
+        cache_keep_time (float): Time in seconds to keep values in TimedCaches
+        cache_purge_frequency (float): Time between purging the TimedCaches
     """
-    def __init__(self, block_store):
+    def __init__(self,
+                 block_store,
+                 cache_keep_time=600,
+                 cache_purge_frequency=30):
         self._block_store = block_store
-        self._batch_info = TimedCache(keep_time=CACHE_KEEP_TIME)
-        self._invalid = TimedCache(keep_time=CACHE_KEEP_TIME)
+        self._batch_info = TimedCache(cache_keep_time, cache_purge_frequency)
+        self._invalid = TimedCache(cache_keep_time, cache_purge_frequency)
         self._pending = set()
 
         self._lock = RLock()

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -68,14 +68,13 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
         response_type (enum): Message status of the response
         tree (MerkleDatabase, optional): State tree to be queried
         block_store (BlockStoreAdapter, optional): Block chain to be queried
-        batch_cache (TimedCache, optional): A cache of Batches being processed
 
     Attributes:
         _status (class): Convenience ref to response_proto for accessing enums
     """
 
     def __init__(self, request_proto, response_proto, response_type,
-                 tree=None, block_store=None, batch_cache=None):
+                 tree=None, block_store=None):
         self._request_proto = request_proto
         self._response_proto = response_proto
         self._response_type = response_type
@@ -83,7 +82,6 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
 
         self._tree = tree
         self._block_store = block_store
-        self._batch_cache = batch_cache
 
     def handle(self, connection_id, message_content):
         """Handles parsing incoming requests, and wrapping the final response.

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -21,7 +21,6 @@ from sawtooth_validator.protobuf.transaction_pb2 import Transaction
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_store import BlockStore
-from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.state.batch_tracker import BatchTracker

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -1266,7 +1266,7 @@ class TestJournal(unittest.TestCase):
 
 class TestTimedCache(unittest.TestCase):
     def test_cache(self):
-        bc = TimedCache(keep_time=1)
+        bc = TimedCache(keep_time=1, purge_frequency=0)
 
         with self.assertRaises(KeyError):
             bc["test"]
@@ -1286,7 +1286,7 @@ class TestTimedCache(unittest.TestCase):
         # use an invasive technique so that we don't have to sleep for
         # the item to expire
 
-        bc = TimedCache(keep_time=1)
+        bc = TimedCache(keep_time=1, purge_frequency=0)
 
         bc["test"] = "value"
         bc["test2"] = "value2"
@@ -1294,14 +1294,14 @@ class TestTimedCache(unittest.TestCase):
 
         # test that expired item i
         bc.cache["test"].timestamp = bc.cache["test"].timestamp - 2
-        bc.purge_expired()
+        bc["test2"] = "value2"  # set value to activate purge
         self.assertEqual(len(bc), 1)
         self.assertFalse("test" in bc)
         self.assertTrue("test2" in bc)
 
     def test_access_update(self):
 
-        bc = TimedCache(keep_time=1)
+        bc = TimedCache(keep_time=1, purge_frequency=0)
 
         bc["test"] = "value"
         bc["test2"] = "value2"
@@ -1310,7 +1310,7 @@ class TestTimedCache(unittest.TestCase):
         bc["test"] = "value"
         bc.cache["test"].timestamp = bc.cache["test"].timestamp - 2
         bc["test"]  # access to update timestamp
-        bc.purge_expired()
+        bc["test2"] = "value2"  # set value to activate purge
         self.assertEqual(len(bc), 2)
         self.assertTrue("test" in bc)
         self.assertTrue("test2" in bc)


### PR DESCRIPTION
Adds the concept of purge frequency internally to TimedCaches. Every time a value is set, if the specified purge frequency has elapsed (default 30s), the cache will be purged. This removes the need to manually purge TimedCaches.

Updates all uses of TimedCaches (and BlockCaches) to take advantage of this behavior, and the BatchTracker class to use init parameters instead of global variables to configure the wait times. Also reduces the BatchTracker keep time from 1 hour, to 10 minutes.