### PR TITLE
Implement Challenge Authorization

### DIFF
--- a/protos/authorization.proto
+++ b/protos/authorization.proto
@@ -72,3 +72,31 @@ message AuthorizationViolation {
   // The Role the requester did not have access to
   RoleType violation = 1;
 }
+
+message AuthorizationChallengeRequest {
+  // Empty message sent to request a payload to sign
+}
+
+message AuthorizationChallengeResponse {
+  // Random payload that the connecting node must sign
+  bytes payload = 1;
+}
+
+message AuthorizationChallengeSubmit {
+  // public key of node
+  string public_key = 1;
+
+  // payload bytes that was signed to make the signature
+  bytes payload = 2;
+
+  // signature derived from signing the challenge payload
+  string signature = 3;
+
+  // A set of requested Roles
+  repeated RoleType roles = 4;
+}
+
+message AuthorizationChallengeResult {
+  // The approved roles for that connection
+  repeated RoleType roles = 1;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -139,6 +139,10 @@ message Message {
         AUTHORIZATION_VIOLATION = 601;
         AUTHORIZATION_TRUST_REQUEST = 602;
         AUTHORIZATION_TRUST_RESPONSE = 603;
+        AUTHORIZATION_CHALLENGE_REQUEST = 604;
+        AUTHORIZATION_CHALLENGE_RESPONSE = 605;
+        AUTHORIZATION_CHALLENGE_SUBMIT = 606;
+        AUTHORIZATION_CHALLENGE_RESULT = 607;
     }
     // The type of message, used to determine how to 'route' the message
     // to the appropriate handler as well as how to deserialize the

--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -44,6 +44,12 @@ scheduler = 'serial'
 network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
 network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
 
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
 # Any off-chain transactor permission roles. The roles should match the roles
 # stored in state for transactor permissioning. Due to the roles having . in the
 # key, the key must be wrapped in quotes so toml can process it. The value

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -94,6 +94,10 @@ def parse_args(args):
     parser.add_argument('--scheduler',
                         choices=['serial', 'parallel'],
                         help='The type of scheduler to be used.')
+    parser.add_argument('--network-auth',
+                        choices=['trust', 'challenge'],
+                        help='The type of authorization required to join the '
+                             'validator network.')
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
@@ -182,7 +186,9 @@ def create_validator_config(opts):
         peering=opts.peering,
         seeds=opts.seeds,
         peers=opts.peers,
-        scheduler=opts.scheduler)
+        scheduler=opts.scheduler,
+        roles=opts.network_auth
+        )
 
 
 def main(args=None):
@@ -200,6 +206,9 @@ def main(args=None):
         opts.seeds = _split_comma_append_args(opts.seeds)
 
     init_console_logging(verbose_level=verbose_level)
+
+    if opts.network_auth:
+        opts.network_auth = {"network": opts.network_auth}
 
     try:
         path_config = load_path_config(config_dir=opts.config_dir)
@@ -297,7 +306,8 @@ def main(args=None):
                           validator_config.scheduler,
                           validator_config.permissions,
                           validator_config.network_public_key,
-                          validator_config.network_private_key
+                          validator_config.network_private_key,
+                          validator_config.roles
                           )
 
     # pylint: disable=broad-except

--- a/validator/tests/test_authorization_handlers/mock.py
+++ b/validator/tests/test_authorization_handlers/mock.py
@@ -1,0 +1,60 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+class MockNetwork():
+    def __init__(self, roles, allow_inbound=True, is_outbound=False,
+                 connection_status=None):
+        self.roles = roles
+        self.allow_inbound = allow_inbound
+        self.is_outbound = is_outbound
+        if connection_status is None:
+            self._connection_status = {}
+        else:
+            self._connection_status = connection_status
+
+    def update_connection_endpoint(self, connection_id, endpoint):
+        pass
+
+    def is_outbound_connection(self, connection_id):
+        return self.is_outbound
+
+    def allow_inbound_connection(self):
+        return self.allow_inbound
+
+    def update_connection_status(self, connection_id, status):
+        pass
+
+    def get_connection_status(self, connection_id):
+        return self._connection_status.get(connection_id)
+
+    def update_connection_public_key(self, connection_id, public_key):
+        pass
+
+    def send_connect_request(self, connection_id):
+        pass
+
+    def remove_connection(self, connection_id):
+        pass
+
+class MockPermissionVerifier():
+    def __init__(self, allow=True):
+        self.allow = allow
+
+    def check_network_role(self, public_key):
+        return self.allow
+
+class MockGossip():
+    def __init_(self):
+        pass

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -1,0 +1,385 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import unittest
+import os
+
+import sawtooth_signing as signing
+
+from sawtooth_validator.networking.interconnect import AuthorizationType
+from sawtooth_validator.networking.interconnect import ConnectionStatus
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.networking.handlers import ConnectHandler
+from sawtooth_validator.networking.handlers import \
+    AuthorizationTrustRequestHandler
+from sawtooth_validator.networking.handlers import \
+    AuthorizationChallengeRequestHandler
+from sawtooth_validator.networking.handlers import \
+    AuthorizationChallengeSubmitHandler
+
+from sawtooth_validator.protobuf.authorization_pb2 import ConnectionRequest
+from sawtooth_validator.protobuf.authorization_pb2 import RoleType
+from sawtooth_validator.protobuf.authorization_pb2 import \
+    AuthorizationTrustRequest
+from sawtooth_validator.protobuf.authorization_pb2 import \
+    AuthorizationChallengeRequest
+from sawtooth_validator.protobuf.authorization_pb2 import \
+    AuthorizationChallengeSubmit
+from sawtooth_validator.protobuf import validator_pb2
+
+from test_authorization_handlers.mock import MockNetwork
+from test_authorization_handlers.mock import MockPermissionVerifier
+from test_authorization_handlers.mock import MockGossip
+
+
+class TestAuthorizationHandlers(unittest.TestCase):
+
+    def test_connect(self):
+        """
+        Test the ConnectHandler correctly responds to a ConnectionRequest.
+        """
+        connect_message = ConnectionRequest(endpoint="endpoint")
+        roles = {"network": AuthorizationType.TRUST}
+        network = MockNetwork(roles)
+        handler = ConnectHandler(network)
+        handler_status = handler.handle("connection_id",
+                                        connect_message.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CONNECTION_RESPONSE)
+
+    def test_connect_bad_role_type(self):
+        """
+        Test the ConnectHandler closes the connection if the role has an
+        unsupported role type.
+        """
+        connect_message = ConnectionRequest(endpoint="endpoint")
+        roles = {"network": "other"}
+        network = MockNetwork(roles)
+        handler = ConnectHandler(network)
+        handler_status = handler.handle("connection_id",
+                                        connect_message.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CONNECTION_RESPONSE)
+
+    def test_connect_not_allowing_incoming_connections(self):
+        """
+        Test the ConnectHandler closes a connection if we are not accepting
+        incoming connections
+        """
+        connect_message = ConnectionRequest(endpoint="endpoint")
+        roles = {"network": AuthorizationType.TRUST}
+        network = MockNetwork(roles, allow_inbound=False)
+        handler = ConnectHandler(network)
+        handler_status = handler.handle("connection_id",
+                                        connect_message.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CONNECTION_RESPONSE)
+
+    def test_connect_wrong_previous_message(self):
+        """
+        Test the ConnectHandler closes a connection if any authorization
+        message has been recieved before this connection request.
+        """
+        connect_message = ConnectionRequest(endpoint="endpoint")
+        roles = {"network": AuthorizationType.TRUST}
+        network = MockNetwork(roles,
+                              connection_status={"connection_id":"other"})
+        handler = ConnectHandler(network)
+        handler_status = handler.handle("connection_id",
+                                        connect_message.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CONNECTION_RESPONSE)
+
+    def test_authorization_trust_request(self):
+        """
+        Test the AuthorizationTrustRequestHandler returns an
+        AuthorizationTrustResponse if the AuthorizationTrustRequest should be
+        approved.
+        """
+        auth_trust_request = AuthorizationTrustRequest(
+            roles=[RoleType.Value("NETWORK")],
+            public_key="public_key")
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.CONNECTION_REQUEST})
+        permission_verifer = MockPermissionVerifier()
+        gossip = MockGossip()
+        handler = AuthorizationTrustRequestHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_trust_request.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_TRUST_RESPONSE)
+
+    def test_authorization_trust_request_bad_last_message(self):
+        """
+        Test the AuthorizationTrustRequestHandler returns an
+        AuthorizationViolation and closes the connection if the last message
+        was not a ConnectionRequest.
+        """
+        auth_trust_request = AuthorizationTrustRequest(
+            roles=[RoleType.Value("NETWORK")],
+            public_key="public_key")
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               "other"})
+        permission_verifer = MockPermissionVerifier()
+        gossip = MockGossip()
+        handler = AuthorizationTrustRequestHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_trust_request.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+    def test_authorization_trust_request_not_permitted(self):
+        """
+        Test the AuthorizationTrustRequestHandler returns an
+        AuthorizationViolation and closes the connection if the permission
+        verifier does not permit the connections public key.
+        """
+        auth_trust_request = AuthorizationTrustRequest(
+            roles=[RoleType.Value("NETWORK")],
+            public_key="public_key")
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.CONNECTION_REQUEST})
+        # say that connection is not permitted
+        permission_verifer = MockPermissionVerifier(allow=False)
+        gossip = MockGossip()
+
+        handler = AuthorizationTrustRequestHandler(
+            network, permission_verifer, gossip)
+
+        handler_status = handler.handle(
+            "connection_id",
+            auth_trust_request.SerializeToString())
+
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+    def test_authorization_challenge_request(self):
+        """
+        Test the AuthorizationChallengeRequestHandler returns an
+        AuthorizationChallengeResponse.
+        """
+        auth_challenge_request = AuthorizationChallengeRequest()
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.CONNECTION_REQUEST})
+        handler = AuthorizationChallengeRequestHandler(network)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_request.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CHALLENGE_RESPONSE)
+
+    def test_authorization_challenge_request_bad_last_message(self):
+        """
+        Test the AuthorizationChallengeRequestHandler returns an
+        AuthorizationViolation and closes the connection if the last message
+        was not a ConnectionRequst
+        """
+        auth_challenge_request = AuthorizationChallengeRequest()
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               "other"})
+        handler = AuthorizationChallengeRequestHandler(network)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_request.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+    def test_authorization_challenge_submit(self):
+        """
+        Test the AuthorizationChallengeSubmitHandler returns an
+        AuthorizationChallengeResult.
+        """
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+        payload = os.urandom(10)
+
+        signature = signing.sign(payload, private_key)
+
+        auth_challenge_submit = AuthorizationChallengeSubmit(
+            public_key=public_key,
+            payload=payload,
+            signature=signature,
+            roles=[RoleType.Value("NETWORK")])
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.AUTH_CHALLENGE_REQUEST})
+        permission_verifer = MockPermissionVerifier()
+        gossip = MockGossip()
+        handler = AuthorizationChallengeSubmitHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_submit.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_CHALLENGE_RESULT)
+
+    def test_authorization_challenge_submit_bad_last_message(self):
+        """
+        Test the AuthorizationChallengeSubmitHandler returns an
+        AuthorizationViolation and closes the connection if the last message
+        was not AuthorizaitonChallengeRequest.
+        """
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+        payload = os.urandom(10)
+
+        signature = signing.sign(payload, private_key)
+
+        auth_challenge_submit = AuthorizationChallengeSubmit(
+            public_key=public_key,
+            payload=payload,
+            signature=signature,
+            roles=[RoleType.Value("NETWORK")])
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               "other"})
+        permission_verifer = MockPermissionVerifier()
+        gossip = MockGossip()
+        handler = AuthorizationChallengeSubmitHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_submit.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+    def test_authorization_challenge_submit_bad_signature(self):
+        """
+        Test the AuthorizationChallengeSubmitHandler returns an
+        AuthorizationViolation and closes the connection if the signature
+        is not verified.
+        """
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+        payload = os.urandom(10)
+
+        signature = signing.sign(payload, private_key)
+
+        auth_challenge_submit = AuthorizationChallengeSubmit(
+            public_key="other",
+            payload=payload,
+            signature=signature,
+            roles=[RoleType.Value("NETWORK")])
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.AUTH_CHALLENGE_REQUEST})
+        permission_verifer = MockPermissionVerifier()
+        gossip = MockGossip()
+        handler = AuthorizationChallengeSubmitHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_submit.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+    def test_authorization_challenge_submit(self):
+        """
+        Test the AuthorizationChallengeSubmitHandler returns an
+        AuthorizationViolation and closes the connection if the permission
+        verifier does not permit the public_key.
+        """
+        private_key = signing.generate_privkey()
+        public_key = signing.generate_pubkey(private_key)
+        payload = os.urandom(10)
+
+        signature = signing.sign(payload, private_key)
+
+        auth_challenge_submit = AuthorizationChallengeSubmit(
+            public_key=public_key,
+            payload=payload,
+            signature=signature,
+            roles=[RoleType.Value("NETWORK")])
+
+        roles = {"network": AuthorizationType.TRUST}
+
+        network = MockNetwork(
+            roles,
+            connection_status={"connection_id":
+                               ConnectionStatus.AUTH_CHALLENGE_REQUEST})
+        permission_verifer = MockPermissionVerifier(allow=False)
+        gossip = MockGossip()
+        handler = AuthorizationChallengeSubmitHandler(
+            network, permission_verifer, gossip)
+        handler_status = handler.handle(
+            "connection_id",
+            auth_challenge_submit.SerializeToString())
+        self.assertEqual(handler_status.status, HandlerStatus.RETURN_AND_CLOSE)
+        self.assertEqual(
+            handler_status.message_type,
+            validator_pb2.Message.AUTHORIZATION_VIOLATION)

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -194,6 +194,11 @@ class TestValidatorConfig(unittest.TestCase):
                 fd.write('seeds = ["tcp://peer:8802"]')
                 fd.write(os.linesep)
                 fd.write('scheduler = "serial"')
+                fd.write(os.linesep)
+                fd.write('[roles]')
+                fd.write(os.linesep)
+                fd.write('network = "trust"')
+                fd.write(os.linesep)
 
             config = load_toml_validator_config(filename)
             self.assertEqual(config.bind_network, "tcp://test:8800")
@@ -203,6 +208,8 @@ class TestValidatorConfig(unittest.TestCase):
             self.assertEqual(config.peers, ["tcp://peer:8801"])
             self.assertEqual(config.seeds, ["tcp://peer:8802"])
             self.assertEqual(config.scheduler, "serial")
+            self.assertEquals(config.roles, {"network": "trust"})
+
         finally:
             os.environ.clear()
             os.environ.update(orig_environ)


### PR DESCRIPTION
Also add the following to sawtooth_validator command line to change AuthType for network
sawtooth-validator -vv --network-auth challenge

Built on top of #822 Remove callback used for Gossip Peering


