### PR TITLE
Reorder interconnect stop

### DIFF
--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -816,9 +816,9 @@ class Interconnect(object):
 
     def stop(self):
         self._send_receive_thread.shutdown()
-        self._future_callback_threadpool.shutdown(wait=True)
         for conn in self.outbound_connections.values():
             conn.stop()
+        self._future_callback_threadpool.shutdown(wait=True)
 
     def get_connection_id_by_endpoint(self, endpoint):
         """Returns the connection id associated with a publically


### PR DESCRIPTION
Shutdown future callback threadpool after connection stops, for cleaner
overall shutdown.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>