### PR TITLE
New Yaml scheduler tester method

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -593,6 +593,13 @@ class ParallelScheduler(Scheduler):
         for predecessor_id in self._txn_predecessors[txn.header_signature]:
             if predecessor_id not in self._txn_results:
                 return True
+            # Since get_initial_state_for_transaction gets context ids not
+            # just from predecessors but also in the case of an enclosing
+            # writer failing, predecessors of that predecessor, this extra
+            # check is needed.
+            for pre_pred_id in self._txn_predecessors[predecessor_id]:
+                if pre_pred_id not in self._txn_results:
+                    return True
 
         return False
 

--- a/validator/tests/test_scheduler/data/complex_batches_multiple_failures.yaml
+++ b/validator/tests/test_scheduler/data/complex_batches_multiple_failures.yaml
@@ -453,3 +453,281 @@
     addresses_to_set:
       - y:sha :
     valid: False
+- #----------------------------- Batch 22
+  -
+    inputs:
+      - c:sha
+    outputs:
+      - ""
+    addresses_to_set:
+      - a:sha :
+      - b:sha :
+      - c:sha :
+      - d:sha :
+    name: helm
+  -
+    inputs:
+      - d:sha
+      - h:sha
+    outputs:
+      - a:sha
+      - b:sha
+    addresses_to_set:
+      - b:sha :
+    valid: False
+- #------------------------------- Batch 23
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+    valid: False
+  -
+    inputs:
+      - b:sha
+    outputs:
+      - b:sha
+    addresses_to_set:
+      - b:sha :
+    valid: False
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+    dependencies:
+      - helm
+- #------------------------------- Batch 24
+  -
+    inputs:
+      - e:sha
+    outputs:
+      - e:sha
+    addresses_to_set:
+      - e:sha :
+    valid: False
+  -
+    inputs:
+      - f:sha
+    outputs:
+      - f:sha
+    addresses_to_set:
+      - f:sha :
+    name: danko
+  -
+    inputs:
+      - g:sha
+    outputs:
+      - g:sha
+    addresses_to_set:
+      - g:sha :
+    valid: False
+- #------------------------------- Batch 25
+  -
+    inputs:
+      - h:sha
+    outputs:
+      - h:sha
+    addresses_to_set:
+      - h:sha :
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+      - b:sha
+    addresses_to_set:
+      - a:sha :
+      - b:sha :
+  -
+    inputs:
+      - c:sha
+    outputs:
+      - c:sha
+    addresses_to_set:
+      - c:sha :
+    dependencies:
+      - danko
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+    valid: False
+- #------------------------------- Batch 26
+  -
+    inputs:
+      - f:sha
+    outputs:
+      - f:sha
+    addresses_to_set:
+      - f:sha :
+    dependencies:
+      - helm
+  -
+    inputs:
+      - g:sha
+    outputs:
+      - g:sha
+    addresses_to_set:
+      - g:sha :
+  -
+    inputs:
+      - h:sha
+    outputs:
+      - h:sha:20
+    addresses_to_set:
+      - h:sha :
+    valid: False
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+    name: robertson
+- # ----------------------------- Batch 27
+  -
+    inputs:
+      - j:sha
+    outputs:
+      - j:sha
+    addresses_to_set:
+      - j:sha :
+    valid: False
+  -
+    inputs:
+      - a:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+    dependencies:
+      - robertson
+  - inputs:
+      - b:sha
+    outputs:
+      - b:sha
+    addresses_to_set:
+      - b:sha :
+  -
+    inputs:
+      - z:sha
+    outputs:
+      - z:sha
+    addresses_to_set:
+      - z:sha :
+- # ------------------------------ Batch 28
+  -
+    inputs:
+      - t:sha
+    outputs:
+      - t:sha
+    addresses_to_set:
+      - t:sha :
+    valid: False
+  -
+    inputs:
+      - w:sha:20
+    outputs:
+      - w:sha:10
+    addresses_to_set:
+      - w:sha :
+- # ------------------------------ Batch 29
+  -
+    inputs:
+      - m:sha
+    outputs:
+      - m:sha
+    addresses_to_set:
+      - m:sha :
+    dependencies:
+      - robertson
+    name: hudson
+  -
+    inputs:
+      - n:sha
+    outputs:
+      - n:sha
+    addresses_to_set:
+      - n:sha :
+- # ---------------------------------- Batch 30
+  -
+    inputs:
+      - g:sha
+    outputs:
+      - g:sha
+    addresses_to_set:
+      - g:sha :
+  -
+    inputs:
+      - c:sha
+    outputs:
+      - c:sha
+    addresses_to_set:
+      - c:sha :
+    name: manuel
+  -
+    inputs:
+      - ""
+    outputs:
+      - ""
+    addresses_to_set:
+      - r:sha :
+      - e:sha :
+      - u:sha :
+      - i:sha :
+- # --------------------------------------- Batch 31
+  -
+    inputs:
+      - r:sha
+    outputs:
+      - r:sha
+    addresses_to_set:
+      - r:sha :
+  -
+    inputs:
+      - i:sha
+    outputs:
+      - i:sha
+    addresses_to_set:
+      - i:sha :
+    dependencies:
+      - manuel
+      - hudson
+- # ---------------------------------------- Batch 32
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+    dependencies:
+      - manuel
+    name: weider
+    valid: False
+  -
+    inputs:
+      - y:sha
+    outputs:
+      - y:sha
+    addresses_to_set:
+      - y:sha :
+- # ------------------------------------- Batch 33
+ -
+  inputs:
+    - o:sha
+  outputs:
+    - o:sha
+  addresses_to_set:
+    - o:sha :
+  dependencies:
+    - weider

--- a/validator/tests/test_scheduler/data/enclosing_writer_fails.yaml
+++ b/validator/tests/test_scheduler/data/enclosing_writer_fails.yaml
@@ -232,3 +232,156 @@
     addresses_to_set:
       - k:sha :
     valid: False
+- #-------------------------- Batch 12
+  -
+    inputs:
+      - h:sha
+    outputs:
+      - h:sha
+      - j:sha:20
+    addresses_to_set:
+      - h:sha :
+      - j:sha :
+    name: simmons
+  -
+    inputs:
+      - g:sha
+      - e:sha
+      - i:sha
+    outputs:
+      - ""
+    addresses_to_set:
+      - z:sha :
+      - w:sha :
+      - x:sha :
+      - y:sha :
+    valid: False
+  -
+    inputs:
+      - m:sha
+    outputs:
+      - m:sha
+    addresses_to_set:
+      - m:sha :
+    name: mcdaniels
+  -
+    inputs:
+      - w:sha
+      - x:sha
+      - y:sha
+      - z:sha
+    outputs:
+      - ""
+    addresses_to_set:
+      - e:sha :
+      - f:sha :
+      - g:sha :
+      - h:sha :
+- #-------------------------- Batch 13
+  -
+    inputs:
+      - t:sha
+    outputs:
+      - t:sha
+    addresses_to_set:
+      - t:sha :
+    name: mizell
+  -
+    inputs:
+      - s:sha
+    outputs:
+      - s:sha
+    addresses_to_set:
+      - s:sha :
+- #--------------------------- Batch 14
+  -
+    inputs:
+      - g:sha
+      - h:sha
+    outputs:
+      - g:sha
+      - h:sha
+    addresses_to_set:
+      - g:sha :
+      - h:sha :
+  -
+    inputs:
+      - d:sha
+    outputs:
+      - d:sha
+    addresses_to_set:
+      - d:sha :
+    dependencies:
+      - mizell
+      - mcdaniels
+  -
+    inputs:
+      - ""
+    outputs:
+      - r:sha
+    addresses_to_set:
+      - r:sha :
+    name: dmc
+- # -------------------------- Batch 15
+  -
+    inputs:
+      - n:sha
+    outputs:
+      - m:sha
+    addresses_to_set:
+      - m:sha :
+    valid: False
+  -
+    inputs:
+      - o:sha
+    outputs:
+      - o:sha
+    addresses_to_set:
+      - o:sha :
+    dependencies:
+      - mcdaniels
+  -
+    inputs:
+      - p:sha
+    outputs:
+      - p:sha
+    addresses_to_set:
+      - p:sha :
+    dependencies:
+      - dmc
+  -
+    inputs:
+      - ""
+    outputs:
+      - ""
+    addresses_to_set:
+      - e:sha :
+      - f:sha :
+      - g:sha :
+      - h:sha :
+  -
+    inputs:
+      - h:sha
+    outputs:
+      - a:sha
+    addresses_to_set:
+      - a:sha :
+    dependencies:
+      - simmons
+- # -------------------------- Batch 16
+  -
+    inputs:
+      - p:sha
+    outputs:
+      - p:sha
+    addresses_to_set:
+      - p:sha :
+  -
+    inputs:
+      - b:sha
+    outputs:
+      - b:sha
+    addresses_to_set:
+      - b:sha :
+    dependencies:
+      - simmons

--- a/validator/tests/test_scheduler/test_schedulers_with_yaml.py
+++ b/validator/tests/test_scheduler/test_schedulers_with_yaml.py
@@ -46,8 +46,8 @@ class TestSchedulersWithYaml(unittest.TestCase):
                                       always_persist=False)
         return context_manager, scheduler
 
-    def test_parallel_simple_scheduler_test(self):
-        """Tests the parallel scheduler against the
+    def test_simple_scheduler_test(self):
+        """Tests the schedulers against the
         test_scheduler/data/simple_scheduler_test.yaml file.
 
         Notes:
@@ -61,16 +61,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='simple_scheduler_test.yaml')
-
-    def test_parallel_lifo_simple_scheduler_test(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/simple_scheduler_test.yaml file.
-
-        Notes:
-            To get a good understanding of the dependencies look at
-            simple_scheduler_test.yaml. In general, there are 4 batches,
-            2 are invalid. There will be 1 state root produced.
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -79,15 +69,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='simple_scheduler_test.yaml',
             lifo=True)
 
-    def test_serial_simple_scheduler_test(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/simple_scheduler_test.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='simple_scheduler_test.yaml')
 
-        Notes:
-            To get a good understanding of the dependencies look at
-            simple_scheduler_test.yaml. In general, there are 4 batches,
-            2 are invalid. There will be 1 state root produced.
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='simple_scheduler_test.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
@@ -95,8 +88,14 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='simple_scheduler_test.yaml')
 
-    def test_parallel_intkey_small_batch(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='simple_scheduler_test.yaml')
+
+    def test_intkey_small_batch(self):
+        """Tests the schedulers against the
         test_scheduler/data/intkey_small_batch.yaml file.
 
         Notes:
@@ -111,17 +110,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='intkey_small_batch.yaml')
-
-    def test_parallel_lifo_intkey_small_batch(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/intkey_small_batch.yaml file.
-
-        Notes:
-            In general, there are 8 batches, all valid, with intkey style
-            txns where the single input is the same as the single output.
-            The txn in batch 4 has an implicit dependency on the txn in
-            batch 3. There will be 1 state root produced
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -130,28 +118,37 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='intkey_small_batch.yaml',
             lifo=True)
 
-    def test_serial_intkey_small_batch(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/intkey_small_batch.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='intkey_small_batch.yaml')
 
-        Notes:
-            In general, there are 8 batches, all valid, with intkey style
-            txns where the single input is the same as the single output.
-            The txn in batch 4 has an implicit dependency on the txn in
-            batch 3. There will be 1 state root produced
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='intkey_small_batch.yaml',
+            lifo=True)
+
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
             context_manager=context_manager,
             name='intkey_small_batch.yaml')
 
-    def test_parallel_batch_fails_valid_txn(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='intkey_small_batch.yaml')
+
+    def test_batch_fails_valid_txn(self):
+        """Tests the schedulers against the
         test_scheduler/data/batch_fails_valid_txn.yaml file.
 
         Notes:
-            The yaml file has 4 batches, batches 1 and 3 are invalid, batch
+            The yaml file has 8 batches, batches 1 and 3 are invalid, batch
             2 has a txn that implicitly depends on batch 1.
             Batch 4 has txns that implicitly depend on batch 2 and 1.
             Batch 2 and Batch 4 are the only valid batches
@@ -162,17 +159,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='batch_fails_valid_txn.yaml')
-
-    def test_parallel_lifo_batch_fails_valid_txn(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/batch_fails_valid_txn.yaml file.
-
-        Notes:
-            The yaml file has 4 batches, batches 1 and 3 are invalid, batch
-            2 has a txn that implicitly depends on batch 1.
-            Batch 4 has txns that implicitly depend on batch 2 and 1.
-            Batch 2 and Batch 4 are the only valid batches
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -181,16 +167,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='batch_fails_valid_txn.yaml',
             lifo=True)
 
-    def test_serial_batch_fails_valid_txn(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/batch_fails_valid_txn.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='batch_fails_valid_txn.yaml')
 
-        Notes:
-            The yaml file has 4 batches, batches 1 and 3 are invalid, batch
-            2 has a txn that implicitly depends on batch 1.
-            Batch 4 has txns that implicitly depend on batch 2 and 1.
-            Batch 2 and Batch 4 are the only valid batches
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='batch_fails_valid_txn.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
@@ -198,12 +186,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='batch_fails_valid_txn.yaml')
 
-    def test_parallel_complex_batches_multiple_failures(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='batch_fails_valid_txn.yaml')
+
+    def test_complex_batches_multiple_failures(self):
+        """Tests the schedulers against the
         test_scheduler/data/complex_batches_multiple_failures.yaml file.
 
         Notes:
-            This yaml file has 21 batches with several txns per batch,
+            This yaml file has 33 batches with several txns per batch,
             multiple implicit dependencies per txn, and several
             failed batches.
         """
@@ -213,16 +207,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='complex_batches_multiple_failures.yaml')
-
-    def test_parallel_lifo_complex_batches_multiple_failures(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/complex_batches_multiple_failures.yaml file.
-
-        Notes:
-            This yaml file has 21 batches with several txns per batch,
-            multiple implicit dependencies per txn, and several
-            failed batches.
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -231,15 +215,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='complex_batches_multiple_failures.yaml',
             lifo=True)
 
-    def test_serial_complex_batches_multiple_failures(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/complex_batches_multiple_failures.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='complex_batches_multiple_failures.yaml')
 
-        Notes:
-            This yaml file has 21 batches with several txns per batch,
-            multiple implicit dependencies per txn, and several
-            failed batches.
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='complex_batches_multiple_failures.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
@@ -247,8 +234,14 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='complex_batches_multiple_failures.yaml')
 
-    def test_parallel_enclosing_writer_fails(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='complex_batches_multiple_failures.yaml')
+
+    def test_enclosing_writer_fails(self):
+        """Tests the schedulers against the
         test_scheduler/data/enclosing_writer_fails.yaml file.
 
         Notes:
@@ -265,19 +258,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='enclosing_writer_fails.yaml')
-
-    def test_parallel_lifo_enclosing_writer_fails(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/enclosing_writer_fails.yaml file.
-
-        Notes:
-            This yaml file has failed batches that have txns that implicitly
-            depend on multiple prior txns because they have the
-            whole tree ('') in the inputs and outputs, and also are
-            the implicit dependency of several subsequent txns. When
-            the batch fails, those dependent txns need to be replayed with
-            a different state.
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -286,18 +266,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='enclosing_writer_fails.yaml',
             lifo=True)
 
-    def test_serial_enclosing_writer_fails(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/complex_batches_multiple_failures.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='enclosing_writer_fails.yaml')
 
-        Notes:
-            This yaml file has failed batches that have txns that implicitly
-            depend on multiple prior txns because they have the
-            whole tree ('') in the inputs and outputs, and also are
-            the implicit dependency of several subsequent txns. When
-            the batch fails, those dependent txns need to be replayed with
-            a different state.
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='enclosing_writer_fails.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
@@ -305,8 +285,14 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='enclosing_writer_fails.yaml')
 
-    def test_parallel_heterogeneous_workload(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='enclosing_writer_fails.yaml')
+
+    def test_heterogeneous_workload(self):
+        """Tests the schedulers against the
         test_scheduler/data/heterogeneous_workload.yaml file.
 
         Notes:
@@ -321,17 +307,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='heterogeneous_workload.yaml')
-
-    def test_parallel_lifo_heterogeneous_workload(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/heterogeneous_workload.yaml file.
-
-        Notes:
-            This yaml file has namespaced addresses with 10 batches. Some
-            batches are composed of txns with only one namespace in inputs
-            and outputs, then other batches with txns with several namespaces.
-            There are 6 failed batches.
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -340,16 +315,18 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='heterogeneous_workload.yaml',
             lifo=True)
 
-    def test_serial_heterogeneous_workload(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/heterogeneous_workload.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='heterogeneous_workload.yaml')
 
-        Notes:
-            This yaml file has namespaced addresses with 10 batches. Some
-            batches are composed of txns with only one namespace in inputs
-            and outputs, then other batches with txns with several namespaces.
-            There are 6 failed batches.
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='heterogeneous_workload.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
@@ -357,8 +334,14 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             name='heterogeneous_workload.yaml')
 
-    def test_parallel_dependencies(self):
-        """Tests the parallel scheduler against the
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='heterogeneous_workload.yaml')
+
+    def test_dependencies(self):
+        """Tests the schedulers against the
         test_scheduler/data/dependencies.yaml file.
 
         Notes:
@@ -371,15 +354,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
             scheduler=scheduler,
             context_manager=context_manager,
             name='dependencies.yaml')
-
-    def test_parallel_lifo_dependencies(self):
-        """Tests the parallel scheduler against the
-        test_scheduler/data/dependencies.yaml file.
-
-        Notes:
-            This yaml file has batches with transactions that have implicit
-            dependencies, explicit dependencies, and multiple failed batches.
-        """
 
         context_manager, scheduler = self._setup_parallel_scheduler()
         self._single_block_files_individually(
@@ -388,20 +362,56 @@ class TestSchedulersWithYaml(unittest.TestCase):
             name='dependencies.yaml',
             lifo=True)
 
-    def test_serial_dependencies(self):
-        """Tests the serial scheduler against the
-        test_scheduler/data/dependencies.yaml file.
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='dependencies.yaml')
 
-        Notes:
-            This yaml file has batches with transactions that have implicit
-            dependencies, explicit dependencies, and multiple failed batches.
-        """
+        context_manager, scheduler = self._setup_parallel_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='dependencies.yaml',
+            lifo=True)
 
         context_manager, scheduler = self._setup_serial_scheduler()
         self._single_block_files_individually(
             scheduler=scheduler,
             context_manager=context_manager,
             name='dependencies.yaml')
+
+        context_manager, scheduler = self._setup_serial_scheduler()
+        self._single_block_files_individually_alt(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            name='dependencies.yaml')
+
+    def _single_block_files_individually_alt(self,
+                                             scheduler,
+                                             context_manager,
+                                             name,
+                                             lifo=False):
+        """Tests scheduler(s) with yaml files that represent a single
+        block.
+
+        Notes:
+            Tests that the serial scheduler has the correct batch validity
+            and state hash, and that 1 state hash is produced.
+
+        """
+
+        file_name = self._path_to_yaml_file(name)
+        tester = SchedulerTester(file_name)
+        defined_batch_results_dict = tester.batch_results
+        batch_results, txns_to_assert_state = tester.run_scheduler_alternating(
+            scheduler=scheduler,
+            context_manager=context_manager,
+            txns_executed_fifo=not lifo)
+
+        self._assertions(tester, defined_batch_results_dict,
+                         batch_results,
+                         txns_to_assert_state, name)
 
     def _single_block_files_individually(self,
                                          scheduler,
@@ -425,6 +435,13 @@ class TestSchedulersWithYaml(unittest.TestCase):
             context_manager=context_manager,
             txns_executed_fifo=not lifo)
 
+        self._assertions(tester, defined_batch_results_dict,
+                         batch_results,
+                         txns_to_assert_state, name)
+
+
+    def _assertions(self, tester, defined_batch_results_dict,
+                    batch_results, txns_to_assert_state, name):
         self.assert_batch_validity(
             defined_batch_results_dict,
             batch_results)
@@ -435,10 +452,10 @@ class TestSchedulersWithYaml(unittest.TestCase):
                 txn_context, state_found, state_assert = state_and_txn_context
 
                 self.assertEqual(state_found, state_assert,
-                                  "Transaction {} in batch {} has the wrong "
-                                  "state in the context".format(
-                                      txn_context.txn_num,
-                                      txn_context.batch_num))
+                                 "Transaction {} in batch {} has the wrong "
+                                 "state in the context".format(
+                                     txn_context.txn_num,
+                                     txn_context.batch_num))
 
         self.assert_one_state_hash(batch_results=batch_results)
 


### PR DESCRIPTION
The main difference with the new yaml scheduler method is that it calls finalize after next_transaction.

There are some small fixes to the parallel scheduler: the fix having to do with predecessors was found from writing more yaml tests. There is also a fix to reduce iteration in finding the next available transaction.