### PR TITLE
Remove extra on_block_validated call

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -344,7 +344,6 @@ class BlockValidator(object):
                             cur_blkw, new_blkw)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                self._done_cb(False, self._result)
                 raise BlockValidationAborted()
             new_chain.append(new_blkw)
             try:


### PR DESCRIPTION
In the case of wrong genesis node, on_block_validated would be called
twice, resulting in an exception due to a double cleanup attempt.
Removing the call and relying on the exception to break the flow (which
results in the normal call), fixes the issue.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>