### PR TITLE
T&T /agents endpoint and DB testing

### DIFF
--- a/bin/build_all
+++ b/bin/build_all
@@ -204,6 +204,7 @@ docker_build() {
 
 build_external() {
     docker_build docker/apache-basic_auth_proxy docker/ apache-basic_auth_proxy
+    docker_build docker/track-and-trade-server docker/ track-and-trade-server
 }
 
 build_debs() {

--- a/docker/track-and-trade-server
+++ b/docker/track-and-trade-server
@@ -1,0 +1,56 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image to be used when developing in JavaScript. The default CMD is to run
+#   build_javascript.
+#
+# Build:
+#   $ cd sawtooth-core/docker
+#   $ docker build . -f sawtooth-dev-javascript -t sawtooth-dev-javascript
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -v $(pwd):/project/sawtooth-core sawtooth-dev-javascript
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="mounted"
+
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    curl \
+    ca-certificates \
+    pkg-config \
+    build-essential \
+    libzmq3-dev \
+ && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_6.x \
+ && chmod 755 /tmp/setup-node.sh \
+ && /tmp/setup-node.sh \
+ && apt-get install nodejs -y -q \
+ && rm /tmp/setup-node.sh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install -g prebuild-install \
+ && npm install -g bcrypt body-parser express js-schema jsonwebtoken lodash protobufjs sawtooth-sdk rethinkdb
+
+EXPOSE 4004/tcp
+
+RUN mkdir -p /project/sawtooth-core/ \
+ && mkdir -p /var/log/sawtooth \
+ && mkdir -p /var/lib/sawtooth \
+ && mkdir -p /etc/sawtooth \
+ && mkdir -p /etc/sawtooth/keys \
+
+ENV PATH=$PATH:/project/sawtooth-core/bin

--- a/families/track_and_trade/server/api/index.js
+++ b/families/track_and_trade/server/api/index.js
@@ -20,12 +20,13 @@ const _ = require('lodash')
 const express = require('express')
 const bodyParser = require('body-parser')
 
-const state = require('../db/state')
-const blockchain = require('../blockchain/')
 const auth = require('./auth')
-
+const blockchain = require('../blockchain/')
 const users = require('./users')
 const { Unauthorized } = require('./errors')
+const agents = require('../db/agents')
+const state = require('../db/state')
+
 
 const router = express.Router()
 router.use(bodyParser.json({ type: 'application/json' }))
@@ -97,6 +98,8 @@ const errorHandler = (err, req, res, next) => {
 router.use(logRequest)
 router.use(initInternalParams)
 router.use(authHandler)
+
+router.get('/agents', handle(agents.list))
 
 router.get('/', (req, res) => {
   state.query(state => state.filter({name: 'message'}))

--- a/families/track_and_trade/server/db/agents.js
+++ b/families/track_and_trade/server/db/agents.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const r = require('rethinkdb')
+
+const db = require('./')
+
+const MAX_BLOCK = Number.MAX_SAFE_INTEGER
+
+const hasCurrentBlock = currentBlock => obj => {
+  return r.and(
+    obj('startBlockNum').le(currentBlock),
+    obj('endBlockNum').gt(currentBlock)
+  )
+}
+
+const getAttribute = attr => obj => obj(attr)
+const getRecordId = getAttribute('recordId')
+const getPublicKey = getAttribute('publicKey')
+const getName = getAttribute('name')
+const getReporters = getAttribute('reporters')
+const getAuthorized = getAttribute('authorized')
+
+const hasPublicKey = key => obj => {
+  return r.eq(
+    key,
+    getPublicKey(obj)
+  )
+}
+
+const getAssociatedAgentId = role => record => record(role).nth(-1)('agentId')
+const getOwnerId = getAssociatedAgentId('owners')
+const getCustodianId = getAssociatedAgentId('custodians')
+
+const isAssociatedWithRecord = association => agent => record => {
+  return r.eq(
+    association(record),
+    getPublicKey(agent)
+  )
+}
+
+const isRecordOwner = isAssociatedWithRecord(getOwnerId)
+const isRecordCustodian = isAssociatedWithRecord(getCustodianId)
+
+const isReporter = agent => property => {
+  return getReporters(property)
+    .filter(hasPublicKey(getPublicKey(agent)))
+    .do(seq => r.branch(
+      seq.isEmpty(),
+      false,
+      getAuthorized(seq.nth(0))
+    ))
+}
+
+const getAgentsQuery = blocks => {
+  return blocks
+    .orderBy(r.desc('blockNum'))
+    .nth(0)('blockNum')
+    .do(currentBlock => {
+      return r.table('agents')
+        .filter(hasCurrentBlock(currentBlock))
+        .map(agent => r.expr({
+          'name': getName(agent),
+          'key': getPublicKey(agent),
+          'owns': r.table('records')
+            .filter(hasCurrentBlock(currentBlock))
+            .filter(isRecordOwner(agent))
+            .map(getRecordId)
+            .distinct(),
+          'custodian': r.table('records')
+            .filter(hasCurrentBlock(currentBlock))
+            .filter(isRecordCustodian(agent))
+            .map(getRecordId)
+            .distinct(),
+          'reports': r.table('properties')
+            .filter(hasCurrentBlock(currentBlock))
+            .filter(isReporter(agent))
+            .map(getRecordId)
+            .distinct()
+        }))
+    })
+}
+
+const list = () => db.queryTable('blocks', getAgentsQuery)
+
+module.exports = {
+  list
+}

--- a/integration/sawtooth_integration/docker/test_track_and_trade.yaml
+++ b/integration/sawtooth_integration/docker/test_track_and_trade.yaml
@@ -26,6 +26,29 @@ services:
     command: track-and-trade-tp -vv tcp://validator:4004
     stop_signal: SIGKILL
 
+  rethinkdb:
+    image: rethinkdb
+    expose:
+      - 8080
+      - 28015
+
+  tnt-server:
+    image: track-and-trade-server:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+      - 3000
+    depends_on:
+      - rethinkdb
+    command: "bash -c \" \
+        set -x && \
+        cd /project/sawtooth-core/families/track_and_trade/server && \
+        npm link bcrypt body-parser express js-schema jsonwebtoken lodash protobufjs sawtooth-sdk rethinkdb && \
+        DB_HOST=rethinkdb node ./scripts/bootstrap_database.js && \
+        VALIDATOR_URL=tcp://validator:4004 DB_HOST=rethinkdb node index.js
+    \""
+
   settings-tp:
     image: sawtooth-settings-tp:$ISOLATION_ID
     volumes:
@@ -42,6 +65,8 @@ services:
     expose:
       - 4004
       - 8800
+    depends_on:
+      - tnt-server
     command: "bash -c \"\
         sawtooth admin keygen && \
         sawtooth config genesis \
@@ -49,7 +74,7 @@ services:
           -o config-genesis.batch && \
         sawtooth admin genesis config-genesis.batch && \
         sawtooth admin genesis && \
-        sawtooth-validator -vv \
+        sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
@@ -62,8 +87,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api -vv --connect tcp://validator:4004 --bind rest-api:8080
+      - 8081
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8081
     stop_signal: SIGKILL
 
   test-track-and-trade:
@@ -72,11 +97,17 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 8080
-    command: nose2-3
+      - 8081
+    depends_on:
+      - tnt-server
+    command: "bash -c \" \
+        sleep 5 && \
+        nose2-3
         -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
         -v
         -s /project/sawtooth-core/integration/sawtooth_integration/tests
         test_track_and_trade.TestTrackAndTrade
+    \""
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\

--- a/integration/sawtooth_integration/tests/test_track_and_trade.py
+++ b/integration/sawtooth_integration/tests/test_track_and_trade.py
@@ -31,12 +31,12 @@ from sawtooth_track_and_trade.protobuf.payload_pb2 import AnswerProposalAction
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
-
-REST_API = 'rest-api:8080'
-URL = 'http://' + REST_API
-
-
 NARRATION = False
+
+
+REST_API = 'rest-api:8081'
+URL = 'http://' + REST_API
+SERVER_URL = 'http://tnt-server:3000'
 
 
 class TTClient(RestClient):
@@ -467,6 +467,13 @@ class TestTrackAndTrade(unittest.TestCase):
             ''')
 
         self.assert_valid(
+            jin.create_proposal(
+                record_id='fish-456',
+                role=Proposal.CUSTODIAN,
+                receiving_agent=sun.public_key,
+            ))
+
+        self.assert_invalid(
             jin.create_proposal(
                 record_id='fish-456',
                 role=Proposal.CUSTODIAN,

--- a/integration/sawtooth_integration/tests/test_track_and_trade.py
+++ b/integration/sawtooth_integration/tests/test_track_and_trade.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import json
 import logging
 import unittest
 
@@ -43,6 +44,9 @@ class TTClient(RestClient):
     def __init__(self, url=URL):
         self.factory = TrackAndTradeMessageFactory()
         self.public_key = self.factory.public_key
+
+        self.auth_token = None
+
         super().__init__(
             url=url,
             namespace=addressing.NAMESPACE)
@@ -101,6 +105,25 @@ class TTClient(RestClient):
         return self._post_tt_transaction(
             self.factory.make_empty_payload(
                 self.public_key))
+
+    def get_agents(self):
+        return self._submit_request(url=SERVER_URL + '/api/agents')[1]
+
+    def post_user(self, username, password, email):
+        response = self._submit_request(
+            url=SERVER_URL + '/api/users',
+            method='POST',
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({
+                'username': username,
+                'password': password,
+                'email': email,
+                'publicKey': self.public_key,
+            }),
+        )
+
+        if self.auth_token is None:
+            self.auth_token = response['authorization']
 
 
 class TestTrackAndTrade(unittest.TestCase):
@@ -497,3 +520,51 @@ class TestTrackAndTrade(unittest.TestCase):
             jin.update_properties(
                 'fish-456',
                 {'temperature': 2}))
+
+        ###
+
+        agents_endpoint = jin.get_agents()
+
+        log_json(agents_endpoint)
+
+        agents_assertion = [
+            [
+                agent['name'],
+                agent['owns'],
+                agent['custodian'],
+            ]
+            for agent in
+            sorted(
+                agents_endpoint,
+                key=lambda agent: agent['name']
+            )
+        ]
+
+        self.assertEqual(
+            agents_assertion,
+            [
+                [
+                    'Jin Kwon',
+                    [],
+                    [],
+                ],
+                [
+                    'Sun Kwon',
+                    ['fish-456'],
+                    ['fish-456'],
+                ],
+                [
+                    'sensor-stark',
+                    [],
+                    [],
+                ],
+            ]
+        )
+
+
+def log_json(msg):
+    LOGGER.debug(
+        json.dumps(
+            msg,
+            indent=4,
+            sort_keys=True))


### PR DESCRIPTION
This PR adds the `/agents` endpoint and adds the server and database to the T&T test.

Two TODOs:

1. The assertion that checks the `/agents` endpoint isn't as rigorous as it could be, as it doesn't assert anything about the records agents report on. The desired TP behavior regarding reporter authorization and transfer of ownership hasn't been thought through very well, so I'd like to put off testing that until we figure out exactly what it should do.

2. Currently transactions are submitted to the rest api. When possible, I'd like to convert the test to submit transactions directly to the server and cut out the rest api entirely if possible.