### PR TITLE
Implement T&T client signup/login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 /families/supplychain/python/build/
 /families/track_and_trade/processor/sawtooth_track_and_trade/protobuf
 /families/track_and_trade/client/public/dist
+/families/track_and_trade/client/src/protos.json
 /families/track_and_trade/server/rethinkdb_data
 /families/block_info/sawtooth_block_info/protobuf
 /families/track_and_trade/**/node_modules

--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -4,8 +4,9 @@
   "description": "A Track and Trade client web app for trading fish",
   "main": "",
   "scripts": {
-    "watch": "webpack-dev-server --env development --hot",
-    "build": "webpack --env production",
+    "compile_protos": "node scripts/compile_protos.js > src/protos.json",
+    "watch": "npm run compile_protos && webpack-dev-server --env development --hot",
+    "build": "npm run compile_protos && webpack --env production",
     "test": "standard src/**/*.js"
   },
   "repository": {

--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -4,7 +4,8 @@
   "description": "A Track and Trade client web app for trading fish",
   "main": "",
   "scripts": {
-    "webpack": "./node_modules/webpack/bin/webpack.js --watch",
+    "watch": "webpack-dev-server --env development --hot",
+    "build": "webpack --env production",
     "test": "standard src/**/*.js"
   },
   "repository": {
@@ -33,6 +34,7 @@
     "sass-loader": "^6.0.6",
     "standard": "^10.0.3",
     "style-loader": "^0.18.2",
-    "webpack": "^3.5.5"
+    "webpack": "^3.5.5",
+    "webpack-dev-server": "^2.7.1"
   }
 }

--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -24,7 +24,8 @@
     "jquery": "^3.2.1",
     "mithril": "^1.1.3",
     "popper.js": "^1.12.3",
-    "sawtooth-sdk": "^0.8.2"
+    "sawtooth-sdk": "^0.8.2",
+    "sjcl": "^1.0.7"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/families/track_and_trade/client/public/index.html
+++ b/families/track_and_trade/client/public/index.html
@@ -4,7 +4,6 @@
     <title>FishNet</title>
   </head>
   <body>
-    <h1>FishNet</h1>
     <div id="app"></div>
     <script src="dist/bundle.js"></script>
   </body>

--- a/families/track_and_trade/client/public/index.html
+++ b/families/track_and_trade/client/public/index.html
@@ -4,7 +4,12 @@
     <title>FishNet</title>
   </head>
   <body>
+    <!-- mount point for the Mithril JS app -->
     <div id="app"></div>
+
+    <!-- mount point for any Bootstrap modals -->
+    <div id="modal-container"></div>
+
     <script src="dist/bundle.js"></script>
   </body>
 </html>

--- a/families/track_and_trade/client/scripts/compile_protos.js
+++ b/families/track_and_trade/client/scripts/compile_protos.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const protobuf = require('protobufjs')
+const jsonTarget = require('../node_modules/protobufjs/cli/targets/json')
+
+let root = new protobuf.Root()
+
+let files = fs
+  .readdirSync(path.resolve(__dirname, '../../protos'))
+  .map(f => path.resolve(__dirname, '../../protos', f))
+  .filter(f => f.endsWith('.proto'))
+
+try {
+  root = root.loadSync(files)
+} catch (e) {
+  console.log('Unable to load protobuf files!')
+  throw e
+}
+
+jsonTarget(root, {}, (err, output) => {
+  if (err) {
+    throw err
+  }
+
+  if (output !== '') {
+    process.stdout.write(output, 'utf8')
+  }
+})

--- a/families/track_and_trade/client/src/components/forms.js
+++ b/families/track_and_trade/client/src/components/forms.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+/**
+ * Returns an input field which modifies a particular value in state
+ */
+const input = (type, onValue, label, required = true) => {
+  return m('.form-group', [
+    m('label', label),
+    m('input.form-control', {
+      type,
+      required,
+      oninput: m.withAttr('value', onValue)
+    })
+  ])
+}
+
+const textInput = _.partial(input, 'text')
+const passwordInput = _.partial(input, 'password')
+const numberInput = _.partial(input, 'number')
+const emailInput = _.partial(input, 'email')
+
+/**
+ * Convenience function for returning partial onValue functions
+ */
+const stateSetter = state => key => value => { state[key] = value }
+
+module.exports = {
+  input,
+  textInput,
+  passwordInput,
+  numberInput,
+  emailInput,
+  stateSetter
+}

--- a/families/track_and_trade/client/src/components/modals.js
+++ b/families/track_and_trade/client/src/components/modals.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+const $ = require('jquery')
+
+/**
+ * A basic Bootstrap modal. Requires at least a title and body be set in
+ * attributes. Also accepts text and functions for accepting/canceling.
+ */
+const BasicModal = {
+  view (vnode) {
+    // Set default accept/cancel values
+    const acceptText = vnode.attrs.acceptText || 'Accept'
+    const cancelText = vnode.attrs.cancelText || 'Cancel'
+    const acceptFn = vnode.attrs.acceptFn || _.identity
+    const cancelFn = vnode.attrs.cancelFn || _.identity
+
+    return m('.modal.fade#modal', {
+      tabindex: '-1',
+      role: 'dialog',
+      'aria-labelby': 'modal'
+    }, [
+      m('.modal-dialog', { role: 'document' },
+        m('.modal-content',
+          m('.modal-header',
+            m('h5.modal-title', vnode.attrs.title),
+            m('button.close', {
+              type: 'button',
+              onclick: cancelFn,
+              'data-dismiss': 'modal',
+              'aria-label': 'Close'
+            }, m('span', { 'aria-hidden': 'true' }, m.trust('&times;')))),
+          m('.modal-body', vnode.attrs.body),
+          m('.modal-footer',
+            m('button.btn.btn-secondary', {
+              onclick: cancelFn,
+              'data-dismiss': 'modal'
+            }, cancelText),
+            m('button.btn.btn-primary', {
+              onclick: acceptFn,
+              'data-dismiss': 'modal'
+            }, acceptText))))
+    ])
+  }
+}
+
+/**
+ * Renders/shows a modal component, with attributes, returning a promise.
+ * On close, unmounts the component and resolves/rejects the promise,
+ * with rejection indicating the cancel button was pressed.
+ */
+const show = (modal, attrs, children) => {
+  let acceptFn = null
+  let cancelFn = null
+  const onClosePromise = new Promise((resolve, reject) => {
+    acceptFn = resolve
+    cancelFn = reject
+  })
+
+  const container = document.getElementById('modal-container')
+  m.render(container,
+           m(modal, _.assign(attrs, { acceptFn, cancelFn }, children)))
+  const $modal = $('#modal')
+  $modal.on('hidden.bs.modal', () => m.mount(container, null))
+  $modal.modal('show')
+
+  return onClosePromise
+}
+
+module.exports = {
+  BasicModal,
+  show
+}

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -40,7 +40,11 @@ const Home = {
           m('li',
             m('a[href="/create"]',
               { oncreate: m.route.link },
-              'Create Fish'))))
+              'Create Fish')),
+          m('li',
+            m('a[href="/signup"]',
+              { oncreate: m.route.link },
+              'Signup Agent'))))
     ])
   }
 }
@@ -50,6 +54,9 @@ document.addEventListener('DOMContentLoaded', () => {
     '/': Home,
     '/create': {
       render: () => m(FishForm, {signingKey: AppState.signingKey})
+    },
+    '/signup': {
+      render: () => m(SignupForm, AppState)
     }
   })
 })

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -25,16 +25,23 @@ const { signer } = require('sawtooth-sdk/client')
 
 const AppState = require('./app_state')
 const FishForm = require('./fish_form')
+const LoginForm = require('./views/login_form')
+const SignupForm = require('./views/signup_form')
 
-let privateKey = signer.makePrivateKey()
-console.log(`Hello ${privateKey}!`)
-AppState.signingKey = privateKey
+AppState.signingKey = signer.makePrivateKey()
 
-let Home = {
+const Home = {
   view () {
-    return m('.container',
-             m('.alert.alert-success', privateKey.substring(0, 8)),
-             m("a[href='/create']", {oncreate: m.route.link}, 'Create Fish'))
+    return m('.container', [
+      m('h1', 'FishNet'),
+      m('.page-list',
+        m('h3', 'Pages'),
+        m('ul',
+          m('li',
+            m('a[href="/create"]',
+              { oncreate: m.route.link },
+              'Create Fish'))))
+    ])
   }
 }
 

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -44,7 +44,11 @@ const Home = {
           m('li',
             m('a[href="/signup"]',
               { oncreate: m.route.link },
-              'Signup Agent'))))
+              'Signup Agent')),
+          m('li',
+            m('a[href="/login"]',
+              { oncreate: m.route.link },
+              'Login Agent'))))
     ])
   }
 }
@@ -57,6 +61,9 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     '/signup': {
       render: () => m(SignupForm, AppState)
+    },
+    '/login': {
+      render: () => m(LoginForm, AppState)
     }
   })
 })

--- a/families/track_and_trade/client/src/services/api.js
+++ b/families/track_and_trade/client/src/services/api.js
@@ -45,22 +45,46 @@ const clearAuth = () => {
   return token
 }
 
+// Adds Authorization header and prepends API path to url
+const baseRequest = opts => {
+  const Authorization = getAuth()
+  const authHeader = Authorization ? { Authorization } : {}
+  opts.headers = _.assign(opts.headers, authHeader)
+  opts.url = `../api/${opts.url}`
+  return m.request(opts)
+}
+
 /**
  * Submits a request to an api endpoint with an auth header if present
  */
 const request = (method, endpoint, data) => {
-  const Authorization = getAuth()
-  return m.request({
+  return baseRequest({
     method,
-    url: `../api/${endpoint}`,
-    headers: Authorization ? { Authorization } : {},
+    url: endpoint,
     data
   })
 }
 
+/**
+ * Method specific versions of request
+ */
 const get = _.partial(request, 'GET')
 const post = _.partial(request, 'POST')
 const patch = _.partial(request, 'PATCH')
+
+/**
+ * Method for posting a binary file to the API
+ */
+const postBinary = (endpoint, data) => {
+  return baseRequest({
+    method: 'POST',
+    url: endpoint,
+    headers: { 'Content-Type': 'application/octet-stream' },
+    // prevent Mithril from trying to JSON stringify the body
+    serialize: x => x,
+    data
+  })
+}
 
 module.exports = {
   getAuth,
@@ -69,5 +93,6 @@ module.exports = {
   request,
   get,
   post,
-  patch
+  patch,
+  postBinary
 }

--- a/families/track_and_trade/client/src/services/api.js
+++ b/families/track_and_trade/client/src/services/api.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const STORAGE_KEY = 'tnt.authorization'
+let authToken = null
+
+/**
+ * Getters and setters to handle the auth token both in memory and storage
+ */
+const getAuth = () => {
+  if (!authToken) {
+    authToken = localStorage.getItem(STORAGE_KEY)
+  }
+  return authToken
+}
+
+const setAuth = token => {
+  localStorage.setItem(STORAGE_KEY, token)
+  authToken = token
+  return authToken
+}
+
+const clearAuth = () => {
+  const token = getAuth()
+  localStorage.clear(STORAGE_KEY)
+  authToken = null
+  return token
+}
+
+/**
+ * Submits a request to an api endpoint with an auth header if present
+ */
+const request = (method, endpoint, data) => {
+  const Authorization = getAuth()
+  return m.request({
+    method,
+    url: `../api/${endpoint}`,
+    headers: Authorization ? { Authorization } : {},
+    data
+  })
+}
+
+const get = _.partial(request, 'GET')
+const post = _.partial(request, 'POST')
+const patch = _.partial(request, 'PATCH')
+
+module.exports = {
+  getAuth,
+  setAuth,
+  clearAuth,
+  request,
+  get,
+  post,
+  patch
+}

--- a/families/track_and_trade/client/src/services/payloads.js
+++ b/families/track_and_trade/client/src/services/payloads.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const path = require('path')
+const _ = require('lodash')
+const protobuf = require('protobufjs')
+const protoJson = require('../protos.json')
+
+// Keys for payload actions
+const ACTIONS = [
+  'CREATE_AGENT',
+  'CREATE_RECORD',
+  'FINALIZE_RECORD',
+  'CREATE_RECORD_TYPE',
+  'UPDATE_PROPERTIES',
+  'CREATE_PROPOSAL',
+  'ANSWER_PROPOSAL',
+  'REVOKE_REPORTER'
+]
+
+// Create dictionary with key, enum and class names
+const titleify = allCaps => {
+  return allCaps
+    .split('_')
+    .map(word => word[0] + word.slice(1).toLowerCase())
+    .join('')
+}
+
+const actionMap = ACTIONS.reduce((map, enumName) => {
+  const key = enumName[0].toLowerCase() + titleify(enumName).slice(1)
+  const className = titleify(enumName) + 'Action'
+  return _.set(map, key, { enum: enumName, name: className })
+}, {})
+
+// Compile Protobufs
+const root = protobuf.Root.fromJSON(protoJson)
+const TTPayload = root.lookup('TTPayload')
+_.each(actionMap, ({ name }, key) => {
+  actionMap[key].proto = root.lookup(name)
+})
+
+/**
+ * Encodes a new TTPayload with the specified action
+ */
+const encode = (actionKey, actionData) => {
+  const action = actionMap[actionKey]
+  if (!action) {
+    throw new Error('There is no payload action with that key')
+  }
+
+  return TTPayload.encode({
+    action: TTPayload.Action[action.enum],
+    timestamp: Math.floor(Date.now() / 1000),
+    [actionKey]: action.proto.create(actionData)
+  }).finish()
+}
+
+/**
+ * Particular encode methods can be called directly with their key name
+ * For example: payloads.createAgent({name: 'Susan'})
+ */
+const actionMethods = _.reduce(actionMap, (methods, value, key) => {
+  return _.set(methods, key, _.partial(encode, key))
+}, {})
+
+module.exports = _.assign({ encode }, actionMethods)

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -34,9 +34,8 @@ const encoderSettings = {
   batcherPubkey: null
 }
 
-// Constant will be replaced with an api request when info endpoint is built
-const BATCHER_PUBKEY = '034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa'
-encoderSettings.batcherPubkey = BATCHER_PUBKEY
+api.get('info')
+  .then(res => { encoderSettings.batcherPubkey = res.pubkey })
 
 const requestPassword = () => {
   let password = null

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const sjcl = require('sjcl')
+const { signer, TransactionEncoder } = require('sawtooth-sdk/client')
+const modals = require('../components/modals')
+const api = require('../services/api')
+
+const STORAGE_KEY = 'tnt.encryptedKey'
+
+let txnEncoder = null
+const encoderSettings = {
+  familyName: 'track_and_trade',
+  familyVersion: '1.0',
+  payloadEncoding: 'application/protobuf',
+  inputs: ['1c1108'],
+  outputs: ['1c1108'],
+  batcherPubkey: null
+}
+
+// Constant will be replaced with an api request when info endpoint is built
+const BATCHER_PUBKEY = '034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa'
+encoderSettings.batcherPubkey = BATCHER_PUBKEY
+
+const requestPassword = () => {
+  let password = null
+
+  return modals.show(modals.BasicModal, {
+    title: 'Enter Password',
+    acceptText: 'Submit',
+    body: m('.container', [
+      m('.mb-4', 'Please confirm your password to decrypt your signing key.'),
+      m('input.form-control', {
+        type: 'password',
+        oninput: m.withAttr('value', value => { password = value })
+      })
+    ])
+  })
+    .then(() => password)
+}
+
+/**
+ * Generates a new private key, saving it it to memory and storage (encrypted).
+ * Returns both a public key and the encrypted private key.
+ */
+const makePrivateKey = password => {
+  const privateKey = signer.makePrivateKey()
+  txnEncoder = new TransactionEncoder(privateKey, encoderSettings)
+
+  const encryptedKey = sjcl.encrypt(password, privateKey)
+  localStorage.setItem(STORAGE_KEY, encryptedKey)
+
+  const publicKey = signer.getPublicKey(privateKey)
+  return { encryptedKey, publicKey }
+}
+
+/**
+ * Saves an encrypted key to storage, and the decrypted version in memory.
+ */
+const setPrivateKey = (password, encryptedKey) => {
+  const privateKey = sjcl.decrypt(password, encryptedKey)
+  txnEncoder = new TransactionEncoder(privateKey, encoderSettings)
+
+  localStorage.setItem(STORAGE_KEY, encryptedKey)
+
+  return encryptedKey
+}
+
+/**
+ * Clears the users private key from memory and storage.
+ */
+const clearPrivateKey = () => {
+  const encryptedKey = localStorage.getItem(STORAGE_KEY)
+
+  localStorage.clearItem(STORAGE_KEY)
+  txnEncoder = null
+
+  return encryptedKey
+}
+
+/**
+ * Wraps a Protobuf payload in a TransactionList and submits it to the API.
+ * Prompts user for their password if their private key is not in memory.
+ */
+const submit = payload => {
+  return Promise.resolve()
+    .then(() => {
+      if (txnEncoder) return
+
+      return requestPassword()
+        .then(password => {
+          const encryptedKey = localStorage.getItem(STORAGE_KEY)
+          setPrivateKey(encryptedKey, password)
+        })
+    })
+    .then(() => {
+      const txnList = txnEncoder.createEncoded(payload)
+      return api.postBinary('transactions', txnList)
+    })
+}
+
+module.exports = {
+  makePrivateKey,
+  setPrivateKey,
+  clearPrivateKey,
+  submit
+}

--- a/families/track_and_trade/client/src/views/login_form.js
+++ b/families/track_and_trade/client/src/views/login_form.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+const api = require('../services/api')
+const forms = require('../components/forms')
+
+/**
+ * The Form for authorizing an existing user.
+ */
+const LoginForm = {
+  view (vnode) {
+    const setter = forms.stateSetter(vnode.state)
+
+    return m('.login-form.container', [
+      m('form', {
+        onsubmit: (e) => {
+          e.preventDefault()
+          api.post('authorization', vnode.state)
+            .then(res => api.setAuth(res.authorization))
+        }
+      },
+      m('legend', 'Login Agent'),
+      forms.textInput(setter('username'), 'Username'),
+      forms.passwordInput(setter('password'), 'Password'),
+      m('.container.text-center',
+        'Or you can ',
+        m('a[href="/signup"]',
+          { oncreate: m.route.link },
+          'create a new Agent')),
+      m('.form-group',
+        m('.row.justify-content-end.align-items-end',
+          m('col-2',
+            m('button.btn.btn-primary',
+              {'data-toggle': 'modal', 'data-target': '#modal'},
+              'Login')))))
+    ])
+  }
+}
+
+module.exports = LoginForm

--- a/families/track_and_trade/client/src/views/login_form.js
+++ b/families/track_and_trade/client/src/views/login_form.js
@@ -19,6 +19,7 @@
 const m = require('mithril')
 
 const api = require('../services/api')
+const transactions = require('../services/transactions')
 const forms = require('../components/forms')
 
 /**
@@ -33,7 +34,11 @@ const LoginForm = {
         onsubmit: (e) => {
           e.preventDefault()
           api.post('authorization', vnode.state)
-            .then(res => api.setAuth(res.authorization))
+            .then(res => {
+              api.setAuth(res.authorization)
+              transactions.setPrivateKey(vnode.state.password,
+                                         res.encryptedKey)
+            })
         }
       },
       m('legend', 'Login Agent'),

--- a/families/track_and_trade/client/src/views/signup_form.js
+++ b/families/track_and_trade/client/src/views/signup_form.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const forms = require('../components/forms')
+
+/**
+ * The Form for authorizing an existing user.
+ */
+const SignupForm = {
+  view (vnode) {
+    const setter = forms.stateSetter(vnode.state)
+
+    return m('.signup-form.container', [
+      m('form', {
+        onsubmit: (e) => {
+          e.preventDefault()
+          api.post('users', _.assign(vnode.state, {publicKey: '' + Date.now()}))
+            .then(res => api.setAuth(res.authorization))
+        }
+      },
+      m('legend', 'Create Agent'),
+      forms.textInput(setter('name'), 'Name'),
+      forms.emailInput(setter('email'), 'Email'),
+      forms.textInput(setter('username'), 'Username'),
+      forms.passwordInput(setter('password'), 'Password'),
+      m('.container.text-center',
+        'Or you can ',
+        m('a[href="/login"]',
+          { oncreate: m.route.link },
+          'login an existing Agent')),
+      m('.form-group',
+        m('.row.justify-content-end.align-items-end',
+          m('col-2',
+            m('button.btn.btn-primary',
+              'Create Agent')))))
+    ])
+  }
+}
+
+module.exports = SignupForm

--- a/families/track_and_trade/client/webpack.config.js
+++ b/families/track_and_trade/client/webpack.config.js
@@ -37,5 +37,14 @@ module.exports = {
       'window.jQuery': 'jquery',
       Popper: ['popper.js', 'default']
     })
-  ]
+  ],
+
+  devServer: {
+    port: 3001,
+    contentBase: path.join(__dirname, 'public'),
+    publicPath: '/dist/',
+    proxy: {
+      '/api': 'http://localhost:3000'
+    }
+  }
 }

--- a/families/track_and_trade/server/blockchain/batcher.js
+++ b/families/track_and_trade/server/blockchain/batcher.js
@@ -32,6 +32,8 @@ if (!PRIVATE_KEY) {
   publicKey = signer.getPublicKey(PRIVATE_KEY)
 }
 
+const getPublicKey = () => publicKey
+
 const batch = (txnList, expectedSigner) => {
   if (!PRIVATE_KEY) {
     throw new Error(`Server has no signing key, and cannot batch transacitons`)
@@ -53,5 +55,6 @@ const batch = (txnList, expectedSigner) => {
 }
 
 module.exports = {
+  getPublicKey,
   batch
 }

--- a/families/track_and_trade/server/blockchain/index.js
+++ b/families/track_and_trade/server/blockchain/index.js
@@ -75,7 +75,7 @@ const submit = (txnBytes, { authedKey }) => {
   .then(response => ClientBatchSubmitResponse.decode(response))
   .then(decoded => {
     const status = _.findKey(ClientBatchSubmitResponse.Status,
-                                 val => val === decoded.status)
+                             val => val === decoded.status)
     if (status !== 'OK') {
       throw new Error(`Batch submission failed with status '${status}'`)
     }

--- a/families/track_and_trade/server/db/state.js
+++ b/families/track_and_trade/server/db/state.js
@@ -20,10 +20,6 @@ const _ = require('lodash')
 const r = require('rethinkdb')
 const db = require('./')
 
-const query = query => db.queryTable('state', query)
-
-const insert = update => db.insertTable('state', update)
-
 const addBlockState = (tableName, indexName, indexValue, doc, blockNum) => {
   return db.modifyTable(tableName, table => {
     return table
@@ -92,8 +88,6 @@ const addProposal = (proposal, blockNum) => {
 }
 
 module.exports = {
-  query,
-  insert,
   addAgent,
   addRecord,
   addRecordType,

--- a/families/track_and_trade/server/scripts/bootstrap_database.js
+++ b/families/track_and_trade/server/scripts/bootstrap_database.js
@@ -104,16 +104,6 @@ r.connect({host: HOST, port: PORT})
         ]).run(conn)
       })
       .then(() => {
-        console.log('Creating and populating "state" table...')
-        return r.db(NAME).tableCreate('state').run(conn)
-      })
-      .then(() => {
-        return r.db(NAME).table('state').insert({
-          name: 'message',
-          value: 'Hello Track and Trade!'
-        }).run(conn)
-      })
-      .then(() => {
         console.log('Bootstrapping complete, closing connection.')
         return conn.close()
       })


### PR DESCRIPTION
This PR builds out many client-side components and services in support of allowing users to signup and login.

## Major Additions

- **API service**: sends HTTP requests to the server API with authorization
- **Payloads service**: encodes Protobuf payloads
- **Transactions service**: 
    - wraps payloads in a signed transaction
    - submits transactions to the API
    - manages encryption and storage of private key
- **Signup form**: 
    - creates a user in the db and a new Agent in the blockchain
    - encrypts a new private key for escrow storage
    - stores the auth token from the API
- **Login form**:  stores the auth token from the API
- **/info endpoint**: returns batcher pubkey and route info

## To Test

- start up a validator at `tcp://localhost:4004`
- start up the T&T processor with `./bin/track-and-trade-tp`
- setup and start the database and server:
    - `cd families/track_and_trade/server/`
    - `npm install`
    - `npm run init`
    - `rethinkdb &` (requires port 8080 to be free)
    - `node index.js`
- setup and run the client:
    - `cd ../client/`
    - `npm install`
    - `npm run build`

Now navigating your browser to `http://localhost:3000` should bring up a simple landing page with the existing forms. Using the signup form will allow you to create new users, and the login form will allow you to log in existing users. User information is stored in Local Storage which can be viewed in your browsers dev tools. Bring up dev tools with `cmd + option + i` and navigate to `Application > Storage > Local Storage`.

Changes should also be reflected in the database, which can be viewed by navigating your browser to `http://localhost:8080/#dataexplorer`. You can use the command`r.db('tnt').table('users')` to list all users, and the command `r.db('tnt').table('agents')` to see the Agents in the blockchain.