### PR TITLE
Add ZMQ stream to Rust SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@
 /families/seth/bin/
 /families/seth/src/sawtooth_seth/protobuf/
 /sdk/rust/target
+/sdk/rust/Cargo.lock
 /sdk/rust/src/messages/*.rs
 !/sdk/rust/src/messages/mod.rs
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -23,3 +23,9 @@ protobuf="1.4.1"
 secp256k1 = "0.7.1"
 rust-crypto = "0.2.36"
 rust-base58 = "0.0.4"
+zmq = "0.8"
+uuid = { version = "0.5", features = ["v4"] }
+log = "0.3"
+
+[dev-dependencies]
+env_logger = "0.3"

--- a/sdk/rust/src/messaging/mod.rs
+++ b/sdk/rust/src/messaging/mod.rs
@@ -14,11 +14,5 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-
-extern crate protobuf;
-#[macro_use]
-extern crate log;
-
-pub mod messages;
-pub mod messaging;
-pub mod signing;
+pub mod stream;
+pub mod zmq_stream;

--- a/sdk/rust/src/messaging/stream.rs
+++ b/sdk/rust/src/messaging/stream.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+use messages::validator::Message;
+use messages::validator::Message_MessageType;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::RecvError;
+
+/// A Message Sender
+///
+/// A message
+pub trait MessageSender {
+
+    fn send(&mut self, destination: Message_MessageType, correlation_id: &str,
+            contents: &[u8])
+        -> Result<MessageFuture, SendError>;
+
+    fn reply(&mut self, destination: Message_MessageType, correlation_id: &str,
+             contents: &[u8])
+        -> Result<(), SendError>;
+
+    fn close(&mut self);
+}
+
+/// Result for a message received.
+pub type MessageResult = Result<Message, ReceiveError>;
+
+/// A message Receiver
+pub type MessageReceiver = Receiver<MessageResult>;
+
+/// A Message Connection
+///
+/// This denotes a connection which can create a MessageSender/Receiver pair.
+pub trait MessageConnection<MS: MessageSender> {
+    fn create(&self) -> (MS, MessageReceiver);
+}
+
+/// Errors that occur on sending a message.
+#[derive(Debug)]
+pub enum SendError {
+    DisconnectedError,
+    TimeoutError,
+    UnknownError
+}
+
+/// Errors that occur on receiving a message.
+#[derive(Debug, Clone)]
+pub enum ReceiveError {
+    TimeoutError,
+    ChannelError(RecvError),
+}
+
+/// MessageFuture is a promise for the reply to a sent message on connection.
+pub struct MessageFuture {
+    inner:  Receiver<MessageResult>,
+    result: Option<MessageResult>
+}
+
+impl MessageFuture {
+    pub fn new(inner: Receiver<MessageResult>) -> Self {
+        MessageFuture {
+            inner: inner,
+            result: None
+        }
+    }
+
+    pub fn get(&mut self) -> MessageResult {
+        if let Some(ref result) = self.result {
+            return result.clone();
+        }
+
+        match self.inner.recv() {
+            Ok(result) => {
+                self.result = Some(result.clone());
+                result
+            }
+            Err(err) => Err(ReceiveError::ChannelError(err))
+        }
+    }
+}
+
+/// Queue for inbound messages, sent directly to this stream.
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    use messages::validator::Message;
+    use messages::validator::Message_MessageType;
+
+    use super::MessageFuture;
+
+    fn make_ping(correlation_id: &str)  -> Message {
+        let mut message = Message::new();
+        message.set_message_type(Message_MessageType::NETWORK_PING);
+        message.set_correlation_id(String::from(correlation_id));
+        message.set_content(String::from("PING").into_bytes());
+
+        message
+    }
+
+    #[test]
+    fn future_get() {
+        let (tx, rx) = channel();
+
+        let mut fut = MessageFuture::new(rx);
+
+        let t = thread::spawn(move || {
+            tx.send(Ok(make_ping("my_test"))).unwrap();
+        });
+
+        let msg = fut.get().expect("Should have a message");
+
+        t.join().unwrap();
+
+        assert_eq!(msg, make_ping("my_test"));
+    }
+}

--- a/sdk/rust/src/messaging/zmq_stream.rs
+++ b/sdk/rust/src/messaging/zmq_stream.rs
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * -----------------------------------------------------------------------------
+ */
+
+extern crate zmq;
+extern crate uuid;
+
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{Receiver, SyncSender, Sender,
+                      sync_channel, channel,
+                      RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
+use std::collections::HashMap;
+
+use protobuf;
+use messages::validator::Message;
+use messages::validator::Message_MessageType;
+
+use super::stream::*;
+
+/// A MessageConnection over ZMQ sockets
+pub struct ZmqMessageConnection {
+    address: String,
+    context: zmq::Context,
+}
+
+const CHANNEL_BUFFER_SIZE: usize = 128;
+
+impl ZmqMessageConnection {
+    /// Create a new ZmqMessageConnection
+    pub fn new(address: &str) -> Self {
+        ZmqMessageConnection {
+            address: String::from(address),
+            context: zmq::Context::new(),
+        }
+    }
+}
+
+impl MessageConnection<ZmqMessageSender> for ZmqMessageConnection {
+    fn create(&self) -> (ZmqMessageSender, MessageReceiver) {
+        // Create the channel for request messages (i.e. non-reply messages)
+        let (request_tx, request_rx) = sync_channel(CHANNEL_BUFFER_SIZE);
+        let router = InboundRouter::new(request_tx);
+        let mut sender = ZmqMessageSender::new(
+            self.context.clone(), self.address.clone(), router);
+
+        sender.start();
+
+        (sender, request_rx)
+    }
+}
+
+
+#[derive(Clone)]
+pub struct ZmqMessageSender {
+    context: zmq::Context,
+    address: String,
+    inbound_router: InboundRouter,
+    outbound_sender: Option<SyncSender<Option<Message>>>,
+}
+
+impl ZmqMessageSender {
+
+    fn new(ctx: zmq::Context, address: String, router: InboundRouter) -> Self {
+        ZmqMessageSender {
+           context: ctx,
+           address: address,
+           inbound_router: router,
+           outbound_sender: None
+        }
+    }
+
+    /// Start the message stream instance
+    fn start(&mut self) {
+        let (outbound_send, outbound_recv) = sync_channel(CHANNEL_BUFFER_SIZE);
+        self.outbound_sender = Some(outbound_send);
+
+        let ctx = self.context.clone();
+        let address = self.address.clone();
+        let inbound_router = self.inbound_router.clone();
+        thread::spawn(move || {
+            let mut inner_stream = SendReceiveStream::new(
+                ctx,
+                &address,
+                outbound_recv,
+                inbound_router,
+            );
+            inner_stream.run();
+        });
+    }
+}
+
+impl Drop for ZmqMessageSender {
+    fn drop(&mut self) {
+        if let Some(ref sender) = self.outbound_sender.take() {
+            // send the shutdown signal
+            match sender.send(None) {
+                Err(_) => {
+                    warn!("Unable to properly shutdown SendReceiveStream.");
+                    ()
+                }
+                _ => ()
+            }
+        }
+    }
+}
+
+
+impl MessageSender for ZmqMessageSender {
+    fn send(&mut self, destination: Message_MessageType, correlation_id: &str,
+            contents: &[u8])
+        -> Result<MessageFuture, SendError>
+    {
+        if let Some(ref sender) = self.outbound_sender {
+            let mut msg = Message::new();
+
+            msg.set_message_type(destination);
+            msg.set_correlation_id(String::from(correlation_id));
+            msg.set_content(Vec::from(contents));
+
+            let future = MessageFuture::new(self.inbound_router.expect_reply(
+                    String::from(correlation_id)));
+
+            sender.send(Some(msg)).unwrap();
+
+            Ok(future)
+        } else {
+            Err(SendError::DisconnectedError)
+        }
+    }
+
+    fn reply(&mut self, destination: Message_MessageType, correlation_id: &str,
+             contents: &[u8])
+        -> Result<(), SendError>
+    {
+        if let Some(ref sender) = self.outbound_sender {
+            let mut msg = Message::new();
+            msg.set_message_type(destination);
+            msg.set_correlation_id(String::from(correlation_id));
+            msg.set_content(Vec::from(contents));
+
+            match sender.send(Some(msg)) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(SendError::UnknownError)
+            }
+        } else {
+            Err(SendError::DisconnectedError)
+        }
+    }
+
+    fn close(&mut self) {
+        if let Some(ref sender) = self.outbound_sender.take() {
+            sender.send(None).unwrap();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct InboundRouter {
+    inbound_tx: SyncSender<MessageResult>,
+    expected_replies: Arc<Mutex<HashMap<String, Sender<MessageResult>>>>,
+}
+
+impl InboundRouter {
+    fn new(inbound_tx: SyncSender<MessageResult>) -> Self {
+        InboundRouter {
+            inbound_tx: inbound_tx,
+            expected_replies: Arc::new(Mutex::new(HashMap::new()))
+        }
+    }
+
+    fn route(&mut self, message: Message) {
+        let mut expected_replies = self.expected_replies.lock().unwrap();
+        match expected_replies.remove(
+            message.get_correlation_id())
+        {
+            Some(sender) => sender.send(Ok(message)).unwrap(),
+            None => self.inbound_tx.send(Ok(message)).unwrap()
+        }
+    }
+
+    fn expect_reply(&mut self, correlation_id: String) -> Receiver<MessageResult> {
+        let (expect_tx, expect_rx) = channel();
+        let mut expected_replies = self.expected_replies.lock().unwrap();
+        expected_replies.insert(correlation_id, expect_tx);
+
+        expect_rx
+    }
+}
+
+impl Drop for InboundRouter {
+    fn drop(&mut self) {
+        let mut expected_replies = self.expected_replies.lock().unwrap();
+        expected_replies.clear();
+    }
+}
+
+/// Internal stream, guarding  a zmq socket.
+struct SendReceiveStream {
+    address: String,
+    socket: zmq::Socket,
+    outbound_recv: Receiver<Option<Message>>,
+    inbound_router: InboundRouter
+}
+
+const POLL_TIMEOUT: i64 = 10;
+
+impl SendReceiveStream {
+    fn new(context: zmq::Context, address: &str,
+           outbound_recv: Receiver<Option<Message>>,
+           inbound_router: InboundRouter)
+        -> Self
+    {
+        let socket = context.socket(zmq::DEALER).unwrap();
+
+        let identity = uuid::Uuid::new(uuid::UuidVersion::Random).unwrap();
+        socket.set_identity(identity.as_bytes()).unwrap();
+
+        SendReceiveStream {
+            address: String::from(address),
+            socket: socket,
+
+            outbound_recv: outbound_recv,
+            inbound_router: inbound_router,
+        }
+    }
+
+    fn run(&mut self) {
+        self.socket.connect(&self.address).unwrap();
+        loop {
+            let mut poll_items = [self.socket.as_poll_item(zmq::POLLIN)];
+            zmq::poll(&mut poll_items, POLL_TIMEOUT).unwrap();
+            if poll_items[0].is_readable() {
+                trace!("Readable!");
+                let mut received_parts = self.socket.recv_multipart(0).unwrap();
+
+                // Grab the last part, which should contain our message
+                if let Some(received_bytes) = received_parts.pop() {
+                    trace!("Received {} bytes", received_bytes.len());
+                    if received_bytes.len() != 0 {
+                        let message = protobuf::parse_from_bytes(&received_bytes).unwrap();
+                        self.inbound_router.route(message);
+                    }
+                } else {
+                    debug!("Empty frame received.");
+                }
+            }
+
+            match self.outbound_recv.recv_timeout(
+                Duration::from_millis(POLL_TIMEOUT as u64))
+            {
+                Ok(Some(msg)) => {
+                    let message_bytes = protobuf::Message::write_to_bytes(&msg).unwrap();
+                    trace!("Sending {} bytes", message_bytes.len());
+                    self.socket.send(&message_bytes, 0).unwrap();
+                }
+                Ok(None) => {
+                    trace!("Shutdown Signal Received");
+                    break;
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    debug!("Disconnected outbound channel");
+                    break
+                }
+                _ => continue
+            }
+        } 
+
+        debug!("Exited stream");
+        self.socket.disconnect(&self.address).unwrap();
+    }
+}


### PR DESCRIPTION
Introduce the Message Stream and ZQM implementation to the rust sdk. A
stream can create a `MessageReceiver` (which is simply a standard `mpsc`
receiver for inbound - that is, not replies -  message results), and a
`MessageSender`, which adds several send and reply methods, as well as
a close method.

The `MessageSender` is cloneable, so it can be cloned and safely used
across threads.  The `MessageReceiver` is not, and therefore must be
owned by one and only one thread. Any muliplexing is up to the user of
the receiver to add on top.

Note: This does *not* have socket monitoring.