### PR TITLE
Catch Unhandled Exceptions on determine_next

### DIFF
--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -219,7 +219,7 @@ class Dispatcher(Thread):
                     msg=message,
                     connection_id=connection_id)
             except KeyError:
-                LOGGER.info("Can't send message %s back to "
+                LOGGER.info("Can't send last message %s back to "
                             "%s because connection %s not in dispatcher",
                             get_enum_name(message.message_type), connection_id,
                             connection)

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -14,7 +14,6 @@
 # ------------------------------------------------------------------------------
 import abc
 import enum
-from functools import partial
 import logging
 from threading import Condition
 from threading import Thread
@@ -142,7 +141,15 @@ class Dispatcher(Thread):
         try:
             handler_manager = next(collection)
             future = handler_manager.execute(connection_id, message.content)
-            future.add_done_callback(partial(self._determine_next, message_id))
+
+            def do_next(future):
+                try:
+                    self._determine_next(message_id, future)
+                except Exception:  # pylint: disable=broad-except
+                    LOGGER.exception(
+                        "Unhandled exception while determining next")
+
+            future.add_done_callback(do_next)
         except IndexError:
             # IndexError is raised if done with handlers
             del self._message_information[message_id]


### PR DESCRIPTION
A potential places where exception could be thrown and swallowed is in the future callback for "determine next".  Replacing the `partial` call with a wrapper function that performs a try/catch should highlight any errors that may occur during the "determine next" operation.
