### PR TITLE
STL-572 Initial Seth RPC Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@
 /sdk/go/src/gopkg.in/
 /families/seth/bin/
 /families/seth/src/sawtooth_seth/protobuf/
+/families/seth/rpc/Cargo.lock
+/families/seth/rpc/target/
+/sdk/rust/Cargo.lock
 /sdk/rust/target
 /sdk/rust/Cargo.lock
 /sdk/rust/src/messages/*.rs

--- a/docker/compose/sawtooth-seth-rpc.yaml
+++ b/docker/compose/sawtooth-seth-rpc.yaml
@@ -1,0 +1,63 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  seth-rpc:
+    image: sawtooth-dev-rust:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/families/seth/rpc
+    expose:
+      - 3030
+      - 4004
+    ports:
+      - 3030:3030
+    environment:
+      RUST_BACKTRACE: 1
+    command: cargo run -- --connect tcp://validator:4004
+
+  validator:
+    image: sawtooth-validator:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        if [ ! -f /etc/sawtooth/keys/validator.priv ]; then sawtooth admin keygen --force; fi && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
+        sawtooth-validator -v \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""
+    stop_signal: SIGKILL
+
+  settings-tp:
+    image: sawtooth-settings-tp:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv tcp://validator:4004
+    stop_signal: SIGKILL

--- a/families/seth/rpc/Cargo.toml
+++ b/families/seth/rpc/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+[package]
+name = "rpc"
+version = "0.1.0"
+authors = ["sawtooth"]
+
+[dependencies]
+jsonrpc-core = "7.1.1"
+jsonrpc-http-server = "7.1.1"
+futures-cpupool = "0.1"
+clap = "2.26"
+protobuf="1.4.1"
+sawtooth_sdk = { path = "../../../sdk/rust" }
+uuid = { version = "0.5", features = ["v4"] }

--- a/families/seth/rpc/src/account.rs
+++ b/families/seth/rpc/src/account.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Params, Value, Error};
+
+use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use super::error;
+
+pub fn get_balance(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_storage_at(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_code(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn sign(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn call(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn accounts(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}

--- a/families/seth/rpc/src/account.rs
+++ b/families/seth/rpc/src/account.rs
@@ -17,24 +17,24 @@
 
 use jsonrpc_core::{Params, Value, Error};
 
-use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use sawtooth_sdk::messaging::stream::MessageSender;
 use super::error;
 
-pub fn get_balance(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_balance<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_storage_at(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_storage_at<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_code(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_code<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn sign(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn sign<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn call(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn call<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn accounts(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn accounts<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }

--- a/families/seth/rpc/src/block.rs
+++ b/families/seth/rpc/src/block.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Params, Value, Error};
+
+use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use super::error;
+
+pub fn block_number(_params: Params, mut sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_block_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_block_by_number(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}

--- a/families/seth/rpc/src/block.rs
+++ b/families/seth/rpc/src/block.rs
@@ -21,7 +21,6 @@ use uuid;
 
 use error;
 
-use sawtooth_sdk::messaging::zmq_stream::*;
 use sawtooth_sdk::messaging::stream::*;
 
 use sawtooth_sdk::messages::client::{
@@ -31,7 +30,7 @@ use sawtooth_sdk::messages::block::BlockHeader;
 use sawtooth_sdk::messages::validator::Message_MessageType;
 
 // Return the block number of the current chain head, in hex, as a string
-pub fn block_number(_params: Params, mut sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn block_number<T>(_params: Params, mut sender: T) -> Result<Value, Error> where T: MessageSender {
     let mut paging = PagingControls::new();
     paging.set_count(1);
     let mut request = ClientBlockListRequest::new();
@@ -90,9 +89,9 @@ pub fn block_number(_params: Params, mut sender: ZmqMessageSender) -> Result<Val
     Ok(Value::String(format!("{:#x}", block_header.block_num).into()))
 }
 
-pub fn get_block_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_block_by_hash<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_block_by_number(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_block_by_number<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }

--- a/families/seth/rpc/src/error.rs
+++ b/families/seth/rpc/src/error.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Error, ErrorCode};
+
+pub fn not_implemented() -> Error {
+    return Error{
+        code: ErrorCode::ServerError(-1),
+        message: String::from("Method not implemented"),
+        data: None,
+    }
+}

--- a/families/seth/rpc/src/log.rs
+++ b/families/seth/rpc/src/log.rs
@@ -17,27 +17,27 @@
 
 use jsonrpc_core::{Params, Value, Error};
 
-use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use sawtooth_sdk::messaging::stream::MessageSender;
 use super::error;
 
-pub fn new_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn new_filter<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn new_block_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn new_block_filter<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn new_pending_transaction_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn new_pending_transaction_filter<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn uninstall_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn uninstall_filter<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_filter_changes(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_filter_changes<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_filter_logs(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_filter_logs<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_logs(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_logs<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }

--- a/families/seth/rpc/src/log.rs
+++ b/families/seth/rpc/src/log.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Params, Value, Error};
+
+use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use super::error;
+
+pub fn new_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn new_block_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn new_pending_transaction_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn uninstall_filter(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_filter_changes(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_filter_logs(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_logs(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}

--- a/families/seth/rpc/src/main.rs
+++ b/families/seth/rpc/src/main.rs
@@ -81,8 +81,8 @@ fn main() {
     server.wait();
 }
 
-fn get_method_list() -> Vec<(String, RequestHandler)> {
-    let mut methods: Vec<(String, RequestHandler)> = Vec::new();
+fn get_method_list<T>() -> Vec<(String, RequestHandler<T>)> where T: MessageSender {
+    let mut methods: Vec<(String, RequestHandler<T>)> = Vec::new();
 
     methods.push((String::from("eth_getBalance"), account::get_balance));
     methods.push((String::from("eth_getStorageAt"), account::get_storage_at));

--- a/families/seth/rpc/src/main.rs
+++ b/families/seth/rpc/src/main.rs
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+#[macro_use]
+extern crate clap;
+extern crate uuid;
+extern crate jsonrpc_core;
+extern crate jsonrpc_http_server;
+extern crate futures_cpupool;
+extern crate sawtooth_sdk;
+extern crate protobuf;
+
+use sawtooth_sdk::messaging::stream::*;
+use sawtooth_sdk::messaging::zmq_stream::*;
+
+use jsonrpc_core::{IoHandler};
+use jsonrpc_http_server::{ServerBuilder};
+use jsonrpc_core::{Params};
+
+mod requests;
+mod error;
+
+mod account;
+mod block;
+mod log;
+mod network;
+mod transaction;
+
+use requests::{RequestExecutor, RequestHandler};
+
+const SERVER_THREADS: usize = 3;
+
+fn main() {
+    let arg_matches = clap_app!(intkey =>
+        (version: "1.0")
+        (about: "Seth RPC Server")
+        (@arg connect: --connect +takes_value
+         "Component endpoint of the validator to communicate with.")
+        (@arg bind: --bind +takes_value
+         "The host and port the RPC server should bind to.")
+    ).get_matches();
+
+    let bind = arg_matches.value_of("bind")
+        .unwrap_or("0.0.0.0:3030");
+    let connect = arg_matches.value_of("connect")
+        .unwrap_or("tcp://localhost:4004");
+
+    let mut io = IoHandler::new();
+    let connection = ZmqMessageConnection::new(connect);
+    let (sender, _) = connection.create();
+    let executor = RequestExecutor::new(sender);
+
+    let methods = get_method_list();
+    for (name, method) in methods {
+        let clone = executor.clone();
+        io.add_async_method(&name, move |params: Params| {
+            clone.run(params, method)
+        });
+    }
+
+    let endpoint: std::net::SocketAddr = bind.parse().unwrap();
+    let server = ServerBuilder::new(io)
+        .threads(SERVER_THREADS)
+        .start_http(&endpoint)
+        .unwrap();
+
+    server.wait();
+}
+
+fn get_method_list() -> Vec<(String, RequestHandler)> {
+    let mut methods: Vec<(String, RequestHandler)> = Vec::new();
+
+    methods.push((String::from("eth_getBalance"), account::get_balance));
+    methods.push((String::from("eth_getStorageAt"), account::get_storage_at));
+    methods.push((String::from("eth_getCode"), account::get_code));
+    methods.push((String::from("eth_sign"), account::sign));
+    methods.push((String::from("eth_call"), account::call));
+    methods.push((String::from("eth_accounts"), account::accounts));
+
+    methods.push((String::from("eth_blockNumber"), block::block_number));
+    methods.push((String::from("eth_getBlockByHash"), block::get_block_by_hash));
+    methods.push((String::from("eth_getBlockByNumber"), block::get_block_by_number));
+
+    methods.push((String::from("eth_newFilter"), log::new_filter));
+    methods.push((String::from("eth_newBlockFilter"), log::new_block_filter));
+    methods.push((String::from("eth_newPendingTransactionFilter"), log::new_pending_transaction_filter));
+    methods.push((String::from("eth_uninstallFilter"), log::uninstall_filter));
+    methods.push((String::from("eth_getFilterChanges"), log::get_filter_changes));
+    methods.push((String::from("eth_getFilterLogs"), log::get_filter_logs));
+    methods.push((String::from("eth_getLogs"), log::get_logs));
+
+    methods.push((String::from("net_version"), network::version));
+    methods.push((String::from("net_peerCount"), network::peer_count));
+    methods.push((String::from("net_listening"), network::listening));
+
+    methods.push((String::from("eth_getTransactionCount"), transaction::get_transaction_count));
+    methods.push((String::from("eth_getBlockTransactionCountByHash"), transaction::get_block_transaction_count_by_hash));
+    methods.push((String::from("eth_getBlockTransactionCountByNumber"), transaction::get_block_transaction_count_by_number));
+    methods.push((String::from("eth_sendTransaction"), transaction::send_transaction));
+    methods.push((String::from("eth_sendRawTransaction"), transaction::send_raw_transaction));
+    methods.push((String::from("eth_getTransactionByHash"), transaction::get_transaction_by_hash));
+    methods.push((String::from("eth_getTransactionByBlockHashAndIndex"), transaction::get_transaction_by_block_hash_and_index));
+    methods.push((String::from("eth_getTransactionByBlockNumberAndIndex"), transaction::get_transaction_by_block_number_and_index));
+    methods.push((String::from("eth_getTransactionReceipt"), transaction::get_transaction_receipt));
+    methods.push((String::from("eth_gasPrice"), transaction::gas_price));
+    methods.push((String::from("eth_estimateGas"), transaction::estimate_gas));
+
+    methods
+}

--- a/families/seth/rpc/src/network.rs
+++ b/families/seth/rpc/src/network.rs
@@ -18,14 +18,20 @@
 use jsonrpc_core::{Params, Value, Error};
 
 use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
-use super::error;
 
+const SAWTOOTH_NET_VERSION: &str = "19";
+
+// Version refers to the particular network this JSON-RPC client is connected to
 pub fn version(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
     Ok(Value::String(String::from(SAWTOOTH_NET_VERSION)))
 }
+
+// Since this is only for HTTP right now, there won't be any connected peers
 pub fn peer_count(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
-    Err(error::not_implemented())
+    Ok(Value::String(format!("{:x}", 0)))
 }
+
+// Return whether we are listening for connections, which is always true
 pub fn listening(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
-    Err(error::not_implemented())
+    Ok(Value::Bool(true))
 }

--- a/families/seth/rpc/src/network.rs
+++ b/families/seth/rpc/src/network.rs
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Params, Value, Error};
+
+use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use super::error;
+
+pub fn version(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Ok(Value::String(String::from(SAWTOOTH_NET_VERSION)))
+}
+pub fn peer_count(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn listening(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}

--- a/families/seth/rpc/src/network.rs
+++ b/families/seth/rpc/src/network.rs
@@ -17,21 +17,21 @@
 
 use jsonrpc_core::{Params, Value, Error};
 
-use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use sawtooth_sdk::messaging::stream::MessageSender;
 
 const SAWTOOTH_NET_VERSION: &str = "19";
 
 // Version refers to the particular network this JSON-RPC client is connected to
-pub fn version(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn version<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Ok(Value::String(String::from(SAWTOOTH_NET_VERSION)))
 }
 
 // Since this is only for HTTP right now, there won't be any connected peers
-pub fn peer_count(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn peer_count<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Ok(Value::String(format!("{:x}", 0)))
 }
 
 // Return whether we are listening for connections, which is always true
-pub fn listening(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn listening<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Ok(Value::Bool(true))
 }

--- a/families/seth/rpc/src/requests.rs
+++ b/families/seth/rpc/src/requests.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use futures_cpupool::{CpuPool};
+use jsonrpc_core::{Params, Value, Error, BoxFuture};
+
+use sawtooth_sdk::messaging::zmq_stream::*;
+
+pub type RequestHandler = fn(params: Params, sender: ZmqMessageSender) -> Result<Value, Error>;
+
+#[derive(Clone)]
+pub struct RequestExecutor {
+    pool: CpuPool,
+    sender: ZmqMessageSender,
+}
+
+impl RequestExecutor {
+    pub fn new(sender: ZmqMessageSender) -> Self {
+        RequestExecutor {
+            pool: CpuPool::new_num_cpus(),
+            sender: sender,
+        }
+    }
+
+    pub fn run(&self, params: Params, handler: RequestHandler) -> BoxFuture<Value, Error> {
+        let sender = self.sender.clone();
+        Box::new(self.pool.spawn_fn(move || {handler(params, sender)}))
+    }
+
+}

--- a/families/seth/rpc/src/transaction.rs
+++ b/families/seth/rpc/src/transaction.rs
@@ -17,39 +17,39 @@
 
 use jsonrpc_core::{Params, Value, Error};
 
-use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use sawtooth_sdk::messaging::stream::MessageSender;
 use super::error;
 
-pub fn get_transaction_count(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_transaction_count<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_block_transaction_count_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_block_transaction_count_by_hash<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_block_transaction_count_by_number(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_block_transaction_count_by_number<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn send_transaction(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn send_transaction<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn send_raw_transaction(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn send_raw_transaction<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_transaction_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_transaction_by_hash<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_transaction_by_block_hash_and_index(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_transaction_by_block_hash_and_index<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_transaction_by_block_number_and_index(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_transaction_by_block_number_and_index<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn get_transaction_receipt(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn get_transaction_receipt<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn gas_price(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn gas_price<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }
-pub fn estimate_gas(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+pub fn estimate_gas<T>(_params: Params, mut _sender: T) -> Result<Value, Error> where T: MessageSender {
     Err(error::not_implemented())
 }

--- a/families/seth/rpc/src/transaction.rs
+++ b/families/seth/rpc/src/transaction.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use jsonrpc_core::{Params, Value, Error};
+
+use sawtooth_sdk::messaging::zmq_stream::ZmqMessageSender;
+use super::error;
+
+pub fn get_transaction_count(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_block_transaction_count_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_block_transaction_count_by_number(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn send_transaction(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn send_raw_transaction(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_transaction_by_hash(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_transaction_by_block_hash_and_index(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_transaction_by_block_number_and_index(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn get_transaction_receipt(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn gas_price(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}
+pub fn estimate_gas(_params: Params, mut _sender: ZmqMessageSender) -> Result<Value, Error> {
+    Err(error::not_implemented())
+}


### PR DESCRIPTION
Creates the core request handling part of the rpc server and creates empty methods for all the calls that need to be implemented. Implements a few methods as well. Unit tests to follow later, but you can test manually with:

`./bin/build_all -l python -l rust`
`docker-compose -f docker/compose/sawtooth-seth-rpc.yaml`
`curl -d '{"jsonrpc": "2.0", "method": "eth_blockNumber", "id": 1}' -H "Content-Type: application/json" 0.0.0.0:3030`