### PR TITLE
Warn if dispatch queue is too large

### DIFF
--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -119,6 +119,11 @@ class Dispatcher(Thread):
                     self._msg_type_handlers[message.message_type])
             )
             self._in_queue.put_nowait(message_id)
+
+            queue_size = self._in_queue.qsize()
+            if queue_size > 10:
+                LOGGER.debug("Dispatch incoming queue size: %s",
+                             queue_size)
         else:
             LOGGER.info("received a message of type %s "
                         "from %s but have no handler for that type",


### PR DESCRIPTION
In order to figure out if the incoming message queue is becoming saturated, log the size of the queue after a there are more than 10 messages backed up.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>