### PR TITLE
Add navbar and dashboard page to T&T client

### DIFF
--- a/families/track_and_trade/client/src/components/navigation.js
+++ b/families/track_and_trade/client/src/components/navigation.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+
+/**
+ * A simple navbar wrapper, which displays children in the responsive collapse.
+ */
+const Navbar = {
+  view (vnode) {
+    return m('nav.navbar.navbar-expand-sm.navbar-dark.bg-dark.mb-5', [
+      m('a.navbar-brand[href="/"]', { oncreate: m.route.link }, 'FishNet'),
+      m('button.navbar-toggler', {
+        type: 'button',
+        'data-toggle': 'collapse',
+        'data-target': '#navbar',
+        'aria-controls': 'navbar',
+        'aria-expanded': 'false',
+        'aria-label': 'Toggle navigation'
+      }, m('span.navbar-toggler-icon')),
+      m('#navbar.collapse.navbar-collapse', vnode.children)
+    ])
+  }
+}
+
+/**
+ * Creates a list of navbar links from an array of href/label tuples.
+ */
+const links = items => {
+  return m('ul.navbar-nav.mr-auto', items.map(([href, label]) => {
+    return m('li.nav-item', [
+      m('a.nav-link', { href, oncreate: m.route.link }, label)
+    ])
+  }))
+}
+
+/**
+ * Creates a navigation button styled for use in the navbar.
+ */
+const button = (href, label) => {
+  return m('a.btn.btn-outline-primary.my-2.my-sm-0', {
+    href,
+    oncreate: m.route.link
+  }, label)
+}
+
+module.exports = {
+  Navbar,
+  links,
+  button
+}

--- a/families/track_and_trade/client/src/fish_form.js
+++ b/families/track_and_trade/client/src/fish_form.js
@@ -95,7 +95,7 @@ const FishForm = {
   },
 
   view (vnode) {
-    return m('.fish_form.container',
+    return m('.fish_form',
              m('form', {
                onsubmit: (e) => {
                  e.preventDefault()

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -87,7 +87,7 @@ const setPrivateKey = (password, encryptedKey) => {
 const clearPrivateKey = () => {
   const encryptedKey = localStorage.getItem(STORAGE_KEY)
 
-  localStorage.clearItem(STORAGE_KEY)
+  localStorage.clear(STORAGE_KEY)
   txnEncoder = null
 
   return encryptedKey

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -105,7 +105,7 @@ const submit = payload => {
       return requestPassword()
         .then(password => {
           const encryptedKey = localStorage.getItem(STORAGE_KEY)
-          setPrivateKey(encryptedKey, password)
+          setPrivateKey(password, encryptedKey)
         })
     })
     .then(() => {

--- a/families/track_and_trade/client/src/views/dashboard.js
+++ b/families/track_and_trade/client/src/views/dashboard.js
@@ -14,9 +14,31 @@
  * limitations under the License.
  * ----------------------------------------------------------------------------
  */
+'use strict'
 
-const AppState = {
-  signingKey: null
+const m = require('mithril')
+
+const Dashboard = {
+  view (vnode) {
+    return m('.container', [
+      m('h1', 'FishNet'),
+      m('.page-list',
+        m('h3', 'Pages'),
+        m('ul',
+          m('li',
+            m('a[href="/create"]',
+              { oncreate: m.route.link },
+              'Create Fish')),
+          m('li',
+            m('a[href="/signup"]',
+              { oncreate: m.route.link },
+              'Signup Agent')),
+          m('li',
+            m('a[href="/login"]',
+              { oncreate: m.route.link },
+              'Login Agent'))))
+    ])
+  }
 }
 
-module.exports = AppState
+module.exports = Dashboard

--- a/families/track_and_trade/client/src/views/dashboard.js
+++ b/families/track_and_trade/client/src/views/dashboard.js
@@ -20,24 +20,46 @@ const m = require('mithril')
 
 const Dashboard = {
   view (vnode) {
-    return m('.container', [
-      m('h1', 'FishNet'),
-      m('.page-list',
-        m('h3', 'Pages'),
-        m('ul',
-          m('li',
-            m('a[href="/create"]',
-              { oncreate: m.route.link },
-              'Create Fish')),
-          m('li',
-            m('a[href="/signup"]',
-              { oncreate: m.route.link },
-              'Signup Agent')),
-          m('li',
-            m('a[href="/login"]',
-              { oncreate: m.route.link },
-              'Login Agent'))))
-    ])
+    return [
+      m('.header.text-center.mb-4',
+        m('h4', 'Welcome To'),
+        m('h1.mb-3', 'FishNet'),
+        m('h5',
+          m('em',
+            'Powered by ',
+            m('strong', 'Sawtooth: Track and Trade')))),
+      m('.blurb',
+        m('p',
+          m('em', 'Track and Trade'),
+          ' is a general purpose supply chain solution built using the ',
+          'power of ',
+          m('a[href="https://github.com/hyperledger/sawtooth-core"]',
+            { target: '_blank' },
+            "Hyperledger Sawtooth's"),
+          ' blockchain technology. It maintains a distributed ledger ',
+          'that tracks both asset provenance and a timestamped history ',
+          'detailing how an asset was stored, handled, and transported.'),
+        m('p',
+          m('em', 'FishNet'),
+          ' demonstrates this unique technology with an illustrative ',
+          'example: tracking the provenance of fish from catch to plate. ',
+          'One day an application like this could be used by restaurants, ',
+          'grocery stores, and their customers to ensure the fish they ',
+          'purchase is ethically sourced and properly transported.'),
+        m('p',
+          'To use ',
+          m('em', 'FishNet'),
+          ', create an account using the link in the navbar above. ',
+          'Once logged in, you will be able to add new fish assets to ',
+          'the blockchain and track them with data like temperature or ',
+          'location. You will be able to authorize other "agents" on the ',
+          'blockchain to track this data as well, or even transfer ',
+          'ownership or possession of the fish entirely. For the ',
+          'adventurous, these actions can also be accomplished directly ',
+          'with the REST API running on the ',
+          m('em', 'Track and Trade'),
+          ' server, perfect for automated IoT sensors.'))
+    ]
   }
 }
 

--- a/families/track_and_trade/client/src/views/login_form.js
+++ b/families/track_and_trade/client/src/views/login_form.js
@@ -29,7 +29,7 @@ const LoginForm = {
   view (vnode) {
     const setter = forms.stateSetter(vnode.state)
 
-    return m('.login-form.container', [
+    return m('.login-form', [
       m('form', {
         onsubmit: (e) => {
           e.preventDefault()
@@ -38,6 +38,7 @@ const LoginForm = {
               api.setAuth(res.authorization)
               transactions.setPrivateKey(vnode.state.password,
                                          res.encryptedKey)
+              m.route.set('/')
             })
         }
       },

--- a/families/track_and_trade/client/src/views/signup_form.js
+++ b/families/track_and_trade/client/src/views/signup_form.js
@@ -33,6 +33,7 @@ const userSubmitter = state => e => {
   api.post('users', user)
     .then(res => api.setAuth(res.authorization))
     .then(() => transactions.submit(agent))
+    .then(() => m.route.set('/'))
 }
 
 /**
@@ -42,7 +43,7 @@ const SignupForm = {
   view (vnode) {
     const setter = forms.stateSetter(vnode.state)
 
-    return m('.signup-form.container', [
+    return m('.signup-form', [
       m('form', { onsubmit: userSubmitter(vnode.state) },
       m('legend', 'Create Agent'),
       forms.textInput(setter('name'), 'Name'),

--- a/families/track_and_trade/server/api/index.js
+++ b/families/track_and_trade/server/api/index.js
@@ -50,6 +50,7 @@ const handleBody = func => handlePromisedResponse(req => {
   return func(req.body, _.assign({}, req.query, req.params, req.internal))
 })
 
+<<<<<<< da00243c847749021c620795fdd511f9a2cdb1b0
 // Parses the endpoints from an Express router
 const getEndpoints = router => {
   return _.chain(router.stack)

--- a/families/track_and_trade/server/api/index.js
+++ b/families/track_and_trade/server/api/index.js
@@ -50,7 +50,6 @@ const handleBody = func => handlePromisedResponse(req => {
   return func(req.body, _.assign({}, req.query, req.params, req.internal))
 })
 
-<<<<<<< da00243c847749021c620795fdd511f9a2cdb1b0
 // Parses the endpoints from an Express router
 const getEndpoints = router => {
   return _.chain(router.stack)


### PR DESCRIPTION
Places all FishNet components into a reusable layout including a navbar. Adds a Dashboard page with a description of the project.

**To Test:**
Start a validator at `tcp://localhost:4004`.

Then from the root sawtooth-core directory:
```
./bin/track-and-trade-tp -vv &
```
```
cd families/track_and_trade/server/
npm install
npm run init
rethinkdb &
PRIVATE_KEY='1111111111111111111111111111111111111111111111111111111111111111' node index.js &
```
```
cd ../client
npm install
npm run build
```

Now navigate to `http://localhost:3000/fish`. You should see a simple landing page with a description of the project. There should be a navbar above, with a _Login/Signup_ button to the left. Using the signup form should create a new user as before. Once logged in, you should see the _Add Fish_ link in the navbar, as well as a button to _Logout_.