### PR TITLE
Reorder architecture toc in docs

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -6,8 +6,8 @@ Architecture
 .. toctree::
    :maxdepth: 2
 
-   architecture/transactions_and_batches
    architecture/global_state
+   architecture/transactions_and_batches
    architecture/journal
    architecture/rest_api
    architecture/poet


### PR DESCRIPTION
Architecture doc needs to lead with State agreement. This is clear from
repeated questions from those ramping on sawtooth.

Signed-off-by: dcmiddle <dan.middleton@intel.com>