### PR TITLE
Add placeholder links to FishNet navbar

### DIFF
--- a/families/track_and_trade/client/src/components/navigation.js
+++ b/families/track_and_trade/client/src/components/navigation.js
@@ -39,7 +39,7 @@ const Navbar = {
 }
 
 /**
- * Creates a list of navbar links from an array of href/label tuples.
+ * Creates a list of left-aligned navbar links from href/label tuples.
  */
 const links = items => {
   return m('ul.navbar-nav.mr-auto', items.map(([href, label]) => {
@@ -47,6 +47,15 @@ const links = items => {
       m('a.nav-link', { href, oncreate: m.route.link }, label)
     ])
   }))
+}
+
+/**
+ * Creates a single link for use in a navbar.
+ */
+const link = (href, label) => {
+  return m('.navbar-nav', [
+    m('a.nav-link', { href, oncreate: m.route.link }, label)
+  ])
 }
 
 /**
@@ -61,6 +70,7 @@ const button = (href, label) => {
 
 module.exports = {
   Navbar,
+  link,
   links,
   button
 }

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -44,16 +44,22 @@ const Layout = {
 
 const loggedInNav = () => {
   const links = [
-    ['/create', 'Add Fish']
+    ['/create', 'Add Fish'],
+    ['/fish', 'View Fish'],
+    ['/agents', 'View Agents']
   ]
   return m(navigation.Navbar, {}, [
     navigation.links(links),
+    navigation.link('/profile', 'Profile'),
     navigation.button('/logout', 'Logout')
   ])
 }
 
 const loggedOutNav = () => {
-  const links = []
+  const links = [
+    ['/fish', 'View Fish'],
+    ['/agents', 'View Agents']
+  ]
   return m(navigation.Navbar, {}, [
     navigation.links(links),
     navigation.button('/login', 'Login/Signup')


### PR DESCRIPTION
These links will all redirect to the dashboard as they have not been
implemented yet, but adding them will allow screenshhots to be taken
of the finished pages, including a finished (in appearance) navbar.
This will unblock some documentation tasks.

Screenshots of the completed navbars:

_Logged Out:_
![Logged Out Navbar](https://user-images.githubusercontent.com/8889580/30663080-0e2c9b84-9e0f-11e7-9996-4da82b0cd66b.png)

_Logged In:_
![Logged In Navbar](https://user-images.githubusercontent.com/8889580/30663079-0e2c6344-9e0f-11e7-9f27-dc798976d167.png)

