### PR TITLE
Properly copy sets as lists

### DIFF
--- a/sdk/python/sawtooth_sdk/messaging/stream.py
+++ b/sdk/python/sawtooth_sdk/messaging/stream.py
@@ -146,7 +146,8 @@ class _SendReceiveThread(Thread):
         LOGGER.debug("monitor socket received disconnect event")
         for future in self._futures.future_values():
             future.set_result(FutureError())
-        for task in asyncio.Task.all_tasks(self._event_loop).copy():
+        tasks = list(asyncio.Task.all_tasks(self._event_loop))
+        for task in tasks:
             task.cancel()
         self._event_loop.stop()
         self._send_queue = None
@@ -176,7 +177,8 @@ class _SendReceiveThread(Thread):
     def _cancel_tasks_yet_to_be_done(self):
         """Cancels all the tasks (pending coroutines and futures)
         """
-        for task in asyncio.Task.all_tasks(self._event_loop).copy():
+        tasks = list(asyncio.Task.all_tasks(self._event_loop))
+        for task in tasks:
             self._event_loop.call_soon_threadsafe(task.cancel)
         self._event_loop.call_soon_threadsafe(self._done_callback)
 

--- a/sdk/python/sawtooth_sdk/workload/workload_generator.py
+++ b/sdk/python/sawtooth_sdk/workload/workload_generator.py
@@ -126,12 +126,11 @@ class WorkloadGenerator(object):
                     self.thread_pool, self._check_on_batch, batch)
 
     def stop(self):
-        tasks = asyncio.Task.all_tasks(self.loop).copy()
+        tasks = list(asyncio.Task.all_tasks(self.loop))
         for task in tasks:
             self.loop.call_soon_threadsafe(task.cancel)
         try:
-            self.loop.run_until_complete(
-                asyncio.gather(*asyncio.Task.all_tasks()))
+            self.loop.run_until_complete(asyncio.gather(*tasks))
         except CancelledError:
             self.loop.call_soon_threadsafe(self.loop.stop)
         self._workload.on_will_stop()

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -524,7 +524,8 @@ class _SendReceive(object):
         self._dispatcher.remove_send_message(self._connection)
         self._dispatcher.remove_send_last_message(self._connection)
         yield from self._stop_auth()
-        for task in asyncio.Task.all_tasks(self._event_loop).copy():
+        tasks = list(asyncio.Task.all_tasks(self._event_loop))
+        for task in tasks:
             task.cancel()
 
         asyncio.ensure_future(self._stop_event_loop())
@@ -549,8 +550,8 @@ class _SendReceive(object):
             # is the Auth Task.
             self._event_loop.run_until_complete(self._stop_auth())
         # Cancel all running tasks
-        tasks = asyncio.Task.all_tasks(self._event_loop)
-        for task in tasks.copy():
+        tasks = list(asyncio.Task.all_tasks(self._event_loop))
+        for task in tasks:
             self._event_loop.call_soon_threadsafe(task.cancel)
         while tasks:
             for task in tasks.copy():


### PR DESCRIPTION
To avoid concurrent modifications of the `all_tasks` set, wrap the call in a list before iterating.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>