### PR TITLE
Add new Network role network.consensus

### DIFF
--- a/docs/source/sysadmin_guide/permissioning.rst
+++ b/docs/source/sysadmin_guide/permissioning.rst
@@ -246,6 +246,12 @@ messages are received:
 - GossipPeersRequest
 - GossipPeersResponse
 
-In the future, sub-roles can be added to further restrict access to specific
-functions of the role. For example network.gossip could control who is allowed
-to send gossip messages.
+network.consensus
+  If a validator receives a GossipMessage that contains a new block published
+  by a node whose public key is not permitted by the policy, the message will
+  be dropped, an AuthorizationViolation will be returned, and the connection
+  will be closed.
+
+In the future, other sub-roles can be added to further restrict access to
+specific functions of the role. For example network.gossip could control who is
+allowed to send gossip messages.

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -25,6 +25,9 @@ from sawtooth_validator.protobuf.authorization_pb2 import \
     AuthorizationViolation
 from sawtooth_validator.protobuf.authorization_pb2 import RoleType
 from sawtooth_validator.protobuf import validator_pb2
+from sawtooth_validator.protobuf.network_pb2 import GossipMessage
+from sawtooth_validator.protobuf.block_pb2 import Block
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.networking.dispatch import Handler
@@ -277,6 +280,36 @@ class PermissionVerifier(object):
                 return False
         return True
 
+    def check_network_consensus_role(self, public_key):
+        """ Check the public key of a node on the network to see if they are
+            permitted to publish blocks. The roles being checked are the
+            following, from first to last:
+                "network.consensus"
+                "default"
+
+            The first role that is set will be the one used to enforce if the
+            node is allowed to publish blocks.
+
+            Args:
+                public_key (string): The public key belonging to a node on the
+                    network
+        """
+        state_root = self._current_root_func()
+        role = self._cache.get_role("network.consensus", state_root)
+
+        if role is None:
+            policy_name = "default"
+        else:
+            policy_name = role.policy_name
+        policy = self._cache.get_policy(policy_name, state_root)
+        if policy is not None:
+            if not self._allowed(public_key, policy):
+                LOGGER.debug(
+                    "Node is not permitted to publish blocks: %s.",
+                    public_key)
+                return False
+        return True
+
     def _allowed(self, public_key, policy):
         for entry in policy.entries:
             if entry.type == Policy.PERMIT_KEY:
@@ -355,6 +388,43 @@ class NetworkPermissionHandler(Handler):
                 HandlerStatus.RETURN_AND_CLOSE,
                 message_out=violation,
                 message_type=validator_pb2.Message.AUTHORIZATION_VIOLATION)
+
+        # if allowed pass message
+        return HandlerResult(HandlerStatus.PASS)
+
+
+class NetworkConsensusPermissionHandler(Handler):
+    def __init__(self, network, permission_verifier, gossip):
+        self._network = network
+        self._permission_verifier = permission_verifier
+        self._gossip = gossip
+
+    def handle(self, connection_id, message_content):
+        message = GossipMessage()
+        message.ParseFromString(message_content)
+        if message.content_type == "BLOCK":
+            public_key = \
+                self._network.connection_id_to_public_key(connection_id)
+            block = Block()
+            block.ParseFromString(message.content)
+            header = BlockHeader()
+            header.ParseFromString(block.header)
+            if header.signer_pubkey == public_key:
+                permitted = \
+                    self._permission_verifier.check_network_consensus_role(
+                        public_key)
+                if not permitted:
+                    LOGGER.debug(
+                        "Public key is not permitted to publish block, "
+                        "remove connection: %s", connection_id)
+                    self._gossip.unregister_peer(connection_id)
+                    violation = AuthorizationViolation(
+                        violation=RoleType.Value("NETWORK"))
+                    return HandlerResult(
+                        HandlerStatus.RETURN_AND_CLOSE,
+                        message_out=violation,
+                        message_type=validator_pb2.Message.
+                        AUTHORIZATION_VIOLATION)
 
         # if allowed pass message
         return HandlerResult(HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -75,6 +75,8 @@ from sawtooth_validator.gossip.permission_verifier import \
     BatchListPermissionVerifier
 from sawtooth_validator.gossip.permission_verifier import \
     NetworkPermissionHandler
+from sawtooth_validator.gossip.permission_verifier import \
+    NetworkConsensusPermissionHandler
 from sawtooth_validator.networking.interconnect import Interconnect
 from sawtooth_validator.gossip.gossip import Gossip
 from sawtooth_validator.gossip.gossip_handlers import GossipBroadcastHandler
@@ -471,6 +473,17 @@ class Validator(object):
         self._network_dispatcher.add_handler(
             validator_pb2.Message.GOSSIP_MESSAGE,
             structure_verifier.GossipHandlerStructureVerifier(),
+            network_thread_pool)
+
+        # GOSSIP_MESSAGE 4) Verifies that the node is allowed to publish a
+        # block
+        self._network_dispatcher.add_handler(
+            validator_pb2.Message.GOSSIP_MESSAGE,
+            NetworkConsensusPermissionHandler(
+                network=self._network,
+                permission_verifier=permission_verifier,
+                gossip=self._gossip
+            ),
             network_thread_pool)
 
         # GOSSIP_MESSAGE 5) Determines if we should broadcast the

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -365,6 +365,59 @@ class TestPermissionVerifier(unittest.TestCase):
         allowed = self.permission_verifier.check_network_role(self.public_key)
         self.assertFalse(allowed)
 
+    def test_network_consensus(self):
+        """
+        Test that if no roles are set and no default policy is set,
+        permit all is used.
+        """
+        allowed = self.permission_verifier.check_network_consensus_role(
+            self.public_key)
+        self.assertTrue(allowed)
+
+    def test_network_consensus_default(self):
+        """
+        Test that if no roles are set, the default policy is used.
+            1. Set default policy to permit all. Public key should be allowed.
+            2. Set default policy to deny all. Public key should be rejected.
+        """
+        self._identity_view_factory.add_policy("default", ["PERMIT_KEY *"])
+        allowed = self.permission_verifier.check_network_consensus_role(
+            self.public_key)
+        self.assertTrue(allowed)
+
+        self._identity_cache.forked()
+        self._identity_view_factory.add_policy("default", ["DENY_KEY *"])
+        allowed = self.permission_verifier.check_network_consensus_role(
+            self.public_key)
+        self.assertFalse(allowed)
+
+    def test_network_consensus_role(self):
+        """
+        Test that role:"network.consensus" is checked properly.
+            1. Set policy to permit signing key. Public key should be allowed.
+            2. Set policy to permit some other key. Public key should be
+                rejected.
+        """
+        self._identity_view_factory.add_policy(
+            "policy1", ["PERMIT_KEY " + self.public_key])
+
+        self._identity_view_factory.add_role(
+                "network.consensus",
+                "policy1")
+
+        allowed = self.permission_verifier.check_network_consensus_role(
+            self.public_key)
+        self.assertTrue(allowed)
+
+        self._identity_cache.forked()
+        self._identity_view_factory.add_policy("policy2", ["PERMIT_KEY other"])
+        self._identity_view_factory.add_role(
+                "network.consensus",
+                "policy2")
+        allowed = self.permission_verifier.check_network_consensus_role(
+            self.public_key)
+        self.assertFalse(allowed)
+
 
 class TestIdentityObserver(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
If a GossipMessage is recieved for a new block, and block's signer
pubkey matches the connections pubkey, check to see if they are
allowed to publish blocks by checking network.consensus.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>