### PR TITLE
Add Agent Detail Page to FishNet

### DIFF
--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -23,6 +23,7 @@
     "bootstrap": "^4.0.0-beta",
     "jquery": "^3.2.1",
     "mithril": "^1.1.3",
+    "octicons": "^6.0.1",
     "popper.js": "^1.12.3",
     "sawtooth-sdk": "^0.8.2",
     "sjcl": "^1.0.7"

--- a/families/track_and_trade/client/public/index.html
+++ b/families/track_and_trade/client/public/index.html
@@ -10,6 +10,9 @@
     <!-- mount point for any Bootstrap modals -->
     <div id="modal-container"></div>
 
+    <!-- mount hidden download links -->
+    <div id="download-container"></div>
+
     <script src="dist/bundle.js"></script>
   </body>
 </html>

--- a/families/track_and_trade/client/src/components/forms.js
+++ b/families/track_and_trade/client/src/components/forms.js
@@ -81,6 +81,18 @@ const validator = (predicate, message, id = null) => e => {
   }
 }
 
+/**
+ * Triggers a download of a dynamically created text file
+ */
+const triggerDownload = (name, ...contents) => {
+  const file = new window.Blob(contents, {type: 'text/plain'})
+  const href = window.URL.createObjectURL(file)
+  const container = document.getElementById('download-container')
+  m.render(container, m('a#downloader', { href, download: name }))
+  document.getElementById('downloader').click()
+  m.mount(container, null)
+}
+
 module.exports = {
   group,
   field,
@@ -91,5 +103,6 @@ module.exports = {
   emailInput,
   clickIcon,
   stateSetter,
-  validator
+  validator,
+  triggerDownload
 }

--- a/families/track_and_trade/client/src/components/forms.js
+++ b/families/track_and_trade/client/src/components/forms.js
@@ -19,6 +19,8 @@
 const m = require('mithril')
 const _ = require('lodash')
 
+const layout = require('./layout')
+
 /**
  * Returns a labeled form group
  */
@@ -55,6 +57,13 @@ const numberInput = _.partial(input, 'number')
 const emailInput = _.partial(input, 'email')
 
 /**
+ * Creates an icon with an onclick function
+ */
+const clickIcon = (name, onclick) => {
+  return m('span.mx-3', { onclick }, layout.icon(name))
+}
+
+/**
  * Convenience function for returning partial onValue functions
  */
 const stateSetter = state => key => value => { state[key] = value }
@@ -80,6 +89,7 @@ module.exports = {
   passwordInput,
   numberInput,
   emailInput,
+  clickIcon,
   stateSetter,
   validator
 }

--- a/families/track_and_trade/client/src/components/layout.js
+++ b/families/track_and_trade/client/src/components/layout.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+/**
+ * Returns a header styled to be a page title
+ */
+const title = title => m('h3.text-center.mb-3', title)
+
+/**
+ * Returns a row of any number of columns, suitable for placing in a container
+ */
+const row = columns => {
+  if (!_.isArray(columns)) columns = [columns]
+  return m('.row', columns.map(col => m('.col-md', col)))
+}
+
+module.exports = {
+  title,
+  row
+}

--- a/families/track_and_trade/client/src/components/layout.js
+++ b/families/track_and_trade/client/src/components/layout.js
@@ -18,6 +18,7 @@
 
 const m = require('mithril')
 const _ = require('lodash')
+const octicons = require('octicons')
 
 /**
  * Returns a header styled to be a page title
@@ -32,7 +33,13 @@ const row = columns => {
   return m('.row', columns.map(col => m('.col-md', col)))
 }
 
+/**
+ * Returns a mithriled icon from Github's octicon set
+ */
+const icon = name => m.trust(octicons[name].toSVG())
+
 module.exports = {
   title,
-  row
+  row,
+  icon
 }

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -27,6 +27,7 @@ const transactions = require('./services/transactions')
 const navigation = require('./components/navigation')
 
 const AddFishForm = require('./views/add_fish_form')
+const AgentDetailPage = require('./views/agent_detail')
 const Dashboard = require('./views/dashboard')
 const LoginForm = require('./views/login_form')
 const SignupForm = require('./views/signup_form')
@@ -80,11 +81,11 @@ const resolve = (view, restricted = false) => {
     }
   }
 
-  resolver.render = () => {
+  resolver.render = vnode => {
     if (api.getAuth()) {
-      return m(Layout, { navbar: loggedInNav() }, m(view))
+      return m(Layout, { navbar: loggedInNav() }, m(view, vnode.attrs))
     }
-    return m(Layout, { navbar: loggedOutNav() }, m(view))
+    return m(Layout, { navbar: loggedOutNav() }, m(view, vnode.attrs))
   }
 
   return resolver
@@ -100,14 +101,25 @@ const logout = () => {
 }
 
 /**
+ * Redirects to user's agent page if logged in.
+ */
+const profile = () => {
+  const publicKey = api.getPublicKey()
+  if (publicKey) m.route.set(`/agents/${publicKey}`)
+  else m.route.set('/')
+}
+
+/**
  * Build and mount app/router
  */
 document.addEventListener('DOMContentLoaded', () => {
   m.route(document.querySelector('#app'), '/', {
     '/': resolve(Dashboard),
+    '/agents/:publicKey': resolve(AgentDetailPage),
     '/create': resolve(AddFishForm, true),
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },
+    '/profile': { onmatch: profile },
     '/signup': resolve(SignupForm)
   })
 })

--- a/families/track_and_trade/client/src/services/api.js
+++ b/families/track_and_trade/client/src/services/api.js
@@ -27,20 +27,20 @@ let authToken = null
  */
 const getAuth = () => {
   if (!authToken) {
-    authToken = localStorage.getItem(STORAGE_KEY)
+    authToken = window.localStorage.getItem(STORAGE_KEY)
   }
   return authToken
 }
 
 const setAuth = token => {
-  localStorage.setItem(STORAGE_KEY, token)
+  window.localStorage.setItem(STORAGE_KEY, token)
   authToken = token
   return authToken
 }
 
 const clearAuth = () => {
   const token = getAuth()
-  localStorage.clear(STORAGE_KEY)
+  window.localStorage.clear(STORAGE_KEY)
   authToken = null
   return token
 }
@@ -51,7 +51,7 @@ const clearAuth = () => {
 const getPublicKey = () => {
   const token = getAuth()
   if (!token) return null
-  return atob(token.split('.')[1])
+  return window.atob(token.split('.')[1])
 }
 
 // Adds Authorization header and prepends API path to url

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -64,7 +64,7 @@ const makePrivateKey = password => {
   txnEncoder = new TransactionEncoder(privateKey, encoderSettings)
 
   const encryptedKey = sjcl.encrypt(password, privateKey)
-  localStorage.setItem(STORAGE_KEY, encryptedKey)
+  window.localStorage.setItem(STORAGE_KEY, encryptedKey)
 
   const publicKey = signer.getPublicKey(privateKey)
   return { encryptedKey, publicKey }
@@ -77,7 +77,7 @@ const setPrivateKey = (password, encryptedKey) => {
   const privateKey = sjcl.decrypt(password, encryptedKey)
   txnEncoder = new TransactionEncoder(privateKey, encoderSettings)
 
-  localStorage.setItem(STORAGE_KEY, encryptedKey)
+  window.localStorage.setItem(STORAGE_KEY, encryptedKey)
 
   return encryptedKey
 }
@@ -86,9 +86,9 @@ const setPrivateKey = (password, encryptedKey) => {
  * Clears the users private key from memory and storage.
  */
 const clearPrivateKey = () => {
-  const encryptedKey = localStorage.getItem(STORAGE_KEY)
+  const encryptedKey = window.localStorage.getItem(STORAGE_KEY)
 
-  localStorage.clear(STORAGE_KEY)
+  window.localStorage.clear(STORAGE_KEY)
   txnEncoder = null
 
   return encryptedKey
@@ -106,7 +106,7 @@ const submit = payloads => {
 
       return requestPassword()
         .then(password => {
-          const encryptedKey = localStorage.getItem(STORAGE_KEY)
+          const encryptedKey = window.localStorage.getItem(STORAGE_KEY)
           setPrivateKey(password, encryptedKey)
         })
     })

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -108,6 +108,18 @@ const getPrivateKey = () => {
 }
 
 /**
+ * Re-encrypts a private key with a new password.
+ */
+const changePassword = password => {
+  return getPrivateKey()
+    .then(privateKey => {
+      const encryptedKey = sjcl.encrypt(password, privateKey)
+      window.localStorage.setItem(STORAGE_KEY, encryptedKey)
+      return encryptedKey
+    })
+}
+
+/**
  * Wraps a Protobuf payload in a TransactionList and submits it to the API.
  * Prompts user for their password if their private key is not in memory.
  */
@@ -135,5 +147,6 @@ module.exports = {
   setPrivateKey,
   clearPrivateKey,
   getPrivateKey,
+  changePassword,
   submit
 }

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -45,7 +45,7 @@ const requestPassword = () => {
     title: 'Enter Password',
     acceptText: 'Submit',
     body: m('.container', [
-      m('.mb-4', 'Please confirm your password to decrypt your signing key.'),
+      m('.mb-4', 'Please confirm your password to unlock your signing key.'),
       m('input.form-control', {
         type: 'password',
         oninput: m.withAttr('value', value => { password = value })
@@ -95,6 +95,19 @@ const clearPrivateKey = () => {
 }
 
 /**
+ * Returns the user's private key as promised, requesting password as needed.
+ */
+const getPrivateKey = () => {
+  return Promise.resolve()
+  .then(() => {
+    if (txnEncoder) return txnEncoder._privateKey
+    const encryptedKey = window.localStorage.getItem(STORAGE_KEY)
+    return requestPassword()
+      .then(password => sjcl.decrypt(password, encryptedKey))
+  })
+}
+
+/**
  * Wraps a Protobuf payload in a TransactionList and submits it to the API.
  * Prompts user for their password if their private key is not in memory.
  */
@@ -121,5 +134,6 @@ module.exports = {
   makePrivateKey,
   setPrivateKey,
   clearPrivateKey,
+  getPrivateKey,
   submit
 }

--- a/families/track_and_trade/client/src/views/agent_detail.js
+++ b/families/track_and_trade/client/src/views/agent_detail.js
@@ -74,6 +74,12 @@ const privateKeyField = state => {
             state.toggled.privateKey = privateKey
             m.redraw()
           })
+      }),
+      forms.clickIcon('cloud-download', () => {
+        return transactions.getPrivateKey()
+          .then(privateKey => {
+            forms.triggerDownload(`${state.agent.username}.priv`, privateKey)
+          })
       })),
     toggledInfo(
       state.toggled.privateKey,

--- a/families/track_and_trade/client/src/views/agent_detail.js
+++ b/families/track_and_trade/client/src/views/agent_detail.js
@@ -102,6 +102,26 @@ const editField = (state, label, key) => {
       infoForm(state, key, onSubmit, {placeholder: currentInfo})))
 }
 
+const passwordField = state => {
+  const onSubmit = () => {
+    return transactions.changePassword(state.update.password)
+      .then(encryptedKey => {
+        return api.patch('users', {
+          encryptedKey,
+          password: state.update.password
+        })
+      })
+      .then(() => m.redraw())
+  }
+
+  return labeledField(
+    fieldHeader('Password', editIcon(state.toggled, 'password')),
+    toggledInfo(
+      state.toggled.password,
+      bullets(16),
+      infoForm(state, 'password', onSubmit, { type: 'password' })))
+}
+
 /**
  * Displays information for a particular Agent.
  * The information can be edited if the user themself.
@@ -121,7 +141,7 @@ const AgentDetailPage = {
       layout.row(privateKeyField(vnode.state)),
       layout.row([
         editField(vnode.state, 'Username', 'username'),
-        staticField('Password', bullets(16))
+        passwordField(vnode.state)
       ]),
       layout.row(editField(vnode.state, 'Email', 'email'))
     ]

--- a/families/track_and_trade/client/src/views/agent_detail.js
+++ b/families/track_and_trade/client/src/views/agent_detail.js
@@ -20,6 +20,7 @@ const m = require('mithril')
 const _ = require('lodash')
 
 const api = require('../services/api')
+const transactions = require('../services/transactions')
 const layout = require('../components/layout')
 const forms = require('../components/forms')
 
@@ -60,6 +61,26 @@ const infoForm = (state, key, onSubmit, opts) => {
   ])
 }
 
+const privateKeyField = state => {
+  return labeledField(
+    fieldHeader('Private Key',
+      forms.clickIcon('eye', () => {
+        if (state.toggled.privateKey) {
+          state.toggled.privateKey = false
+          return
+        }
+        return transactions.getPrivateKey()
+          .then(privateKey => {
+            state.toggled.privateKey = privateKey
+            m.redraw()
+          })
+      })),
+    toggledInfo(
+      state.toggled.privateKey,
+      bullets(64),
+      state.toggled.privateKey))
+}
+
 // Pencil icon that simply toggles visibility
 const editIcon = (obj, key) => {
   return forms.clickIcon('pencil', () => { obj[key] = !obj[key] })
@@ -97,7 +118,7 @@ const AgentDetailPage = {
     const publicKey = _.get(vnode.state, 'agent.publicKey', '')
 
     const profileContent = [
-      layout.row(staticField('PrivateKey', bullets(64))),
+      layout.row(privateKeyField(vnode.state)),
       layout.row([
         editField(vnode.state, 'Username', 'username'),
         staticField('Password', bullets(16))

--- a/families/track_and_trade/client/src/views/agent_detail.js
+++ b/families/track_and_trade/client/src/views/agent_detail.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const layout = require('../components/layout')
+
+// Basis for info fields with headers
+const labeledField = (header, field) => {
+  return m('.field-group.mt-5', header, field)
+}
+
+const fieldHeader = (label, ...additions) => {
+  return m('.field-header', [
+    m('span.h5.mr-3', label),
+    additions
+  ])
+}
+
+// Simple info field with a label
+const staticField = (label, info) => labeledField(fieldHeader(label), info)
+
+/**
+ * Displays information for a particular Agent.
+ */
+const AgentDetailPage = {
+  oninit (vnode) {
+    api.get(`agents/${vnode.attrs.publicKey}`)
+      .then(agent => { vnode.state.agent = agent })
+  },
+
+  view (vnode) {
+    const publicKey = _.get(vnode.state, 'agent.publicKey', '')
+
+    return [
+      layout.title(_.get(vnode.state, 'agent.name', '')),
+      m('.container',
+        layout.row(staticField('Public Key', publicKey)))
+    ]
+  }
+}
+
+module.exports = AgentDetailPage

--- a/families/track_and_trade/client/src/views/agent_detail.js
+++ b/families/track_and_trade/client/src/views/agent_detail.js
@@ -21,6 +21,10 @@ const _ = require('lodash')
 
 const api = require('../services/api')
 const layout = require('../components/layout')
+const forms = require('../components/forms')
+
+// Returns a string of bullets
+const bullets = count => _.fill(Array(count), '•').join('')
 
 // Basis for info fields with headers
 const labeledField = (header, field) => {
@@ -37,11 +41,54 @@ const fieldHeader = (label, ...additions) => {
 // Simple info field with a label
 const staticField = (label, info) => labeledField(fieldHeader(label), info)
 
+const toggledInfo = (isToggled, initialView, toggledView) => {
+  return m('.field-info', isToggled ? toggledView : initialView)
+}
+
+// An in-line form for updating a single field
+const infoForm = (state, key, onSubmit, opts) => {
+  return m('form.form-inline', {
+    onsubmit: () => onSubmit().then(() => { state.toggled[key] = false })
+  }, [
+    m('input.form-control-sm.mr-1', _.assign({
+      oninput: m.withAttr('value', value => { state.update[key] = value })
+    }, opts)),
+    m('button.btn.btn-secondary.btn-sm.mr-1', {
+      onclick: () => { state.toggled[key] = false }
+    }, 'Cancel'),
+    m('button.btn.btn-primary.btn-sm.mr-1', { type: 'submit' }, 'Update')
+  ])
+}
+
+// Pencil icon that simply toggles visibility
+const editIcon = (obj, key) => {
+  return forms.clickIcon('pencil', () => { obj[key] = !obj[key] })
+}
+
+// Edits a field in state
+const editField = (state, label, key) => {
+  const currentInfo = _.get(state, ['agent', key], '')
+  const onSubmit = () => {
+    return api.patch('users', _.pick(state.update, key))
+      .then(() => { state.agent[key] = state.update[key] })
+  }
+
+  return labeledField(
+    fieldHeader(label, editIcon(state.toggled, key)),
+    toggledInfo(
+      state.toggled[key],
+      currentInfo,
+      infoForm(state, key, onSubmit, {placeholder: currentInfo})))
+}
+
 /**
  * Displays information for a particular Agent.
+ * The information can be edited if the user themself.
  */
 const AgentDetailPage = {
   oninit (vnode) {
+    vnode.state.toggled = {}
+    vnode.state.update = {}
     api.get(`agents/${vnode.attrs.publicKey}`)
       .then(agent => { vnode.state.agent = agent })
   },
@@ -49,10 +96,20 @@ const AgentDetailPage = {
   view (vnode) {
     const publicKey = _.get(vnode.state, 'agent.publicKey', '')
 
+    const profileContent = [
+      layout.row(staticField('PrivateKey', bullets(64))),
+      layout.row([
+        editField(vnode.state, 'Username', 'username'),
+        staticField('Password', bullets(16))
+      ]),
+      layout.row(editField(vnode.state, 'Email', 'email'))
+    ]
+
     return [
       layout.title(_.get(vnode.state, 'agent.name', '')),
       m('.container',
-        layout.row(staticField('Public Key', publicKey)))
+        layout.row(staticField('Public Key', publicKey)),
+        publicKey === api.getPublicKey() ? profileContent : null)
     ]
   }
 }

--- a/families/track_and_trade/client/styles/main.scss
+++ b/families/track_and_trade/client/styles/main.scss
@@ -1,1 +1,2 @@
 @import "~bootstrap/scss/bootstrap";
+@import "~octicons/build/octicons.min";


### PR DESCRIPTION
Adds an Agent detail page, accessible through the URL `http://localhost:3000/#!/agents/{PUBLIC KEY}`. This is just a public key and name for most Agents, but the logged in user, they will see additional profile information, and be able to edit it.

This closes [PR-658](https://jira.hyperledger.org/browse/STL-658)

_Screenshot_:
<img width="972" alt="screen shot 2017-09-22 at 11 57 20 am" src="https://user-images.githubusercontent.com/8889580/30755793-9e4ca824-9f8d-11e7-9baa-9832b2a4c4c4.png">

To test, follow the [setup instructions in PR-879](https://github.com/hyperledger/sawtooth-core/pull/879), and navigate to the profile page via the navbar.
