### PR TITLE
Fix lack of base64 encoding on dummy data

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+from base64 import b64encode
 import logging
 import hashlib
 import time
@@ -305,10 +306,11 @@ class PoetBlockPublisher(BlockPublisherInterface):
             # we don't try to keep signing up.  However, we are going to mark
             # that key state store entry as being refreshed so that we will
             # never actually try to use it.
+            dummy_data = b64encode(b'No sealed signup data').decode('utf-8')
             self._poet_key_state_store[
                 validator_info.signup_info.poet_public_key] = \
                 PoetKeyState(
-                    sealed_signup_data='No sealed signup data',
+                    sealed_signup_data=dummy_data,
                     has_been_refreshed=True)
 
             return False


### PR DESCRIPTION
Signed-off-by: Boyd Johnson <boydx.johnson@intel.com>

This is the probable cause of the "poet_key_state is invalid: Incorrect padding" exception being raised in the publisher.