### PR TITLE
Fix fish submission for T&T

### DIFF
--- a/families/track_and_trade/client/src/services/payloads.js
+++ b/families/track_and_trade/client/src/services/payloads.js
@@ -52,6 +52,7 @@ const root = protobuf.Root.fromJSON(protoJson)
 const TTPayload = root.lookup('TTPayload')
 const PropertyValue = root.lookup('PropertyValue')
 const PropertySchema = root.lookup('PropertySchema')
+const Location = root.lookup('Location')
 const Proposal = root.lookup('Proposal')
 _.map(actionMap, action => {
   return _.set(action, 'proto', root.lookup(action.name))
@@ -62,7 +63,12 @@ const propertiesXformer = xform => data => {
   return _.set(data, 'properties', data.properties.map(xform))
 }
 const valueXform = propertiesXformer(prop => PropertyValue.create(prop))
-const schemaXform = propertiesXformer(prop => PropertySchema.create(prop))
+const schemaXform = propertiesXformer(prop => {
+  if (prop.locationValue) {
+    prop.locationValue = Location.create(prop.locationValue)
+  }
+  return PropertySchema.create(prop)
+})
 
 _.map(actionMap, action => _.set(action, 'xform', x => x))
 actionMap.createRecord.xform = valueXform

--- a/families/track_and_trade/client/src/views/add_fish_form.js
+++ b/families/track_and_trade/client/src/views/add_fish_form.js
@@ -228,23 +228,26 @@ const _handleSubmit = (signingKey, state) => {
     properties: [
       {
         name: 'species',
-        value: state.species,
-        type: payloads.createRecord.enum.STRING
+        stringValue: state.species,
+        dataType: payloads.createRecord.enum.STRING
       },
       {
         name: 'length',
-        value: state.lengthInCM,
-        type: payloads.createRecord.enum.FLOAT
+        intValue: state.lengthInCM,
+        dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'weight',
-        value: state.weightInKg,
-        type: payloads.createRecord.enum.FLOAT
+        intValue: state.weightInKg,
+        dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'location',
-        value: [state.latitude, state.longitude],
-        type: payloads.createRecord.enum.LOCATION
+        locationValue: {
+          latitude: state.latitude,
+          longitude: state.longitude
+        },
+        dataType: payloads.createRecord.enum.LOCATION
       }
     ]
   })

--- a/families/track_and_trade/processor/sawtooth_track_and_trade/processor/handler.py
+++ b/families/track_and_trade/processor/sawtooth_track_and_trade/processor/handler.py
@@ -751,10 +751,15 @@ def _make_new_reported_value(reporter_index, timestamp, prop):
 
     attribute = DATA_TYPE_TO_ATTRIBUTE[prop.data_type]
 
-    setattr(
-        reported_value,
-        attribute,
-        getattr(prop, attribute))
+    # Cannot set messages, must set their attributes individually
+    if attribute == 'location_value':
+        reported_value.location_value.latitude = prop.location_value.latitude
+        reported_value.location_value.longitude = prop.location_value.longitude
+    else:
+        setattr(
+            reported_value,
+            attribute,
+            getattr(prop, attribute))
 
     return reported_value
 


### PR DESCRIPTION
There were three bugs preventing new Record from being submitted:
Values/types were being set improperly in the fish form, Locations
were being set improperly in the client, and Locations were being
set improperly in the Transaction Processor. This commit fixes these.