### PR TITLE
made example command consistent for arguments

### DIFF
--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -640,7 +640,7 @@ following command:
 
 .. code-block:: console
 
-  $ docker logs CONTAINER
+  $ docker logs {CONTAINER}
 
 
 .. note:: 


### PR DESCRIPTION
rest of doc uses braces around argument to sample commands to indicate argument

Signed-off-by: crow15 <crowe.ny@gmail.com>