### PR TITLE
BlockValidator now uses current chain_head when checking a block.

### DIFF
--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -170,7 +170,7 @@ class BlockTreeManager(object):
         block_builder.set_state_hash('0'*70)
 
         consensus = mock_consensus.BlockPublisher()
-        consensus.finalize_block(block_builder.block_header)
+        consensus.finalize_block(block_builder.block_header, weight=weight)
 
         header_bytes = block_builder.block_header.SerializeToString()
         signature = signing.sign(header_bytes, self.identity_signing_key)
@@ -191,7 +191,6 @@ class BlockTreeManager(object):
         if invalid_consensus:
             block_wrapper.header.consensus = b'BAD'
 
-        block_wrapper.weight = weight
         block_wrapper.status = status
 
         if add_to_cache:

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -56,7 +56,7 @@ class BlockPublisher(BlockPublisherInterface):
         """
         return True
 
-    def finalize_block(self, block_header):
+    def finalize_block(self, block_header, weight=0):
         """Finalize a block_header to be claimed.
 
         Args:
@@ -64,7 +64,7 @@ class BlockPublisher(BlockPublisherInterface):
         Returns:
             Boolean: True if the candidate block should be claimed.
         """
-        block_header.consensus = b"test_mode"
+        block_header.consensus = "test_mode:{}".format(weight).encode()
         return True
 
 
@@ -85,7 +85,7 @@ class BlockVerifier(BlockVerifierInterface):
             validator_id)
 
     def verify_block(self, block_wrapper):
-        return block_wrapper.consensus == b"test_mode"
+        return block_wrapper.consensus.startswith(b"test_mode")
 
 
 class ForkResolver(ForkResolverInterface):
@@ -115,9 +115,14 @@ class ForkResolver(ForkResolverInterface):
             bool: True if the new chain should replace the current chain.
             False if the new chain should be discarded.
         """
-
-        new_num, new_weight = new_fork_head.block_num, new_fork_head.weight
-        cur_num, cur_weight = cur_fork_head.block_num, cur_fork_head.weight
+        new_num = new_fork_head.block_num
+        new_weight = 0
+        if new_fork_head.consensus:
+            new_weight = int(new_fork_head.consensus.decode().split(':')[1])
+        cur_num = cur_fork_head.block_num
+        cur_weight = 0
+        if cur_fork_head.consensus:
+            cur_weight = int(cur_fork_head.consensus.decode().split(':')[1])
 
         # chains are ordered by length first, then weight
         if new_num == cur_num:

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -770,7 +770,6 @@ class TestBlockValidator(unittest.TestCase):
         return BlockValidator(
             consensus_module=mock_consensus,
             new_block=new_block,
-            chain_head=self.block_tree_manager.chain_head,
             state_view_factory=self.state_view_factory,
             block_cache=self.block_tree_manager.block_cache,
             done_cb=on_block_validated,


### PR DESCRIPTION
Previously the BlockValidator had used the chain_head of when the Block was
queued for validation. This caused wasted block validations, as if a Block
was earlier in the queue was determined to be the chain_head the later
would detect the change after it finished validation and would requeue
the validation. If that requeue was not at the front of the queue then
the same case would happen again.

Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>