### PR TITLE
Add basic fish detail screen

### DIFF
--- a/families/track_and_trade/client/src/components/forms.js
+++ b/families/track_and_trade/client/src/components/forms.js
@@ -93,6 +93,60 @@ const triggerDownload = (name, ...contents) => {
   m.mount(container, null)
 }
 
+/**
+ * A MultiSelect component.
+ *
+ * Given a set of options, and currently selected values, allows the user to
+ * select all, deselect all, or select multiple.
+ */
+const MultiSelect = {
+  view (vnode) {
+    let handleChange = vnode.attrs.onchange || (() => null)
+    let selected = vnode.attrs.selected
+    return [
+      m('.dropdown',
+        m('button.btn.btn-light.btn-block.dropdown-toggle.text-left',
+          {
+            'data-toggle': 'dropdown',
+            onclick: (e) => {
+              e.preventDefault()
+              vnode.state.show = !vnode.state.show
+            }
+          }, vnode.attrs.label),
+        m('.dropdown-menu.w-100', {className: vnode.state.show ? 'show' : ''},
+          m("a.dropdown-item[href='#']", {
+            onclick: (e) => {
+              e.preventDefault()
+              handleChange(vnode.attrs.options.map(([value, label]) => value))
+            }
+          }, 'Select All'),
+          m("a.dropdown-item[href='#']", {
+            onclick: (e) => {
+              e.preventDefault()
+              handleChange([])
+            }
+          }, 'Deselect All'),
+          m('.dropdown-divider'),
+          vnode.attrs.options.map(
+            ([value, label]) =>
+             m("a.dropdown-item[href='#']", {
+               onclick: (e) => {
+                 e.preventDefault()
+
+                 let setLocation = selected.indexOf(value)
+                 if (setLocation >= 0) {
+                   selected.splice(setLocation, 1)
+                 } else {
+                   selected.push(value)
+                 }
+
+                 handleChange(selected)
+               }
+             }, label, (selected.indexOf(value) > -1 ? ' \u2714' : '')))))
+    ]
+  }
+}
+
 module.exports = {
   group,
   field,
@@ -104,5 +158,6 @@ module.exports = {
   clickIcon,
   stateSetter,
   validator,
-  triggerDownload
+  triggerDownload,
+  MultiSelect
 }

--- a/families/track_and_trade/client/src/components/forms.js
+++ b/families/track_and_trade/client/src/components/forms.js
@@ -103,9 +103,10 @@ const MultiSelect = {
   view (vnode) {
     let handleChange = vnode.attrs.onchange || (() => null)
     let selected = vnode.attrs.selected
+    let color = vnode.attrs.color || 'light'
     return [
       m('.dropdown',
-        m('button.btn.btn-light.btn-block.dropdown-toggle.text-left',
+        m(`button.btn.btn-${color}.btn-block.dropdown-toggle.text-left`,
           {
             'data-toggle': 'dropdown',
             onclick: (e) => {

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -30,6 +30,7 @@ const AddFishForm = require('./views/add_fish_form')
 const AgentDetailPage = require('./views/agent_detail')
 const AgentList = require('./views/list_agents')
 const FishList = require('./views/list_fish')
+const FishDetail = require('./views/fish_detail')
 const Dashboard = require('./views/dashboard')
 const LoginForm = require('./views/login_form')
 const PropertyDetailPage = require('./views/property_detail')
@@ -121,6 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
     '/agents/:publicKey': resolve(AgentDetailPage),
     '/agents': resolve(AgentList),
     '/create': resolve(AddFishForm, true),
+    '/fish/:recordId': resolve(FishDetail),
     '/fish': resolve(FishList),
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },

--- a/families/track_and_trade/client/src/services/payloads.js
+++ b/families/track_and_trade/client/src/services/payloads.js
@@ -105,4 +105,7 @@ actionMethods.updateProperties.enum = PropertySchema.DataType
 actionMethods.createProposal.enum = Proposal.Role
 actionMethods.answerProposal.enum = actionMap.answerProposal.proto.Response
 
-module.exports = _.assign({ encode }, actionMethods)
+module.exports = _.assign({
+  encode,
+  FLOAT_PRECISION: 1000000
+}, actionMethods)

--- a/families/track_and_trade/client/src/services/payloads.js
+++ b/families/track_and_trade/client/src/services/payloads.js
@@ -16,7 +16,6 @@
  */
 'use strict'
 
-const path = require('path')
 const _ = require('lodash')
 const protobuf = require('protobufjs')
 const protoJson = require('../protos.json')

--- a/families/track_and_trade/client/src/utils/records.js
+++ b/families/track_and_trade/client/src/utils/records.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const _getProp = (record, propName) => {
+  return record.properties.find((prop) => prop.name === propName)
+}
+
+const getPropertyValue = (record, propName, defaultValue = null) => {
+  let prop = _getProp(record, propName)
+  if (prop) {
+    return prop.value
+  } else {
+    return defaultValue
+  }
+}
+
+const isReporter = (record, propName, publicKey) => {
+  let prop = _getProp(record, propName)
+  if (prop) {
+    return prop.reporters.indexOf(publicKey) > -1
+  } else {
+    return false
+  }
+}
+
+const _getPropTimeByComparison = (compare) => (record) => {
+  if (!record.updates.properties) {
+    return null
+  }
+
+  return Object.values(record.updates.properties)
+      .reduce((acc, updates) => acc.concat(updates), [])
+      .reduce((selected, update) =>
+              compare(selected.timestamp, update.timestamp) ? update : selected)
+      .timestamp
+}
+
+const getLatestPropertyUpdateTime =
+  _getPropTimeByComparison((selected, timestamp) => selected < timestamp)
+
+const getOldestPropertyUpdateTime =
+  _getPropTimeByComparison((selected, timestamp) => selected > timestamp)
+
+const countPropertyUpdates = (record) => {
+  if (!record.updates.properties) {
+    return 0
+  }
+
+  return Object.values(record.updates.properties).reduce(
+    (sum, updates) => sum + updates.length, 0)
+}
+
+module.exports = {
+  getPropertyValue,
+  isReporter,
+  getLatestPropertyUpdateTime,
+  getOldestPropertyUpdateTime,
+  countPropertyUpdates
+}

--- a/families/track_and_trade/client/src/views/add_fish_form.js
+++ b/families/track_and_trade/client/src/views/add_fish_form.js
@@ -21,6 +21,8 @@ const payloads = require('../services/payloads')
 const transactions = require('../services/transactions')
 const {MultiSelect} = require('../components/forms')
 
+const PRECISION = payloads.FLOAT_PRECISION
+
 /**
  * Possible selection options
  */
@@ -76,7 +78,7 @@ const AddFishForm = {
                    min: 0,
                    step: 'any',
                    oninput: m.withAttr('value', (value) => {
-                     vnode.state.lengthInCM = parseFloat(value)
+                     vnode.state.lengthInCM = value
                    }),
                    value: vnode.state.lengthInCM
                  })),
@@ -87,7 +89,7 @@ const AddFishForm = {
                    min: -90,
                    max: 90,
                    oninput: m.withAttr('value', (value) => {
-                     vnode.state.latitude = parseFloat(value)
+                     vnode.state.latitude = value
                    }),
                    value: vnode.state.latitude
                  }))),
@@ -97,7 +99,7 @@ const AddFishForm = {
                    type: 'number',
                    step: 'any',
                    oninput: m.withAttr('value', (value) => {
-                     vnode.state.weightInKg = parseFloat(value)
+                     vnode.state.weightInKg = value
                    }),
                    value: vnode.state.weightInKg
                  })),
@@ -108,7 +110,7 @@ const AddFishForm = {
                    min: -180,
                    max: 180,
                    oninput: m.withAttr('value', (value) => {
-                     vnode.state.longitude = parseFloat(value)
+                     vnode.state.longitude = value
                    }),
                    value: vnode.state.longitude
                  })))),
@@ -182,19 +184,19 @@ const _handleSubmit = (signingKey, state) => {
       },
       {
         name: 'length',
-        intValue: state.lengthInCM,
+        intValue: parseFloat(state.lengthInCM) * PRECISION,
         dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'weight',
-        intValue: state.weightInKg,
+        intValue: parseFloat(state.weightInKg) * PRECISION,
         dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'location',
         locationValue: {
-          latitude: state.latitude,
-          longitude: state.longitude
+          latitude: parseFloat(state.latitude) * PRECISION,
+          longitude: parseFloat(state.longitude) * PRECISION
         },
         dataType: payloads.createRecord.enum.LOCATION
       }

--- a/families/track_and_trade/client/src/views/add_fish_form.js
+++ b/families/track_and_trade/client/src/views/add_fish_form.js
@@ -19,6 +19,7 @@ const m = require('mithril')
 
 const payloads = require('../services/payloads')
 const transactions = require('../services/transactions')
+const {MultiSelect} = require('../components/forms')
 
 /**
  * Possible selection options
@@ -29,58 +30,6 @@ const authorizableProperties = [
   ['tilt', 'Tilt'],
   ['shock', 'Shock']
 ]
-
-/**
- * A MultiSelect component.
- *
- * Given a set of options, and currently selected values, allows the user to
- * select all, deselect all, or select multiple.
- */
-const MultiSelect = {
-  view (vnode) {
-    let handleChange = vnode.attrs.onchange || (() => null)
-    let selected = vnode.attrs.selected
-    return m('.dropdown',
-             m('button.btn.btn-light.btn-block.dropdown-toggle.text-left',
-               {
-                 'data-toggle': 'dropdown',
-                 onclick: (e) => {
-                   e.preventDefault()
-                   vnode.state.show = !vnode.state.show
-                 }
-               }, vnode.attrs.label),
-             m('.dropdown-menu.w-100', {className: vnode.state.show ? 'show' : ''},
-               m("a.dropdown-item[href='#']", {
-                 onclick: (e) => {
-                   e.preventDefault()
-                   handleChange(vnode.attrs.options.map(([value, label]) => value))
-                 }
-               }, 'Select All'),
-               m("a.dropdown-item[href='#']", {
-                 onclick: (e) => {
-                   e.preventDefault()
-                   handleChange([])
-                 }
-               }, 'Deselect All'),
-               m('.dropdown-divider'),
-               vnode.attrs.options.map(
-                 ([value, label]) =>
-                  m("a.dropdown-item[href='#']", {
-                    onclick: (e) => {
-                      e.preventDefault()
-
-                      let setLocation = selected.indexOf(value)
-                      if (setLocation >= 0) {
-                        selected.splice(setLocation, 1)
-                      } else {
-                        selected.push(value)
-                      }
-
-                      handleChange(selected)
-                    }
-                  }, label, (selected.indexOf(value) > -1 ? ' \u2714' : '')))))
-  }
-}
 
 /**
  * The Form for tracking a new fish.

--- a/families/track_and_trade/client/src/views/add_fish_form.js
+++ b/families/track_and_trade/client/src/views/add_fish_form.js
@@ -28,7 +28,7 @@ const PRECISION = payloads.FLOAT_PRECISION
  */
 const authorizableProperties = [
   ['location', 'Location'],
-  ['temp', 'Temperature'],
+  ['temperature', 'Temperature'],
   ['tilt', 'Tilt'],
   ['shock', 'Shock']
 ]

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -30,6 +30,8 @@ const {
   isReporter
 } = require('../utils/records')
 
+const PRECISION = payloads.FLOAT_PRECISION
+
 const _labelProperty = (label, value) => [
   m('dl',
     m('dt', label),
@@ -204,9 +206,9 @@ const FishDetail = {
 
         m('.row',
           m('.col',
-            _labelProperty('Length (cm)', getPropertyValue(record, 'length'))),
+            _labelProperty('Length (cm)', getPropertyValue(record, 'length', 0) / PRECISION)),
           m('.col',
-            _labelProperty('Weight (kg)', getPropertyValue(record, 'weight')))),
+            _labelProperty('Weight (kg)', getPropertyValue(record, 'weight', 0) / PRECISION))),
 
         m('.row',
           m('.col',
@@ -217,7 +219,7 @@ const FishDetail = {
 
         m('.row',
           m('.col',
-            _labelProperty('Temperature (C°)', getPropertyValue(record, 'temperature', 'Unknown'))),
+            _labelProperty('Temperature', _formatTemp(getPropertyValue(record, 'temperature')))),
           (isReporter(record, 'temperature', publicKey)
            ? m('.col', m(ReportValue,
              {
@@ -274,10 +276,20 @@ const FishDetail = {
 
 const _formatLocation = (location) => {
   if (location && location.latitude && location.longitude) {
-    return `${location.latitude.toFixed(6)}, ${location.longitude.toFixed(6)}`
+    let latitude = location.latitude / PRECISION
+    let longitude = location.longitude / PRECISION
+    return `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`
   } else {
     return 'Unknown'
   }
+}
+
+const _formatTemp = (temp) => {
+  if (temp) {
+    return `${(temp / PRECISION).toFixed(6)} C°`
+  }
+
+  return 'Unknown'
 }
 
 const _formatTimestamp = (sec) => {

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -242,7 +242,7 @@ const FishDetail = {
 
         _row(
           _labelProperty('Owner', _agentLink(owner)),
-          (owner.key === publicKey
+          (owner.key === publicKey && !record.final
            ? m(TransferDropdown, {
              agents: vnode.state.agents,
              handleSelected: _doTransfer(record, payloads.createProposal.enum.OWNER)
@@ -251,7 +251,7 @@ const FishDetail = {
 
         _row(
             _labelProperty('Custodian', _agentLink(custodian)),
-          (custodian.key === publicKey
+          (custodian.key === publicKey && !record.final
            ? m(TransferDropdown, {
              agents: vnode.state.agents,
              handleSelected: _doTransfer(record, payloads.createProposal.enum.CUSTODIAN)
@@ -266,13 +266,13 @@ const FishDetail = {
 
         _row(
           _labelProperty('Location', _formatLocation(getPropertyValue(record, 'location'))),
-          (isReporter(record, 'location', publicKey)
+          (isReporter(record, 'location', publicKey) && !record.final
            ? m(ReportLocation, { record })
            : null)),
 
         _row(
           _labelProperty('Temperature', _formatTemp(getPropertyValue(record, 'temperature'))),
-          (isReporter(record, 'temperature', publicKey)
+          (isReporter(record, 'temperature', publicKey) && !record.final
           ? m(ReportValue,
             {
               name: 'temperature',
@@ -286,7 +286,7 @@ const FishDetail = {
 
         _row(
           _labelProperty('Tilt', getPropertyValue(record, 'tilt', 'Unknown')),
-          (isReporter(record, 'tilt', publicKey)
+          (isReporter(record, 'tilt', publicKey) && !record.final
            ? m(ReportValue, {
              name: 'tilt',
              label: 'Tilt',
@@ -298,7 +298,7 @@ const FishDetail = {
 
         _row(
           _labelProperty('Shock', getPropertyValue(record, 'shock', 'Unknown')),
-          (isReporter(record, 'shock', publicKey)
+          (isReporter(record, 'shock', publicKey) && !record.final
            ? m(ReportValue, {
              name: 'shock',
              label: 'Shock',

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -45,14 +45,6 @@ const _row = (...cols) =>
     .map((col) => m('.col', col)))
 
 const TransferDropdown = {
-  oninit (vnode) {
-    let publicKey = api.getPublicKey()
-    vnode.state.agents = []
-    api.get('agents').then(agents => {
-      vnode.state.agents = agents.filter((agent) => agent.key !== publicKey)
-    })
-  },
-
   view (vnode) {
     // Default to no-op
     let handleSelected = vnode.attrs.handleSelected || (() => null)
@@ -62,7 +54,7 @@ const TransferDropdown = {
           { 'data-toggle': 'dropdown' },
           vnode.children),
         m('.dropdown-menu',
-          vnode.state.agents.map(agent =>
+          vnode.attrs.agents.map(agent =>
             m("a.dropdown-item[href='#']", {
               onclick: (e) => {
                 e.preventDefault()
@@ -75,7 +67,7 @@ const TransferDropdown = {
 }
 
 const _agentLink = (agent) =>
-  m(`a[href=/agents/${agent.publicKey}]`,
+  m(`a[href=/agents/${agent.key}]`,
     { oncreate: m.route.link },
     agent.name)
 
@@ -154,16 +146,17 @@ const ReportValue = {
 
 const FishDetail = {
   oninit (vnode) {
+    let publicKey = api.getPublicKey()
     api.get(`records/${vnode.attrs.recordId}`)
     .then(record =>
       Promise.all([
         record,
-        api.get(`agents/${record.owner}`),
-        api.get(`agents/${record.custodian}`)]))
-    .then(([record, owner, custodian]) => {
+        api.get('agents')]))
+    .then(([record, agents, owner, custodian]) => {
       vnode.state.record = record
-      vnode.state.owner = owner
-      vnode.state.custodian = custodian
+      vnode.state.agents = agents.filter((agent) => agent.key !== publicKey)
+      vnode.state.owner = agents.find((agent) => agent.key === record.owner)
+      vnode.state.custodian = agents.find((agent) => agent.key === record.custodian)
     })
   },
 

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -254,7 +254,20 @@ const FishDetail = {
              typeField: 'stringValue',
              type: payloads.updateProperties.enum.STRING
            }))
-           : '')))
+           : '')),
+
+        ((record.owner === publicKey && !record.final)
+         ? m('.row.mb-3',
+             m('.col.text-center',
+               m('button.btn.btn-danger', {
+                 onclick: (e) => {
+                   e.preventDefault()
+                   _finalizeRecord(record)
+                 }
+               },
+               'Finalize')))
+         : '')
+       )
     ]
   }
 }
@@ -294,6 +307,16 @@ const _updateProperty = (record, value) => {
 
   transactions.submit([updatePayload]).then(() => {
     console.log('Successfully submitted property update')
+  })
+}
+
+const _finalizeRecord = (record) => {
+  let finalizePayload = payloads.finalizeRecord({
+    recordId: record.recordId
+  })
+
+  transactions.submit([finalizePayload]).then(() => {
+    console.log('finalized')
   })
 }
 

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -38,6 +38,12 @@ const _labelProperty = (label, value) => [
     m('dd', value))
 ]
 
+const _row = (...cols) =>
+  m('.row',
+    cols
+    .filter((col) => col !== null)
+    .map((col) => m('.col', col)))
+
 const TransferDropdown = {
   oninit (vnode) {
     let publicKey = api.getPublicKey()
@@ -173,90 +179,79 @@ const FishDetail = {
     return [
       m('.fish-detail',
         m('h1.text-center', record.recordId),
-        m('.row',
-          m('.col',
-            _labelProperty('Created',
-                           _formatTimestamp(getOldestPropertyUpdateTime(record)))),
-          m('.col',
-            _labelProperty('Updated',
-                           _formatTimestamp(getLatestPropertyUpdateTime(record))))),
+        _row(
+          _labelProperty('Created',
+                         _formatTimestamp(getOldestPropertyUpdateTime(record))),
+          _labelProperty('Updated',
+                         _formatTimestamp(getLatestPropertyUpdateTime(record)))),
 
-        m('.row',
-          m('.col',
-            _labelProperty(
-              'Owner', _agentLink(owner))),
-          (owner.publicKey === publicKey
-           ? m('.col',
-               m(TransferDropdown, {
-                 handleSelected: _doTransfer(record, payloads.createProposal.enum.OWNER)
-               }, 'Transfer Ownership'))
-           : '')),
-        m('.row',
-          m('.col',
-            _labelProperty('Custodian', _agentLink(custodian))),
-          (custodian.publicKey === publicKey
-           ? m('.col',
-               m(TransferDropdown, {
-                 handleSelected: _doTransfer(record, payloads.createProposal.enum.CUSTODIAN)
-               }, 'Transfer Custodianship'))
-           : '')),
-        m('.row',
-          m('.col',
-            _labelProperty('Species', getPropertyValue(record, 'species')))),
+        _row(
+          _labelProperty('Owner', _agentLink(owner)),
+          (owner.key === publicKey
+           ? m(TransferDropdown, {
+             agents: vnode.state.agents,
+             handleSelected: _doTransfer(record, payloads.createProposal.enum.OWNER)
+           }, 'Transfer Ownership')
+           : null)),
 
-        m('.row',
-          m('.col',
-            _labelProperty('Length (cm)', getPropertyValue(record, 'length', 0) / PRECISION)),
-          m('.col',
-            _labelProperty('Weight (kg)', getPropertyValue(record, 'weight', 0) / PRECISION))),
+        _row(
+            _labelProperty('Custodian', _agentLink(custodian)),
+          (custodian.key === publicKey
+           ? m(TransferDropdown, {
+             agents: vnode.state.agents,
+             handleSelected: _doTransfer(record, payloads.createProposal.enum.CUSTODIAN)
+           }, 'Transfer Custodianship')
+           : null)),
 
-        m('.row',
-          m('.col',
-            _labelProperty('Location', _formatLocation(getPropertyValue(record, 'location')))),
+        _row(_labelProperty('Species', getPropertyValue(record, 'species'))),
+
+        _row(
+          _labelProperty('Length (cm)', getPropertyValue(record, 'length', 0) / PRECISION),
+          _labelProperty('Weight (kg)', getPropertyValue(record, 'weight', 0) / PRECISION)),
+
+        _row(
+          _labelProperty('Location', _formatLocation(getPropertyValue(record, 'location'))),
           (isReporter(record, 'location', publicKey)
-           ? m('.col', m(ReportLocation, { record }))
-          : '')),
+           ? m(ReportLocation, { record })
+           : null)),
 
-        m('.row',
-          m('.col',
-            _labelProperty('Temperature', _formatTemp(getPropertyValue(record, 'temperature')))),
+        _row(
+          _labelProperty('Temperature', _formatTemp(getPropertyValue(record, 'temperature'))),
           (isReporter(record, 'temperature', publicKey)
-           ? m('.col', m(ReportValue,
-             {
-               name: 'temperature',
-               label: 'Temperature (C°)',
-               record,
-               typeField: 'intValue',
-               type: payloads.updateProperties.enum.INT,
-               xform: (x) => parseInt(x)
-             }))
-          : '')),
+          ? m(ReportValue,
+            {
+              name: 'temperature',
+              label: 'Temperature (C°)',
+              record,
+              typeField: 'intValue',
+              type: payloads.updateProperties.enum.INT,
+              xform: (x) => parseInt(x)
+            })
+           : null)),
 
-        m('.row',
-          m('.col',
-            _labelProperty('Tilt', getPropertyValue(record, 'tilt', 'Unknown'))),
+        _row(
+          _labelProperty('Tilt', getPropertyValue(record, 'tilt', 'Unknown')),
           (isReporter(record, 'tilt', publicKey)
-           ? m('.col', m(ReportValue, {
+           ? m(ReportValue, {
              name: 'tilt',
              label: 'Tilt',
              record,
              typeField: 'stringValue',
              type: payloads.updateProperties.enum.STRING
-           }))
-           : '')),
+           })
+           : null)),
 
-        m('.row',
-          m('.col',
-            _labelProperty('Shock', getPropertyValue(record, 'shock', 'Unknown'))),
+        _row(
+          _labelProperty('Shock', getPropertyValue(record, 'shock', 'Unknown')),
           (isReporter(record, 'shock', publicKey)
-           ? m('.col', m(ReportValue, {
+           ? m(ReportValue, {
              name: 'shock',
              label: 'Shock',
              record,
              typeField: 'stringValue',
              type: payloads.updateProperties.enum.STRING
-           }))
-           : '')),
+           })
+           : null)),
 
         ((record.owner === publicKey && !record.final)
          ? m('.row.mb-3',

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -89,8 +89,8 @@ const ReportLocation = {
         _updateProperty(vnode.attrs.record, {
           name: 'location',
           locationValue: {
-            latitude: parseFloat(vnode.state.latitude),
-            longitude: parseFloat(vnode.state.longitude)
+            latitude: parseFloat(vnode.state.latitude) * PRECISION,
+            longitude: parseFloat(vnode.state.longitude) * PRECISION
           },
           dataType: payloads.updateProperties.enum.LOCATION
         })
@@ -280,7 +280,7 @@ const FishDetail = {
               record,
               typeField: 'intValue',
               type: payloads.updateProperties.enum.INT,
-              xform: (x) => parseInt(x)
+              xform: (x) => parseInt(x) * PRECISION
             })
            : null)),
 

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -1,0 +1,300 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const moment = require('moment')
+const truncate = require('lodash/truncate')
+
+const payloads = require('../services/payloads')
+const transactions = require('../services/transactions')
+const api = require('../services/api')
+const {
+  getPropertyValue,
+  getLatestPropertyUpdateTime,
+  getOldestPropertyUpdateTime,
+  isReporter
+} = require('../utils/records')
+
+const _labelProperty = (label, value) => [
+  m('dl',
+    m('dt', label),
+    m('dd', value))
+]
+
+const TransferDropdown = {
+  oninit (vnode) {
+    let publicKey = api.getPublicKey()
+    vnode.state.agents = []
+    api.get('agents').then(agents => {
+      vnode.state.agents = agents.filter((agent) => agent.key !== publicKey)
+    })
+  },
+
+  view (vnode) {
+    // Default to no-op
+    let handleSelected = vnode.attrs.handleSelected || (() => null)
+    return [
+      m('.dropdown',
+        m('button.btn.btn-primary.btn-block.dropdown-toggle.text-left',
+          { 'data-toggle': 'dropdown' },
+          vnode.children),
+        m('.dropdown-menu',
+          vnode.state.agents.map(agent =>
+            m("a.dropdown-item[href='#']", {
+              onclick: (e) => {
+                e.preventDefault()
+                handleSelected(agent.key)
+              }
+            }, m('span.text-truncate',
+                 truncate(agent.name, { length: 32 }))))))
+    ]
+  }
+}
+
+const _agentLink = (agent) =>
+  m(`a[href=/agents/${agent.publicKey}]`,
+    { oncreate: m.route.link },
+    agent.name)
+
+const ReportLocation = {
+  view: (vnode) =>
+    m('form', {
+      onsubmit: (e) => {
+        e.preventDefault()
+        _updateProperty(vnode.attrs.record, {
+          name: 'location',
+          locationValue: {
+            latitude: parseFloat(vnode.state.latitude),
+            longitude: parseFloat(vnode.state.longitude)
+          },
+          dataType: payloads.updateProperties.enum.LOCATION
+        })
+      }
+    },
+    m('.form-row',
+      m('.form-group.col-5',
+        m('label.sr-only', { 'for': 'latitude' }, 'Latitude'),
+        m("input.form-control[type='text']", {
+          name: 'latitude',
+          onchange: m.withAttr('value', (value) => {
+            vnode.state.latitude = value
+          }),
+          value: vnode.state.latitude,
+          placeholder: 'Latitude'
+        })),
+
+      m('.form-group.col-5',
+        m('label.sr-only', { 'for': 'longitude' }, 'Longitude'),
+        m("input.form-control[type='text']", {
+          name: 'longitude',
+          onchange: m.withAttr('value', (value) => {
+            vnode.state.longitude = value
+          }),
+          value: vnode.state.longitude,
+          placeholder: 'Longitude'
+        })),
+
+      m('.col-2',
+        m('button.btn.btn-primary', 'Update'))))
+}
+
+const ReportValue = {
+  view: (vnode) => {
+    let xform = vnode.attrs.xform || ((x) => x)
+    return [
+      m('form', {
+        onsubmit: (e) => {
+          e.preventDefault()
+          _updateProperty(vnode.attrs.record, {
+            name: vnode.attrs.name,
+            [vnode.attrs.typeField]: xform(vnode.state.value),
+            dataType: vnode.attrs.type
+          })
+        }
+      },
+        m('.form-row',
+          m('.form-group.col-10',
+            m('label.sr-only', { 'for': vnode.attrs.name }, vnode.attrs.label),
+            m("input.form-control[type='text']", {
+              name: vnode.attrs.name,
+              onchange: m.withAttr('value', (value) => {
+                vnode.state.value = value
+              }),
+              value: vnode.state.value,
+              placeholder: vnode.attrs.label
+            })),
+         m('.col-2',
+           m('button.btn.btn-primary', 'Update'))))
+    ]
+  }
+}
+
+const FishDetail = {
+  oninit (vnode) {
+    api.get(`records/${vnode.attrs.recordId}`)
+    .then(record =>
+      Promise.all([
+        record,
+        api.get(`agents/${record.owner}`),
+        api.get(`agents/${record.custodian}`)]))
+    .then(([record, owner, custodian]) => {
+      vnode.state.record = record
+      vnode.state.owner = owner
+      vnode.state.custodian = custodian
+    })
+  },
+
+  view (vnode) {
+    if (!vnode.state.record) {
+      return m('.alert-warning', `Loading ${vnode.attrs.recordId}`)
+    }
+
+    let publicKey = api.getPublicKey()
+    let owner = vnode.state.owner
+    let custodian = vnode.state.custodian
+    let record = vnode.state.record
+    return [
+      m('.fish-detail',
+        m('h1.text-center', record.recordId),
+        m('.row',
+          m('.col',
+            _labelProperty('Created',
+                           _formatTimestamp(getOldestPropertyUpdateTime(record)))),
+          m('.col',
+            _labelProperty('Updated',
+                           _formatTimestamp(getLatestPropertyUpdateTime(record))))),
+
+        m('.row',
+          m('.col',
+            _labelProperty(
+              'Owner', _agentLink(owner))),
+          (owner.publicKey === publicKey
+           ? m('.col',
+               m(TransferDropdown, {
+                 handleSelected: _doTransfer(record, payloads.createProposal.enum.OWNER)
+               }, 'Transfer Ownership'))
+           : '')),
+        m('.row',
+          m('.col',
+            _labelProperty('Custodian', _agentLink(custodian))),
+          (custodian.publicKey === publicKey
+           ? m('.col',
+               m(TransferDropdown, {
+                 handleSelected: _doTransfer(record, payloads.createProposal.enum.CUSTODIAN)
+               }, 'Transfer Custodianship'))
+           : '')),
+        m('.row',
+          m('.col',
+            _labelProperty('Species', getPropertyValue(record, 'species')))),
+
+        m('.row',
+          m('.col',
+            _labelProperty('Length (cm)', getPropertyValue(record, 'length'))),
+          m('.col',
+            _labelProperty('Weight (kg)', getPropertyValue(record, 'weight')))),
+
+        m('.row',
+          m('.col',
+            _labelProperty('Location', _formatLocation(getPropertyValue(record, 'location')))),
+          (isReporter(record, 'location', publicKey)
+           ? m('.col', m(ReportLocation, { record }))
+          : '')),
+
+        m('.row',
+          m('.col',
+            _labelProperty('Temperature (C°)', getPropertyValue(record, 'temperature', 'Unknown'))),
+          (isReporter(record, 'temperature', publicKey)
+           ? m('.col', m(ReportValue,
+             {
+               name: 'temperature',
+               label: 'Temperature (C°)',
+               record,
+               typeField: 'intValue',
+               type: payloads.updateProperties.enum.INT,
+               xform: (x) => parseInt(x)
+             }))
+          : '')),
+
+        m('.row',
+          m('.col',
+            _labelProperty('Tilt', getPropertyValue(record, 'tilt', 'Unknown'))),
+          (isReporter(record, 'tilt', publicKey)
+           ? m('.col', m(ReportValue, {
+             name: 'tilt',
+             label: 'Tilt',
+             record,
+             typeField: 'stringValue',
+             type: payloads.updateProperties.enum.STRING
+           }))
+           : '')),
+
+        m('.row',
+          m('.col',
+            _labelProperty('Shock', getPropertyValue(record, 'shock', 'Unknown'))),
+          (isReporter(record, 'shock', publicKey)
+           ? m('.col', m(ReportValue, {
+             name: 'shock',
+             label: 'Shock',
+             record,
+             typeField: 'stringValue',
+             type: payloads.updateProperties.enum.STRING
+           }))
+           : '')))
+    ]
+  }
+}
+
+const _formatLocation = (location) => {
+  if (location && location.latitude && location.longitude) {
+    return `${location.latitude.toFixed(6)}, ${location.longitude.toFixed(6)}`
+  } else {
+    return 'Unknown'
+  }
+}
+
+const _formatTimestamp = (sec) => {
+  if (!sec) {
+    sec = Date.now() / 1000
+  }
+  return moment.unix(sec).format('YYYY-MM-DD')
+}
+
+const _doTransfer = (record, role) => (publicKey) => {
+  let transferPayload = payloads.createProposal({
+    recordId: record.recordId,
+    receivingAgent: publicKey,
+    role: role
+  })
+
+  transactions.submit([transferPayload]).then(() => {
+    console.log('Successfully submitted proposal')
+  })
+}
+
+const _updateProperty = (record, value) => {
+  let updatePayload = payloads.updateProperties({
+    recordId: record.recordId,
+    properties: [value]
+  })
+
+  transactions.submit([updatePayload]).then(() => {
+    console.log('Successfully submitted property update')
+  })
+}
+
+module.exports = FishDetail

--- a/families/track_and_trade/server/scripts/create_fish_type_batch.js
+++ b/families/track_and_trade/server/scripts/create_fish_type_batch.js
@@ -74,7 +74,7 @@ protos.compile()
       action: protos.TTPayload.Action.CREATE_AGENT,
       timestamp: Math.floor(Date.now() / 1000),
       createAgent: protos.CreateAgentAction.create({
-        name: signer.getPublicKey(privateKey)
+        name: 'FishNet Admin'
       })
     }).finish()
 


### PR DESCRIPTION
Add initial fish detail screen, which allows the user to transfer
ownership/custodianship, and update any property for which the user is
an authorized reporter.

Additionally,

- refactors common record-related items into `utils/records.js`
- fixes some linting issues