### PR TITLE
Add basic property detail page

### DIFF
--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/hyperledger/sawtooth-core#readme",
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
+    "google-maps": "^3.2.1",
     "jquery": "^3.2.1",
     "mithril": "^1.1.3",
     "moment": "^2.18.1",

--- a/families/track_and_trade/client/src/components/data.js
+++ b/families/track_and_trade/client/src/components/data.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const GoogleMapsLoader = require('google-maps')
+
+// Google Maps Dev API key
+GoogleMapsLoader.KEY = 'AIzaSyAF75RJvbpC-NhYERNuWadktXnEkrmGDDI'
+let google = null
+
+const MapWidget = {
+  view (vnode) {
+    return m('#map-container')
+  },
+
+  oncreate (vnode) {
+    GoogleMapsLoader.load(goog => {
+      google = goog
+      const coordinates = vnode.attrs.coordinates.map(coord => ({
+        lat: coord.latitude,
+        lng: coord.longitude
+      }))
+
+      const container = document.getElementById('map-container')
+      vnode.state.map = new google.maps.Map(container, { zoom: 4 })
+      vnode.state.markers = coordinates.map(position => {
+        return new google.maps.Marker({ position, map: vnode.state.map })
+      })
+
+      vnode.state.path = new google.maps.Polyline({
+        map: vnode.state.map,
+        path: coordinates,
+        geodesic: true,
+        strokeColor: '#FF0000'
+      })
+
+      vnode.state.bounds = new google.maps.LatLngBounds()
+      coordinates.forEach(position => vnode.state.bounds.extend(position))
+      vnode.state.map.fitBounds(vnode.state.bounds)
+    })
+  },
+
+  onbeforeupdate (vnode, old) {
+    // Coordinates exist and have changed
+    return vnode.attrs.coordinates &&
+      vnode.attrs.coordinates.length !== old.attrs.coordinates.length
+  },
+
+  onupdate (vnode) {
+    const coordinates = vnode.attrs.coordinates.map(coord => ({
+      lat: coord.latitude,
+      lng: coord.longitude
+    }))
+
+    vnode.state.markers.forEach(marker => marker.setMap(null))
+    vnode.state.markers = coordinates.map(position => {
+      return new google.maps.Marker({ position, map: vnode.state.map })
+    })
+
+    vnode.state.path.setPath(coordinates)
+    coordinates.forEach(position => vnode.state.bounds.extend(position))
+    vnode.state.map.fitBounds(vnode.state.bounds)
+  }
+}
+
+module.exports = {
+  MapWidget
+}

--- a/families/track_and_trade/client/src/main.js
+++ b/families/track_and_trade/client/src/main.js
@@ -32,6 +32,7 @@ const AgentList = require('./views/list_agents')
 const FishList = require('./views/list_fish')
 const Dashboard = require('./views/dashboard')
 const LoginForm = require('./views/login_form')
+const PropertyDetailPage = require('./views/property_detail')
 const SignupForm = require('./views/signup_form')
 
 /**
@@ -124,6 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
     '/login': resolve(LoginForm),
     '/logout': { onmatch: logout },
     '/profile': { onmatch: profile },
+    '/properties/:recordId/:name': resolve(PropertyDetailPage),
     '/signup': resolve(SignupForm)
   })
 })

--- a/families/track_and_trade/client/src/services/parsing.js
+++ b/families/track_and_trade/client/src/services/parsing.js
@@ -18,6 +18,28 @@
 
 const moment = require('moment')
 
+const parseThen = fn => v => fn(JSON.parse(v))
+
+const STRINGIFIERS = {
+  LOCATION: v => `${v.latitude}, ${v.longitude}`,
+  tilt: parseThen(v => `X: ${v.x}, Y: ${v.y}`),
+  shock: parseThen(v => `Accel: ${v.accel}, Duration: ${v.duration}`),
+  '*': v => JSON.stringify(v, null, 1).replace(/[{}"]/g, '')
+}
+
+/**
+ * Parses a property value by its name or type, returning a string for display
+ */
+const stringifyValue = (value, type, name) => {
+  if (STRINGIFIERS[type]) {
+    return STRINGIFIERS[type](value)
+  }
+  if (STRINGIFIERS[name]) {
+    return STRINGIFIERS[name](value)
+  }
+  return STRINGIFIERS['*'](value)
+}
+
 /**
  * Parses seconds into a date/time string
  */
@@ -29,5 +51,6 @@ const formatTimestamp = sec => {
 }
 
 module.exports = {
+  stringifyValue,
   formatTimestamp
 }

--- a/families/track_and_trade/client/src/services/parsing.js
+++ b/families/track_and_trade/client/src/services/parsing.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const moment = require('moment')
+
+/**
+ * Parses seconds into a date/time string
+ */
+const formatTimestamp = sec => {
+  if (!sec) {
+    sec = Date.now() / 1000
+  }
+  return moment.unix(sec).format('MM/DD/YYYY, h:mm:ss a')
+}
+
+module.exports = {
+  formatTimestamp
+}

--- a/families/track_and_trade/client/src/services/transactions.js
+++ b/families/track_and_trade/client/src/services/transactions.js
@@ -123,7 +123,7 @@ const changePassword = password => {
  * Wraps a Protobuf payload in a TransactionList and submits it to the API.
  * Prompts user for their password if their private key is not in memory.
  */
-const submit = payloads => {
+const submit = (payloads, wait = false) => {
   if (!_.isArray(payloads)) payloads = [payloads]
   return Promise.resolve()
     .then(() => {
@@ -138,7 +138,7 @@ const submit = payloads => {
     .then(() => {
       const txns = payloads.map(payload => txnEncoder.create(payload))
       const txnList = txnEncoder.encode(txns)
-      return api.postBinary('transactions', txnList)
+      return api.postBinary(`transactions${wait ? '?wait' : ''}`, txnList)
     })
 }
 

--- a/families/track_and_trade/client/src/views/list_fish.js
+++ b/families/track_and_trade/client/src/views/list_fish.js
@@ -21,6 +21,7 @@ const truncate = require('lodash/truncate')
 const moment = require('moment')
 const {Table, FilterGroup, PagingButtons} = require('../components/tables')
 const api = require('../services/api')
+const { formatTimestamp } = require('../services/parsing')
 
 const PAGE_SIZE = 50
 
@@ -58,8 +59,8 @@ const FishList = {
                   _getProp(rec, 'species'),
                   // This is the "created" time, synthesized from properties
                   // added on the initial create
-                  _formatTimestamp(_getOldestPropUpdateTime(rec)),
-                  _formatTimestamp(_getLatestPropUpdateTime(rec)),
+                  formatTimestamp(_getOldestPropUpdateTime(rec)),
+                  formatTimestamp(_getLatestPropUpdateTime(rec)),
                   _countPropUpdates(rec)
                 ]),
           noRowsText: 'No records found'
@@ -139,13 +140,6 @@ const _countPropUpdates = (record) => {
 
   return Object.values(record.updates.properties).reduce(
     (sum, updates) => sum + updates.length, 0)
-}
-
-const _formatTimestamp = (sec) => {
-  if (!sec) {
-    sec = Date.now() / 1000
-  }
-  return moment.unix(sec).format('MM/DD/YYYY, h:mm:ss a')
 }
 
 module.exports = FishList

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -24,9 +24,22 @@ const payloads = require('../services/payloads')
 const parsing = require('../services/parsing')
 const transactions = require('../services/transactions')
 const layout = require('../components/layout')
-const { Table, PagingButtons } = require('../components/tables.js')
+const { MapWidget } = require('../components/data')
+const { Table, PagingButtons } = require('../components/tables')
 
 const PAGE_SIZE = 50
+
+const typedWidget = state => {
+  const property = _.get(state, 'property', {})
+
+  if (property.dataType === 'LOCATION') {
+    return m(MapWidget, {
+      coordinates: property.updates.map(update => update.value)
+    })
+  }
+
+  return null
+}
 
 const updateSubmitter = state => e => {
   e.preventDefault()
@@ -154,6 +167,7 @@ const PropertyDetailPage = {
 
     return [
       layout.title(`${name} of ${record}`),
+      typedWidget(vnode.state),
       isReporter ? updateForm(vnode.state) : null,
       m('.container',
         layout.row([

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -102,7 +102,9 @@ const PropertyDetailPage = {
           headers: ['Value', 'Reporter', 'Time'],
           rows: page.map(update => {
             return [
-              JSON.stringify(update.value, null, 1).replace(/[{}"]/g, ''),
+              parsing.stringifyValue(update.value,
+                                     vnode.state.property.dataType,
+                                     vnode.state.property.name),
               update.reporter.name,
               parsing.formatTimestamp(update.timestamp)
             ]

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ----------------------------------------------------------------------------
+ */
+'use strict'
+
+const m = require('mithril')
+const _ = require('lodash')
+
+const api = require('../services/api')
+const payloads = require('../services/payloads')
+const parsing = require('../services/parsing')
+const transactions = require('../services/transactions')
+const layout = require('../components/layout')
+const { Table, PagingButtons } = require('../components/tables.js')
+
+const PAGE_SIZE = 50
+
+const updateSubmitter = state => e => {
+  e.preventDefault()
+  const { name, dataType, recordId } = state.property
+  const update = { name }
+  update.dataType = payloads.updateProperties.enum[dataType]
+  update[`${dataType.toLowerCase()}Value`] = state.update
+
+  const payload = payloads.updateProperties({
+    recordId,
+    properties: [update]
+  })
+
+  transactions.submit(payload, true)
+    .then(() => api.get(`records/${recordId}/${name}`))
+    .then(property => {
+      e.target.elements[0].value = null
+      state.update = null
+      state.property = property
+    })
+}
+
+const updateForm = state => {
+  return m('form.my-5', {
+    onsubmit: updateSubmitter(state)
+  }, [
+    m('.container',
+      m('.row.justify-content-center',
+        m('.col-md-8',
+          m('input.form-control', {
+            oninput: m.withAttr('value', value => { state.update = value })
+          })),
+        m('.col-md-2',
+          m('button.btn.btn-primary', { type: 'submit' }, 'Update'))))
+  ])
+}
+
+/**
+ * Displays updates to a property, and form for submitting new updates.
+ */
+const PropertyDetailPage = {
+  oninit (vnode) {
+    vnode.state.currentPage = 0
+
+    api.get(`records/${vnode.attrs.recordId}/${vnode.attrs.name}`)
+      .then(property => { vnode.state.property = property })
+  },
+
+  view (vnode) {
+    const name = _.capitalize(vnode.attrs.name)
+    const record = vnode.attrs.recordId
+
+    const reporters = _.get(vnode.state, 'property.reporters', [])
+    const isReporter = reporters.includes(api.getPublicKey())
+
+    const updates = _.get(vnode.state, 'property.updates', [])
+    const page = updates.slice(vnode.state.currentPage * PAGE_SIZE,
+                               (vnode.state.currentPage + 1) * PAGE_SIZE)
+
+    return [
+      layout.title(`${name} of ${record}`),
+      isReporter ? updateForm(vnode.state) : null,
+      m('.container',
+        layout.row([
+          m('h5.mr-auto', 'Update History'),
+          m(PagingButtons, {
+            setPage: page => { vnode.state.currentPage = page },
+            currentPage: vnode.state.currentPage,
+            maxPage: updates.length / PAGE_SIZE
+          })
+        ]),
+        m(Table, {
+          headers: ['Value', 'Reporter', 'Time'],
+          rows: page.map(update => {
+            return [
+              JSON.stringify(update.value, null, 1).replace(/[{}"]/g, ''),
+              update.reporter.name,
+              parsing.formatTimestamp(update.timestamp)
+            ]
+          }),
+          noRowsText: 'This property has never been updated'
+        }))
+    ]
+  }
+}
+
+module.exports = PropertyDetailPage

--- a/families/track_and_trade/client/styles/main.scss
+++ b/families/track_and_trade/client/styles/main.scss
@@ -1,2 +1,8 @@
+// Styling for Google Maps API
+#map-container {
+  height: 400px;
+  width: 100%;
+}
+
 @import "~bootstrap/scss/bootstrap";
 @import "~octicons/build/octicons.min";

--- a/families/track_and_trade/server/api/index.js
+++ b/families/track_and_trade/server/api/index.js
@@ -92,6 +92,14 @@ const initInternalParams = (req, res, next) => {
   next()
 }
 
+// Middleware for parsing the wait query parameter
+const waitParser = (req, res, next) => {
+  const DEFAULT_WAIT = 60
+  const parsed = req.query.wait === '' ? DEFAULT_WAIT : Number(req.query.wait)
+  req.query.wait = _.isNaN(parsed) ? null : parsed
+  next()
+}
+
 // Check the Authorization header if present.
 // Saves the encoded public key to the request object.
 const authHandler = (req, res, next) => {
@@ -131,6 +139,7 @@ router.use(bodyParser.raw({ type: 'application/octet-stream' }))
 
 router.use(logRequest)
 router.use(initInternalParams)
+router.use(waitParser)
 router.use(authHandler)
 
 router.get('/agents', handle(agents.list))


### PR DESCRIPTION
Adds a property detail page which lists a history of value updates, and if properly authorized displays a form to submit new updates. Currently includes a map for location, but no graph widget.

To test, follow the setup instructions in [PR-889](https://github.com/hyperledger/sawtooth-core/pull/889). Then signup a new user, create a new record, and navigate to the property detail url:
```
http://localhost:3000/fish/#!/properties/{RECORD ID}/{PROPERTY NAME}
```

_Screenshots:_
<img width="876" alt="screen shot 2017-09-26 at 2 26 44 pm" src="https://user-images.githubusercontent.com/8889580/30880176-5591c064-a2c7-11e7-8404-b63c45b0904e.png">

<img width="873" alt="screen shot 2017-09-26 at 10 55 19 pm" src="https://user-images.githubusercontent.com/8889580/30895138-d93b94c6-a30d-11e7-8bc4-53d5dc518300.png">
