### PR TITLE
Add Nonces to Gossip Request Messages

### DIFF
--- a/protos/network.proto
+++ b/protos/network.proto
@@ -74,6 +74,10 @@ message GossipBlockRequest {
     // The identity of the validator that is requesting the block
     bytes node_id = 2;
 
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 3;
+
 }
 
 message GossipBlockResponse {
@@ -99,6 +103,10 @@ message GossipBatchByBatchIdRequest {
     // The identity of the validator that is requesting the batch
     bytes node_id = 2;
 
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 3;
+
 }
 
 message GossipBatchByTransactionIdRequest {
@@ -107,5 +115,9 @@ message GossipBatchByTransactionIdRequest {
 
     // The identity of the validator that is requesting the batches
     bytes node_id = 2;
+
+    // A random string that provides uniqueness for requests with
+    // otherwise identical fields.
+    string nonce = 3;
 
 }

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -16,6 +16,8 @@ import logging
 import copy
 import time
 import random
+import os
+import binascii
 from threading import Thread
 from threading import Lock
 from functools import partial
@@ -211,12 +213,16 @@ class Gossip(object):
 
     def broadcast_block_request(self, block_id):
         # Need to define node identity to be able to route directly back
-        block_request = GossipBlockRequest(block_id=block_id)
+        block_request = GossipBlockRequest(
+            block_id=block_id,
+            nonce=binascii.b2a_hex(os.urandom(16)))
         self.broadcast(block_request,
                        validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
 
     def send_block_request(self, block_id, connection_id):
-        block_request = GossipBlockRequest(block_id=block_id)
+        block_request = GossipBlockRequest(
+            block_id=block_id,
+            nonce=binascii.b2a_hex(os.urandom(16)))
         self.send(validator_pb2.Message.GOSSIP_BLOCK_REQUEST,
                   block_request.SerializeToString(),
                   connection_id)
@@ -232,7 +238,8 @@ class Gossip(object):
     def broadcast_batch_by_transaction_id_request(self, transaction_ids):
         # Need to define node identity to be able to route directly back
         batch_request = GossipBatchByTransactionIdRequest(
-            ids=transaction_ids
+            ids=transaction_ids,
+            nonce=binascii.b2a_hex(os.urandom(16))
         )
         self.broadcast(
             batch_request,
@@ -241,7 +248,8 @@ class Gossip(object):
     def broadcast_batch_by_batch_id_request(self, batch_id):
         # Need to define node identity to be able to route directly back
         batch_request = GossipBatchByBatchIdRequest(
-            id=batch_id
+            id=batch_id,
+            nonce=binascii.b2a_hex(os.urandom(16))
         )
         self.broadcast(
             batch_request,

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -47,7 +47,7 @@ class Completer(object):
     def __init__(self,
                  block_store,
                  gossip,
-                 cache_keep_time=30,
+                 cache_keep_time=300,
                  cache_purge_frequency=30,
                  requested_keep_time=1200):
         """

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -358,7 +358,8 @@ class _SendReceive(object):
 
         yield from self._socket.send_multipart(message_bundle)
         if identity is None:
-            self.shutdown()
+            if self._connection != "ServerThread":
+                self.shutdown()
         else:
             self.remove_connected_identity(identity)
 


### PR DESCRIPTION
If the same message is received again drop the message. It has already been handled. 

Also includes increasing the keep time for caches in the completer and adding a check to make sure the send_last_message does not shutdown the server thread. 