### PR TITLE
Unify unit handling in FishNet

### DIFF
--- a/families/track_and_trade/client/src/views/add_fish_form.js
+++ b/families/track_and_trade/client/src/views/add_fish_form.js
@@ -19,9 +19,8 @@ const m = require('mithril')
 
 const payloads = require('../services/payloads')
 const transactions = require('../services/transactions')
+const parsing = require('../services/parsing')
 const {MultiSelect} = require('../components/forms')
-
-const PRECISION = payloads.FLOAT_PRECISION
 
 /**
  * Possible selection options
@@ -73,7 +72,7 @@ const AddFishForm = {
 
              m('.row',
                m('.col-sm',
-                 _formGroup('Length (cm)', m('input.form-control', {
+                 _formGroup('Length (m)', m('input.form-control', {
                    type: 'number',
                    min: 0,
                    step: 'any',
@@ -184,19 +183,19 @@ const _handleSubmit = (signingKey, state) => {
       },
       {
         name: 'length',
-        intValue: parseFloat(state.lengthInCM) * PRECISION,
+        intValue: parsing.toInt(state.lengthInCM),
         dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'weight',
-        intValue: parseFloat(state.weightInKg) * PRECISION,
+        intValue: parsing.toInt(state.weightInKg),
         dataType: payloads.createRecord.enum.INT
       },
       {
         name: 'location',
         locationValue: {
-          latitude: parseFloat(state.latitude) * PRECISION,
-          longitude: parseFloat(state.longitude) * PRECISION
+          latitude: parsing.toInt(state.latitude),
+          longitude: parsing.toInt(state.longitude)
         },
         dataType: payloads.createRecord.enum.LOCATION
       }

--- a/families/track_and_trade/client/src/views/fish_detail.js
+++ b/families/track_and_trade/client/src/views/fish_detail.js
@@ -22,6 +22,7 @@ const truncate = require('lodash/truncate')
 
 const {MultiSelect} = require('../components/forms')
 const payloads = require('../services/payloads')
+const parsing = require('../services/parsing')
 const transactions = require('../services/transactions')
 const api = require('../services/api')
 const {
@@ -31,7 +32,6 @@ const {
   isReporter
 } = require('../utils/records')
 
-const PRECISION = payloads.FLOAT_PRECISION
 /**
  * Possible selection options
  */
@@ -198,8 +198,8 @@ const ReportLocation = {
           _updateProperty(vnode.attrs.record, {
             name: 'location',
             locationValue: {
-              latitude: parseFloat(vnode.state.latitude) * PRECISION,
-              longitude: parseFloat(vnode.state.longitude) * PRECISION
+              latitude: parsing.toInt(vnode.state.latitude),
+              longitude: parsing.toInt(vnode.state.longitude)
             },
             dataType: payloads.updateProperties.enum.LOCATION
           }).then(() => {
@@ -220,7 +220,6 @@ const ReportLocation = {
             value: vnode.state.latitude,
             placeholder: 'Latitude'
           })),
-
         m('.form-group.col-5',
           m('label.sr-only', { 'for': 'longitude' }, 'Longitude'),
           m("input.form-control[type='text']", {
@@ -373,8 +372,8 @@ const FishDetail = {
         _row(_labelProperty('Species', getPropertyValue(record, 'species'))),
 
         _row(
-          _labelProperty('Length (cm)', getPropertyValue(record, 'length', 0) / PRECISION),
-          _labelProperty('Weight (kg)', getPropertyValue(record, 'weight', 0) / PRECISION)),
+          _labelProperty('Length (m)', parsing.toFloat(getPropertyValue(record, 'length', 0))),
+          _labelProperty('Weight (kg)', parsing.toFloat(getPropertyValue(record, 'weight', 0)))),
 
         _row(
           _labelProperty(
@@ -397,7 +396,7 @@ const FishDetail = {
               record,
               typeField: 'intValue',
               type: payloads.updateProperties.enum.INT,
-              xform: (x) => parseFloat(x) * PRECISION,
+              xform: (x) => parsing.toInt(x),
               onsuccess: () => _loadData(vnode.attrs.recordId, vnode.state)
             })
            : null)),
@@ -458,9 +457,9 @@ const FishDetail = {
 
 const _formatLocation = (location) => {
   if (location && location.latitude !== undefined && location.longitude !== undefined) {
-    let latitude = location.latitude / PRECISION
-    let longitude = location.longitude / PRECISION
-    return `${latitude.toFixed(6)}, ${longitude.toFixed(6)}`
+    let latitude = parsing.toFloat(location.latitude)
+    let longitude = parsing.toFloat(location.longitude)
+    return `${latitude}, ${longitude}`
   } else {
     return 'Unknown'
   }
@@ -468,7 +467,7 @@ const _formatLocation = (location) => {
 
 const _formatTemp = (temp) => {
   if (temp !== undefined || temp !== null) {
-    return `${(temp / PRECISION).toFixed(6)} C°`
+    return `${parsing.toFloat(temp)} °C`
   }
 
   return 'Unknown'

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -29,6 +29,8 @@ const { Table, PagingButtons } = require('../components/tables')
 
 const PAGE_SIZE = 50
 
+const withIntVal = fn => m.withAttr('value', v => fn(parsing.toInt(v)))
+
 const typedWidget = state => {
   const property = _.get(state, 'property', {})
 
@@ -69,6 +71,9 @@ const updateSubmitter = state => e => {
       _.each(e.target.elements, el => { el.value = null })
       state.update = null
       state.tmp = {}
+      property.updates.forEach(update => {
+        update.value = parsing.floatifyValue(update.value)
+      })
       state.property = property
     })
 }
@@ -82,12 +87,12 @@ const typedInput = state => {
       m('.col.md-4.mr-1',
         m('input.form-control', {
           placeholder: 'Enter Latitude...',
-          oninput: m.withAttr('value', value => { state.tmp.latitude = value })
+          oninput: withIntVal(value => { state.tmp.latitude = value })
         })),
       m('.col.md-4',
         m('input.form-control', {
           placeholder: 'Enter Longitude...',
-          oninput: m.withAttr('value', value => { state.tmp.longitude = value })
+          oninput: withIntVal(value => { state.tmp.longitude = value })
         }))
     ]
   }
@@ -97,12 +102,12 @@ const typedInput = state => {
       m('.col.md-4.mr-1',
         m('input.form-control', {
           placeholder: 'Enter X...',
-          oninput: m.withAttr('value', value => { state.tmp.x = value })
+          oninput: withIntVal(value => { state.tmp.x = value })
         })),
       m('.col.md-4',
         m('input.form-control', {
           placeholder: 'Enter Y...',
-          oninput: m.withAttr('value', value => { state.tmp.y = value })
+          oninput: withIntVal(value => { state.tmp.y = value })
         }))
     ]
   }
@@ -112,12 +117,12 @@ const typedInput = state => {
       m('.col.md-4.mr-1',
         m('input.form-control', {
           placeholder: 'Enter Acceleration...',
-          oninput: m.withAttr('value', value => { state.tmp.accel = value })
+          oninput: withIntVal(value => { state.tmp.accel = value })
         })),
       m('.col.md-4',
         m('input.form-control', {
           placeholder: 'Enter Duration...',
-          oninput: m.withAttr('value', value => { state.tmp.duration = value })
+          oninput: withIntVal(value => { state.tmp.duration = value })
         }))
     ]
   }
@@ -126,7 +131,7 @@ const typedInput = state => {
     return m('.col-md-8', [
       m('input.form-control', {
         placeholder: 'Enter Temperature...',
-        oninput: m.withAttr('value', value => { state.update = value })
+        oninput: withIntVal(value => { state.update = value })
       })
     ])
   }
@@ -158,7 +163,12 @@ const PropertyDetailPage = {
     vnode.state.tmp = {}
 
     api.get(`records/${vnode.attrs.recordId}/${vnode.attrs.name}`)
-      .then(property => { vnode.state.property = property })
+      .then(property => {
+        property.updates.forEach(update => {
+          update.value = parsing.floatifyValue(update.value)
+        })
+        vnode.state.property = property
+      })
   },
 
   view (vnode) {

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -122,21 +122,28 @@ const typedInput = state => {
     ]
   }
 
-  return m('.col-md-8', [
-    m('input.form-control', {
-      placeholder: 'Enter new value...',
-      oninput: m.withAttr('value', value => { state.update = value })
-    })
-  ])
+  if (name === 'temperature') {
+    return m('.col-md-8', [
+      m('input.form-control', {
+        placeholder: 'Enter Temperature...',
+        oninput: m.withAttr('value', value => { state.update = value })
+      })
+    ])
+  }
+
+  return null
 }
 
 const updateForm = state => {
+  const inputField = typedInput(state)
+  if (!inputField) return null
+
   return m('form.my-5', {
     onsubmit: updateSubmitter(state)
   }, [
     m('.container',
       m('.row.justify-content-center',
-        typedInput(state),
+        inputField,
         m('.col-md-2',
           m('button.btn.btn-primary', { type: 'submit' }, 'Update'))))
   ])


### PR DESCRIPTION
All units now go through a limited set of parsing functions, ensuring floating point values get converted into integer millionths and back again and are displayed the same way.