### PR TITLE
Add Line Graphs to Property Detail Page

### DIFF
--- a/families/track_and_trade/client/package.json
+++ b/families/track_and_trade/client/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/hyperledger/sawtooth-core#readme",
   "dependencies": {
     "bootstrap": "^4.0.0-beta",
+    "chart.js": "^2.7.0",
     "google-maps": "^3.2.1",
     "jquery": "^3.2.1",
     "mithril": "^1.1.3",

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -24,7 +24,7 @@ const payloads = require('../services/payloads')
 const parsing = require('../services/parsing')
 const transactions = require('../services/transactions')
 const layout = require('../components/layout')
-const { MapWidget } = require('../components/data')
+const { LineGraphWidget, MapWidget } = require('../components/data')
 const { Table, PagingButtons } = require('../components/tables')
 
 const PAGE_SIZE = 50
@@ -38,6 +38,10 @@ const typedWidget = state => {
     return m(MapWidget, {
       coordinates: property.updates.map(update => update.value)
     })
+  }
+
+  if (property.dataType === 'INT' || property.dataType === 'FLOAT') {
+    return m(LineGraphWidget, { updates: property.updates })
   }
 
   return null

--- a/families/track_and_trade/client/src/views/property_detail.js
+++ b/families/track_and_trade/client/src/views/property_detail.js
@@ -44,6 +44,26 @@ const typedWidget = state => {
     return m(LineGraphWidget, { updates: property.updates })
   }
 
+  if (property.name === 'tilt') {
+    return m(LineGraphWidget, {
+      updates: property.updates.map(update => {
+        const amplitude = Math.sqrt(update.value.x ** 2 + update.value.y ** 2)
+        return _.assign({}, update, {value: amplitude.toFixed(3)})
+      })
+    })
+  }
+
+  if (property.name === 'shock') {
+    return m(LineGraphWidget, {
+      updates: property.updates.map(update => {
+        const degree = update.value.duration === 0
+          ? 0
+          : update.value.accel / update.value.duration
+        return _.assign({}, update, {value: degree.toFixed(3)})
+      })
+    })
+  }
+
   return null
 }
 


### PR DESCRIPTION
Line graphs will appear for any int/float type data. For tilt and shock, a line graph is used with a calculated "amplitude" value. Tilt's x/y values are converted into a quantity of movement with pythagorean's theorem, and Shock's accel/duration are converted to a degree of shock with simple division (shorter duration means greater shock).

_Screenshot_:
<img width="628" alt="screen shot 2017-09-28 at 2 09 43 pm" src="https://user-images.githubusercontent.com/8889580/30985716-c05556be-a456-11e7-8712-0b35bfe6c032.png">
