### PR TITLE
Add T&T run script

### DIFF
--- a/docker/compose/sawtooth-track-and-trade.yaml
+++ b/docker/compose/sawtooth-track-and-trade.yaml
@@ -1,0 +1,86 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  tnt-server:
+    image: track-and-trade-server:latest
+    volumes:
+      - ../..:/project/sawtooth-core
+    expose:
+      - 8080
+      - 3000
+    ports:
+      - "3000:3000"
+    command: "bash -c \" \
+        set -x && \
+        cd /project/sawtooth-core/families/track_and_trade/server && \
+        npm link bcrypt body-parser express js-schema jsonwebtoken lodash protobufjs sawtooth-sdk rethinkdb && \
+        npm run make-fish && \
+        curl --request POST --header 'Content-Type: application/octet-stream' --data-binary @fish.batch 'http://rest-api:8008/batches' && \
+        DB_HOST=rethinkdb node ./scripts/bootstrap_database.js && \
+        VALIDATOR_URL=tcp://validator:4004 DB_HOST=rethinkdb PRIVATE_KEY='1111111111111111111111111111111111111111111111111111111111111111' node index.js
+    \""
+
+  track-and-trade-tp:
+    image: sawtooth-track-and-trade-tp:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: track-and-trade-tp -vv tcp://validator:4004
+
+  rethinkdb:
+    image: rethinkdb
+    expose:
+      - 8080
+      - 28015
+    ports:
+      - "18080:8080"
+      - "28015:28015"
+
+  rest-api:
+    image: sawtooth-rest-api:latest
+    volumes:
+      - ../..:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    ports:
+      - "8008:8008"
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:latest
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        sawtooth admin keygen --force && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth admin genesis config-genesis.batch && \
+        sawtooth admin genesis && \
+        sawtooth-validator -v \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+    \""

--- a/families/track_and_trade/run-tnt.sh
+++ b/families/track_and_trade/run-tnt.sh
@@ -1,0 +1,24 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+set -x
+
+docker-compose -f ../../docker/compose/sawtooth-track-and-trade.yaml up &
+
+cd client
+
+npm install
+
+npm run build


### PR DESCRIPTION
The script itself is very simple: it runs docker-compose and then builds the client. 

It runs out of `/families/track_and_trade`; should it be in `/bin` instead?