### PR TITLE
Hash client password before sending to server

### DIFF
--- a/families/track_and_trade/client/src/services/api.js
+++ b/families/track_and_trade/client/src/services/api.js
@@ -18,9 +18,19 @@
 
 const m = require('mithril')
 const _ = require('lodash')
+const sjcl = require('sjcl')
 
 const STORAGE_KEY = 'tnt.authorization'
 let authToken = null
+
+/**
+ * Generates a base-64 encoded SHA-256 hash of a plain text password
+ * for submission to authorization routes
+ */
+const hashPassword = password => {
+  const bits = sjcl.hash.sha256.hash(password)
+  return sjcl.codec.base64.fromBits(bits)
+}
 
 /**
  * Getters and setters to handle the auth token both in memory and storage
@@ -96,6 +106,7 @@ const postBinary = (endpoint, data) => {
 }
 
 module.exports = {
+  hashPassword,
   getAuth,
   setAuth,
   clearAuth,

--- a/families/track_and_trade/client/src/views/login_form.js
+++ b/families/track_and_trade/client/src/views/login_form.js
@@ -33,7 +33,11 @@ const LoginForm = {
       m('form', {
         onsubmit: (e) => {
           e.preventDefault()
-          api.post('authorization', vnode.state)
+          const credentials = {
+            username: vnode.state.username,
+            password: api.hashPassword(vnode.state.password)
+          }
+          api.post('authorization', credentials)
             .then(res => {
               api.setAuth(res.authorization)
               transactions.setPrivateKey(vnode.state.password,

--- a/families/track_and_trade/client/src/views/signup_form.js
+++ b/families/track_and_trade/client/src/views/signup_form.js
@@ -65,7 +65,8 @@ const userSubmitter = state => e => {
   e.preventDefault()
 
   const keys = transactions.makePrivateKey(state.password)
-  const user = _.assign(keys, _.pick(state, 'username', 'password', 'email'))
+  const user = _.assign(keys, _.pick(state, 'username', 'email'))
+  user.password = api.hashPassword(state.password)
   const agent = payloads.createAgent(_.pick(state, 'name'))
 
   transactions.submit(agent, true)


### PR DESCRIPTION
With this change, the server will never see a plain text persion
of FishNet's password. Even a completely compromised server would
be unable to decrypt a FishNet user's private key.