### PR TITLE
Add missing imports

### DIFF
--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -14,9 +14,11 @@
 # ------------------------------------------------------------------------------
 
 import argparse
+import getpass
 import logging
 import random
 import threading
+from  base64 import b64encode
 from collections import namedtuple
 from datetime import datetime
 from http.client import RemoteDisconnected


### PR DESCRIPTION
#881 with the obligatory signoff

Added missing imports:
* import getpass
* from base64 import b64encode

Signed-off-by: Chris Clauss <cclauss@bluewin.ch>