### PR TITLE
Pin gomock v1.0.0

### DIFF
--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -45,9 +45,9 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
 
 ENV GOPATH=/go:/project/sawtooth-core/sdk/go:/project/sawtooth-core/sdk/examples/intkey_go:/project/sawtooth-core/sdk/examples/noop_go:/project/sawtooth-core/families/seth:/project/sawtooth-core/sdk/examples/xo_go
 
-RUN mkdir /go \
- && go get -u \
-    github.com/golang/protobuf/proto \
+RUN mkdir /go
+
+RUN go get -u github.com/golang/protobuf/proto \
     github.com/golang/protobuf/protoc-gen-go \
     github.com/pebbe/zmq4 \
     github.com/brianolson/cbor_go \
@@ -58,9 +58,22 @@ RUN mkdir /go \
     golang.org/x/crypto/ripemd160 \
     github.com/jessevdk/go-flags \
     github.com/pelletier/go-toml \
-    github.com/golang/mock/gomock \
-    github.com/golang/mock/mockgen \
-    golang.org/x/crypto/ssh/terminal
+    golang.org/x/crypto/ssh/terminal \
+ && cd /go/src/github.com/golang \
+ && git clone https://github.com/golang/mock \
+ && cd mock \
+ && git checkout v1.0.0 \
+ && cd /go/src/github.com/golang/mock/mockgen \
+ && go build -o /go/bin/mockgen
+
+# A PR was merged into the github.com/golang/mock repository on 10/10/17 that
+# broke it due to an import issue. Since the "go get" command does not support
+# checking out specific commits/tags/branches, the above hack was used instead
+# to retrieve the dependency and checkout a stable version. The following was
+# created to track the issue: https://github.com/golang/mock/issues/116. Once
+# the issue is resolved, we can revert to using "go get" again with the paths:
+# - github.com/golang/mock/gomock
+# - github.com/golang/mock/mockgen
 
 EXPOSE 4004/tcp
 


### PR DESCRIPTION
A pull request was merged into the gomock repo that breaks it. This package is
not a runtime dependency, it is only used for tests, so just pin it to a
working, stable version. This can be reverted once the problem is addressed by
the gomock repository.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>