### PR TITLE
Remove unused method _generate_id()

### DIFF
--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -91,11 +91,6 @@ class TestCompleter(unittest.TestCase):
 
         return txn_list
 
-    def _generate_id(self):
-        return hashlib.sha512(''.join(
-            [random.choice(string.ascii_letters)
-                for _ in range(0, 1024)]).encode()).hexdigest()
-
     def _create_batches(self, batch_count, txn_count,
                         missing_dep=False):
 


### PR DESCRIPTION
Implement  #882 in a way that satisfies the DCO bot.

Signed-off-by: Chris Clauss <cclauss@bluewin.ch>