### PR TITLE
Add a dynamic version selector to 0-8 docs

### DIFF
--- a/docs/source/_static/version_switcher.js
+++ b/docs/source/_static/version_switcher.js
@@ -1,0 +1,27 @@
+var VERSION_URL = 'https://sawtooth.hyperledger.org/docs/versions.json';
+var versionRequest = new XMLHttpRequest();
+var versionSwitcher = document.getElementById('version_switcher');
+
+versionSwitcher.onchange = function() {
+  if (this.value) {
+    window.location.assign(this.value);
+  }
+};
+
+versionRequest.onreadystatechange = function() {
+  if (!versionSwitcher.length && versionRequest.responseText) {
+    var versions = JSON.parse(versionRequest.responseText);
+    versions.forEach(function(versionTuple) {
+      var option = document.createElement('option');
+      option.innerText = versionTuple[0];
+      option.value = versionTuple[1];
+      versionSwitcher.appendChild(option);
+      if (window.location.href === option.value) {
+        option.selected = true;
+      }
+    });
+  }
+};
+
+versionRequest.open('GET', VERSION_URL, true);
+versionRequest.send(null);

--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -4,19 +4,7 @@
 
   <h1>Hyperledger Sawtooth documentation</h1>
 
-  <p>
-  <select name="version_switch" id="version_switch">
-  <option value="http://intelledger.github.io/0.7/">Version 0.7</option>
-  <option value="http://intelledger.github.io/0.8/">Version 0.8(master)</option>
-  <option selected value="http://intelledger.github.io/">Version 0.8(latest release)</option>
-  </select>
-  <script type="text/javascript">
-   var urlmenu = document.getElementById( 'version_switch' );
-   urlmenu.onchange = function() {
-        window.location.replace( this.options[ this.selectedIndex ].value );
-   };
-  </script>
-  </p>
+  <p><select id="version_switcher"></select></p>
 
   <p class="biglink"><a class="biglink" href="{{ pathto("introduction") }}">{% trans %}Introduction{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Hyperledger Sawtooth{% endtrans %}</span></p>
@@ -51,5 +39,6 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Table of Contents{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}detailed list of documentation sections{% endtrans %}</span></p>
 
+<script src="_static/version_switcher.js">
 
 {% endblock %}


### PR DESCRIPTION
Note that as coded, this solution will only work at URLs starting
with https://sawtooth.hyperledger.orgs/docs/

Signed-off-by: Zac Delventhal <zac@bitwise.io>