### PR TITLE
basestring was removed from Python 3

### DIFF
--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -279,11 +279,8 @@ class BlockTreeManager(object):
     def _get_block_id(self, block):
         if block is None:
             return None
-        elif isinstance(block, Block) or\
-                isinstance(block, BlockWrapper):
+        elif isinstance(block, (Block, BlockWrapper)):
             return block.header_signature
-        elif isinstance(block, basestring):
-            return block
         else:
             return str(block)
 


### PR DESCRIPTION
This reformulation makes the test against basestring unnecessary (and avoids backslash line termination).

Signed-off-by: cclauss <cclauss@bluewin.ch>