### PR TITLE
Standardize use of public key and private key

### DIFF
--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -78,8 +78,8 @@ def do_keygen(args):
             raise CliException(
                 'files exist, rerun with --force to overwrite existing files')
 
-    privkey = signing.generate_privkey()
-    public_key = signing.generate_public_key(privkey)
+    private_key = signing.generate_private_key()
+    public_key = signing.generate_public_key(private_key)
 
     try:
         priv_exists = os.path.exists(priv_filename)
@@ -89,7 +89,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(priv_filename))
                 else:
                     print('writing file: {}'.format(priv_filename))
-            priv_fd.write(privkey)
+            priv_fd.write(private_key)
             priv_fd.write('\n')
 
         pub_exists = os.path.exists(pub_filename)

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -79,7 +79,7 @@ def do_keygen(args):
                 'files exist, rerun with --force to overwrite existing files')
 
     privkey = signing.generate_privkey()
-    pubkey = signing.generate_pubkey(privkey)
+    public_key = signing.generate_public_key(privkey)
 
     try:
         priv_exists = os.path.exists(priv_filename)
@@ -99,7 +99,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(pub_filename))
                 else:
                     print('writing file: {}'.format(pub_filename))
-            pub_fd.write(pubkey)
+            pub_fd.write(public_key)
             pub_fd.write('\n')
 
     except IOError as ioe:

--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -156,7 +156,7 @@ def do_batch_list(args):
         return (
             batch['header_signature'],
             len(batch.get('transactions', [])),
-            batch['header']['signer_pubkey'])
+            batch['header']['signer_public_key'])
 
     if args.format == 'default':
         fmt.print_terminal_table(headers, batches, parse_batch_row)

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -80,7 +80,7 @@ def do_block(args):
                 block['header_signature'],
                 len(batches),
                 len(txns),
-                block['header']['signer_pubkey'])
+                block['header']['signer_public_key'])
 
         if args.format == 'default':
             fmt.print_terminal_table(headers, blocks, parse_block_row)

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -80,8 +80,8 @@ def do_keygen(args):
             raise CliException(
                 'files exist, rerun with --force to overwrite existing files')
 
-    privkey = signing.generate_privkey()
-    public_key = signing.generate_public_key(privkey)
+    private_key = signing.generate_private_key()
+    public_key = signing.generate_public_key(private_key)
 
     try:
         priv_exists = os.path.exists(priv_filename)
@@ -91,7 +91,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(priv_filename))
                 else:
                     print('writing file: {}'.format(priv_filename))
-            priv_fd.write(privkey)
+            priv_fd.write(private_key)
             priv_fd.write('\n')
 
         pub_exists = os.path.exists(pub_filename)

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -81,7 +81,7 @@ def do_keygen(args):
                 'files exist, rerun with --force to overwrite existing files')
 
     privkey = signing.generate_privkey()
-    pubkey = signing.generate_pubkey(privkey)
+    public_key = signing.generate_public_key(privkey)
 
     try:
         priv_exists = os.path.exists(priv_filename)
@@ -101,7 +101,7 @@ def do_keygen(args):
                     print('overwriting file: {}'.format(pub_filename))
                 else:
                     print('writing file: {}'.format(pub_filename))
-            pub_fd.write(pubkey)
+            pub_fd.write(public_key)
             pub_fd.write('\n')
 
     except IOError as ioe:

--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -70,9 +70,9 @@ class TestKeygen(unittest.TestCase):
         args = self._parse_keygen_command(self._key_name)
         keygen.do_keygen(args)
 
-        pubkey, signing_key = _read_signing_keys(self._priv_filename)
+        public_key, signing_key = _read_signing_keys(self._priv_filename)
 
-        self.assertIsNotNone(pubkey)
+        self.assertIsNotNone(public_key)
         self.assertIsNotNone(signing_key)
 
     def test_force_write(self):
@@ -85,9 +85,9 @@ class TestKeygen(unittest.TestCase):
         args = self._parse_keygen_command('--force', self._key_name)
         keygen.do_keygen(args)
 
-        pubkey, signing_key = _read_signing_keys(self._priv_filename)
+        public_key, signing_key = _read_signing_keys(self._priv_filename)
 
-        self.assertIsNotNone(pubkey)
+        self.assertIsNotNone(public_key)
         self.assertIsNotNone(signing_key)
 
     def remove_key_files(self):
@@ -118,8 +118,8 @@ def _read_signing_keys(key_filename):
     try:
         with open(filename, 'r') as key_file:
             signing_key = key_file.read().strip()
-            pubkey = signing.generate_pubkey(signing_key)
+            public_key = signing.generate_public_key(signing_key)
 
-            return pubkey, signing_key
+            return public_key, signing_key
     except IOError as e:
         raise CliException('Unable to read key file: {}'.format(str(e)))

--- a/cli/tests/test_genesis.py
+++ b/cli/tests/test_genesis.py
@@ -171,7 +171,7 @@ class TestGenesisDependencyValidation(unittest.TestCase):
 
     def make_batch(self, batch_sig, *txns):
         txn_ids = [txn.header_signature for txn in txns]
-        batch_header = BatchHeader(signer_pubkey='test_pubkey',
+        batch_header = BatchHeader(signer_public_key='test_public_key',
                                    transaction_ids=txn_ids).SerializeToString()
 
         batch = Batch(
@@ -191,14 +191,14 @@ class TestGenesisDependencyValidation(unittest.TestCase):
 
 def transaction(txn_sig, dependencies):
     header = TransactionHeader(
-        signer_pubkey='test_pubkey',
+        signer_public_key='test_public_key',
         family_name='test_family',
         family_version='1.0',
         inputs=[],
         outputs=[],
         dependencies=dependencies,
         payload_sha512='some_sha512',
-        batcher_pubkey='test_pubkey'
+        batcher_public_key='test_public_key'
     ).SerializeToString()
 
     return Transaction(

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -59,15 +59,15 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         get_data_dir_fn.return_value = self._temp_dir
         get_key_dir_fn.return_value = self._temp_dir
 
-        pubkey = self._create_key()
+        public_key = self._create_key()
 
         main('poet',
              args=['genesis',
                    '-o', os.path.join(self._temp_dir, 'poet-genesis.batch')])
 
-        self._assert_validator_transaction(pubkey, 'poet-genesis.batch')
+        self._assert_validator_transaction(public_key, 'poet-genesis.batch')
 
-    def _assert_validator_transaction(self, pubkey, target_file):
+    def _assert_validator_transaction(self, public_key, target_file):
         filename = os.path.join(self._temp_dir, target_file)
         batch_list = batch_pb.BatchList()
         with open(filename, 'rb') as batch_file:
@@ -80,13 +80,13 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         batch_header = batch_pb.BatchHeader()
         batch_header.ParseFromString(batch.header)
 
-        self.assertEqual(pubkey, batch_header.signer_pubkey)
+        self.assertEqual(public_key, batch_header.signer_public_key)
 
         txn = batch.transactions[0]
         txn_header = txn_pb.TransactionHeader()
         txn_header.ParseFromString(txn.header)
 
-        self.assertEqual(pubkey, txn_header.signer_pubkey)
+        self.assertEqual(public_key, txn_header.signer_public_key)
         self.assertEqual('sawtooth_validator_registry', txn_header.family_name)
 
         payload = vr_pb.ValidatorRegistryPayload()
@@ -105,4 +105,4 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         with open(priv_file, 'w') as priv_fd:
             priv_fd.write(privkey)
 
-        return signing.generate_pubkey(privkey)
+        return signing.generate_public_key(privkey)

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -100,9 +100,9 @@ class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
         self.assertTrue(poet_public_key in self._store)
 
     def _create_key(self, key_name='validator.priv'):
-        privkey = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         priv_file = os.path.join(self._temp_dir, key_name)
         with open(priv_file, 'w') as priv_fd:
-            priv_fd.write(privkey)
+            priv_fd.write(private_key)
 
-        return signing.generate_public_key(privkey)
+        return signing.generate_public_key(private_key)

--- a/consensus/poet/common/tests/test_validator_registry_view/tests.py
+++ b/consensus/poet/common/tests/test_validator_registry_view/tests.py
@@ -34,7 +34,7 @@ class TestValidatorRegistryView(unittest.TestCase):
             to_address('my_id'): ValidatorInfo(
                 name='my_validator',
                 id='my_id',
-                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                signup_info=SignUpInfo(poet_public_key='my_public_key',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
                 transaction_id="signature"
@@ -46,7 +46,7 @@ class TestValidatorRegistryView(unittest.TestCase):
         self.assertEqual('my_id', info.id)
         self.assertEqual('my_validator', info.name)
         self.assertEqual("signature", info.transaction_id)
-        self.assertEqual('my_pubkey', info.signup_info.poet_public_key)
+        self.assertEqual('my_public_key', info.signup_info.poet_public_key)
         self.assertEqual('beleive me', info.signup_info.proof_data)
         self.assertEqual('no sybil', info.signup_info.anti_sybil_id)
 
@@ -69,7 +69,7 @@ class TestValidatorRegistryView(unittest.TestCase):
             to_address('my_id'): ValidatorInfo(
                 name='my_validator',
                 id='my_id',
-                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                signup_info=SignUpInfo(poet_public_key='my_public_key',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
                 transaction_id="signature"
@@ -99,7 +99,7 @@ class TestValidatorRegistryView(unittest.TestCase):
             to_address('my_id'): ValidatorInfo(
                 name='my_validator',
                 id='my_id',
-                signup_info=SignUpInfo(poet_public_key='my_pubkey',
+                signup_info=SignUpInfo(poet_public_key='my_public_key',
                                        proof_data='beleive me',
                                        anti_sybil_id='no sybil'),
                 transaction_id="signature"
@@ -107,7 +107,7 @@ class TestValidatorRegistryView(unittest.TestCase):
             to_address('another_id'): ValidatorInfo(
                 name='your_validator',
                 id='another_id',
-                signup_info=SignUpInfo(poet_public_key='your_pubkey',
+                signup_info=SignUpInfo(poet_public_key='your_public_key',
                                        proof_data='you betcha',
                                        anti_sybil_id='poor sybil'),
                 transaction_id="signature"

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -181,7 +181,7 @@ class ConsensusState(object):
                     ValidatorRegistryView(state_view=state_view)
                 validator_info = \
                     validator_registry_view.get_validator_info(
-                        validator_id=block.header.signer_pubkey)
+                        validator_id=block.header.signer_public_key)
 
                 LOGGER.debug(
                     'We need to build consensus state for block: %s...%s',
@@ -380,7 +380,7 @@ class ConsensusState(object):
                         ConsensusState._EstimateInfo(
                             population_estimate=population_estimate,
                             previous_block_id=block.previous_block_id,
-                            validator_id=block.header.signer_pubkey)
+                            validator_id=block.header.signer_public_key)
                     ConsensusState._population_estimate_cache[block_id] = \
                         population_cache_entry
 

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -124,7 +124,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # freshness as we need to account for non-PoET blocks.
         public_key_hash = \
             hashlib.sha256(
-                block_header.signer_pubkey.encode()).hexdigest()
+                block_header.signer_public_key.encode()).hexdigest()
         nonce = SignupInfo.block_id_to_nonce(block_header.previous_block_id)
         signup_info = \
             SignupInfo.create_signup_info(
@@ -136,8 +136,8 @@ class PoetBlockPublisher(BlockPublisherInterface):
         payload = \
             vr_pb.ValidatorRegistryPayload(
                 verb='register',
-                name='validator-{}'.format(block_header.signer_pubkey[:8]),
-                id=block_header.signer_pubkey,
+                name='validator-{}'.format(block_header.signer_public_key[:8]),
+                id=block_header.signer_public_key,
                 signup_info=vr_pb.SignUpInfo(
                     poet_public_key=signup_info.poet_public_key,
                     proof_data=signup_info.proof_data,
@@ -150,7 +150,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
         # registry transaction.  Seems like a potential for refactoring..
         validator_entry_address = \
             PoetBlockPublisher._validator_registry_namespace + \
-            hashlib.sha256(block_header.signer_pubkey.encode()).hexdigest()
+            hashlib.sha256(block_header.signer_public_key.encode()).hexdigest()
 
         # Create a transaction header and transaction for the validator
         # registry update amd then hand it off to the batch publisher to
@@ -169,14 +169,14 @@ class PoetBlockPublisher(BlockPublisherInterface):
 
         header = \
             txn_pb.TransactionHeader(
-                signer_pubkey=block_header.signer_pubkey,
+                signer_public_key=block_header.signer_public_key,
                 family_name='sawtooth_validator_registry',
                 family_version='1.0',
                 inputs=input_addresses,
                 outputs=output_addresses,
                 dependencies=[],
                 payload_sha512=hashlib.sha512(serialized).hexdigest(),
-                batcher_pubkey=block_header.signer_pubkey,
+                batcher_public_key=block_header.signer_public_key,
                 nonce=time.time().hex().encode()).SerializeToString()
         signature = \
             signing.sign(header, self._batch_publisher.identity_signing_key)
@@ -253,7 +253,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
         validator_info = None
 
         try:
-            validator_id = block_header.signer_pubkey
+            validator_id = block_header.signer_public_key
             validator_info = \
                 validator_registry_view.get_validator_info(
                     validator_id=validator_id)
@@ -459,7 +459,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
             WaitTimer.create_wait_timer(
                 poet_enclave_module=poet_enclave_module,
                 sealed_signup_data=sealed_signup_data,
-                validator_address=block_header.signer_pubkey,
+                validator_address=block_header.signer_public_key,
                 previous_certificate_id=previous_certificate_id,
                 consensus_state=consensus_state,
                 poet_settings_view=poet_settings_view)

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -112,14 +112,14 @@ class PoetBlockVerifier(BlockVerifierInterface):
         try:
             validator_info = \
                 validator_registry_view.get_validator_info(
-                    block_wrapper.header.signer_pubkey)
+                    block_wrapper.header.signer_public_key)
         except KeyError:
             LOGGER.error(
                 'Block %s rejected: Received block from an unregistered '
                 'validator %s...%s',
                 block_wrapper.identifier[:8],
-                block_wrapper.header.signer_pubkey[:8],
-                block_wrapper.header.signer_pubkey[-8:])
+                block_wrapper.header.signer_public_key[:8],
+                block_wrapper.header.signer_public_key[-8:])
             return False
 
         LOGGER.debug(

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -258,7 +258,7 @@ class PoetForkResolver(ForkResolverInterface):
                 # fork head
                 validator_info = \
                     validator_registry_view.get_validator_info(
-                        new_fork_head.header.signer_pubkey)
+                        new_fork_head.header.signer_public_key)
 
                 # Get the consensus state for the new fork head's previous
                 # block, let the consensus state update itself appropriately
@@ -293,8 +293,8 @@ class PoetForkResolver(ForkResolverInterface):
                 LOGGER.error(
                     'New fork head claimed by validator not in validator '
                     'registry: %s...%s',
-                    new_fork_head.header.signer_pubkey[:8],
-                    new_fork_head.header.signer_pubkey[-8:])
+                    new_fork_head.header.signer_public_key[:8],
+                    new_fork_head.header.signer_public_key[-8:])
                 chosen_fork_head = cur_fork_head
 
         return chosen_fork_head == new_fork_head

--- a/consensus/poet/core/tests/test_consensus/test_consensus_state.py
+++ b/consensus/poet/core/tests/test_consensus/test_consensus_state.py
@@ -699,14 +699,14 @@ class TestConsensusState(TestCase):
 
         mock_block = mock.Mock()
         mock_block.previous_block_id = 'block_000'
-        mock_block.header.signer_pubkey = 'validator_001_key'
+        mock_block.header.signer_public_key = 'validator_001_key'
 
         mock_block_cache = mock.MagicMock()
         mock_block_cache.__getitem__.return_value = mock_block
 
         validator_info = \
             ValidatorInfo(
-                id=mock_block.header.signer_pubkey,
+                id=mock_block.header.signer_public_key,
                 signup_info=SignUpInfo(
                     poet_public_key='key_002'))
 

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -110,7 +110,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -218,7 +218,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -342,7 +342,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -456,7 +456,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -566,7 +566,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -675,7 +675,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -765,7 +765,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -873,7 +873,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -117,7 +117,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -224,7 +225,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -347,7 +349,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -460,7 +463,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key =  \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -569,7 +573,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -677,7 +682,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -766,7 +772,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -873,7 +880,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
@@ -110,7 +110,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'
@@ -208,7 +209,8 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_block_header with the following fields
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
         mock_block.header.previous_block_id = '2'
         mock_block.header.block_num = 1
         mock_block.header.state_root_hash = '6'

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
@@ -103,7 +103,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
@@ -202,7 +202,7 @@ class TestPoetBlockPublisher(TestCase):
 
         # create mock_batch_publisher
         mock_batch_publisher = mock.Mock(
-            identity_signing_key=signing.generate_privkey())
+            identity_signing_key=signing.generate_private_key())
 
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
@@ -210,7 +210,8 @@ class TestPoetBlockVerifier(TestCase):
         mock_block_cache = mock.MagicMock()
         mock_state_view_factory = mock.Mock()
         mock_block = mock.Mock(identifier='0123456789abcdefedcba9876543210')
-        mock_block.header.signer_pubkey = '90834587139405781349807435098745'
+        mock_block.header.signer_public_key = \
+            '90834587139405781349807435098745'
 
         with mock.patch('sawtooth_poet.poet_consensus.poet_block_verifier.'
                         'LOGGER') as mock_logger:

--- a/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
@@ -85,7 +85,7 @@ class TestPoetForkResolver(TestCase):
         mock_cur_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543210',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -93,7 +93,7 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543211',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -167,7 +167,7 @@ class TestPoetForkResolver(TestCase):
         mock_cur_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543210',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -175,7 +175,7 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543211',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -284,7 +284,7 @@ class TestPoetForkResolver(TestCase):
         mock_cur_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543210',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -292,7 +292,7 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543211',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -445,7 +445,7 @@ class TestPoetForkResolver(TestCase):
         mock_cur_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543210',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='2',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -453,7 +453,7 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_header = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543211',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='3',
                 header_signature='00112233445566778899aabbccddeeff')
 
@@ -575,7 +575,7 @@ class TestPoetForkResolver(TestCase):
         mock_smaller_header_signature = \
             mock.Mock(
                 identifier='0123456789abcdefedcba9876543211',
-                signer_pubkey='90834587139405781349807435098745',
+                signer_public_key='90834587139405781349807435098745',
                 previous_block_id='4',
                 header_signature='00112233445566778899aabbccddee')
 

--- a/consensus/poet/core/tests/test_consensus/utils.py
+++ b/consensus/poet/core/tests/test_consensus/utils.py
@@ -40,7 +40,7 @@ def create_random_private_key():
 
 
 def create_random_public_key():
-    return signing.generate_pubkey(create_random_private_key())
+    return signing.generate_public_key(create_random_private_key())
 
 
 def create_random_public_key_hash():

--- a/consensus/poet/core/tests/test_consensus/utils.py
+++ b/consensus/poet/core/tests/test_consensus/utils.py
@@ -36,7 +36,7 @@ def random_name(length=16):
 
 
 def create_random_private_key():
-    return signing.generate_privkey()
+    return signing.generate_private_key()
 
 
 def create_random_public_key():

--- a/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
+++ b/consensus/poet/families/sawtooth_validator_registry/protos/validator_registry.proto
@@ -22,7 +22,7 @@ message ValidatorInfo {
     // The name of the endpoint. It should be a human readable name.
     string name = 1;
 
-    // The validator's public key (currently using signer_pubkey as this is
+    // The validator's public key (currently using signer_public_key as this is
     // stored in the transaction header)
     string id = 2;
 
@@ -73,7 +73,7 @@ message ValidatorRegistryPayload {
     // The name of the endpoint. It should be a human readable name.
     string name = 2;
 
-    // Validator's public key (currently using signer_pubkey as this is
+    // Validator's public key (currently using signer_public_key as this is
     // stored in the transaction header)
     string id = 3;
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -443,7 +443,7 @@ class ValidatorRegistryTransactionHandler(object):
     def apply(self, transaction, state):
         txn_header = TransactionHeader()
         txn_header.ParseFromString(transaction.header)
-        pubkey = txn_header.signer_pubkey
+        public_key = txn_header.signer_public_key
 
         val_reg_payload = ValidatorRegistryPayload()
         val_reg_payload.ParseFromString(transaction.payload)
@@ -456,12 +456,12 @@ class ValidatorRegistryTransactionHandler(object):
 
         # Check registering validator matches transaction signer.
         validator_id = val_reg_payload.id
-        if validator_id != pubkey:
+        if validator_id != public_key:
             raise InvalidTransaction(
                 'Signature mismatch on validator registration with validator'
-                ' {} signed by {}'.format(validator_id, pubkey))
+                ' {} signed by {}'.format(validator_id, public_key))
 
-        public_key_hash = hashlib.sha256(pubkey.encode()).hexdigest()
+        public_key_hash = hashlib.sha256(public_key.encode()).hexdigest()
         signup_info = val_reg_payload.signup_info
 
         try:

--- a/consensus/poet/families/tests/test_tp_validator_registry.py
+++ b/consensus/poet/families/tests/test_tp_validator_registry.py
@@ -111,7 +111,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
         # Respond with address for val_1
         # val_1 address is derived from the validators id
-        # val id is the same as the pubkey for the factory
+        # val id is the same as the public_key for the factory
         self.validator.respond(
             self.factory.create_set_response_validator_info(),
             received)
@@ -120,7 +120,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
     def test_valid_signup_info(self):
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
         self._test_valid_signup_info(signup_info)
 
         # Re-register the same validator. Expect success.
@@ -128,7 +128,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
     def test_out_of_date_tcb(self):
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000", "OUT_OF_DATE")
+            self.factory.public_key_hash, "000", "OUT_OF_DATE")
         self._test_valid_signup_info(signup_info)
 
     def test_invalid_name(self):
@@ -137,7 +137,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         # The name is longer the 64 characters
         payload = ValidatorRegistryPayload(
@@ -156,12 +156,12 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
     def test_invalid_id(self):
         """
         Test that a transaction with an id that does not match the
-        signer_pubkey returns an invalid transaction.
+        signer_public_key returns an invalid transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
-        # The idea should match the signer_pubkey in the transaction_header
+        # The idea should match the signer_public_key in the transaction_header
         payload = ValidatorRegistryPayload(
             verb="reg",
             name="val_1",
@@ -175,13 +175,13 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
         self._expect_invalid_transaction()
 
-    def test_invalid_poet_pubkey(self):
+    def test_invalid_poet_public_key(self):
         """
         Test that a transaction without a poet_public_key returns an invalid
         transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         signup_info.poet_public_key = "bad"
 
@@ -272,7 +272,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         an invalid transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         # Verification Report is None
         proof_data = signup_info.proof_data
@@ -343,7 +343,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         invalid transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         proof_data = signup_info.proof_data
         proof_data_dict = json.loads(proof_data)
@@ -432,7 +432,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         invalid transaction.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         proof_data = signup_info.proof_data
         proof_data_dict = json.loads(proof_data)
@@ -558,7 +558,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
 
         hash_input = \
             '{0}{1}'.format(
-                self.factory.pubkey_hash,
+                self.factory.public_key_hash,
                 "Not a valid PPK").encode()
         sgx_quote.report_body.report_data.d = \
             hashlib.sha256(hash_input).digest()
@@ -601,7 +601,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         PEM from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
@@ -629,7 +629,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         public key PEM from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
@@ -657,7 +657,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         measurements from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
@@ -694,7 +694,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         enclave measurements from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
@@ -732,7 +732,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         basenames from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,
@@ -778,7 +778,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
         enclave basenames from the config setting.
         """
         signup_info = self.factory.create_signup_info(
-            self.factory.pubkey_hash, "000")
+            self.factory.public_key_hash, "000")
 
         payload = ValidatorRegistryPayload(
             verb="reg", name="val_1", id=self.factory.public_key,

--- a/consensus/poet/families/tests/validator_reg_message_factory.py
+++ b/consensus/poet/families/tests/validator_reg_message_factory.py
@@ -88,7 +88,7 @@ class ValidatorRegistryMessageFactory(object):
             private=private,
             public=public
         )
-        self.pubkey_hash = hashlib.sha256(public.encode()).hexdigest()
+        self.public_key_hash = hashlib.sha256(public.encode()).hexdigest()
         self._report_private_key = \
             serialization.load_pem_private_key(
                 self.__REPORT_PRIVATE_KEY_PEM__.encode(),
@@ -100,7 +100,7 @@ class ValidatorRegistryMessageFactory(object):
         self._poet_private_key = \
             "1f70fa2518077ad18483f48e77882d11983b537fa5f7cf158684d2c670fe4f1f"
         self.poet_public_key = \
-            signing.generate_pubkey(self._poet_private_key)
+            signing.generate_public_key(self._poet_private_key)
 
     @property
     def public_key(self):
@@ -231,7 +231,7 @@ class ValidatorRegistryMessageFactory(object):
     def create_set_request_validator_info(
             self, validator_name, transaction_id, signup_info=None):
         if signup_info is None:
-            signup_info = self.create_signup_info(self.pubkey_hash, "000")
+            signup_info = self.create_signup_info(self.public_key_hash, "000")
         data = ValidatorInfo(
             name=validator_name,
             id=self.public_key,
@@ -268,14 +268,16 @@ class ValidatorRegistryMessageFactory(object):
     def create_get_response_validator_map(self):
         address = self._key_to_address("validator_map")
         validator_map = ValidatorMap()
-        validator_map.entries.add(key=self.pubkey_hash, value=self.public_key)
+        validator_map.entries.add(key=self.public_key_hash,
+                                  value=self.public_key)
         data = validator_map.SerializeToString()
         return self._factory.create_get_response({address: data})
 
     def create_set_request_validator_map(self):
         address = self._key_to_address("validator_map")
         validator_map = ValidatorMap()
-        validator_map.entries.add(key=self.pubkey_hash, value=self.public_key)
+        validator_map.entries.add(key=self.public_key_hash,
+                                  value=self.public_key)
         data = validator_map.SerializeToString()
         return self._factory.create_set_request({address: data})
 

--- a/consensus/poet/sgx/tests/test_sgx/utils.py
+++ b/consensus/poet/sgx/tests/test_sgx/utils.py
@@ -31,7 +31,7 @@ def create_random_private_key():
 
 
 def create_random_public_key():
-    return signing.generate_pubkey(create_random_private_key())
+    return signing.generate_public_key(create_random_private_key())
 
 
 def create_random_public_key_hash():

--- a/consensus/poet/sgx/tests/test_sgx/utils.py
+++ b/consensus/poet/sgx/tests/test_sgx/utils.py
@@ -27,7 +27,7 @@ def random_name(length=16):
 
 
 def create_random_private_key():
-    return signing.generate_privkey()
+    return signing.generate_private_key()
 
 
 def create_random_public_key():

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -57,7 +57,7 @@ class _PoetEnclaveSimulator(object):
 
     # The private key we generate to sign the certificate ID when creating
     # the random wait timeout value
-    _seal_private_key = signing.generate_privkey()
+    _seal_private_key = signing.generate_private_key()
     _seal_public_key = signing.generate_public_key(_seal_private_key)
 
     # The basename and enclave measurement values we will put into and verify
@@ -175,7 +175,7 @@ class _PoetEnclaveSimulator(object):
             # First we need to create a public/private key pair for the PoET
             # enclave to use.
             # Counter ID is a placeholder for a hardware counter in a TEE.
-            poet_private_key = signing.generate_privkey()
+            poet_private_key = signing.generate_private_key()
             poet_public_key = \
                 signing.generate_public_key(poet_private_key)
             counter_id = None

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -58,7 +58,7 @@ class _PoetEnclaveSimulator(object):
     # The private key we generate to sign the certificate ID when creating
     # the random wait timeout value
     _seal_private_key = signing.generate_privkey()
-    _seal_public_key = signing.generate_pubkey(_seal_private_key)
+    _seal_public_key = signing.generate_public_key(_seal_private_key)
 
     # The basename and enclave measurement values we will put into and verify
     # are in the enclave quote in the attestation verification report.
@@ -177,7 +177,7 @@ class _PoetEnclaveSimulator(object):
             # Counter ID is a placeholder for a hardware counter in a TEE.
             poet_private_key = signing.generate_privkey()
             poet_public_key = \
-                signing.generate_pubkey(poet_private_key)
+                signing.generate_public_key(poet_private_key)
             counter_id = None
 
             # Simulate sealing (encrypting) the signup data.

--- a/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_certificate.py
+++ b/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_certificate.py
@@ -26,7 +26,7 @@ from sawtooth_poet_simulator.poet_enclave_simulator.enclave_wait_certificate \
 class TestEnclaveSimulatorWaitCertificate(unittest.TestCase):
     @classmethod
     def _create_random_key(cls):
-        return signing.generate_privkey()
+        return signing.generate_private_key()
 
     def test_create_wait_certificate(self):
         wait_timer = \

--- a/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_timer.py
+++ b/consensus/poet/simulator/tests/test_simulator/test_enclave_wait_timer.py
@@ -26,7 +26,7 @@ class TestEnclaveSimulatorWaitTimer(unittest.TestCase):
 
     @classmethod
     def _create_random_key(cls):
-        return signing.generate_privkey()
+        return signing.generate_private_key()
 
     def test_create_wait_timer(self):
         wait_timer = \

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -207,7 +207,7 @@ an empty string if the action isn't 'take'). So our {% if language == 'JavaScrip
     const _unpackTransaction = (transaction) =>
       new Promise((resolve, reject) => {
         let header = TransactionHeader.decode(transaction.header)
-        let signer = header.signerPubkey
+        let signer = header.signerPublicKey
         try {
           let payload = _decodeData(transaction.payload)
           resolve({gameName: payload[0],
@@ -226,7 +226,7 @@ an empty string if the action isn't 'take'). So our {% if language == 'JavaScrip
 
     private TransactionData getUnpackedTransaction(TpProcessRequest transactionRequest)
         throws InvalidTransactionException {
-      String signer = transactionRequest.getHeader().getSignerPubkey();
+      String signer = transactionRequest.getHeader().getSignerPublicKey();
       ArrayList<String> payload
           = decodeData(transactionRequest.getPayload().toStringUtf8());
 

--- a/docs/source/_templates/sdk_submit_tutorial.rst
+++ b/docs/source/_templates/sdk_submit_tutorial.rst
@@ -74,9 +74,9 @@ A *TransactionEncoder* stores your private key, and (optionally) default
 TransactionHeader values and a function to encode each payload. Once
 instantiated, multiple Transactions can be created using these common elements,
 and without any explicit hashing or signing. You will never need to specify the
-*nonce*, *signer pubkey*, or *payload Sha512* properties of a TransactionHeader,
+*nonce*, *signer public_key*, or *payload Sha512* properties of a TransactionHeader,
 as the SDK will generate these automatically. You will only need to set a
-*batcher pubkey* if a different private key will be used to sign Batches containing
+*batcher public_key* if a different private key will be used to sign Batches containing
 these Transactions (see below).
 
 
@@ -87,9 +87,9 @@ these Transactions (see below).
     const {TransactionEncoder} = require('sawtooth-sdk')
 
     const encoder = new TransactionEncoder(privateKey, {
-        // We don't want a batcher pubkey or dependencies for our example,
+        // We don't want a batcher public_key or dependencies for our example,
         // but this is what setting them might look like:
-        // batcherPubkey: '02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758',
+        // batcherPublicKey: '02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758',
         // dependencies: ['540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a'],
         familyName: 'intkey',
         familyVersion: '1.0',
@@ -106,9 +106,9 @@ these Transactions (see below).
 
     encoder = TransactionEncoder(
         private_key,
-        # We don't want a batcher pubkey or dependencies for our example,
+        # We don't want a batcher public_key or dependencies for our example,
         # but this is what setting them might look like:
-        # batcherPubkey='02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758',
+        # batcherPublicKey='02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758',
         # dependencies=['540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a'],
         payload_encoder=cbor.dumps,
         family_name='intkey',
@@ -121,14 +121,14 @@ these Transactions (see below).
 
 .. note::
 
-   Remember that a *batcher pubkey* is the hex public key matching the private
+   Remember that a *batcher public_key* is the hex public key matching the private
    key that will later be used to sign a Transaction's Batch, and
    *dependencies* are the *header signatures* of Transactions that must be
    committed before this one (see *TransactionHeaders* in
    :doc:`/architecture/transactions_and_batches`).
 
    Although possible, it would be unusual to set these properties when
-   creating a *TransactionEncoder*. The default batcher pubkey will be valid
+   creating a *TransactionEncoder*. The default batcher public_key will be valid
    as long as the Transactions and Batches are signed by the same key, and
    dependencies are typically different from Transaction to Transaction.
 
@@ -335,7 +335,7 @@ can happen in one step.
 .. note::
 
    Note, if the transaction creator is using a different private key than the
-   batcher, the *batcher pubkey* must have been specified for every Transaction,
+   batcher, the *batcher public_key* must have been specified for every Transaction,
    and must have been generated from the private key being used to sign the
    Batch, or validation will fail.
 

--- a/docs/source/_templates/sdk_submit_tutorial.rst
+++ b/docs/source/_templates/sdk_submit_tutorial.rst
@@ -32,9 +32,9 @@ key, and it is fairly simple to generate this using the SDK's *signer* module.
 
 .. code-block::  python
 
-    from sawtooth_signing.secp256k1_signer import generate_privkey
+    from sawtooth_signing.secp256k1_signer import generate_private_key
 
-    private_key = privkey = generate_privkey(privkey_format='bytes')
+    private_key = private_key = generate_private_key(private_key_format='bytes')
 
 
 {% endif %}

--- a/docs/source/_templates/txn_submit_tutorial.rst
+++ b/docs/source/_templates/txn_submit_tutorial.rst
@@ -46,7 +46,7 @@ Transaction.
 
 .. code-block:: python
 
-    public_key_bytes = key_handler.pubkey.serialize()
+    public_key_bytes = key_handler.public_key.serialize()
 
     public_key_hex = public_key_bytes.hex()
 
@@ -111,7 +111,7 @@ the right data into the right keys.
     from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 
     txn_header = TransactionHeader(
-        batcher_pubkey=public_key_hex,
+        batcher_public_key=public_key_hex,
         # If we had any dependencies, this is what it might look like:
         # dependencies=['540a6803971d1880ec73a96cb97815a95d374cbad5d865925e5aa0432fcf1931539afe10310c122c5eaae15df61236079abbf4f258889359c4d175516934484a'],
         family_name='intkey',
@@ -120,7 +120,7 @@ the right data into the right keys.
         nonce=str(randint(0, 1000000000)),
         outputs=['1cf1266e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'],
         payload_sha512=payload_sha512,
-        signer_pubkey=public_key_hex)
+        signer_public_key=public_key_hex)
 
     txn_header_bytes = txn_header.SerializeToString()
 
@@ -231,8 +231,8 @@ must be decoded before being wrapped in a batch. Here we assume you used a
 The process for creating a *BatchHeader* is very similar to a
 TransactionHeader. Compile the *batch.proto* file, and then instantiate the
 appropriate class with the appropriate values. This time, there
-are just two properties: a *signer pubkey*, and a set of *Transaction ids*.
-Just like with a TransactionHeader, the signer pubkey must have been generated
+are just two properties: a *signer public_key*, and a set of *Transaction ids*.
+Just like with a TransactionHeader, the signer public_key must have been generated
 from the private key used to sign the Batch. The Transaction ids are a list of
 the *header signatures* from the Transactions to be batched. They must be in
 the same order as the Transactions themselves.
@@ -242,7 +242,7 @@ the same order as the Transactions themselves.
     from sawtooth_sdk.protobuf.batch_pb2 import BatchHeader
 
     batch_header = BatchHeader(
-        signer_pubkey=public_key_hex,
+        signer_public_key=public_key_hex,
         transaction_ids=[txn.header_signature])
 
     batch_header_bytes = batch_header.SerializeToString()
@@ -267,7 +267,7 @@ steps may be handled automatically by the library you are using.
 
 .. note::
 
-   The *batcher pubkey* specified in every TransactionHeader must have been
+   The *batcher public_key* specified in every TransactionHeader must have been
    generated from the private key being used to sign the Batch, or validation
    will fail.
 

--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -202,13 +202,13 @@ quite long. It should look something like this:
 
   batches:
   - header:
-      signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+      signer_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
       transaction_ids:
       - 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
     header_signature: a93731646a8fd2bce03b3a17bc2cb3192d8597da93ce735950dccbf0e3cf0b005468fadb94732e013be0bc2afb320be159b452cf835b35870db5fa953220fb35
     transactions:
     - header:
-        batcher_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+        batcher_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
         dependencies: []
         family_name: sawtooth_settings
         family_version: '1.0'
@@ -222,7 +222,7 @@ quite long. It should look something like this:
         - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c1c0cbf0fbcaf64c0b
         - 000000a87cb5eafdcca6a8f82af32160bc531176b5001cb05e10bce3b0c44298fc1c14
         payload_sha512: 944b6b55e831a2ba37261d904b14b4e729399e4a7c41bd22fcb09c46f0b3821cd41750e38640e33f79b6b5745a20225a1f5427bd5085f3800c166bbb7fb899e8
-        signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+        signer_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
       header_signature: 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
       payload: EtwBCidzYXd0b290aC52YWxpZGF0b3IudHJhbnNhY3Rpb25fZmFtaWxpZXMSngFbeyJmYW1pbHkiOiAiaW50a2V5IiwgInZlcnNpb24iOiAiMS4wIiwgImVuY29kaW5nIjogImFwcGxpY2F0aW9uL3Byb3RvYnVmIn0sIHsiZmFtaWx5Ijoic2F3dG9vdGhfY29uZmlnIiwgInZlcnNpb24iOiIxLjAiLCAiZW5jb2RpbmciOiJhcHBsaWNhdGlvbi9wcm90b2J1ZiJ9XRoQMTQ5NzQ0ODgzMy4zODI5Mw==
   header:
@@ -231,7 +231,7 @@ quite long. It should look something like this:
     block_num: 3
     consensus: RGV2bW9kZQ==
     previous_block_id: 042f08e1ff49bbf16914a53dc9056fb6e522ca0e2cff872547eac9555c1de2a6200e67fb9daae6dfb90f02bef6a9088e94e5bdece04f622bce67ccecd678d56e
-    signer_pubkey: 033fbed13b51eafaca8d1a27abc0d4daf14aab8c0cbc1bb4735c01ff80d6581c52
+    signer_public_key: 033fbed13b51eafaca8d1a27abc0d4daf14aab8c0cbc1bb4735c01ff80d6581c52
     state_root_hash: 5d5ea37cbbf8fe793b6ea4c1ba6738f5eee8fc4c73cdca797736f5afeb41fbef
   header_signature: ff4f6705bf57e2a1498dc1b649cc9b6a4da2cc8367f1b70c02bc6e7f648a28b53b5f6ad7c2aa639673d873959f5d3fcc11129858ecfcb4d22c79b6845f96c5e3
 

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -246,7 +246,7 @@ should be similar to this example:
           "block_num": 0,
           "consensus": "R2VuZXNpcw==",
           "previous_block_id": "0000000000000000",
-          "signer_pubkey": "03061436bef428626d11c17782f9e9bd8bea55ce767eb7349f633d4bfea4dd4ae9",
+          "signer_public_key": "03061436bef428626d11c17782f9e9bd8bea55ce767eb7349f633d4bfea4dd4ae9",
           "state_root_hash": "708ca7fbb701799bb387f2e50deaca402e8502abe229f705693d2d4f350e1ad6"
         },
         "header_signature": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b"
@@ -364,13 +364,13 @@ quite long. It should look something like this:
 
   batches:
   - header:
-      signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+      signer_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
       transaction_ids:
       - 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
     header_signature: a93731646a8fd2bce03b3a17bc2cb3192d8597da93ce735950dccbf0e3cf0b005468fadb94732e013be0bc2afb320be159b452cf835b35870db5fa953220fb35
     transactions:
     - header:
-        batcher_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+        batcher_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
         dependencies: []
         family_name: sawtooth_settings
         family_version: '1.0'
@@ -384,7 +384,7 @@ quite long. It should look something like this:
         - 000000a87cb5eafdcca6a8b79606fb3afea5bdab274474a6aa82c1c0cbf0fbcaf64c0b
         - 000000a87cb5eafdcca6a8f82af32160bc531176b5001cb05e10bce3b0c44298fc1c14
         payload_sha512: 944b6b55e831a2ba37261d904b14b4e729399e4a7c41bd22fcb09c46f0b3821cd41750e38640e33f79b6b5745a20225a1f5427bd5085f3800c166bbb7fb899e8
-        signer_pubkey: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
+        signer_public_key: 0276023d4f7323103db8d8683a4b7bc1eae1f66fbbf79c20a51185f589e2d304ce
       header_signature: 24b168aaf5ea4a76a6c316924a1c26df0878908682ea5740dd70814e7c400d56354dee788191be8e28393c70398906fb467fac8db6279e90e4e61619589d42bf
       payload: EtwBCidzYXd0b290aC52YWxpZGF0b3IudHJhbnNhY3Rpb25fZmFtaWxpZXMSngFbeyJmYW1pbHkiOiAiaW50a2V5IiwgInZlcnNpb24iOiAiMS4wIiwgImVuY29kaW5nIjogImFwcGxpY2F0aW9uL3Byb3RvYnVmIn0sIHsiZmFtaWx5Ijoic2F3dG9vdGhfY29uZmlnIiwgInZlcnNpb24iOiIxLjAiLCAiZW5jb2RpbmciOiJhcHBsaWNhdGlvbi9wcm90b2J1ZiJ9XRoQMTQ5NzQ0ODgzMy4zODI5Mw==
   header:
@@ -393,7 +393,7 @@ quite long. It should look something like this:
     block_num: 3
     consensus: RGV2bW9kZQ==
     previous_block_id: 042f08e1ff49bbf16914a53dc9056fb6e522ca0e2cff872547eac9555c1de2a6200e67fb9daae6dfb90f02bef6a9088e94e5bdece04f622bce67ccecd678d56e
-    signer_pubkey: 033fbed13b51eafaca8d1a27abc0d4daf14aab8c0cbc1bb4735c01ff80d6581c52
+    signer_public_key: 033fbed13b51eafaca8d1a27abc0d4daf14aab8c0cbc1bb4735c01ff80d6581c52
     state_root_hash: 5d5ea37cbbf8fe793b6ea4c1ba6738f5eee8fc4c73cdca797736f5afeb41fbef
   header_signature: ff4f6705bf57e2a1498dc1b649cc9b6a4da2cc8367f1b70c02bc6e7f648a28b53b5f6ad7c2aa639673d873959f5d3fcc11129858ecfcb4d22c79b6845f96c5e3
 

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -432,7 +432,7 @@ shown):
 
     batches:
   - header:
-      signer_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
+      signer_public_key: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
       transaction_ids:
       - c498c916da09450597053ada1938858a11d94e2ed5c18f92cd7d34b865af646144d180bdc121a48eb753b4abd326baa3ea26ee8a29b07119052320370d24ab84
       - c68de164421bbcfcc9ea60b725bae289aecd02ddde6f520e6e85b3227337e2971e89bbff468bdebe408e0facc343c612a32db98e5ac4da2296a7acf4033073cd
@@ -440,7 +440,7 @@ shown):
     header_signature: 2ff874edfa80a8e6b718e7d10e91970150fcc3fcfd46d38eb18f356e7a733baa40d9e816247985d7ea7ef2492c09cd9c1830267471c6e35dca0d19f5c6d2b61e
     transactions:
     - header:
-        batcher_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
+        batcher_public_key: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
         dependencies:
         - 19ad647bd292c980e00f05eed6078b471ca2d603b842bc4eaecf301d61f15c0d3705a4ec8d915ceb646f35d443da43569f58c906faf3713853fe638c7a0ea410
         family_name: intkey
@@ -451,7 +451,7 @@ shown):
         outputs:
         - 1cf126c15b04cb20206d45c4d0e432d036420401dbd90f064683399fae55b99af1a543f7de79cfafa4f220a22fa248f8346fb1ad0343fcf8d7708565ebb8a3deaac09d
         payload_sha512: 942a09c0254c4a5712ffd152dc6218fc5453451726d935ac1ba67de93147b5e7be605da7ab91245f48029b41f493a1cc8dfc45bb090ac97420580eb1bdded01f
-        signer_pubkey: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
+        signer_public_key: 0380be3421629849b1d03af520d7fa2cdc24c2d2611771ddf946ef3aaae216be84
       header_signature: c498c916da09450597053ada1938858a11d94e2ed5c18f92cd7d34b865af646144d180bdc121a48eb753b4abd326baa3ea26ee8a29b07119052320370d24ab84
       payload: o2ROYW1lZnFrbGR1emVWYWx1ZQFkVmVyYmNpbmM=
 

--- a/docs/source/architecture/rest_api.rst
+++ b/docs/source/architecture/rest_api.rst
@@ -200,7 +200,7 @@ specific to a single endpoint are not listed here.
        case of nested header keys; appending `.length` sorts by the length of
        the property; a minus-sign specifies descending order; multiple keys can
        be used if comma-separated. For example:
-       `?sort=header.signer_pubkey,-transaction_ids.length`
+       `?sort=header.signer_public_key,-transaction_ids.length`
    * - **wait**
      - For submission endpoints, instructs the REST API to wait until batches
        have been committed to the blockchain before responding to the client.

--- a/docs/source/architecture/transactions_and_batches.rst
+++ b/docs/source/architecture/transactions_and_batches.rst
@@ -38,10 +38,10 @@ transaction) and the resulting signature is stored in header_signature.  The
 header is present in the serialized form so that the exact bytes can be
 verified against the signature upon receipt of the Transaction.
 
-The verification process verifies that the key in signer_pubkey signed the
+The verification process verifies that the key in signer_public_key signed the
 header bytes resulting in header_signature.
 
-The batcher_pubkey field must match the public key used to sign the batch in
+The batcher_public_key field must match the public key used to sign the batch in
 which this transaction is contained.
 
 
@@ -135,7 +135,7 @@ header_signature.  The header is present in the serialized form so that the
 exact bytes can be verified against the signature upon receipt of the Batch.
 
 The process of header_signature verification recovers the public key used
-during signing.  This public key must match the one stored in signer_pubkey or
+during signing.  This public key must match the one stored in signer_public_key or
 the transaction will be considered invalid.
 
 Transactions
@@ -183,7 +183,7 @@ multiple transactors into an atomic operation (the batch).
 
 There is an important restriction enforced between transactions and batches,
 which is that the transaction must contain the public key of the batch signer
-in the batcher_pubkey field.  This is to prevent transactions from being reused
+in the batcher_public_key field.  This is to prevent transactions from being reused
 separate from the intended batch.  So, for example, unless you have the
 batcher's private key, it is not possible to take transactions from a batch and
 repackage them into a new batch, omitting some of the transactions.

--- a/docs/source/examples/supplychain/supplychain_transaction_family.rst
+++ b/docs/source/examples/supplychain/supplychain_transaction_family.rst
@@ -235,7 +235,7 @@ Create Agent
 ++++++++++++
 
 Register a signing participant that can update Records and Applications. The
-``signer_pubkey`` in the transaction header will be used as the Agent's public
+``signer_public_key`` in the transaction header will be used as the Agent's public
 key.
 
 .. code-block:: protobuf

--- a/docs/source/sysadmin_guide/log_configuration.rst
+++ b/docs/source/sysadmin_guide/log_configuration.rst
@@ -26,8 +26,8 @@ rarely be used.
 
 The name of the validator logs will look like the following:
 
-- validator-{first 8 characters of the validator's pubkey}-debug.log
-- validator-{first 8 characters of the validator's pubkey}-error.log
+- validator-{first 8 characters of the validator's public_key}-debug.log
+- validator-{first 8 characters of the validator's public_key}-error.log
 
 Examples:
 

--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -97,7 +97,7 @@ following protobuf message:
 
   	// Public key for the component internal to the validator that
   	// signed the BlockHeader
-  	string signer_pubkey = 3;
+  	string signer_public_key = 3;
 
   	// The signature derived from signing the header
   	string header_signature = 4;

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -44,7 +44,7 @@ The following protocol buffers definition defines the validator info:
     // The name of the endpoint. It should be a human readable name.
     string name = 2;
 
-    // The validator's public key (currently using signer_pubkey as this is
+    // The validator's public key (currently using signer_public_key as this is
     // stored in the transaction header)
     string id = 3;
 
@@ -156,7 +156,7 @@ protocol buffers code:
     string name = 2;
 
 
-    // Validator's public key (currently using signer_pubkey as this is
+    // Validator's public key (currently using signer_public_key as this is
     // stored in the transaction header)
     string id = 3;
 
@@ -225,7 +225,7 @@ invalid. The current requirement is that the validator_name is 64 characters
 or less.
 
 If the validator_id does not match the transaction signer, the transaction is
-invalid. The validator_id should be the same as the signer_pubkey stored in the
+invalid. The validator_id should be the same as the signer_public_key stored in the
 transaction header.
 
 The signup info needs to be verified next. The signup info, public key hash, and

--- a/families/battleship/sawtooth_battleship/battleship_cli.py
+++ b/families/battleship/sawtooth_battleship/battleship_cli.py
@@ -244,12 +244,12 @@ def do_init(args, config):
             if not os.path.exists(os.path.dirname(priv_filename)):
                 os.makedirs(os.path.dirname(priv_filename))
 
-            privkey = signing.generate_privkey()
-            public_key = signing.generate_public_key(privkey)
+            private_key = signing.generate_private_key()
+            public_key = signing.generate_public_key(private_key)
 
             with open(priv_filename, "w") as priv_fd:
                 print("writing file: {}".format(priv_filename))
-                priv_fd.write(privkey)
+                priv_fd.write(private_key)
                 priv_fd.write("\n")
 
             with open(public_key_filename, "w") as public_key_fd:

--- a/families/battleship/sawtooth_battleship/battleship_cli.py
+++ b/families/battleship/sawtooth_battleship/battleship_cli.py
@@ -235,9 +235,9 @@ def do_init(args, config):
 
     priv_filename = config.get('DEFAULT', 'key_file')
     if priv_filename.endswith(".priv"):
-        pubkey_filename = priv_filename[0:-len(".priv")] + ".pub"
+        public_key_filename = priv_filename[0:-len(".priv")] + ".pub"
     else:
-        pubkey_filename = priv_filename + ".pub"
+        public_key_filename = priv_filename + ".pub"
 
     if not os.path.exists(priv_filename):
         try:
@@ -245,17 +245,17 @@ def do_init(args, config):
                 os.makedirs(os.path.dirname(priv_filename))
 
             privkey = signing.generate_privkey()
-            pubkey = signing.generate_pubkey(privkey)
+            public_key = signing.generate_public_key(privkey)
 
             with open(priv_filename, "w") as priv_fd:
                 print("writing file: {}".format(priv_filename))
                 priv_fd.write(privkey)
                 priv_fd.write("\n")
 
-            with open(pubkey_filename, "w") as pubkey_fd:
-                print("writing file: {}".format(pubkey_filename))
-                pubkey_fd.write(pubkey)
-                pubkey_fd.write("\n")
+            with open(public_key_filename, "w") as public_key_fd:
+                print("writing file: {}".format(public_key_filename))
+                public_key_fd.write(public_key)
+                public_key_fd.write("\n")
         except IOError as ioe:
             raise BattleshipException("IOError: {}".format(str(ioe)))
 
@@ -407,18 +407,18 @@ def do_show(args, config):
     print("PLAYER 2  : {}".format(player2))
     print("STATE     : {}".format(game_state))
 
-    # figure out the proper user's target board, given the pubkey
+    # figure out the proper user's target board, given the public_key
     priv_filename = config.get('DEFAULT', 'key_file')
     if priv_filename.endswith(".priv"):
-        pubkey_filename = priv_filename[0:-len(".priv")] + ".pub"
+        public_key_filename = priv_filename[0:-len(".priv")] + ".pub"
     else:
-        pubkey_filename = priv_filename + ".pub"
-    pubkey_file = open(pubkey_filename, mode='r')
-    pubkey = pubkey_file.readline().rstrip('\n')
+        public_key_filename = priv_filename + ".pub"
+    public_key_file = open(public_key_filename, mode='r')
+    public_key = public_key_file.readline().rstrip('\n')
 
-    if 'Player1' in game and pubkey == game['Player1']:
+    if 'Player1' in game and public_key == game['Player1']:
         target_board_name = 'TargetBoard1'
-    elif 'Player2' in game and pubkey == game['Player2']:
+    elif 'Player2' in game and public_key == game['Player2']:
         target_board_name = 'TargetBoard2'
     else:
         raise BattleshipException("Player hasn't joined game.")

--- a/families/battleship/sawtooth_battleship/battleship_client.py
+++ b/families/battleship/sawtooth_battleship/battleship_client.py
@@ -58,7 +58,7 @@ class BattleshipClient:
         except:
             raise IOError("Failed to read keys.")
 
-        self._public_key = signing.generate_pubkey(self._private_key)
+        self._public_key = signing.generate_public_key(self._private_key)
         self._transaction_family = "battleship"
         self._family_version = "1.0"
         self._wait = wait
@@ -87,14 +87,14 @@ class BattleshipClient:
         address = self._get_address(update['Name'])
 
         header = TransactionHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             family_name=self._transaction_family,
             family_version=self._family_version,
             inputs=[address],
             outputs=[address],
             dependencies=[],
             payload_sha512=self._sha512(payload),
-            batcher_pubkey=self._public_key,
+            batcher_public_key=self._public_key,
             nonce=time.time().hex().encode()
         ).SerializeToString()
 
@@ -210,7 +210,7 @@ class BattleshipClient:
         transaction_signatures = [t.header_signature for t in transactions]
 
         header = BatchHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             transaction_ids=transaction_signatures
         ).SerializeToString()
 

--- a/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
+++ b/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
@@ -47,7 +47,7 @@ class BattleshipTransaction:
             raise InvalidTransaction("Invalid payload serialization")
 
         LOGGER.debug("payload recieved by battleship tp: %s", repr(payload))
-        self._signer_pubkey = header.signer_pubkey
+        self._signer_public_key = header.signer_public_key
         self._name = payload['Name'] if 'Name' in payload else None
         self._action = payload['Action'] if 'Action' in payload else None
         self._board = payload['Board'] if 'Board' in payload else None
@@ -68,7 +68,8 @@ class BattleshipTransaction:
         self._size = 10
 
     def __str__(self):
-        oid = "unknown" if not self._signer_pubkey else self._signer_pubkey
+        oid = "unknown" if not self._signer_public_key else \
+            self._signer_public_key
 
         return "{} {} {}".format(oid, self._action, self._name) \
             if self._action == "CREATE" \
@@ -171,12 +172,12 @@ class BattleshipTransaction:
             if state == 'P1-NEXT':
                 player1_firing = True
                 player = store[self._name]['Player1']
-                if player != self._signer_pubkey:
+                if player != self._signer_public_key:
                     raise InvalidTransaction('invalid player 1')
             elif state == 'P2-NEXT':
                 player1_firing = False
                 player = store[self._name]['Player2']
-                if player != self._signer_pubkey:
+                if player != self._signer_public_key:
                     raise InvalidTransaction('invalid player 2')
             else:
                 raise InvalidTransaction(
@@ -247,12 +248,12 @@ class BattleshipTransaction:
                 game['HashedBoard1'] = self._board
                 size = len(self._board)
                 game['TargetBoard1'] = [['?'] * size for _ in range(size)]
-                game['Player1'] = self._signer_pubkey
+                game['Player1'] = self._signer_public_key
             else:
                 game['HashedBoard2'] = self._board
                 size = len(self._board)
                 game['TargetBoard2'] = [['?'] * size for _ in range(size)]
-                game['Player2'] = self._signer_pubkey
+                game['Player2'] = self._signer_public_key
 
                 # Move to 'P1-NEXT' as both boards have been entered.
                 game["State"] = 'P1-NEXT'

--- a/families/block_info/protos/block_info.proto
+++ b/families/block_info/protos/block_info.proto
@@ -33,7 +33,7 @@ message BlockInfo {
     string previous_block_id = 2;
     // Public key for the component internal to the validator that
     // signed the BlockHeader
-    string signer_pubkey = 3;
+    string signer_public_key = 3;
     // The signature derived from signing the header
     string header_signature = 4;
     // Approximately when this block was committed, as a Unix UTC timestamp

--- a/families/block_info/sawtooth_block_info/injector.py
+++ b/families/block_info/sawtooth_block_info/injector.py
@@ -46,14 +46,14 @@ class BlockInfoInjector(BatchInjector):
     def create_batch(self, block_info):
         payload = BlockInfoTxn(block=block_info).SerializeToString()
         header = TransactionHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             family_name=FAMILY_NAME,
             family_version=FAMILY_VERSION,
             inputs=[CONFIG_ADDRESS, BLOCK_INFO_NAMESPACE],
             outputs=[CONFIG_ADDRESS, BLOCK_INFO_NAMESPACE],
             dependencies=[],
             payload_sha512=hashlib.sha512(payload).hexdigest(),
-            batcher_pubkey=self._public_key,
+            batcher_public_key=self._public_key,
         ).SerializeToString()
 
         transaction_signature = signing.sign(header, self._signing_key)
@@ -65,7 +65,7 @@ class BlockInfoInjector(BatchInjector):
         )
 
         header = BatchHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             transaction_ids=[transaction_signature],
         ).SerializeToString()
 
@@ -94,7 +94,7 @@ class BlockInfoInjector(BatchInjector):
         block_info = BlockInfo(
             block_num=previous_header.block_num,
             previous_block_id=previous_header.previous_block_id,
-            signer_pubkey=previous_header.signer_pubkey,
+            signer_public_key=previous_header.signer_public_key,
             header_signature=previous_block.header_signature,
             timestamp=int(time.time()))
 

--- a/families/block_info/sawtooth_block_info/processor/handler.py
+++ b/families/block_info/sawtooth_block_info/processor/handler.py
@@ -82,9 +82,9 @@ class BlockInfoTransactionHandler(object):
             raise InvalidTransaction("Invalid previous block id '{}'".format(
                 next_block.previous_block_id))
 
-        if not validate_hex(next_block.signer_pubkey, 66):
-            raise InvalidTransaction("Invalid signer pubkey '{}'".format(
-                next_block.signer_pubkey))
+        if not validate_hex(next_block.signer_public_key, 66):
+            raise InvalidTransaction("Invalid signer public_key '{}'".format(
+                next_block.signer_public_key))
 
         if not validate_hex(next_block.header_signature, 128):
             raise InvalidTransaction("Invalid header signature '{}'".format(

--- a/families/block_info/tests/test_tp_block_info.py
+++ b/families/block_info/tests/test_tp_block_info.py
@@ -32,14 +32,14 @@ from sawtooth_block_info.common import DEFAULT_TARGET_COUNT
 from sawtooth_block_info.common import create_block_address
 
 
-def create_block_info(block_num, signer_pubkey="2" * 66,
+def create_block_info(block_num, signer_public_key="2" * 66,
                       header_signature="1" * 128, timestamp=None,
                       previous_block_id="0" * 128):
     if timestamp is None:
         timestamp = int(time.time())
 
     return BlockInfo(
-        block_num=block_num, signer_pubkey=signer_pubkey,
+        block_num=block_num, signer_public_key=signer_public_key,
         header_signature=header_signature, timestamp=timestamp,
         previous_block_id=previous_block_id)
 

--- a/families/identity/sawtooth_identity/processor/handler.py
+++ b/families/identity/sawtooth_identity/processor/handler.py
@@ -126,19 +126,19 @@ def _check_allowed_transactor(transaction, context):
     if not entries_list:
         raise InvalidTransaction(
             "The transaction signer is not authorized to submit transactions: "
-            "{}".format(header.signer_pubkey))
+            "{}".format(header.signer_public_key))
 
     setting = Setting()
     setting.ParseFromString(entries_list[0].data)
     for entry in setting.entries:
         if entry.key == "sawtooth.identity.allowed_keys":
             allowed_signer = entry.value.split(",")
-            if header.signer_pubkey in allowed_signer:
+            if header.signer_public_key in allowed_signer:
                 return
 
     raise InvalidTransaction(
         "The transction signer is not authorized to submit transactions: "
-        "{}".format(header.signer_pubkey))
+        "{}".format(header.signer_public_key))
 
 
 def _set_policy(data, context):

--- a/families/seth/rpc/src/accounts.rs
+++ b/families/seth/rpc/src/accounts.rs
@@ -119,7 +119,7 @@ impl Account {
             alias: String::from(alias),
             private_key: key.as_hex(),
             public_key: pub_key.as_hex(),
-            address: pubkey_to_address(pub_key.as_slice()),
+            address: public_key_to_address(pub_key.as_slice()),
         })
     }
 
@@ -145,11 +145,11 @@ impl Account {
         &self.address
     }
 
-    pub fn pubkey(&self) -> &str {
+    pub fn public_key(&self) -> &str {
         &self.public_key
     }
 }
 
-pub fn pubkey_to_address(pub_key: &[u8]) -> String {
+pub fn public_key_to_address(pub_key: &[u8]) -> String {
     transform::bytes_to_hex_str(&tiny_keccak::keccak256(pub_key)[..20])
 }

--- a/families/seth/rpc/src/client.rs
+++ b/families/seth/rpc/src/client.rs
@@ -271,7 +271,7 @@ impl<S: MessageSender> ValidatorClient<S> {
                 Error::NoResource})?;
 
         let mut txn_header = TransactionHeader::new();
-        txn_header.set_batcher_pubkey(String::from(account.pubkey()));
+        txn_header.set_batcher_public_key(String::from(account.public_key()));
         txn_header.set_family_name(String::from("seth"));
         txn_header.set_family_version(String::from("1.0"));
         txn_header.set_inputs(protobuf::RepeatedField::from_vec(
@@ -284,7 +284,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         let hash = sha.result_str();
         txn_header.set_payload_sha512(hash);
 
-        txn_header.set_signer_pubkey(String::from(account.pubkey()));
+        txn_header.set_signer_public_key(String::from(account.public_key()));
         let txn_header_bytes = protobuf::Message::write_to_bytes(&txn_header).map_err(|error|
             Error::ParseError(String::from(
                 format!("Error serializing transaction header: {:?}", error))))?;
@@ -297,7 +297,7 @@ impl<S: MessageSender> ValidatorClient<S> {
         txn.set_payload(payload);
 
         let mut batch_header = BatchHeader::new();
-        batch_header.set_signer_pubkey(String::from(account.pubkey()));
+        batch_header.set_signer_public_key(String::from(account.public_key()));
         batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(
             vec![txn_signature.clone()]));
         let batch_header_bytes = protobuf::Message::write_to_bytes(&batch_header).map_err(|error|

--- a/families/seth/rpc/src/transactions.rs
+++ b/families/seth/rpc/src/transactions.rs
@@ -39,7 +39,7 @@ use client::{
     BlockKey,
 };
 use transform;
-use accounts::pubkey_to_address;
+use accounts::public_key_to_address;
 
 pub enum SethTransaction {
     CreateExternalAccount(CreateExternalAccountTxnPb),
@@ -93,7 +93,7 @@ pub enum TransactionKey {
 }
 
 pub struct Transaction {
-    signer_pubkey: String,
+    signer_public_key: String,
     signature: String,
     inner: SethTransaction,
 }
@@ -109,7 +109,7 @@ impl Transaction {
                 .map(|seth_txn_pb| SethTransaction::try_from(seth_txn_pb))?;
         match inner {
             Some(seth_txn) => Ok(Transaction{
-                signer_pubkey: header.take_signer_pubkey(),
+                signer_public_key: header.take_signer_public_key(),
                 signature: txn.take_header_signature(),
                 inner: seth_txn,
             }),
@@ -141,7 +141,7 @@ impl Transaction {
     }
 
     pub fn from_addr(&self) -> String {
-        pubkey_to_address(&transform::hex_str_to_bytes(&self.signer_pubkey).unwrap())
+        public_key_to_address(&transform::hex_str_to_bytes(&self.signer_public_key).unwrap())
     }
 
     pub fn to_addr(&self) -> Option<String> {

--- a/families/seth/rpc/tests/test_seth_rpc.py
+++ b/families/seth/rpc/tests/test_seth_rpc.py
@@ -69,7 +69,7 @@ class SethRpcTest(unittest.TestCase):
         cls.txn_id = "c" * 64
         cls.gas = 456
         # account values
-        cls.pubkey = "036d7bb6ca0fd581eb037e91042320af97508003264f08545a9db134df215f373e"
+        cls.public_key = "036d7bb6ca0fd581eb037e91042320af97508003264f08545a9db134df215f373e"
         cls.account_address = "434d46456b6973a678b77382fca0252629f4389f"
         cls.contract_address = "f" * 20 * 2
         cls.contract_address_b = bytes([0xff] * 20)
@@ -1217,7 +1217,7 @@ class SethRpcTest(unittest.TestCase):
             transaction = Transaction(
                 header=TransactionHeader(
                     family_name="seth",
-                    signer_pubkey=self.pubkey,
+                    signer_public_key=self.public_key,
                 ).SerializeToString(),
                 header_signature=self.txn_id,
                 payload=SethTransaction(
@@ -1285,12 +1285,12 @@ class SethRpcTest(unittest.TestCase):
         batch = request.batches[0]
         batch_header = BatchHeader()
         batch_header.ParseFromString(batch.header)
-        self.assertEqual(batch_header.signer_pubkey, self.pubkey)
+        self.assertEqual(batch_header.signer_public_key, self.public_key)
 
         txn = batch.transactions[0]
         txn_header = TransactionHeader()
         txn_header.ParseFromString(txn.header)
-        self.assertEqual(txn_header.signer_pubkey, self.pubkey)
+        self.assertEqual(txn_header.signer_public_key, self.public_key)
         self.assertEqual(txn_header.family_name, "seth")
         self.assertEqual(txn_header.family_version, "1.0")
 
@@ -1309,7 +1309,7 @@ class SethRpcTest(unittest.TestCase):
         nonce = self.nonce
         block_id = self.block_id
         block_num = self.block_num
-        pub_key = self.pubkey
+        pub_key = self.public_key
         to = self.contract_address_b
         init = self.contract_init_b
         data = self.contract_call_b
@@ -1317,7 +1317,7 @@ class SethRpcTest(unittest.TestCase):
             Transaction(
                 header=TransactionHeader(
                     family_name="seth",
-                    signer_pubkey=pub_key,
+                    signer_public_key=pub_key,
                 ).SerializeToString(),
                 header_signature=txn_ids[i],
                 payload=txn.SerializeToString())

--- a/families/seth/src/burrow/evm/native.go
+++ b/families/seth/src/burrow/evm/native.go
@@ -68,7 +68,7 @@ func ecrecoverFunc(appState AppState, caller *Account, input []byte, gas *int64)
 	v := byte(input[32] - 27) // ignore input[33:64], v is small.
 	sig := append(input[64:], v)
 
-	recovered, err := secp256k1.RecoverPubkey(hash, sig)
+	recovered, err := secp256k1.RecoverPublicKey(hash, sig)
 	if err != nil {
 		return nil, err
 	}

--- a/families/seth/src/sawtooth_seth/processor/handler/handler.go
+++ b/families/seth/src/sawtooth_seth/processor/handler/handler.go
@@ -84,16 +84,16 @@ func (self *BurrowEVMHandler) Apply(request *processor_pb2.TpProcessRequest, con
 
 	// Construct address of sender. This is the address used by the EVM to
 	// access the account.
-	pubkey, decodeErr := hex.DecodeString(header.GetSignerPubkey())
+	public_key, decodeErr := hex.DecodeString(header.GetSignerPublicKey())
 	if decodeErr != nil {
 		return &processor.InternalError{Msg: fmt.Sprintf(
 			"Couldn't decode public key",
 		)}
 	}
-	sender, err := PubToEvmAddr(pubkey)
+	sender, err := PubToEvmAddr(public_key)
 	if err != nil {
 		return &processor.InvalidTransactionError{Msg: fmt.Sprintf(
-			"Couldn't determine sender from public key: %v", header.GetSignerPubkey(),
+			"Couldn't determine sender from public key: %v", header.GetSignerPublicKey(),
 		)}
 	}
 
@@ -186,7 +186,7 @@ func unpackHeader(headerBytes []byte) (*transaction_pb2.TransactionHeader, error
 		}
 	}
 
-	if header.GetSignerPubkey() == "" {
+	if header.GetSignerPublicKey() == "" {
 		return nil, &processor.InvalidTransactionError{Msg: "Public Key not set"}
 	}
 

--- a/families/settings/tests/test_tp_settings.py
+++ b/families/settings/tests/test_tp_settings.py
@@ -202,7 +202,7 @@ class TestSettings(TransactionProcessorTestCase):
         )
         proposal_id = _to_hash(proposal.SerializeToString())
         record = SettingCandidate.VoteRecord(
-            public_key="some_other_pubkey",
+            public_key="some_other_public_key",
             vote=SettingVote.ACCEPT)
         candidate = SettingCandidate(
             proposal_id=proposal_id,
@@ -214,7 +214,7 @@ class TestSettings(TransactionProcessorTestCase):
         self._vote(proposal_id, 'my.config.setting', SettingVote.ACCEPT)
 
         self._expect_get('sawtooth.settings.vote.authorized_keys',
-                         self._public_key + ',some_other_pubkey')
+                         self._public_key + ',some_other_public_key')
         self._expect_get('sawtooth.settings.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.settings.vote.approval_threshold', '2')
@@ -242,7 +242,7 @@ class TestSettings(TransactionProcessorTestCase):
         )
         proposal_id = _to_hash(proposal.SerializeToString())
         record = SettingCandidate.VoteRecord(
-            public_key="some_other_pubkey",
+            public_key="some_other_public_key",
             vote=SettingVote.ACCEPT)
         candidate = SettingCandidate(
             proposal_id=proposal_id,
@@ -254,7 +254,8 @@ class TestSettings(TransactionProcessorTestCase):
         self._vote(proposal_id, 'my.config.setting', SettingVote.ACCEPT)
 
         self._expect_get('sawtooth.settings.vote.authorized_keys',
-                         self._public_key + ',some_other_pubkey,third_pubkey')
+                         self._public_key +
+                         ',some_other_public_key,third_public_key')
         self._expect_get('sawtooth.settings.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.settings.vote.approval_threshold', '3')
@@ -264,7 +265,7 @@ class TestSettings(TransactionProcessorTestCase):
                          base64.b64encode(candidates.SerializeToString()))
 
         record = SettingCandidate.VoteRecord(
-            public_key="some_other_pubkey",
+            public_key="some_other_public_key",
             vote=SettingVote.ACCEPT)
         new_record = SettingCandidate.VoteRecord(
             public_key=self._public_key,
@@ -296,10 +297,10 @@ class TestSettings(TransactionProcessorTestCase):
             proposal=proposal,
             votes=[
                 SettingCandidate.VoteRecord(
-                    public_key='some_other_pubkey',
+                    public_key='some_other_public_key',
                     vote=SettingVote.ACCEPT),
                 SettingCandidate.VoteRecord(
-                    public_key='a_rejectors_pubkey',
+                    public_key='a_rejectors_public_key',
                     vote=SettingVote.REJECT)
             ])
 
@@ -309,7 +310,7 @@ class TestSettings(TransactionProcessorTestCase):
 
         self._expect_get(
             'sawtooth.settings.vote.authorized_keys',
-            self._public_key + ',some_other_pubkey,a_rejectors_pubkey')
+            self._public_key + ',some_other_public_key,a_rejectors_public_key')
         self._expect_get('sawtooth.settings.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.settings.vote.approval_threshold', '2')
@@ -338,7 +339,7 @@ class TestSettings(TransactionProcessorTestCase):
             proposal=proposal,
             votes=[
                 SettingCandidate.VoteRecord(
-                    public_key='some_other_pubkey',
+                    public_key='some_other_public_key',
                     vote=SettingVote.ACCEPT),
             ])
 
@@ -347,7 +348,7 @@ class TestSettings(TransactionProcessorTestCase):
         self._vote(proposal_id, 'my.config.setting', SettingVote.REJECT)
 
         self._expect_get('sawtooth.settings.vote.authorized_keys',
-                         self._public_key + ',some_other_pubkey')
+                         self._public_key + ',some_other_public_key')
         self._expect_get('sawtooth.settings.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.settings.vote.approval_threshold', '2')

--- a/families/supplychain/python/sawtooth_supplychain/cli/init.py
+++ b/families/supplychain/python/sawtooth_supplychain/cli/init.py
@@ -75,8 +75,8 @@ def do_init(args, config):
                 os.makedirs(os.path.dirname(priv_filename))
 
             privkey = signing.generate_privkey()
-            pubkey = signing.generate_pubkey(privkey)
-            addr = signing.generate_identifier(pubkey)
+            public_key = signing.generate_public_key(privkey)
+            addr = signing.generate_identifier(public_key)
 
             with open(priv_filename, "w") as priv_fd:
                 print("writing file: {}".format(priv_filename))

--- a/families/supplychain/python/sawtooth_supplychain/cli/init.py
+++ b/families/supplychain/python/sawtooth_supplychain/cli/init.py
@@ -74,13 +74,13 @@ def do_init(args, config):
             if not os.path.exists(os.path.dirname(priv_filename)):
                 os.makedirs(os.path.dirname(priv_filename))
 
-            privkey = signing.generate_privkey()
-            public_key = signing.generate_public_key(privkey)
+            private_key = signing.generate_private_key()
+            public_key = signing.generate_public_key(private_key)
             addr = signing.generate_identifier(public_key)
 
             with open(priv_filename, "w") as priv_fd:
                 print("writing file: {}".format(priv_filename))
-                priv_fd.write(privkey)
+                priv_fd.write(private_key)
                 priv_fd.write("\n")
 
             with open(addr_filename, "w") as addr_fd:

--- a/families/supplychain/python/sawtooth_supplychain/client.py
+++ b/families/supplychain/python/sawtooth_supplychain/client.py
@@ -102,7 +102,7 @@ class SupplyChainClient(object):
         except:
             raise IOError("Failed to read keys.")
 
-        self._public_key = signing.generate_pubkey(self._private_key)
+        self._public_key = signing.generate_public_key(self._private_key)
 
     @property
     def public_key(self):
@@ -321,14 +321,14 @@ class SupplyChainClient(object):
             SupplyChainPayload(action=action, data=_pb_dumps(action_payload)))
 
         header = TransactionHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             family_name="sawtooth_supplychain",
             family_version="0.5",
             inputs=inputs or [],
             outputs=outputs or [],
             dependencies=[],
             payload_sha512=_sha512(payload),
-            batcher_pubkey=self._public_key,
+            batcher_public_key=self._public_key,
             nonce=time.time().hex().encode()
         ).SerializeToString()
 
@@ -353,7 +353,7 @@ class SupplyChainClient(object):
         transaction_signatures = [t.header_signature for t in transactions]
 
         header = BatchHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             transaction_ids=transaction_signatures
         ).SerializeToString()
 

--- a/families/supplychain/python/sawtooth_supplychain/processor/handler.py
+++ b/families/supplychain/python/sawtooth_supplychain/processor/handler.py
@@ -67,7 +67,7 @@ class SupplyChainHandler(object):
         try:
             txn_header = TransactionHeader()
             txn_header.ParseFromString(transaction.header)
-            originator = txn_header.signer_pubkey
+            originator = txn_header.signer_public_key
             payload = SupplyChainPayload()
             payload.ParseFromString(transaction.payload)
 

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -126,7 +126,7 @@ class TestNetworkPermissioning(unittest.TestCase):
 
         wait_for_consensus(self.clients, amount=2)
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "non_genesis_out_of_network",
             "network",
             permit_keys=[genesis_key],
@@ -136,7 +136,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "allow_all",
             "network",
             permit_keys=[genesis_key, non_genesis_key],
@@ -146,7 +146,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "non_genesis_out_of_network",
             "network.consensus",
             permit_keys=[genesis_key],
@@ -156,7 +156,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "allow_all_for_consensus",
             "network.consensus",
             permit_keys=[genesis_key, non_genesis_key],
@@ -240,7 +240,7 @@ class TestNetworkPermissioning(unittest.TestCase):
 
         wait_for_consensus(self.clients, amount=2)
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "non_genesis_out_of_network",
             "network",
             permit_keys=[genesis_key],
@@ -250,7 +250,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "allow_all_for_consensus",
             "network",
             permit_keys=[genesis_key, non_genesis_key],
@@ -260,7 +260,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "non_genesis_out_of_network",
             "network.consensus",
             permit_keys=[genesis_key],
@@ -270,7 +270,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
-        walter.set_pubkey_for_role(
+        walter.set_public_key_for_role(
             "allow_all_for_consensus",
             "network.consensus",
             permit_keys=[genesis_key, non_genesis_key],
@@ -309,7 +309,7 @@ class Client(object):
 
     def __init__(self, rest_endpoint):
         self.priv_key = signer.generate_privkey()
-        self.pub_key = signer.generate_pubkey(self.priv_key)
+        self.pub_key = signer.generate_public_key(self.priv_key)
         self._namespace = hashlib.sha512('intkey'.encode()).hexdigest()[:6]
         self._factory = MessageFactory(
             'intkey',
@@ -332,7 +332,7 @@ class Client(object):
     def block_list(self):
         return [(item['header']['block_num'],
                  item['header_signature'],
-                 item['header']['signer_pubkey'])
+                 item['header']['signer_public_key'])
                 for item in self._rest.block_list()['data']]
 
 
@@ -340,7 +340,7 @@ class Admin(object):
 
     def __init__(self, rest_endpoint):
         self.priv_key = signer.generate_privkey()
-        self.pub_key = signer.generate_pubkey(self.priv_key)
+        self.pub_key = signer.generate_public_key(self.priv_key)
 
         self._priv_key_file = os.path.join("/tmp", uuid4().hex[:20])
         with open(self._priv_key_file, mode='w') as out:
@@ -348,7 +348,7 @@ class Admin(object):
 
         self._rest_endpoint = rest_endpoint
 
-    def set_pubkey_for_role(self, policy, role, permit_keys, deny_keys):
+    def set_public_key_for_role(self, policy, role, permit_keys, deny_keys):
         permits = ["PERMIT_KEY {}".format(key) for key in permit_keys]
         denies = ["DENY_KEY {}".format(key) for key in deny_keys]
         self._run_identity_commands(policy, role, denies + permits)

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -308,7 +308,7 @@ def show_blocks(block_list):
 class Client(object):
 
     def __init__(self, rest_endpoint):
-        self.priv_key = signer.generate_privkey()
+        self.priv_key = signer.generate_private_key()
         self.pub_key = signer.generate_public_key(self.priv_key)
         self._namespace = hashlib.sha512('intkey'.encode()).hexdigest()[:6]
         self._factory = MessageFactory(
@@ -339,7 +339,7 @@ class Client(object):
 class Admin(object):
 
     def __init__(self, rest_endpoint):
-        self.priv_key = signer.generate_privkey()
+        self.priv_key = signer.generate_private_key()
         self.pub_key = signer.generate_public_key(self.priv_key)
 
         self._priv_key_file = os.path.join("/tmp", uuid4().hex[:20])

--- a/integration/sawtooth_integration/tests/test_transactor_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_transactor_permissioning.py
@@ -73,7 +73,7 @@ class TestTransactorPermissioning(unittest.TestCase):
         # From local configuration Dave is denied from being a batch_signer,
         # and Chuck and Mallory are denied from all transactor permissions.
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             'deny_bob_allow_alice_walter',
             'transactor',
             permit_keys=[self.alice.public_key, self.walter.public_key],
@@ -89,7 +89,7 @@ class TestTransactorPermissioning(unittest.TestCase):
             (self.chuck, Families.INTKEY),
             (self.mallory, Families.INTKEY))
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             'deny_alice_allow_bob_walter',
             'transactor',
             permit_keys=[self.bob.public_key, self.walter.public_key],
@@ -105,7 +105,7 @@ class TestTransactorPermissioning(unittest.TestCase):
             (self.dave, Families.INTKEY),
             (self.mallory, Families.INTKEY))
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "allow_all_transactors",
             "transactor",
             permit_keys=["*"],
@@ -117,7 +117,7 @@ class TestTransactorPermissioning(unittest.TestCase):
         # From local configuration both Alice and Bob are allowed batch_signers,
         # while Dave is denied.
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "deny_alice_as_batcher_allow_bob",
             "transactor.batch_signer",
             permit_keys=[self.bob.public_key, self.walter.public_key],
@@ -143,7 +143,7 @@ class TestTransactorPermissioning(unittest.TestCase):
             daves_txns,
             (self.dave, Families.INTKEY))
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "allow_all_batchers",
             "transactor.batch_signer",
             permit_keys=["*"],
@@ -156,7 +156,7 @@ class TestTransactorPermissioning(unittest.TestCase):
         # other transactor permissions, Mallory and Chuck are denied from all
         # transactor permissions.
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "allow_carol_and_no_others",
             "transactor.transaction_signer",
             permit_keys=[self.carol.public_key, self.walter.public_key],
@@ -178,7 +178,7 @@ class TestTransactorPermissioning(unittest.TestCase):
             (self.mallory, Families.INTKEY),
             (self.mallory, Families.XO))
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "allow_all_transaction_signers",
             "transactor.transaction_signer",
             permit_keys=["*"],
@@ -190,7 +190,7 @@ class TestTransactorPermissioning(unittest.TestCase):
         # From local configuration Dave is denied from being a batch_signer,
         # Mallory and Chuck are denied being transactors.
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "deny_alice_from_xo_allow_bob",
             "transactor.transaction_signer.xo",
             permit_keys=[self.bob.public_key, self.dave.public_key],
@@ -204,7 +204,7 @@ class TestTransactorPermissioning(unittest.TestCase):
             (self.mallory, Families.XO),
             (self.dave, Families.XO))
 
-        self.walter.set_pubkey_for_role(
+        self.walter.set_public_key_for_role(
             "deny_bob_from_intkey_allow_dave_alice",
             "transactor.transaction_signer.intkey",
             permit_keys=[self.alice.public_key, self.dave.public_key],
@@ -373,7 +373,7 @@ class Transactor(object):
 
         self._client.send_batches(batch_list=batch_list)
 
-    def set_pubkey_for_role(self, policy, role, permit_keys, deny_keys):
+    def set_public_key_for_role(self, policy, role, permit_keys, deny_keys):
         permits = ["PERMIT_KEY {}".format(key) for key in permit_keys]
         denies = ["DENY_KEY {}".format(key) for key in deny_keys]
         self._run_identity_commands(policy, role, denies + permits)

--- a/perf/sawtooth_perf/src/batch_gen.rs
+++ b/perf/sawtooth_perf/src/batch_gen.rs
@@ -142,10 +142,10 @@ impl<'a> SignedBatchProducer<'a> {
 
         let mut batch_header = BatchHeader::new();
 
-        // set signer_pubkey
+        // set signer_public_key
         let txn_ids = txns.iter().cloned().map(|mut txn| txn.take_header_signature()).collect();
         batch_header.set_transaction_ids(protobuf::RepeatedField::from_vec(txn_ids));
-        batch_header.set_signer_pubkey(self.public_key.clone());
+        batch_header.set_signer_public_key(self.public_key.clone());
 
         let header_bytes = batch_header.write_to_bytes().unwrap();
         let signature = try!(self.signer.sign(&header_bytes).map_err(BatchingError::SigningError));
@@ -332,10 +332,10 @@ mod tests {
     fn make_txn(sig: &str) -> Transaction {
         let mut txn_header = TransactionHeader::new();
 
-        txn_header.set_batcher_pubkey(String::from("some_pubkey"));
+        txn_header.set_batcher_public_key(String::from("some_public_key"));
         txn_header.set_family_name(String::from("test_family"));
         txn_header.set_family_version(String::from("1.0"));
-        txn_header.set_signer_pubkey(String::from("some_pubkey"));
+        txn_header.set_signer_public_key(String::from("some_public_key"));
         txn_header.set_payload_sha512(String::from("some_sha512_hash"));
 
         let mut txn = Transaction::new();

--- a/perf/smallbank_workload/src/playlist.rs
+++ b/perf/smallbank_workload/src/playlist.rs
@@ -131,8 +131,8 @@ pub fn process_smallbank_playlist(output: &mut Write,
         sha.result(hash);
 
         txn_header.set_payload_sha512(bytes_to_hex_str(hash));
-        txn_header.set_signer_pubkey(pub_key_hex.clone());
-        txn_header.set_batcher_pubkey(pub_key_hex.clone());
+        txn_header.set_signer_public_key(pub_key_hex.clone());
+        txn_header.set_batcher_public_key(pub_key_hex.clone());
 
         let header_bytes = try!(txn_header.write_to_bytes().map_err(PlaylistError::MessageError));
 

--- a/protos/batch.proto
+++ b/protos/batch.proto
@@ -23,7 +23,7 @@ import "transaction.proto";
 
 message BatchHeader {
     // Public key for the client that signed the BatchHeader
-    string signer_pubkey = 1;
+    string signer_public_key = 1;
 
     // List of transaction.header_signatures that match the order of
     // transactions required for the batch

--- a/protos/block.proto
+++ b/protos/block.proto
@@ -29,7 +29,7 @@ message BlockHeader {
 
     // Public key for the component internal to the validator that
     // signed the BlockHeader
-    string signer_pubkey = 3;
+    string signer_public_key = 3;
 
     // List of batch.header_signatures that match the order of batches
     // required for the block

--- a/protos/client.proto
+++ b/protos/client.proto
@@ -90,7 +90,7 @@ message PagingResponse {
 // Sorting controls to be sent with List requests. More than one can be sent.
 // If so, the first is used, and additional controls are tie-breakers.
 // Attributes:
-//     keys: Nested set of keys to sort by (i.e. ['header', 'signer_pubkey'])
+//     keys: Nested set of keys to sort by (i.e. ['header', 'signer_public_key'])
 //     reverse: Whether or not to reverse the sort (i.e. descending order)
 //     compare_length: Sorts by value length, rather than the property itself
 message SortControls {

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -21,7 +21,7 @@ option go_package = "transaction_pb2";
 
 message TransactionHeader {
     // Public key for the client who added this transaction to a batch
-    string batcher_pubkey = 1;
+    string batcher_public_key = 1;
 
     // A list of transaction signatures that describe the transactions that
     // must be processed before this transaction can be valid
@@ -51,7 +51,7 @@ message TransactionHeader {
     string payload_sha512 = 9;
 
     // Public key for the client that signed the TransactionHeader
-    string signer_pubkey = 10;
+    string signer_public_key = 10;
 }
 
 message Transaction {

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -535,7 +535,7 @@ parameters:
         - dot-notation indicates nested keys
         - starting a key with a minus-sign indicates descending order
         - ending a key with `.length` sorts by the length
-        - example: `sort=header.signer_pubkey,-transaction_ids.length`
+        - example: `sort=header.signer_public_key,-transaction_ids.length`
 
 definitions:
   Head:
@@ -615,7 +615,7 @@ definitions:
 
   TransactionHeader:
     properties:
-      batcher_pubkey:
+      batcher_public_key:
         type: string
         example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
       dependencies:
@@ -645,7 +645,7 @@ definitions:
       payload_sha512:
         type: string
         example: fb6135ef73f4fe77367f9384b3bbbb158f4b8603c9d612157108e5c271868fce2242ee4abd7a29397ba63780c3ccab13783dfd4d9f0167beda03cdb0e37b87f4
-      signer_pubkey:
+      signer_public_key:
         type: string
         example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
   Transaction:
@@ -711,7 +711,7 @@ definitions:
 
   BatchHeader:
     properties:
-      signer_pubkey:
+      signer_public_key:
         type: string
         example: 038bba5708acc262464c9fe30d3de9e905a9a5fa30cedd151dd9cd09ea26d46d00
       transaction_ids:
@@ -745,7 +745,7 @@ definitions:
       previous_block_id:
         type: string
         example: 65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
-      signer_pubkey:
+      signer_public_key:
         type: string
         example: 02d260a46457a064733153e09840c322bee1dff34445d7d49e19e60abd18fd0758
       batch_ids:

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -355,7 +355,7 @@ class BaseApiTest(AioHTTPTestCase):
         for batch, expected_id in zip(batches, expected_ids):
             self.assertEqual(expected_id, batch['header_signature'])
             self.assertIsInstance(batch['header'], dict)
-            self.assertEqual('pubkey', batch['header']['signer_pubkey'])
+            self.assertEqual('public_key', batch['header']['signer_public_key'])
 
             txns = batch['transactions']
             self.assertIsInstance(txns, list)
@@ -431,7 +431,7 @@ class Mocks(object):
             blk_header = BlockHeader(
                 block_num=len(blocks),
                 previous_block_id=blocks[-1].header_signature if blocks else '',
-                signer_pubkey='pubkey',
+                signer_public_key='public_key',
                 batch_ids=[b.header_signature for b in batches],
                 consensus=b'consensus',
                 state_root_hash='root_hash')
@@ -456,7 +456,7 @@ class Mocks(object):
             txns = cls.make_txns(batch_id)
 
             batch_header = BatchHeader(
-                signer_pubkey='pubkey',
+                signer_public_key='public_key',
                 transaction_ids=[t.header_signature for t in txns])
 
             batch = Batch(
@@ -477,11 +477,11 @@ class Mocks(object):
 
         for txn_id in txn_ids:
             txn_header = TransactionHeader(
-                batcher_pubkey='pubkey',
+                batcher_public_key='public_key',
                 family_name='family',
                 family_version='0.0',
                 nonce=txn_id,
-                signer_pubkey='pubkey')
+                signer_public_key='public_key')
 
             txn = Transaction(
                 header=txn_header.SerializeToString(),

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -561,12 +561,12 @@ class BatchListTests(BaseApiTest):
 
         It should send a Protobuf request with:
             - empty paging controls
-            - sort controls with keys of 'header' and 'signer_pubkey'
+            - sort controls with keys of 'header' and 'signer_public_key'
 
         It should send back a JSON response with:
             - a status of 200
             - a head property of '2'
-            - a link ending in '/batches?head=2&sort=header.signer_pubkey'
+            - a link ending in '/batches?head=2&sort=header.signer_public_key'
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids '0', '1', and '2'
@@ -576,16 +576,16 @@ class BatchListTests(BaseApiTest):
         self.connection.preset_response(head_id='2', paging=paging, batches=batches)
 
         response = await self.get_assert_200(
-            '/batches?sort=header.signer_pubkey')
+            '/batches?sort=header.signer_public_key')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
+        sorting = Mocks.make_sort_controls('header', 'signer_public_key')
         self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=header.signer_pubkey')
+            '/batches?head=2&sort=header.signer_public_key')
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], '0', '1', '2')

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -561,12 +561,12 @@ class BlockListTests(BaseApiTest):
 
         It should send a Protobuf request with:
             - empty paging controls
-            - sort controls with keys of 'header' and 'signer_pubkey'
+            - sort controls with keys of 'header' and 'signer_public_key'
 
         It should send back a JSON response with:
             - a status of 200
             - a head property of '2'
-            - a link ending in '/blocks?head=2&sort=header.signer_pubkey'
+            - a link ending in '/blocks?head=2&sort=header.signer_public_key'
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full blocks with ids '0', '1', and '2'
@@ -576,16 +576,16 @@ class BlockListTests(BaseApiTest):
         self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
 
         response = await self.get_assert_200(
-            '/blocks?sort=header.signer_pubkey')
+            '/blocks?sort=header.signer_public_key')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
+        sorting = Mocks.make_sort_controls('header', 'signer_public_key')
         self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=header.signer_pubkey')
+            '/blocks?head=2&sort=header.signer_public_key')
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_blocks_well_formed(response['data'], '0', '1', '2')

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -580,12 +580,12 @@ class TransactionListTests(BaseApiTest):
 
         It should send a Protobuf request with:
             - empty paging controls
-            - sort controls with keys of 'header' and 'signer_pubkey'
+            - sort controls with keys of 'header' and 'signer_public_key'
 
         It should send back a JSON response with:
             - a status of 200
             - a head property of '2'
-            - a link ending in '/transactions?head=2&sort=header.signer_pubkey'
+            - a link ending in '/transactions?head=2&sort=header.signer_public_key'
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full transactions with ids '0', '1', and '2'
@@ -595,16 +595,16 @@ class TransactionListTests(BaseApiTest):
         self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
 
         response = await self.get_assert_200(
-            '/transactions?sort=header.signer_pubkey')
+            '/transactions?sort=header.signer_public_key')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header', 'signer_pubkey')
+        sorting = Mocks.make_sort_controls('header', 'signer_public_key')
         self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, '2')
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=header.signer_pubkey')
+            '/transactions?head=2&sort=header.signer_public_key')
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], '0', '1', '2')

--- a/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
+++ b/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
@@ -73,14 +73,14 @@ def create_jvm_sc_transaction(verb, private_key, public_key,
 
     addresses.append(addr)
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='jvm_sc',
         family_version='1.0',
         inputs=addresses,
         outputs=addresses,
         dependencies=[],
         payload_sha512=payload.sha512(),
-        batcher_pubkey=public_key,
+        batcher_public_key=public_key,
         nonce=str(time.time()))
     header_bytes = header.SerializeToString()
 
@@ -98,7 +98,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_signatures = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_signatures)
 
     header_bytes = header.SerializeToString()
@@ -134,7 +134,7 @@ def generate_word_list(count):
 
 def do_generate(args):
     private_key = signing.generate_privkey()
-    public_key = signing.generate_pubkey(private_key)
+    public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
+++ b/sdk/examples/intkey_jvm_sc/sawtooth_intkey/cli/generate.py
@@ -133,7 +133,7 @@ def generate_word_list(count):
 
 
 def do_generate(args):
-    private_key = signing.generate_privkey()
+    private_key = signing.generate_private_key()
     public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -143,7 +143,7 @@ def generate_word_list(count):
 
 
 def do_populate(args, batches, keys):
-    private_key = signing.generate_privkey()
+    private_key = signing.generate_private_key()
     public_key = signing.generate_public_key(private_key)
 
     total_txn_count = 0
@@ -172,7 +172,7 @@ def do_populate(args, batches, keys):
 
 
 def do_generate(args, batches, keys):
-    private_key = signing.generate_privkey()
+    private_key = signing.generate_private_key()
     public_key = signing.generate_public_key(private_key)
 
     start = time.time()

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -75,7 +75,7 @@ def create_intkey_transaction(verb, name, value, deps,
             processing this transaction
         private_key (str): the private key used to sign the transaction
         public_key (str): the public key associated with the private key -
-            the public key is included in the transaction as signer_pubkey
+            the public key is included in the transaction as signer_public_key
 
     Returns:
         transaction (transaction_pb2.Transaction): the signed intkey
@@ -89,14 +89,14 @@ def create_intkey_transaction(verb, name, value, deps,
     addr = make_intkey_address(name)
 
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='intkey',
         family_version='1.0',
         inputs=[addr],
         outputs=[addr],
         dependencies=deps,
         payload_sha512=payload.sha512(),
-        batcher_pubkey=public_key,
+        batcher_public_key=public_key,
         nonce=time.time().hex().encode())
 
     header_bytes = header.SerializeToString()
@@ -115,7 +115,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_signatures = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_signatures)
 
     header_bytes = header.SerializeToString()
@@ -144,7 +144,7 @@ def generate_word_list(count):
 
 def do_populate(args, batches, keys):
     private_key = signing.generate_privkey()
-    public_key = signing.generate_pubkey(private_key)
+    public_key = signing.generate_public_key(private_key)
 
     total_txn_count = 0
     txns = []
@@ -173,7 +173,7 @@ def do_populate(args, batches, keys):
 
 def do_generate(args, batches, keys):
     private_key = signing.generate_privkey()
-    public_key = signing.generate_pubkey(private_key)
+    public_key = signing.generate_public_key(private_key)
 
     start = time.time()
     total_txn_count = 0

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
@@ -125,7 +125,7 @@ def generate_word_list(count):
 
 
 def do_generate(args):
-    private_key = signing.generate_privkey()
+    private_key = signing.generate_private_key()
     public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
@@ -71,14 +71,14 @@ def create_intkey_transaction(verb, name, value, private_key, public_key):
     addr = make_intkey_address(name)
 
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='intkey',
         family_version='1.0',
         inputs=[addr],
         outputs=[addr],
         dependencies=[],
         payload_sha512=payload.sha512(),
-        batcher_pubkey=public_key,
+        batcher_public_key=public_key,
         nonce=time.time().hex().encode())
 
     header_bytes = header.SerializeToString()
@@ -97,7 +97,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_signatures = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_signatures)
 
     header_bytes = header.SerializeToString()
@@ -126,7 +126,7 @@ def generate_word_list(count):
 
 def do_generate(args):
     private_key = signing.generate_privkey()
-    public_key = signing.generate_pubkey(private_key)
+    public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
@@ -71,14 +71,14 @@ def create_intkey_transaction(verb, name, value, private_key, public_key):
     addr = make_intkey_address(name)
 
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='intkey',
         family_version='1.0',
         inputs=[addr],
         outputs=[addr],
         dependencies=[],
         payload_sha512=payload.sha512(),
-        batcher_pubkey=public_key,
+        batcher_public_key=public_key,
         nonce=time.time().hex().encode())
 
     header_bytes = header.SerializeToString()
@@ -97,7 +97,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_ids = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_ids)
 
     header_bytes = header.SerializeToString()
@@ -126,7 +126,7 @@ def generate_word_list(count):
 
 def do_populate(args):
     private_key = signing.generate_privkey()
-    public_key = signing.generate_pubkey(private_key)
+    public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
@@ -125,7 +125,7 @@ def generate_word_list(count):
 
 
 def do_populate(args):
-    private_key = signing.generate_privkey()
+    private_key = signing.generate_private_key()
     public_key = signing.generate_public_key(private_key)
 
     words = generate_word_list(args.pool_size)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
@@ -86,7 +86,7 @@ class IntKeyWorkload(Workload):
         self._delegate = delegate
         self._deps = {}
         self._private_key = signing.generate_privkey()
-        self._public_key = signing.generate_pubkey(self._private_key)
+        self._public_key = signing.generate_public_key(self._private_key)
 
     def on_will_start(self):
         pass

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload.py
@@ -85,7 +85,7 @@ class IntKeyWorkload(Workload):
         self._lock = threading.Lock()
         self._delegate = delegate
         self._deps = {}
-        self._private_key = signing.generate_privkey()
+        self._private_key = signing.generate_private_key()
         self._public_key = signing.generate_public_key(self._private_key)
 
     def on_will_start(self):

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
@@ -48,14 +48,14 @@ def create_noop_transaction(private_key, public_key):
     payload = NoopPayload()
 
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='noop',
         family_version='1.0',
         inputs=[],
         outputs=[],
         dependencies=[],
         payload_sha512=payload.sha512(),
-        batcher_pubkey=public_key,
+        batcher_public_key=public_key,
         nonce=time.time().hex().encode())
 
     header_bytes = header.SerializeToString()
@@ -74,7 +74,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_signatures = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_signatures)
 
     header_bytes = header.SerializeToString()

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -66,7 +66,7 @@ class NoopWorkload(Workload):
         self._lock = threading.Lock()
         self._delegate = delegate
         self._private_key = signing.generate_privkey()
-        self._public_key = signing.generate_pubkey(self._private_key)
+        self._public_key = signing.generate_public_key(self._private_key)
 
     def on_will_start(self):
         pass

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -65,7 +65,7 @@ class NoopWorkload(Workload):
         self._urls = []
         self._lock = threading.Lock()
         self._delegate = delegate
-        self._private_key = signing.generate_privkey()
+        self._private_key = signing.generate_private_key()
         self._public_key = signing.generate_public_key(self._private_key)
 
     def on_will_start(self):

--- a/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
+++ b/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
@@ -70,7 +70,7 @@ func (self *XoHandler) Apply(request *processor_pb2.TpProcessRequest, context *p
 	if err != nil {
 		return err
 	}
-	player := header.GetSignerPubkey()
+	player := header.GetSignerPublicKey()
 
 	// The payload is sent to the transaction processor as bytes (just as it
 	// appears in the transaction constructed by the transactor).  We unpack

--- a/sdk/examples/xo_java/XoHandler.java
+++ b/sdk/examples/xo_java/XoHandler.java
@@ -109,7 +109,7 @@ public class XoHandler implements TransactionHandler {
     String player;
     try {
       TransactionHeader header = TransactionHeader.parseFrom(transactionRequest.getHeader());
-      player = header.getSignerPubkey();
+      player = header.getSignerPublicKey();
     } catch (InvalidProtocolBufferException e) {
       throw new InternalError("Protocol Buffer Error: " + e.toString());
     }

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -276,7 +276,7 @@ class XOHandler extends TransactionHandler {
       .catch(_toInternalError)
       .then((update) => {
         let header = TransactionHeader.decode(transactionProcessRequest.header)
-        let player = header.signerPubkey
+        let player = header.signerPublicKey
         if (!update.name) {
           throw new InvalidTransaction('Name is required')
         }

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -83,7 +83,7 @@ def _unpack_transaction(transaction):
     header.ParseFromString(transaction.header)
 
     # The transaction signer is the player
-    signer = header.signer_pubkey
+    signer = header.signer_public_key
 
     try:
         # The payload is csv utf-8 encoded string

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -51,7 +51,7 @@ class XoClient:
         except OSError:
             raise XoException("Failed to read keys.")
 
-        self._public_key = signing.generate_pubkey(self._private_key)
+        self._public_key = signing.generate_public_key(self._private_key)
 
     def create(self, name, wait=None, auth_user=None, auth_password=None):
         return self._send_xo_txn(name, "create", wait=wait,
@@ -162,14 +162,14 @@ class XoClient:
         address = self._get_address(name)
 
         header = TransactionHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             family_name="xo",
             family_version="1.0",
             inputs=[address],
             outputs=[address],
             dependencies=[],
             payload_sha512=_sha512(payload),
-            batcher_pubkey=self._public_key,
+            batcher_public_key=self._public_key,
             nonce=time.time().hex().encode()
         ).SerializeToString()
 
@@ -218,7 +218,7 @@ class XoClient:
         transaction_signatures = [t.header_signature for t in transactions]
 
         header = BatchHeader(
-            signer_pubkey=self._public_key,
+            signer_public_key=self._public_key,
             transaction_ids=transaction_signatures
         ).SerializeToString()
 

--- a/sdk/go/src/sawtooth_sdk/client/encoder.go
+++ b/sdk/go/src/sawtooth_sdk/client/encoder.go
@@ -37,19 +37,19 @@ type TransactionParams struct {
 }
 
 type Encoder struct {
-	privkey    []byte
-	public_key string
-	defaults   TransactionParams
+	private_key []byte
+	public_key  string
+	defaults    TransactionParams
 }
 
 // NewTransactionEncoder constructs a new encoder which can be used to generate
 // transactions and batches, and to serialize batches for submitting to the
 // REST API.
-func NewEncoder(privkey []byte, defaults TransactionParams) *Encoder {
+func NewEncoder(private_key []byte, defaults TransactionParams) *Encoder {
 	return &Encoder{
-		privkey:    privkey,
-		public_key: hex.EncodeToString(GenPubKey(privkey)),
-		defaults:   defaults,
+		private_key: private_key,
+		public_key:  hex.EncodeToString(GenPubKey(private_key)),
+		defaults:    defaults,
 	}
 }
 
@@ -112,7 +112,7 @@ func (self *Encoder) NewTransaction(payload []byte, p TransactionParams) *Transa
 	if err != nil {
 		panic(err)
 	}
-	hs := hex.EncodeToString(Sign(hb, self.privkey))
+	hs := hex.EncodeToString(Sign(hb, self.private_key))
 
 	transaction := &transaction_pb2.Transaction{
 		Header:          hb,
@@ -184,7 +184,7 @@ func (self *Encoder) NewBatch(transactions []*Transaction) *Batch {
 		panic(err)
 	}
 
-	hs := hex.EncodeToString(Sign(hb, self.privkey))
+	hs := hex.EncodeToString(Sign(hb, self.private_key))
 
 	batch := &batch_pb2.Batch{
 		Header:          hb,

--- a/sdk/go/src/sawtooth_sdk/client/encoder.go
+++ b/sdk/go/src/sawtooth_sdk/client/encoder.go
@@ -27,19 +27,19 @@ import (
 )
 
 type TransactionParams struct {
-	FamilyName    string
-	FamilyVersion string
-	Nonce         string
-	BatcherPubkey string
-	Dependencies  []string
-	Inputs        []string
-	Outputs       []string
+	FamilyName       string
+	FamilyVersion    string
+	Nonce            string
+	BatcherPublicKey string
+	Dependencies     []string
+	Inputs           []string
+	Outputs          []string
 }
 
 type Encoder struct {
-	privkey  []byte
-	pubkey   string
-	defaults TransactionParams
+	privkey    []byte
+	public_key string
+	defaults   TransactionParams
 }
 
 // NewTransactionEncoder constructs a new encoder which can be used to generate
@@ -47,9 +47,9 @@ type Encoder struct {
 // REST API.
 func NewEncoder(privkey []byte, defaults TransactionParams) *Encoder {
 	return &Encoder{
-		privkey:  privkey,
-		pubkey:   hex.EncodeToString(GenPubKey(privkey)),
-		defaults: defaults,
+		privkey:    privkey,
+		public_key: hex.EncodeToString(GenPubKey(privkey)),
+		defaults:   defaults,
 	}
 }
 
@@ -60,18 +60,18 @@ func NewEncoder(privkey []byte, defaults TransactionParams) *Encoder {
 func (self *Encoder) NewTransaction(payload []byte, p TransactionParams) *Transaction {
 	h := &transaction_pb2.TransactionHeader{
 		// Load defaults
-		FamilyName:    self.defaults.FamilyName,
-		FamilyVersion: self.defaults.FamilyVersion,
-		Nonce:         self.defaults.Nonce,
-		BatcherPubkey: self.defaults.BatcherPubkey,
+		FamilyName:       self.defaults.FamilyName,
+		FamilyVersion:    self.defaults.FamilyVersion,
+		Nonce:            self.defaults.Nonce,
+		BatcherPublicKey: self.defaults.BatcherPublicKey,
 
 		Inputs:       self.defaults.Inputs,
 		Outputs:      self.defaults.Outputs,
 		Dependencies: self.defaults.Dependencies,
 
 		// Set unique fields
-		PayloadSha512: hex.EncodeToString(SHA512(payload)),
-		SignerPubkey:  self.pubkey,
+		PayloadSha512:   hex.EncodeToString(SHA512(payload)),
+		SignerPublicKey: self.public_key,
 	}
 
 	// Override defaults if set
@@ -84,8 +84,8 @@ func (self *Encoder) NewTransaction(payload []byte, p TransactionParams) *Transa
 	if p.Nonce != "" {
 		h.Nonce = p.Nonce
 	}
-	if p.BatcherPubkey != "" {
-		h.BatcherPubkey = p.BatcherPubkey
+	if p.BatcherPublicKey != "" {
+		h.BatcherPublicKey = p.BatcherPublicKey
 	}
 
 	if p.Inputs != nil {
@@ -103,9 +103,9 @@ func (self *Encoder) NewTransaction(payload []byte, p TransactionParams) *Transa
 		h.Nonce = fmt.Sprintf("%x", time.Now().UTC().UnixNano())
 	}
 
-	// If a BatcherPubkey hasn't been set yet, assume its our key
-	if h.BatcherPubkey == "" {
-		h.BatcherPubkey = self.pubkey
+	// If a BatcherPublicKey hasn't been set yet, assume its our key
+	if h.BatcherPublicKey == "" {
+		h.BatcherPublicKey = self.public_key
 	}
 
 	hb, err := proto.Marshal(h)
@@ -175,8 +175,8 @@ func (self *Encoder) NewBatch(transactions []*Transaction) *Batch {
 	}
 
 	h := &batch_pb2.BatchHeader{
-		SignerPubkey:   self.pubkey,
-		TransactionIds: txnIds,
+		SignerPublicKey: self.public_key,
+		TransactionIds:  txnIds,
 	}
 
 	hb, err := proto.Marshal(h)

--- a/sdk/go/src/sawtooth_sdk/client/signer.go
+++ b/sdk/go/src/sawtooth_sdk/client/signer.go
@@ -68,10 +68,10 @@ func Sign(data, privkey []byte) []byte {
 // created from the given data using the associated private key. A sha256 hash
 // of the data is calculated first and this is what is actually used to verify
 // the signature.
-func Verify(data, signature, pubkey []byte) bool {
+func Verify(data, signature, public_key []byte) bool {
 	sig := deserializeCompact(signature)
 	hash := SHA256(data)
-	pub, err := ellcurv.ParsePubKey(pubkey, ellcurv.S256())
+	pub, err := ellcurv.ParsePubKey(public_key, ellcurv.S256())
 	if err != nil {
 		panic(err.Error())
 	}

--- a/sdk/go/src/sawtooth_sdk/client/signer.go
+++ b/sdk/go/src/sawtooth_sdk/client/signer.go
@@ -40,8 +40,8 @@ func GenPrivKey() []byte {
 
 // GenPubKey generates a new public key from a given private key and returns it
 // using the 33 byte compressed format
-func GenPubKey(privkey []byte) []byte {
-	_, pub := ellcurv.PrivKeyFromBytes(ellcurv.S256(), privkey)
+func GenPubKey(private_key []byte) []byte {
+	_, pub := ellcurv.PrivKeyFromBytes(ellcurv.S256(), private_key)
 	return pub.SerializeCompressed()
 }
 
@@ -51,8 +51,8 @@ func GenPubKey(privkey []byte) []byte {
 // A sha256 hash of the data is first calculated and this is what is actually
 // signed. Returns the signature as bytes using the compact serialization
 // (which is just (r, s)).
-func Sign(data, privkey []byte) []byte {
-	priv, _ := ellcurv.PrivKeyFromBytes(ellcurv.S256(), privkey)
+func Sign(data, private_key []byte) []byte {
+	priv, _ := ellcurv.PrivKeyFromBytes(ellcurv.S256(), private_key)
 
 	hash := SHA256(data)
 

--- a/sdk/go/tests/client_test.go
+++ b/sdk/go/tests/client_test.go
@@ -108,7 +108,7 @@ func TestEncoder(t *testing.T) {
     txn2 := encoder.NewTransaction(data, TransactionParams{
         Nonce: "456",
         Outputs: []string{"ghi"},
-        BatcherPubkey: pubstr,
+        BatcherPublicKey: pubstr,
     })
 
     // Test serialization

--- a/sdk/javascript/client/encoders.js
+++ b/sdk/javascript/client/encoders.js
@@ -48,7 +48,7 @@ class TransactionEncoder {
    * @param {string|Buffer} privateKey - 256-bit private key encoded as either
    *      a hex string or binary Buffer.
    * @param {Object} [template={}] - Default values for each Transaction.
-   * @param {string} [template.batcherPubkey] - Hex string encoded public key
+   * @param {string} [template.batcherPublicKey] - Hex string encoded public key
    *     of the batcher, if not the same as the transaction encoder.
    * @param {string[]} [template.dependencies=[]] - Ids of Transactions that
    *     must be committed before Transactions created by encoder (unusual).
@@ -69,7 +69,7 @@ class TransactionEncoder {
     this._payloadEncoder = template.payloadEncoder || (x => x)
 
     // TransactionHeader defaults can be modified after instantiation
-    this.batcherPubkey = template.batcherPubkey || this._publicKey
+    this.batcherPublicKey = template.batcherPublicKey || this._publicKey
     this.dependencies = template.dependencies || []
     this.familyName = template.familyName || ''
     this.familyVersion = template.familyVersion || ''
@@ -88,7 +88,7 @@ class TransactionEncoder {
    *     If no payloadEncoder was set, it must be a binary Buffer.
    * @param {Object} [settings={}] - Values for the header of the Transaction.
    *     Overrides any template values set during encoder instantiation.
-   * @param {string} [settings.batcherPubkey] - Hex string encoded public key
+   * @param {string} [settings.batcherPublicKey] - Hex string encoded public key
    *     of the batcher, if not the same as the transaction encoder.
    * @param {string[]} [settings.dependencies=[]] - Ids of Transactions that
    *     must be committed before this Transaction.
@@ -104,7 +104,7 @@ class TransactionEncoder {
     const payloadSha512 = createHash('sha512').update(payload).digest('hex')
 
     const header = TransactionHeader.encode({
-      batcherPubkey: settings.batcherPubkey || this.batcherPubkey,
+      batcherPublicKey: settings.batcherPublicKey || this.batcherPublicKey,
       dependencies: settings.dependencies || this.dependencies,
       familyName: settings.familyName || this.familyName,
       familyVersion: settings.familyVersion || this.familyVersion,
@@ -112,7 +112,7 @@ class TransactionEncoder {
       nonce: _generateNonce(),
       outputs: settings.outputs || this.outputs,
       payloadSha512: payloadSha512,
-      signerPubkey: this._publicKey
+      signerPublicKey: this._publicKey
     }).finish()
 
     return Transaction.create({
@@ -171,7 +171,7 @@ class BatchEncoder {
    * Creates and signs a new Batch from one or more Transactions.
    *
    * @param {Buffer|str|Transaction|Transaction[]} transactions - Transactions
-   *     to be combined into a single Batch. The `batcher_pubkey` property in
+   *     to be combined into a single Batch. The `batcher_public_key` property in
    *     every Transactions' header must match this BatchEncoder's public key,
    *     or this Batch will be rejected by the validator.
    *
@@ -195,7 +195,7 @@ class BatchEncoder {
     }
 
     const header = BatchHeader.encode({
-      signerPubkey: this._publicKey,
+      signerPublicKey: this._publicKey,
       transactionIds: transactions.map(t => t.headerSignature)
     }).finish()
 

--- a/sdk/javascript/spec/client/encoder_tests.js
+++ b/sdk/javascript/spec/client/encoder_tests.js
@@ -36,7 +36,7 @@ describe('TransactionEncoder', () => {
 
   describe('create', () => {
     const headerTemplate = {
-      batcherPubkey: 'test',
+      batcherPublicKey: 'test',
       familyName: 'test',
       familyVersion: 'test',
       inputs: ['test'],
@@ -85,7 +85,7 @@ describe('TransactionEncoder', () => {
       const txn = transactor.create(payload)
 
       const header = TransactionHeader.decode(txn.header)
-      assert.equal('test', header.batcherPubkey)
+      assert.equal('test', header.batcherPublicKey)
       assert.equal('test', header.familyName)
       assert.equal('test', header.familyVersion)
       assert.deepEqual(['test'], header.inputs)
@@ -103,7 +103,7 @@ describe('TransactionEncoder', () => {
       const payload = randomBytes(100)
 
       const txn = transactor.create(payload, {
-        batcherPubkey: 'new',
+        batcherPublicKey: 'new',
         familyName: 'new',
         familyVersion: 'new',
         inputs: ['new'],
@@ -111,7 +111,7 @@ describe('TransactionEncoder', () => {
       })
 
       const header = TransactionHeader.decode(txn.header)
-      assert.equal('new', header.batcherPubkey)
+      assert.equal('new', header.batcherPublicKey)
       assert.equal('new', header.familyName)
       assert.equal('new', header.familyVersion)
       assert.deepEqual(['new'], header.inputs)
@@ -214,7 +214,7 @@ describe('BatchEncoder', () => {
 
     it('should create a Batch from a binary TransactionList', () => {
       const transactor = new TransactionEncoder(transactorKey, {
-        batcherPubkey: publicKey
+        batcherPublicKey: publicKey
       })
       const batcher = new BatchEncoder(privateKey)
 
@@ -238,7 +238,7 @@ describe('BatchEncoder', () => {
 
     it('should create a Batch from a base64 TransactionList', () => {
       const transactor = new TransactionEncoder(transactorKey, {
-        batcherPubkey: publicKey
+        batcherPublicKey: publicKey
       })
       const batcher = new BatchEncoder(privateKey)
 

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -53,7 +53,7 @@ def is_valid_merkle_address(address):
 
 
 def _private():
-    return signing.generate_privkey()
+    return signing.generate_private_key()
 
 
 def _private_to_public(private):

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -57,7 +57,7 @@ def _private():
 
 
 def _private_to_public(private):
-    return signing.generate_pubkey(private)
+    return signing.generate_public_key(private)
 
 
 def _sign(content, private):
@@ -128,14 +128,14 @@ class MessageFactory(object):
             nonce = ""
         pub_key = self._public if batcher_pub_key is None else batcher_pub_key
         header = TransactionHeader(
-            signer_pubkey=self._public,
+            signer_public_key=self._public,
             family_name=self.family_name,
             family_version=self.family_version,
             inputs=inputs,
             outputs=outputs,
             dependencies=deps,
             payload_sha512=self.sha512(payload),
-            batcher_pubkey=pub_key,
+            batcher_public_key=pub_key,
             nonce=nonce
         )
         return header.SerializeToString()
@@ -186,7 +186,7 @@ class MessageFactory(object):
             txn_signatures = [txn.signature for txn in transactions]
 
         header = BatchHeader(
-            signer_pubkey=self._public,
+            signer_public_key=self._public,
             transaction_ids=txn_signatures
         ).SerializeToString()
 

--- a/sdk/python/sawtooth_sdk/client/encoding.py
+++ b/sdk/python/sawtooth_sdk/client/encoding.py
@@ -69,7 +69,7 @@ class TransactionEncoder(object):
                  outputs=None):
         self._private_key = private_key
         self._public_key = generate_public_key(
-            private_key, privkey_format='bytes')
+            private_key, private_key_format='bytes')
 
         self.payload_encoder = payload_encoder
 
@@ -150,7 +150,7 @@ class TransactionEncoder(object):
             header=header_bytes,
             header_signature=sign(header_bytes,
                                   self._private_key,
-                                  privkey_format='bytes'),
+                                  private_key_format='bytes'),
             payload=payload)
 
     def encode(self, transactions):
@@ -229,7 +229,7 @@ class BatchEncoder(object):
     def __init__(self, private_key):
         self._private_key = private_key
         self._public_key = generate_public_key(
-            private_key, privkey_format='bytes')
+            private_key, private_key_format='bytes')
 
     def create(self, transactions):
         """Creates and signs a new Batch message with one or more Transactions.
@@ -259,7 +259,7 @@ class BatchEncoder(object):
             header=header_bytes,
             header_signature=sign(header_bytes,
                                   self._private_key,
-                                  privkey_format='bytes'),
+                                  private_key_format='bytes'),
             transactions=transactions)
 
     def encode(self, batches):

--- a/signing/sawtooth_signing/__init__.py
+++ b/signing/sawtooth_signing/__init__.py
@@ -24,7 +24,7 @@
         import sawtooth_signing as signing
 
         msg = 'this is a message'
-        priv = signing.generate_privkey()
+        priv = signing.generate_private_key()
         pub = signing.generate_public_key(priv)
         sig = signing.sign(msg, priv)
         ver = signing.verify(msg, sig, pub)

--- a/signing/sawtooth_signing/__init__.py
+++ b/signing/sawtooth_signing/__init__.py
@@ -25,7 +25,7 @@
 
         msg = 'this is a message'
         priv = signing.generate_privkey()
-        pub = signing.generate_pubkey(priv)
+        pub = signing.generate_public_key(priv)
         sig = signing.sign(msg, priv)
         ver = signing.verify(msg, sig, pub)
 

--- a/signing/sawtooth_signing/secp256k1_signer.py
+++ b/signing/sawtooth_signing/secp256k1_signer.py
@@ -87,47 +87,47 @@ def _decode_privkey(encoded_privkey, encoding_format='wif'):
     return secp256k1.PrivateKey(priv, ctx=__CTX__)
 
 
-def generate_pubkey(privkey, privkey_format='wif'):
+def generate_public_key(privkey, privkey_format='wif'):
     """ Generate the public key based on a given private key
     Args:
         privkey: a serialized private key string
         privkey_format: the format of the privkey ('wif', 'hex', or 'bytes')
     Returns:
-        pubkey: a serialized public key string
+        public_key: a serialized public key string
      """
-    return _encode_pubkey(
+    return _encode_public_key(
         _decode_privkey(privkey, privkey_format).pubkey, 'hex')
 
 
-def _encode_pubkey(pubkey, encoding_format='hex'):
+def _encode_public_key(public_key, encoding_format='hex'):
     with warnings.catch_warnings() as enc:  # squelch secp256k1 warning
         warnings.simplefilter('ignore')
-        enc = pubkey.serialize()
+        enc = public_key.serialize()
     if encoding_format == 'hex':
         enc = binascii.hexlify(enc).decode()
     elif encoding_format != 'bytes':
-        raise ValueError("Unrecognized pubkey encoding format")
+        raise ValueError("Unrecognized public_key encoding format")
     return enc
 
 
-def _decode_pubkey(serialized_pubkey, encoding_format='hex'):
+def _decode_public_key(serialized_public_key, encoding_format='hex'):
     if encoding_format == 'hex':
-        serialized_pubkey = binascii.unhexlify(serialized_pubkey)
+        serialized_public_key = binascii.unhexlify(serialized_public_key)
     elif encoding_format != 'bytes':
-        raise ValueError("Unrecognized pubkey encoding format")
-    pub = __PK__.deserialize(serialized_pubkey)
+        raise ValueError("Unrecognized public_key encoding format")
+    pub = __PK__.deserialize(serialized_public_key)
     return secp256k1.PublicKey(pub, ctx=__CTX__)
 
 
-def generate_identifier(pubkey):
+def generate_identifier(public_key):
     """ Generate an identifier based on the public key
     Args:
-        pubkey: a serialized public key string
+        public_key: a serialized public key string
 
     Returns:
         Returns a 32 byte identifier
     """
-    return hashlib.sha256(pubkey.encode('utf-8')).hexdigest()
+    return hashlib.sha256(public_key.encode('utf-8')).hexdigest()
 
 
 def sign(message, privkey, privkey_format='wif'):
@@ -152,19 +152,19 @@ def sign(message, privkey, privkey_format='wif'):
     return sig
 
 
-def verify(message, signature, pubkey):
-    """ Verification of signature based on message and pubkey
+def verify(message, signature, public_key):
+    """ Verification of signature based on message and public_key
     Args:
         message: Message string
         signature: A 64 byte compact signature
-        pubkey: A serialized Public Key string
+        public_key: A serialized Public Key string
 
     Returns:
         boolean True / False
     """
     verified = False
     try:
-        pubkey = _decode_pubkey(pubkey, 'hex')
+        public_key = _decode_public_key(public_key, 'hex')
         if isinstance(message, str):
             message = message.encode('utf-8')
         try:  # check python3
@@ -172,8 +172,8 @@ def verify(message, signature, pubkey):
         except (ValueError, AttributeError):
             signature = binascii.unhexlify(signature)
 
-        sig = pubkey.ecdsa_deserialize_compact(signature)
-        verified = pubkey.ecdsa_verify(message, sig)
+        sig = public_key.ecdsa_deserialize_compact(signature)
+        verified = public_key.ecdsa_verify(message, sig)
 
     # Fail Securely (even if it's not pythonic)
     # pylint: disable=broad-except
@@ -182,10 +182,10 @@ def verify(message, signature, pubkey):
     return verified
 
 
-def recover_pubkey(message, signature):
+def recover_public_key(message, signature):
     """
     No support yet for recoverable signatures.
     """
 
     raise NotImplementedError("Public key recovery is not yet supported.")
-    # return pubkey
+    # return public_key

--- a/signing/tests/test_secp256k1.py
+++ b/signing/tests/test_secp256k1.py
@@ -22,27 +22,27 @@ from sawtooth_signing import secp256k1_signer as signer
 class TestSecp256kSigner(unittest.TestCase):
     def test_basic_ops(self):
         msg = 'this is a message'
-        priv = signer.generate_privkey()
+        priv = signer.generate_private_key()
         pub = signer.generate_public_key(priv)
         sig = signer.sign(msg, priv)
         ver = signer.verify(msg, sig, pub)
         self.assertTrue(ver)
 
-    def test_privkey_serialization(self):
+    def test_private_key_serialization(self):
         # pylint: disable=protected-access
-        priv = signer.generate_privkey()
-        priv2 = signer._encode_privkey(signer._decode_privkey(priv))
+        priv = signer.generate_private_key()
+        priv2 = signer._encode_private_key(signer._decode_private_key(priv))
         self.assertTrue(priv == priv2)
 
-    def test_privkey_deserialization(self):
+    def test_private_key_deserialization(self):
         # pylint: disable=protected-access
         priv = '5KZeUdoHCRXxT3srGfkeXRNWCdn1XjzpJqFdNoehZ9gEEkLMKVD'
-        priv2 = signer._encode_privkey(signer._decode_privkey(priv))
+        priv2 = signer._encode_private_key(signer._decode_private_key(priv))
         self.assertTrue(priv == priv2)
 
     def test_public_key_serialization(self):
         # pylint: disable=protected-access
-        priv = signer.generate_privkey()
+        priv = signer.generate_private_key()
         pub = signer.generate_public_key(priv)
         raw_pub = signer._decode_public_key(pub, 'hex')
         pub2 = signer._encode_public_key(raw_pub, 'hex')
@@ -50,8 +50,8 @@ class TestSecp256kSigner(unittest.TestCase):
 
     def test_invalid_signature(self):
         msg = "This is a message"
-        priv = signer.generate_privkey()
-        priv2 = signer.generate_privkey()
+        priv = signer.generate_private_key()
+        priv2 = signer.generate_private_key()
         sig = signer.sign(msg, priv)
         pub = signer.generate_public_key(priv2)
         ver = signer.verify(msg, sig, pub)

--- a/signing/tests/test_secp256k1.py
+++ b/signing/tests/test_secp256k1.py
@@ -23,7 +23,7 @@ class TestSecp256kSigner(unittest.TestCase):
     def test_basic_ops(self):
         msg = 'this is a message'
         priv = signer.generate_privkey()
-        pub = signer.generate_pubkey(priv)
+        pub = signer.generate_public_key(priv)
         sig = signer.sign(msg, priv)
         ver = signer.verify(msg, sig, pub)
         self.assertTrue(ver)
@@ -40,12 +40,12 @@ class TestSecp256kSigner(unittest.TestCase):
         priv2 = signer._encode_privkey(signer._decode_privkey(priv))
         self.assertTrue(priv == priv2)
 
-    def test_pubkey_serialization(self):
+    def test_public_key_serialization(self):
         # pylint: disable=protected-access
         priv = signer.generate_privkey()
-        pub = signer.generate_pubkey(priv)
-        raw_pub = signer._decode_pubkey(pub, 'hex')
-        pub2 = signer._encode_pubkey(raw_pub, 'hex')
+        pub = signer.generate_public_key(priv)
+        raw_pub = signer._decode_public_key(pub, 'hex')
+        pub2 = signer._encode_public_key(raw_pub, 'hex')
         self.assertTrue(str(pub) == str(pub2))
 
     def test_invalid_signature(self):
@@ -53,7 +53,7 @@ class TestSecp256kSigner(unittest.TestCase):
         priv = signer.generate_privkey()
         priv2 = signer.generate_privkey()
         sig = signer.sign(msg, priv)
-        pub = signer.generate_pubkey(priv2)
+        pub = signer.generate_public_key(priv2)
         ver = signer.verify(msg, sig, pub)
         self.assertFalse(ver)
 

--- a/utility/ias_proxy/tests/test_ias_proxy/utils.py
+++ b/utility/ias_proxy/tests/test_ias_proxy/utils.py
@@ -31,7 +31,7 @@ def create_random_private_key():
 
 
 def create_random_public_key():
-    return signing.generate_pubkey(create_random_private_key())
+    return signing.generate_public_key(create_random_private_key())
 
 
 def create_random_public_key_hash():

--- a/utility/ias_proxy/tests/test_ias_proxy/utils.py
+++ b/utility/ias_proxy/tests/test_ias_proxy/utils.py
@@ -27,7 +27,7 @@ def random_name(length=16):
 
 
 def create_random_private_key():
-    return signing.generate_privkey()
+    return signing.generate_private_key()
 
 
 def create_random_public_key():

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -87,14 +87,14 @@ class PermissionVerifier(object):
         if policy is None:
             allowed = True
         else:
-            allowed = self._allowed(header.signer_pubkey, policy)
+            allowed = self._allowed(header.signer_public_key, policy)
 
         if allowed:
             return self.is_transaction_signer_authorized(
                         batch.transactions,
                         state_root)
         LOGGER.debug("Batch Signer: %s is not permitted.",
-                     header.signer_pubkey)
+                     header.signer_public_key)
         return False
 
     def is_transaction_signer_authorized(self, transactions, state_root):
@@ -148,16 +148,16 @@ class PermissionVerifier(object):
                 family_policy = family_roles[header.family_name]
 
             if family_policy is not None:
-                if not self._allowed(header.signer_pubkey, family_policy):
+                if not self._allowed(header.signer_public_key, family_policy):
                     LOGGER.debug("Transaction Signer: %s is not permitted.",
-                                 header.signer_pubkey)
+                                 header.signer_public_key)
                     return False
             else:
                 if policy is not None:
-                    if not self._allowed(header.signer_pubkey, policy):
+                    if not self._allowed(header.signer_public_key, policy):
                         LOGGER.debug(
                             "Transaction Signer: %s is not permitted.",
-                            header.signer_pubkey)
+                            header.signer_public_key)
                         return False
         return True
 
@@ -190,13 +190,13 @@ class PermissionVerifier(object):
 
         allowed = True
         if policy is not None:
-            allowed = self._allowed(header.signer_pubkey, policy)
+            allowed = self._allowed(header.signer_public_key, policy)
 
         if allowed:
             return self.check_off_chain_transaction_roles(batch.transactions)
 
         LOGGER.debug("Batch Signer: %s is not permitted by local"
-                     " configuration.", header.signer_pubkey)
+                     " configuration.", header.signer_public_key)
         return False
 
     def check_off_chain_transaction_roles(self, transactions):
@@ -231,17 +231,17 @@ class PermissionVerifier(object):
                 family_policy = self._permissions[family_role]
 
             if family_policy is not None:
-                if not self._allowed(header.signer_pubkey, family_policy):
+                if not self._allowed(header.signer_public_key, family_policy):
                     LOGGER.debug("Transaction Signer: %s is not permitted"
                                  "by local configuration.",
-                                 header.signer_pubkey)
+                                 header.signer_public_key)
                     return False
 
             elif policy is not None:
-                if not self._allowed(header.signer_pubkey, policy):
+                if not self._allowed(header.signer_public_key, policy):
                     LOGGER.debug("Transaction Signer: %s is not permitted"
                                  "by local configuration.",
-                                 header.signer_pubkey)
+                                 header.signer_public_key)
                     return False
 
         return True
@@ -413,7 +413,7 @@ class NetworkConsensusPermissionHandler(Handler):
             block.ParseFromString(message.content)
             header = BlockHeader()
             header.ParseFromString(block.header)
-            if header.signer_pubkey == public_key:
+            if header.signer_public_key == public_key:
                 permitted = \
                     self._permission_verifier.check_network_consensus_role(
                         public_key)

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -46,7 +46,7 @@ def is_valid_block(block):
 
     if not signing.verify(block.header,
                           block.header_signature,
-                          header.signer_pubkey):
+                          header.signer_public_key):
         LOGGER.debug("block failed signature validation: %s",
                      block.header_signature)
         return False
@@ -66,7 +66,7 @@ def is_valid_batch(batch):
 
     if not signing.verify(batch.header,
                           batch.header_signature,
-                          header.signer_pubkey):
+                          header.signer_public_key):
         LOGGER.debug("batch failed signature validation: %s",
                      batch.header_signature)
         return False
@@ -78,9 +78,9 @@ def is_valid_batch(batch):
 
         txn_header = TransactionHeader()
         txn_header.ParseFromString(txn.header)
-        if txn_header.batcher_pubkey != header.signer_pubkey:
-            LOGGER.debug("txn batcher pubkey does not match signer"
-                         "pubkey for batch: %s txn: %s",
+        if txn_header.batcher_public_key != header.signer_public_key:
+            LOGGER.debug("txn batcher public_key does not match signer"
+                         "public_key for batch: %s txn: %s",
                          batch.header_signature,
                          txn.header_signature)
             return False
@@ -95,7 +95,7 @@ def is_valid_transaction(txn):
 
     if not signing.verify(txn.header,
                           txn.header_signature,
-                          header.signer_pubkey):
+                          header.signer_public_key):
         LOGGER.debug("transaction signature invalid for txn: %s",
                      txn.header_signature)
         return False

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -70,7 +70,7 @@ class DefaultBatchInjectorFactory:
         self._block_store = block_store
         self._state_view_factory = state_view_factory
         self._signing_key = signing_key
-        self._public_key = signing.generate_pubkey(signing_key)
+        self._public_key = signing.generate_public_key(signing_key)
 
     def _read_injector_setting(self, block_id):
         state_view = self._state_view_factory.create_view(

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -134,7 +134,7 @@ class BlockValidator(object):
         self._squash_handler = squash_handler
         self._identity_signing_key = identity_signing_key
         self._identity_public_key = \
-            signing.generate_pubkey(self._identity_signing_key)
+            signing.generate_public_key(self._identity_signing_key)
         self._data_dir = data_dir
         self._config_dir = config_dir
         self._result = {
@@ -575,7 +575,7 @@ class ChainController(object):
         self._squash_handler = squash_handler
         self._identity_signing_key = identity_signing_key
         self._identity_public_key = \
-            signing.generate_pubkey(self._identity_signing_key)
+            signing.generate_public_key(self._identity_signing_key)
         self._data_dir = data_dir
         self._config_dir = config_dir
 

--- a/validator/sawtooth_validator/journal/consensus/batch_publisher.py
+++ b/validator/sawtooth_validator/journal/consensus/batch_publisher.py
@@ -33,7 +33,7 @@ class BatchPublisher(object):
         self._batch_sender = batch_sender
         self._identity_signing_key = identity_signing_key
         self._identity_public_key = \
-            signing.generate_pubkey(self._identity_signing_key)
+            signing.generate_public_key(self._identity_signing_key)
 
     def send(self, transactions):
         """ Package up transactions into a batch and send them to the
@@ -43,7 +43,7 @@ class BatchPublisher(object):
         """
         txn_signatures = [txn.header_signature for txn in transactions]
         header = BatchHeader(
-            signer_pubkey=self._identity_public_key,
+            signer_public_key=self._identity_public_key,
             transaction_ids=txn_signatures
         ).SerializeToString()
 

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -108,7 +108,7 @@ class BlockPublisher(BlockPublisherInterface):
             Boolean: True if the candidate block_header should be claimed.
         """
         if self._valid_block_publishers\
-                and block_header.signer_pubkey \
+                and block_header.signer_public_key \
                 not in self._valid_block_publishers:
             return False
         elif self._min_wait_time == 0:
@@ -177,9 +177,9 @@ class ForkResolver(ForkResolverInterface):
             validator_id)
 
     @staticmethod
-    def hash_signer_pubkey(signer_pubkey, header_signature):
+    def hash_signer_public_key(signer_public_key, header_signature):
         m = hashlib.sha256()
-        m.update(signer_pubkey.encode())
+        m.update(signer_public_key.encode())
         m.update(header_signature.encode())
         digest = m.hexdigest()
         number = int(digest, 16)
@@ -226,11 +226,11 @@ class ForkResolver(ForkResolverInterface):
                         cur_fork_head.identifier[:8]))
 
         if new_fork_head.block_num == cur_fork_head.block_num:
-            cur_fork_hash = self.hash_signer_pubkey(
-                cur_fork_head.header.signer_pubkey,
+            cur_fork_hash = self.hash_signer_public_key(
+                cur_fork_head.header.signer_public_key,
                 cur_fork_head.header.previous_block_id)
-            new_fork_hash = self.hash_signer_pubkey(
-                new_fork_head.header.signer_pubkey,
+            new_fork_hash = self.hash_signer_public_key(
+                new_fork_head.header.signer_public_key,
                 new_fork_head.header.previous_block_id)
 
             result = new_fork_hash < cur_fork_hash

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -76,7 +76,7 @@ class GenesisController(object):
         self._state_view_factory = state_view_factory
         self._identity_priv_key = identity_key
         self._identity_public_key = \
-            signing.generate_pubkey(self._identity_priv_key)
+            signing.generate_public_key(self._identity_priv_key)
         self._data_dir = data_dir
         self._config_dir = config_dir
         self._chain_id_manager = chain_id_manager
@@ -261,7 +261,7 @@ class GenesisController(object):
         genesis_header = block_pb2.BlockHeader(
             block_num=0,
             previous_block_id=NULL_BLOCK_IDENTIFIER,
-            signer_pubkey=self._identity_public_key)
+            signer_public_key=self._identity_public_key)
 
         return BlockBuilder(genesis_header)
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -385,7 +385,7 @@ class BlockPublisher(object):
         self._squash_handler = squash_handler
         self._identity_signing_key = identity_signing_key
         self._identity_public_key = \
-            signing.generate_pubkey(self._identity_signing_key)
+            signing.generate_public_key(self._identity_signing_key)
         self._data_dir = data_dir
         self._config_dir = config_dir
         self._permission_verifier = permission_verifier
@@ -436,7 +436,7 @@ class BlockPublisher(object):
         block_header = BlockHeader(
             block_num=chain_head.block_num + 1,
             previous_block_id=chain_head.header_signature,
-            signer_pubkey=self._identity_public_key)
+            signer_public_key=self._identity_public_key)
         block_builder = BlockBuilder(block_header)
         if not consensus.initialize_block(block_builder.block_header):
             LOGGER.debug("Consensus not ready to build candidate block.")

--- a/validator/sawtooth_validator/journal/validation_rule_enforcer.py
+++ b/validator/sawtooth_validator/journal/validation_rule_enforcer.py
@@ -46,7 +46,7 @@ class ValidationRuleEnforcer(object):
         for batch in block.batches:
             transactions += batch.transactions
 
-        expected_signer = block.header.signer_pubkey
+        expected_signer = block.header.signer_public_key
 
         rules = rules.split(";")
         valid = True
@@ -172,7 +172,7 @@ class ValidationRuleEnforcer(object):
             header = TransactionHeader()
             header.ParseFromString(txn.header)
 
-            if header.signer_pubkey != expected_signer:
+            if header.signer_public_key != expected_signer:
                 LOGGER.debug("Transaction at postion %s was not signed by the"
                              " same key as the block.", index)
                 return False

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -449,8 +449,8 @@ class _SendReceive(object):
                 if self._secured:
                     # Generate ephemeral certificates for this connection
 
-                    pubkey, secretkey = zmq.curve_keypair()
-                    self._socket.curve_publickey = pubkey
+                    public_key, secretkey = zmq.curve_keypair()
+                    self._socket.curve_publickey = public_key
                     self._socket.curve_secretkey = secretkey
                     self._socket.curve_serverkey = self._server_public_key
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -249,7 +249,7 @@ class Validator(object):
             max_incoming_connections=100,
             max_future_callback_workers=10,
             authorize=True,
-            public_key=signing.generate_pubkey(identity_signing_key),
+            public_key=signing.generate_public_key(identity_signing_key),
             priv_key=identity_signing_key,
             roles=roles,
             metrics_registry=metrics_registry)

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -44,9 +44,9 @@ def load_identity_signing_key(key_dir, key_name):
     LOGGER.info('Loading signing key: %s', key_path)
     try:
         with open(key_path, 'r') as key_file:
-            privkey = key_file.read().strip()
+            private_key = key_file.read().strip()
     except IOError as e:
         raise LocalConfigurationError(
             "Could not load key file: {}".format(str(e)))
 
-    return privkey
+    return private_key

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -308,7 +308,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the AuthorizationChallengeSubmitHandler returns an
         AuthorizationChallengeResult.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
@@ -344,7 +344,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         AuthorizationViolation and closes the connection if the last message
         was not AuthorizaitonChallengeRequest.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
@@ -380,7 +380,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         AuthorizationViolation and closes the connection if the signature
         is not verified.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
@@ -416,7 +416,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         AuthorizationViolation and closes the connection if the permission
         verifier does not permit the public_key.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -309,7 +309,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         AuthorizationChallengeResult.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
         signature = signing.sign(payload, private_key)
@@ -345,7 +345,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         was not AuthorizaitonChallengeRequest.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
         signature = signing.sign(payload, private_key)
@@ -381,7 +381,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         is not verified.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
         signature = signing.sign(payload, private_key)
@@ -417,7 +417,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         verifier does not permit the public_key.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
         payload = os.urandom(10)
 
         signature = signing.sign(payload, private_key)

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -36,11 +36,11 @@ def _increment_key(key, offset=1):
 def _make_mock_transaction(base_id='id', payload='payload'):
     txn_id = 't-' + base_id
     header = TransactionHeader(
-        batcher_pubkey='pubkey-' + base_id,
+        batcher_public_key='public_key-' + base_id,
         family_name='family',
         family_version='0.0',
         nonce=txn_id,
-        signer_pubkey='pubkey-' + base_id)
+        signer_public_key='public_key-' + base_id)
 
     return Transaction(
         header=header.SerializeToString(),
@@ -52,7 +52,7 @@ def make_mock_batch(base_id='id'):
     txn = _make_mock_transaction(base_id)
 
     header = BatchHeader(
-        signer_pubkey='pubkey-' + base_id,
+        signer_public_key='public_key-' + base_id,
         transaction_ids=[txn.header_signature])
 
     return Batch(
@@ -88,7 +88,7 @@ class MockBlockStore(BlockStore):
         header = BlockHeader(
             block_num=num,
             previous_block_id=previous_id,
-            signer_pubkey='pubkey-' + base_id,
+            signer_public_key='public_key-' + base_id,
             batch_ids=[block_id],
             consensus=b'consensus',
             state_root_hash=root)

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -443,7 +443,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assertFalse(response.batches)
 
     def test_batch_list_sorted_by_nested_key(self):
-        """Verifies batch list requests work sorted by header.signer_pubkey.
+        """Verifies batch list requests work sorted by header.signer_public_key.
 
         Queries the default mock block store with three blocks:
             {header_signature: 'B-2', batches: [{header_signature: 'b-2' ...}] ...}
@@ -459,7 +459,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 'b-0'
             - the last item has a header_signature of 'b-2'
         """
-        controls = self.make_sort_controls('header', 'signer_pubkey')
+        controls = self.make_sort_controls('header', 'signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
@@ -487,7 +487,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 'b-0'
             - the last item has a header_signature of 'b-2'
         """
-        controls = self.make_sort_controls('signer_pubkey')
+        controls = self.make_sort_controls('signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -438,7 +438,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assertFalse(response.blocks)
 
     def test_block_list_sorted_by_nested_key(self):
-        """Verifies block list requests work sorted by header.signer_pubkey.
+        """Verifies block list requests work sorted by header.signer_public_key.
 
         Queries the default mock block store with three blocks:
             {header: {block_num: 2 ...}, header_signature: 'B-2' ...},
@@ -454,7 +454,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 'B-0'
             - the last item has a header_signature of 'B-2'
         """
-        controls = self.make_sort_controls('header', 'signer_pubkey')
+        controls = self.make_sort_controls('header', 'signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
@@ -482,7 +482,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 'B-0'
             - the last item has a header_signature of 'B-2'
         """
-        controls = self.make_sort_controls('signer_pubkey')
+        controls = self.make_sort_controls('signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
@@ -511,7 +511,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - the last item has a header_signature of 'B-2'
         """
         controls = (self.make_sort_controls('consensus') +
-                    self.make_sort_controls('signer_pubkey'))
+                    self.make_sort_controls('signer_public_key'))
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -597,7 +597,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assertFalse(response.transactions)
 
     def test_txn_list_sorted_by_nested_key(self):
-        """Verifies txn list requests work sorted by header.signer_pubkey.
+        """Verifies txn list requests work sorted by header.signer_public_key.
 
         Queries the default mock block store:
             {
@@ -624,7 +624,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 't-0'
             - the last item has a header_signature of 't-2'
         """
-        controls = self.make_sort_controls('header', 'signer_pubkey')
+        controls = self.make_sort_controls('header', 'signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
@@ -663,7 +663,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - the first item has a header_signature of 't-0'
             - the last item has a header_signature of 't-2'
         """
-        controls = self.make_sort_controls('signer_pubkey')
+        controls = self.make_sort_controls('signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
@@ -703,7 +703,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - the last item has a header_signature of 't-2'
         """
         controls = (self.make_sort_controls('family_name') +
-                    self.make_sort_controls('signer_pubkey'))
+                    self.make_sort_controls('signer_public_key'))
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -35,7 +35,7 @@ class TestCompleter(unittest.TestCase):
         self.completer = Completer(self.block_store, self.gossip)
         self.completer._on_block_received = self._on_block_received
         self.completer._on_batch_received = self._on_batch_received
-        self.private_key = signing.generate_privkey()
+        self.private_key = signing.generate_private_key()
         self.public_key = signing.generate_public_key(self.private_key)
         self.blocks = []
         self.batches = []

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -36,7 +36,7 @@ class TestCompleter(unittest.TestCase):
         self.completer._on_block_received = self._on_block_received
         self.completer._on_batch_received = self._on_batch_received
         self.private_key = signing.generate_privkey()
-        self.public_key = signing.generate_pubkey(self.private_key)
+        self.public_key = signing.generate_public_key(self.private_key)
         self.blocks = []
         self.batches = []
 
@@ -64,7 +64,7 @@ class TestCompleter(unittest.TestCase):
             payload_encode = hashlib.sha512(cbor.dumps(payload)).hexdigest()
 
             header = TransactionHeader(
-                signer_pubkey=self.public_key,
+                signer_public_key=self.public_key,
                 family_name='intkey',
                 family_version='1.0',
                 inputs=[addr],
@@ -100,7 +100,7 @@ class TestCompleter(unittest.TestCase):
                                                  missing_dep=missing_dep)
             txn_sig_list = [txn.header_signature for txn in txn_list]
 
-            batch_header = BatchHeader(signer_pubkey=self.public_key)
+            batch_header = BatchHeader(signer_public_key=self.public_key)
             batch_header.transaction_ids.extend(txn_sig_list)
 
             header_bytes = batch_header.SerializeToString()
@@ -134,7 +134,7 @@ class TestCompleter(unittest.TestCase):
                     NULL_BLOCK_IDENTIFIER)
 
             block_header = BlockHeader(
-                signer_pubkey=self.public_key,
+                signer_public_key=self.public_key,
                 batch_ids=batch_ids,
                 block_num=i,
                 previous_block_id= predecessor

--- a/validator/tests/test_devmode_consensus/tests.py
+++ b/validator/tests/test_devmode_consensus/tests.py
@@ -33,8 +33,8 @@ class TestCheckPublishBlock(unittest.TestCase):
     def __init__(self, test_name):
         super().__init__(test_name)
 
-    def create_block_header(self, signer_pubkey=None):
-        return BlockHeader(signer_pubkey=signer_pubkey)
+    def create_block_header(self, signer_public_key=None):
+        return BlockHeader(signer_public_key=signer_public_key)
 
     def create_state_view_factory(self, values):
         state_db = {}

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -69,7 +69,7 @@ def create_block(block_num=85,
 
 
 def create_chain(num=10):
-    priv_key = signer.generate_privkey()
+    priv_key = signer.generate_private_key()
     pub_key = signer.generate_public_key(priv_key)
 
     counter = 1

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -70,7 +70,7 @@ def create_block(block_num=85,
 
 def create_chain(num=10):
     priv_key = signer.generate_privkey()
-    pub_key = signer.generate_pubkey(priv_key)
+    pub_key = signer.generate_public_key(priv_key)
 
     counter = 1
     previous_block_id = "0000000000000000"

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -39,7 +39,7 @@ class TestGenesisController(unittest.TestCase):
 
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
-        self._identity_key = signing.generate_privkey()
+        self._identity_key = signing.generate_private_key()
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir)

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -105,7 +105,7 @@ class BlockTreeManager(object):
 
         self.state_view_factory = MockStateViewFactory(self.state_db)
         self.signing_key = signing.generate_privkey()
-        self.public_key = signing.generate_pubkey(self.signing_key)
+        self.public_key = signing.generate_public_key(self.signing_key)
 
         self.identity_signing_key = signing.generate_privkey()
         chain_head = None
@@ -151,7 +151,7 @@ class BlockTreeManager(object):
 
         header = BlockHeader(
             previous_block_id=previous.identifier,
-            signer_pubkey=self.public_key,
+            signer_public_key=self.public_key,
             block_num=previous.block_num+1)
 
         block_builder = BlockBuilder(header)
@@ -233,7 +233,7 @@ class BlockTreeManager(object):
                      previous_block_id=NULL_BLOCK_IDENTIFIER, block_num=0):
         header = BlockHeader(
             previous_block_id=previous_block_id,
-            signer_pubkey=self.public_key,
+            signer_public_key=self.public_key,
             block_num=block_num)
 
         block_builder = BlockBuilder(header)
@@ -328,7 +328,7 @@ class BlockTreeManager(object):
             txns[-1] = txn_missing_deps
 
         batch_header = BatchHeader(
-            signer_pubkey=self.public_key,
+            signer_public_key=self.public_key,
             transaction_ids=[txn.header_signature for txn in txns]
         ).SerializeToString()
 
@@ -346,12 +346,12 @@ class BlockTreeManager(object):
 
         txn_header = TransactionHeader(
             dependencies=([] if deps is None else deps),
-            batcher_pubkey=self.public_key,
+            batcher_public_key=self.public_key,
             family_name='test',
             family_version='1',
             nonce=_generate_id(16),
             payload_sha512=hasher.hexdigest().encode(),
-            signer_pubkey=self.public_key
+            signer_public_key=self.public_key
         ).SerializeToString()
 
         txn = Transaction(
@@ -365,7 +365,7 @@ class BlockTreeManager(object):
         txn = self.generate_transaction(payload)
 
         batch_header = BatchHeader(
-            signer_pubkey=self.public_key,
+            signer_public_key=self.public_key,
             transaction_ids=[txn.header_signature]
         ).SerializeToString()
 

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -104,10 +104,10 @@ class BlockTreeManager(object):
             'sawtooth.consensus.algorithm', 'test_journal.mock_consensus')
 
         self.state_view_factory = MockStateViewFactory(self.state_db)
-        self.signing_key = signing.generate_privkey()
+        self.signing_key = signing.generate_private_key()
         self.public_key = signing.generate_public_key(self.signing_key)
 
-        self.identity_signing_key = signing.generate_privkey()
+        self.identity_signing_key = signing.generate_private_key()
         chain_head = None
         if with_genesis:
             self.genesis_block = self.generate_genesis_block()

--- a/validator/tests/test_message_validation/tests.py
+++ b/validator/tests/test_message_validation/tests.py
@@ -30,7 +30,7 @@ from sawtooth_validator.gossip import structure_verifier
 class TestMessageValidation(unittest.TestCase):
     def setUp(self):
         self.private_key = signing.generate_privkey()
-        self.public_key = signing.generate_pubkey(self.private_key)
+        self.public_key = signing.generate_public_key(self.private_key)
 
     def broadcast(self, msg):
         pass
@@ -55,7 +55,7 @@ class TestMessageValidation(unittest.TestCase):
             payload_encode = hashlib.sha512(cbor.dumps(payload)).hexdigest()
 
             header = TransactionHeader(
-                signer_pubkey=self.public_key,
+                signer_public_key=self.public_key,
                 family_name='intkey',
                 family_version='1.0',
                 inputs=[addr],
@@ -64,9 +64,9 @@ class TestMessageValidation(unittest.TestCase):
                 payload_sha512=payload_encode)
 
             if valid_batcher:
-                header.batcher_pubkey = self.public_key
+                header.batcher_public_key = self.public_key
             else:
-                header.batcher_pubkey = "bad_batcher"
+                header.batcher_public_key = "bad_batcher"
 
             header_bytes = header.SerializeToString()
 
@@ -107,7 +107,7 @@ class TestMessageValidation(unittest.TestCase):
             if not valid_structure:
                 txn_sig_list.pop()
 
-            batch_header = BatchHeader(signer_pubkey=self.public_key)
+            batch_header = BatchHeader(signer_public_key=self.public_key)
             batch_header.transaction_ids.extend(txn_sig_list)
 
             header_bytes = batch_header.SerializeToString()
@@ -136,7 +136,7 @@ class TestMessageValidation(unittest.TestCase):
                 batch_count, 2, valid_batch=valid_batch)
             batch_ids = [batch.header_signature for batch in batch_list]
 
-            block_header = BlockHeader(signer_pubkey=self.public_key,
+            block_header = BlockHeader(signer_public_key=self.public_key,
                                        batch_ids=batch_ids)
 
             header_bytes = block_header.SerializeToString()

--- a/validator/tests/test_message_validation/tests.py
+++ b/validator/tests/test_message_validation/tests.py
@@ -29,7 +29,7 @@ from sawtooth_validator.gossip import structure_verifier
 
 class TestMessageValidation(unittest.TestCase):
     def setUp(self):
-        self.private_key = signing.generate_privkey()
+        self.private_key = signing.generate_private_key()
         self.public_key = signing.generate_public_key(self.private_key)
 
     def broadcast(self, msg):

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -37,7 +37,7 @@ from test_permission_verifier.mocks import make_policy
 
 class TestPermissionVerifier(unittest.TestCase):
     def setUp(self):
-        self.private_key = signing.generate_privkey()
+        self.private_key = signing.generate_private_key()
         self.public_key = signing.generate_public_key(self.private_key)
         self._identity_view_factory = MockIdentityViewFactory()
         self.permissions = {}

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -38,7 +38,7 @@ from test_permission_verifier.mocks import make_policy
 class TestPermissionVerifier(unittest.TestCase):
     def setUp(self):
         self.private_key = signing.generate_privkey()
-        self.public_key = signing.generate_pubkey(self.private_key)
+        self.public_key = signing.generate_public_key(self.private_key)
         self._identity_view_factory = MockIdentityViewFactory()
         self.permissions = {}
         self._identity_cache = IdentityCache(
@@ -68,7 +68,7 @@ class TestPermissionVerifier(unittest.TestCase):
             payload_encode = hashlib.sha512(cbor.dumps(payload)).hexdigest()
 
             header = TransactionHeader(
-                signer_pubkey=self.public_key,
+                signer_public_key=self.public_key,
                 family_name='intkey',
                 family_version='1.0',
                 inputs=[addr],
@@ -76,7 +76,7 @@ class TestPermissionVerifier(unittest.TestCase):
                 dependencies=[],
                 payload_sha512=payload_encode)
 
-            header.batcher_pubkey = self.public_key
+            header.batcher_public_key = self.public_key
 
             header_bytes = header.SerializeToString()
 
@@ -101,7 +101,7 @@ class TestPermissionVerifier(unittest.TestCase):
             txn_list = self._create_transactions(txn_count)
             txn_sig_list = [txn.header_signature for txn in txn_list]
 
-            batch_header = BatchHeader(signer_pubkey=self.public_key)
+            batch_header = BatchHeader(signer_public_key=self.public_key)
             batch_header.transaction_ids.extend(txn_sig_list)
 
             header_bytes = batch_header.SerializeToString()

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -107,7 +107,7 @@ class TestSchedulers(unittest.TestCase):
         """
 
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         transaction_validity = {}
 
@@ -269,7 +269,7 @@ class TestSchedulers(unittest.TestCase):
         """
 
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         transaction_validity = {}
 
@@ -382,7 +382,7 @@ class TestSchedulers(unittest.TestCase):
         """
 
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
             payload='a'.encode(),
@@ -442,7 +442,7 @@ class TestSchedulers(unittest.TestCase):
         This test should work for both a serial and parallel scheduler.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
             payload='a'.encode(),
@@ -501,7 +501,7 @@ class TestSchedulers(unittest.TestCase):
         This test should work for both a serial and parallel scheduler.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         # Create a basic transaction and batch.
         txn, _ = create_transaction(
@@ -611,7 +611,7 @@ class TestSchedulers(unittest.TestCase):
         This test should work for both a serial and parallel scheduler.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         # 1)
         batch_signatures = []
@@ -733,7 +733,7 @@ class TestSchedulers(unittest.TestCase):
         """
 
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         # 1)
         batch_signatures = []
@@ -842,7 +842,7 @@ class TestSerialScheduler(unittest.TestCase):
         is thrown by the iterator.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txns = []
 
@@ -896,7 +896,7 @@ class TestSerialScheduler(unittest.TestCase):
         is thrown by the iterator, and the complete is true in the at the end.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txns = []
 
@@ -957,7 +957,7 @@ class TestSerialScheduler(unittest.TestCase):
         step.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txns = []
 
@@ -1018,7 +1018,7 @@ class TestParallelScheduler(unittest.TestCase):
         to a finalized scheduler is invalid.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         # Finalize prior to attempting to add a batch.
         self.scheduler.finalize()
@@ -1048,7 +1048,7 @@ class TestParallelScheduler(unittest.TestCase):
         iterator or calling next_transaction()).
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
             payload='a'.encode(),
@@ -1080,7 +1080,7 @@ class TestParallelScheduler(unittest.TestCase):
         is thrown by the iterator.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txns = []
 
@@ -1129,7 +1129,7 @@ class TestParallelScheduler(unittest.TestCase):
         Creates one batch with four transactions.
         """
         private_key = signing.generate_privkey()
-        public_key = signing.generate_pubkey(private_key)
+        public_key = signing.generate_public_key(private_key)
 
         txns = []
         headers = []

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -106,7 +106,7 @@ class TestSchedulers(unittest.TestCase):
 
         """
 
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         transaction_validity = {}
@@ -268,7 +268,7 @@ class TestSchedulers(unittest.TestCase):
              3. Assert that only txn A is run.
         """
 
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         transaction_validity = {}
@@ -381,7 +381,7 @@ class TestSchedulers(unittest.TestCase):
         This test should work for both a serial and parallel scheduler.
         """
 
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
@@ -441,7 +441,7 @@ class TestSchedulers(unittest.TestCase):
 
         This test should work for both a serial and parallel scheduler.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
@@ -500,7 +500,7 @@ class TestSchedulers(unittest.TestCase):
 
         This test should work for both a serial and parallel scheduler.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         # Create a basic transaction and batch.
@@ -610,7 +610,7 @@ class TestSchedulers(unittest.TestCase):
 
         This test should work for both a serial and parallel scheduler.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         # 1)
@@ -732,7 +732,7 @@ class TestSchedulers(unittest.TestCase):
                is invalid and consequently has no state hash.
         """
 
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         # 1)
@@ -841,7 +841,7 @@ class TestSerialScheduler(unittest.TestCase):
         This test also finalizes the scheduler and verifies that StopIteration
         is thrown by the iterator.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txns = []
@@ -895,7 +895,7 @@ class TestSerialScheduler(unittest.TestCase):
         This test also finalizes the scheduler and verifies that StopIteration
         is thrown by the iterator, and the complete is true in the at the end.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txns = []
@@ -956,7 +956,7 @@ class TestSerialScheduler(unittest.TestCase):
         since the first Transaction was marked as applied in the previous
         step.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txns = []
@@ -1017,7 +1017,7 @@ class TestParallelScheduler(unittest.TestCase):
         The result is expected to be a SchedulerError, since adding a batch
         to a finalized scheduler is invalid.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         # Finalize prior to attempting to add a batch.
@@ -1047,7 +1047,7 @@ class TestParallelScheduler(unittest.TestCase):
         transaction without first causing it to be scheduled (by using an
         iterator or calling next_transaction()).
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txn, _ = create_transaction(
@@ -1079,7 +1079,7 @@ class TestParallelScheduler(unittest.TestCase):
         This test also finalizes the scheduler and verifies that StopIteration
         is thrown by the iterator.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txns = []
@@ -1128,7 +1128,7 @@ class TestParallelScheduler(unittest.TestCase):
 
         Creates one batch with four transactions.
         """
-        private_key = signing.generate_privkey()
+        private_key = signing.generate_private_key()
         public_key = signing.generate_public_key(private_key)
 
         txns = []

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -621,7 +621,7 @@ class SchedulerTester(object):
 
     def _create_batches(self):
         test_yaml = self._yaml_from_file()
-        priv_key = signing.generate_privkey()
+        priv_key = signing.generate_private_key()
         pub_key = signing.generate_public_key(priv_key)
 
         batches, batch_results = self._process_batches(

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -51,7 +51,7 @@ def create_transaction(payload, private_key, public_key, inputs=None,
         dependencies = []
 
     header = transaction_pb2.TransactionHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         family_name='scheduler_test',
         family_version='1.0',
         inputs=inputs,
@@ -59,7 +59,7 @@ def create_transaction(payload, private_key, public_key, inputs=None,
         dependencies=dependencies,
         nonce=str(time.time()),
         payload_sha512=hashlib.sha512(payload).hexdigest(),
-        batcher_pubkey=public_key)
+        batcher_public_key=public_key)
 
     header_bytes = header.SerializeToString()
 
@@ -77,7 +77,7 @@ def create_batch(transactions, private_key, public_key):
     transaction_ids = [t.header_signature for t in transactions]
 
     header = batch_pb2.BatchHeader(
-        signer_pubkey=public_key,
+        signer_public_key=public_key,
         transaction_ids=transaction_ids)
 
     header_bytes = header.SerializeToString()
@@ -622,7 +622,7 @@ class SchedulerTester(object):
     def _create_batches(self):
         test_yaml = self._yaml_from_file()
         priv_key = signing.generate_privkey()
-        pub_key = signing.generate_pubkey(priv_key)
+        pub_key = signing.generate_public_key(priv_key)
 
         batches, batch_results = self._process_batches(
             yaml_batches=test_yaml,

--- a/validator/tests/test_validation_rule_enforcer/test.py
+++ b/validator/tests/test_validation_rule_enforcer/test.py
@@ -32,20 +32,20 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
         self._validation_rule_enforcer = ValidationRuleEnforcer(
             self._settings_view_factory)
 
-    def _make_block(self, txns_family, signer_pubkey, same_pubkey=True):
+    def _make_block(self, txns_family, signer_public_key, same_public_key=True):
         transactions = []
         for family in txns_family:
             txn_header = TransactionHeader(
                 family_name=family,
-                signer_pubkey=signer_pubkey)
+                signer_public_key=signer_public_key)
             txn = Transaction(header=txn_header.SerializeToString())
             transactions.append(txn)
 
         batch = Batch(transactions=transactions)
-        if same_pubkey:
-            block_header = BlockHeader(signer_pubkey=signer_pubkey)
+        if same_public_key:
+            block_header = BlockHeader(signer_public_key=signer_public_key)
         else:
-            block_header = BlockHeader(signer_pubkey="other")
+            block_header = BlockHeader(signer_public_key="other")
         block = Block(header=block_header.SerializeToString(), batches=[batch])
         return BlockWrapper(block)
 


### PR DESCRIPTION
Protobufs are updated to use public_key instead of pubkey. To standardize around this, all instance of pubkey and privkey (except where required by bitcoin) have been replaced with public_key and private_key