### PR TITLE
Add TransactionHandler Abstract Base Class to Python SDK

### DIFF
--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.exceptions import InvalidSignature
 
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.processor.context import StateEntry
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
@@ -178,7 +179,7 @@ def _get_config_setting(context, key):
     raise KeyError('Setting for {} not found'.format(key))
 
 
-class ValidatorRegistryTransactionHandler(object):
+class ValidatorRegistryTransactionHandler(TransactionHandler):
     def __init__(self):
         pass
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -88,11 +88,11 @@ def _config_key_to_address(key):
     return _CONFIG_NAMESPACE + ''.join(addr_parts)
 
 
-def _get_state(state, address, value_type):
+def _get_state(context, address, value_type):
     try:
-        entries_list = state.get([address], timeout=STATE_TIMEOUT_SEC)
+        entries_list = context.get([address], timeout=STATE_TIMEOUT_SEC)
     except FutureTimeoutError:
-        LOGGER.warning('Timeout occurred on state.get([%s])', address)
+        LOGGER.warning('Timeout occurred on context.get([%s])', address)
         raise InternalError('Unable to get {}'.format(address))
 
     value = value_type()
@@ -107,7 +107,7 @@ def _get_address(key):
     return address
 
 
-def _get_validator_state(state, validator_id=None):
+def _get_validator_state(context, validator_id=None):
     if validator_id is None:
         address = _get_address('validator_map')
         value_type = ValidatorMap
@@ -115,46 +115,46 @@ def _get_validator_state(state, validator_id=None):
         address = _get_address(validator_id)
         value_type = ValidatorInfo
 
-    return _get_state(state=state, address=address, value_type=value_type)
+    return _get_state(context=context, address=address, value_type=value_type)
 
 
-def _update_validator_state(state,
+def _update_validator_state(context,
                             validator_id,
                             anti_sybil_id,
                             validator_info):
 
-    validator_map = _get_validator_state(state)
+    validator_map = _get_validator_state(context)
     updated_map = ValidatorMap()
     # Clean out old entries in ValidatorInfo and ValidatorMap
     # Protobuf doesn't offer delete item for ValidatorMap so create a new list
     for entry in validator_map.entries:
         if anti_sybil_id == entry.key:
             address = _get_address(entry.value)
-            _set_data(state, address, b'')
+            _set_data(context, address, b'')
         else:
             updated_map.entries.add(key=entry.key, value=entry.value)
 
     # Add new state entries to ValidatorMap and ValidatorInfo
     updated_map.entries.add(key=anti_sybil_id, value=validator_id)
     address_map = _get_address('validator_map')
-    _set_data(state, address_map, updated_map.SerializeToString())
+    _set_data(context, address_map, updated_map.SerializeToString())
 
     address = _get_address(validator_id)
-    _set_data(state, address, validator_info)
+    _set_data(context, address, validator_info)
     LOGGER.info("Validator id %s was added to the validator_map and set.",
                 validator_id)
 
 
-def _set_data(state, address, data):
+def _set_data(context, address, data):
     try:
-        addresses = list(state.set(
+        addresses = list(context.set(
             [StateEntry(address=address, data=data)],
             timeout=STATE_TIMEOUT_SEC)
         )
 
     except FutureTimeoutError:
         LOGGER.warning(
-            'Timeout occurred on state.set([%s, <value>])', address)
+            'Timeout occurred on context.set([%s, <value>])', address)
         raise InternalError(
             'Failed to save value on address {}'.format(address))
 
@@ -165,10 +165,10 @@ def _set_data(state, address, data):
             'Failed to save value on address {}'.format(address))
 
 
-def _get_config_setting(state, key):
+def _get_config_setting(context, key):
     setting = \
         _get_state(
-            state=state,
+            context=context,
             address=_config_key_to_address(key),
             value_type=Setting)
     for setting_entry in setting.entries:
@@ -198,7 +198,7 @@ class ValidatorRegistryTransactionHandler(object):
                             signup_info,
                             originator_public_key_hash,
                             val_reg_payload,
-                            state):
+                            context):
 
         # Verify the attestation verification report signature
         proof_data_dict = json.loads(signup_info.proof_data)
@@ -215,7 +215,7 @@ class ValidatorRegistryTransactionHandler(object):
         try:
             report_public_key_pem = \
                 _get_config_setting(
-                    state=state,
+                    context=context,
                     key='sawtooth.poet.report_public_key_pem')
             report_public_key = \
                 serialization.load_pem_public_key(
@@ -235,7 +235,7 @@ class ValidatorRegistryTransactionHandler(object):
         try:
             valid_measurements = \
                 _get_config_setting(
-                    state=state,
+                    context=context,
                     key='sawtooth.poet.valid_enclave_measurements')
             valid_enclave_mesaurements = \
                 [bytes.fromhex(m) for m in valid_measurements.split(',')]
@@ -255,7 +255,7 @@ class ValidatorRegistryTransactionHandler(object):
         try:
             valid_basenames = \
                 _get_config_setting(
-                    state=state,
+                    context=context,
                     key='sawtooth.poet.valid_enclave_basenames')
             valid_enclave_basenames = \
                 [bytes.fromhex(b) for b in valid_basenames.split(',')]
@@ -440,7 +440,7 @@ class ValidatorRegistryTransactionHandler(object):
                         nonce,
                         val_reg_payload.signup_info.nonce))
 
-    def apply(self, transaction, state):
+    def apply(self, transaction, context):
         txn_header = TransactionHeader()
         txn_header.ParseFromString(transaction.header)
         pubkey = txn_header.signer_pubkey
@@ -469,7 +469,7 @@ class ValidatorRegistryTransactionHandler(object):
                 signup_info=signup_info,
                 originator_public_key_hash=public_key_hash,
                 val_reg_payload=val_reg_payload,
-                state=state)
+                context=context)
 
         except ValueError as error:
             raise InvalidTransaction(
@@ -484,7 +484,7 @@ class ValidatorRegistryTransactionHandler(object):
             transaction_id=transaction.signature
         )
 
-        _update_validator_state(state,
+        _update_validator_state(context,
                                 validator_id,
                                 signup_info.anti_sybil_id,
                                 validator_info.SerializeToString())

--- a/families/battleship/sawtooth_battleship/processor/handler.py
+++ b/families/battleship/sawtooth_battleship/processor/handler.py
@@ -15,13 +15,14 @@
 
 import logging
 
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_battleship.processor.battleship_transaction \
     import BattleshipTransaction
 
 LOGGER = logging.getLogger(__name__)
 
 
-class BattleshipTransactionHandler:
+class BattleshipTransactionHandler(TransactionHandler):
     def __init__(self, namespace_prefix):
         self._namespace_prefix = namespace_prefix
 

--- a/families/block_info/sawtooth_block_info/processor/handler.py
+++ b/families/block_info/sawtooth_block_info/processor/handler.py
@@ -16,6 +16,7 @@
 import logging
 import time
 
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.processor.context import StateEntry
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
@@ -53,7 +54,7 @@ def validate_timestamp(timestamp, tolerance):
                 timestamp, now, tolerance))
 
 
-class BlockInfoTransactionHandler(object):
+class BlockInfoTransactionHandler(TransactionHandler):
     @property
     def family_name(self):
         return FAMILY_NAME

--- a/families/identity/sawtooth_identity/processor/handler.py
+++ b/families/identity/sawtooth_identity/processor/handler.py
@@ -17,6 +17,7 @@ import logging
 import hashlib
 
 from sawtooth_sdk.processor.context import StateEntry
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
@@ -85,7 +86,7 @@ ALLOWED_SIGNER_ADDRESS = _setting_key_to_address(
     "sawtooth.identity.allowed_keys")
 
 
-class IdentityTransactionHandler(object):
+class IdentityTransactionHandler(TransactionHandler):
     @property
     def family_name(self):
         return 'sawtooth_identity'

--- a/families/settings/sawtooth_settings/processor/handler.py
+++ b/families/settings/sawtooth_settings/processor/handler.py
@@ -19,6 +19,7 @@ import base64
 from functools import lru_cache
 
 from sawtooth_sdk.processor.context import StateEntry
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
@@ -41,7 +42,7 @@ SETTINGS_NAMESPACE = '000000'
 STATE_TIMEOUT_SEC = 10
 
 
-class SettingsTransactionHandler(object):
+class SettingsTransactionHandler(TransactionHandler):
 
     @property
     def family_name(self):

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
@@ -19,6 +19,7 @@ import hashlib
 import cbor
 
 from sawtooth_sdk.processor.context import StateEntry
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
 
@@ -43,7 +44,7 @@ def make_intkey_address(name):
         name.encode('utf-8')).hexdigest()[-64:]
 
 
-class IntkeyTransactionHandler:
+class IntkeyTransactionHandler(TransactionHandler):
     @property
     def family_name(self):
         return FAMILY_NAME

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -17,6 +17,7 @@ import hashlib
 import logging
 
 from sawtooth_sdk.processor.context import StateEntry
+from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
 from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
@@ -24,7 +25,7 @@ from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 LOGGER = logging.getLogger(__name__)
 
 
-class XoTransactionHandler:
+class XoTransactionHandler(TransactionHandler):
     def __init__(self, namespace_prefix):
         self._namespace_prefix = namespace_prefix
 

--- a/sdk/python/sawtooth_sdk/processor/handler.py
+++ b/sdk/python/sawtooth_sdk/processor/handler.py
@@ -1,0 +1,61 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import abc
+
+
+class TransactionHandler(object, metaclass=abc.ABCMeta):
+    """
+    TransactionHandler is the Abstract Base Class that defines the business
+    logic for a new transaction family.
+
+    The family_name, family_versions, and namespaces properties are
+    used by the processor to route processing requests to the handler.
+    """
+
+    @abc.abstractproperty
+    def family_name(self):
+        """
+        family_name should return the name of the transaction family that this
+        handler can process. Eg., "intkey"
+        """
+        pass
+
+    @abc.abstractproperty
+    def family_versions(self):
+        """
+        family_versions should return a list of versions the this transaction
+        family handler can process. Eg., ["1.0"]
+        """
+        pass
+
+    @abc.abstractproperty
+    def namespaces(self):
+        """
+        namespaces should return a list containing all the handler's
+        namespaces. Eg., ["abcdef"]
+        """
+        pass
+
+    @abc.abstractmethod
+    def apply(self, transaction, context):
+        """
+        Apply is the single method where all the business logic for a
+        transaction family is defined. The method will be called by the
+        transaction processor upon receiving a TpProcessRequest that the
+        handler understands and will pass in the TpProcessRequest and an
+        initialized instance of the Context type.
+        """
+        pass


### PR DESCRIPTION
The other SDKs have an interface defined for TransactionHandlers, but python did not. This PR adds an Abstract Base Class that all TransactionHandlers should inherit from. It also updates the ValidatorRegistryTransactionHandler to expect context instead of state.