### PR TITLE
Make run_docker_test output more helpful

### DIFF
--- a/bin/run_docker_test
+++ b/bin/run_docker_test
@@ -16,10 +16,8 @@
 
 import subprocess
 import os
-import sys
 import argparse
 import time
-import traceback
 import logging
 import yaml
 
@@ -30,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 600
 COMPOSE_DOWN_RETRY_TIMEOUT = 60
-DOCKER_PS_TIMEOUT=30
+DOCKER_PS_TIMEOUT = 30
 
 
 class RunDockerTestError(BaseException):
@@ -74,8 +72,6 @@ def main():
 
     compose_down = compose + ['down', '--remove-orphans']
 
-    compose_kill = compose + ['kill']
-
     scrape = [
         'docker', 'ps', '-a',
         '--format={{.Names}},{{.Image}},{{.Label "install-type"}}',
@@ -93,7 +89,8 @@ def main():
     _validate_compose_dict(compose_dict, test_service, compose_file)
 
     if not args.clean:
-        _check_for_existing_containers(compose_file, compose_dict, isolation_id)
+        _check_for_existing_containers(
+            compose_file, compose_dict, isolation_id)
 
     for service in compose_dict['services']:
         scrape += [
@@ -102,7 +99,6 @@ def main():
 
     timer = Timer(args.timeout)
 
-
     # Run tests
     try:
         if not args.clean:
@@ -110,9 +106,13 @@ def main():
             timer.start()
 
             LOGGER.info("Bringing up with %s", str(compose_up))
+
             try:
                 # 1. Run the tests
-                subprocess.run(compose_up, check=True, timeout=timer.remaining())
+                subprocess.run(
+                    compose_up,
+                    check=True,
+                    timeout=timer.remaining())
 
             except FileNotFoundError as err:
                 LOGGER.error("Bad docker-compose up command")
@@ -158,24 +158,25 @@ def main():
                     scrape, stdout=subprocess.PIPE,
                     timeout=timer.remaining(), check=True
                 ).stdout.decode().strip()
+
                 for line in info.split('\n'):
                     container, image, install_type = line.split(',')
                     LOGGER.info(
-                        "Container {} ran image {} with install-type {}".format(
-                            container, image, install_type
-                        )
+                        "Container %s ran image %s with install-type %s",
+                        container, image, install_type
                     )
 
             except BaseException:
                 LOGGER.error("Could not gather information about image used.")
 
-        else: # cleaning
+        else:  # cleaning
             exit_status = 0
 
         LOGGER.info("Shutting down with: %s", str(compose_down))
+
         shutdown_success = False
-        for i in range(2):
-            if shutdown_success == False:
+        for _ in range(2):
+            if not shutdown_success:
 
                 # Always give compose down time to cleanup
                 timeout = max(timer.remaining(), COMPOSE_DOWN_RETRY_TIMEOUT)
@@ -206,7 +207,9 @@ def main():
         exit(int(exit_status))
 
     except KeyboardInterrupt:
-        subprocess.run(compose_down, check=True,
+        subprocess.run(
+            compose_down,
+            check=True,
             timeout=COMPOSE_DOWN_RETRY_TIMEOUT)
         exit(1)
 
@@ -254,7 +257,9 @@ def parse_args():
 
 
 def _get_test_service(compose_file):
-    return os.path.basename(compose_file).replace('.yaml', '').replace('_', '-')
+    return os.path.basename(
+        compose_file
+    ).replace('.yaml', '').replace('_', '-')
 
 
 def _validate_compose_dict(compose_dict, test_service, compose_file):
@@ -278,7 +283,8 @@ def _check_for_existing_containers(compose_file, compose_dict, isolation_id):
                     )
                 )
 
-def _check_for_existing_network(isolation_id):
+
+def _check_for_existing_network(isolation_id, compose_file):
     networks = _get_existing_networks()
     network_to_create = '{}_default'.format(isolation_id)
     if network_to_create in networks:

--- a/bin/run_docker_test
+++ b/bin/run_docker_test
@@ -105,6 +105,10 @@ def main():
             exit_status = 0
             timer.start()
 
+            test_service_uppercase = test_service.upper()
+
+            LOGGER.info('Starting test %s', test_service_uppercase)
+
             LOGGER.info("Bringing up with %s", str(compose_up))
 
             try:
@@ -120,12 +124,12 @@ def main():
                 exit(1)
 
             except subprocess.CalledProcessError as err:
-                LOGGER.error("Test error")
+                LOGGER.error("Test error in %s", test_service_uppercase)
                 LOGGER.exception(err)
                 exit_status = 1
 
             except subprocess.TimeoutExpired as err:
-                LOGGER.error("Test timed out.")
+                LOGGER.error("Test %s timed out.", test_service_uppercase)
                 LOGGER.exception(err)
                 exit_status = 1
 
@@ -133,10 +137,10 @@ def main():
                 LOGGER.info("Getting result with: %s", str(inspect))
                 try:
                     # 2. Get the exit code of the test container
-                    exit_status = subprocess.run(
+                    exit_status = int(subprocess.run(
                         inspect, stdout=subprocess.PIPE,
                         timeout=timer.remaining(), check=True
-                    ).stdout.decode().strip()
+                    ).stdout.decode().strip())
 
                 except FileNotFoundError as err:
                     LOGGER.error("Bad docker inspect or ps command")
@@ -204,7 +208,10 @@ def main():
                 " see what was left behind or use `run_docker_test --clean`!"
             )
 
-        exit(int(exit_status))
+        if exit_status != 0:
+            LOGGER.error('Test %s failed', test_service_uppercase)
+
+        exit(exit_status)
 
     except KeyboardInterrupt:
         subprocess.run(

--- a/bin/run_docker_test
+++ b/bin/run_docker_test
@@ -120,7 +120,7 @@ def main():
                 exit(1)
 
             except subprocess.CalledProcessError as err:
-                LOGGER.error("Failed to start test.")
+                LOGGER.error("Test error")
                 LOGGER.exception(err)
                 exit_status = 1
 

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -164,14 +164,11 @@ PYTHONPATH=$top_dir/families/identity
 PYTHONPATH=$top_dir/families/block_info
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/families/supplychain/python
-PYTHONPATH=$PYTHONPATH:$top_dir/families/track_and_trade/processor
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
 export PYTHONPATH
 lint families/settings "$SINCE" || retval=1
 lint families/identity "$SINCE" || retval=1
 lint families/supplychain/python "$SINCE" || retval=1
-lint families/track_and_trade/processor/sawtooth_track_and_trade/ "$SINCE" || retval=1
-lint families/track_and_trade/tests/sawtooth_tt_test "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/families/battleship
 PYTHONPATH=$PYTHONPATH:$top_dir/signing

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -41,11 +41,9 @@ class TestCompleter(unittest.TestCase):
         self.batches = []
 
     def _on_block_received(self, block):
-        print("Block received")
         return self.blocks.append(block.header_signature)
 
     def _on_batch_received(self, batch):
-        print("Batch received")
         return self.batches.append(batch.header_signature)
 
     def _create_transactions(self, count, missing_dep=False):

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -299,7 +299,6 @@ class TestBlockPublisher(unittest.TestCase):
         # with a batch limit
         addr, value = CreateSetting(
             'sawtooth.publisher.max_batches_per_block', 1)
-        print('test', addr)
         self.state_view_factory = MockStateViewFactory(
             {addr: value})
 


### PR DESCRIPTION
I got sick of searching through `run_docker_test`'s output to find which test failed.
```
Removing 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_rest-api_1 ... [32mdone[0m
[2B[4A[2K
Removing 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_intkey-tp-java_1 ... [32mdone[0m
[4BRemoving network 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_default
/data/jenkins/workspace/jenkins-Sawtooth-Hyperledger-sawtooth-core-PR-1012-8
INFO:__main__:Bringing up with ['docker-compose', '-p', '5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e', '-f', './sdk/examples/xo_python/tests/test_tp_xo_java.yaml', 'up', '--abort-on-container-exit']
Creating network "5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_default" with the default driver
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_xo-tp-java_1 ... 
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_test-tp-xo-java_1 ... 
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_xo-tp-java_1
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_test-tp-xo-java_1
[1A[2K
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_xo-tp-java_1 ... [32mdone[0m
[1B[1A[2K
Creating 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_test-tp-xo-java_1 ... [32mdone[0m
[1BERROR:__main__:Test timed out.
ERROR:__main__:Command '['docker-compose', '-p', '5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e', '-f', './sdk/examples/xo_python/tests/test_tp_xo_java.yaml', 'up', '--abort-on-container-exit']' timed out after 599.9997000694275 seconds
Traceback (most recent call last):
  File "/usr/lib/python3.5/subprocess.py", line 695, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.5/subprocess.py", line 1072, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.5/subprocess.py", line 1741, in _communicate
    self.wait(timeout=self._remaining_time(endtime))
  File "/usr/lib/python3.5/subprocess.py", line 1650, in wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['docker-compose', '-p', '5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e', '-f', './sdk/examples/xo_python/tests/test_tp_xo_java.yaml', 'up', '--abort-on-container-exit']' timed out after 599.9996553534293 seconds

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/data/jenkins/workspace/jenkins-Sawtooth-Hyperledger-sawtooth-core-PR-1012-8/bin/run_docker_test", line 115, in main
    subprocess.run(compose_up, check=True, timeout=timer.remaining())
  File "/usr/lib/python3.5/subprocess.py", line 700, in run
    stderr=stderr)
subprocess.TimeoutExpired: Command '['docker-compose', '-p', '5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e', '-f', './sdk/examples/xo_python/tests/test_tp_xo_java.yaml', 'up', '--abort-on-container-exit']' timed out after 599.9997000694275 seconds
ERROR:__main__:Could not gather information about image used.
INFO:__main__:Shutting down with: ['docker-compose', '-p', '5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e', '-f', './sdk/examples/xo_python/tests/test_tp_xo_java.yaml', 'down', '--remove-orphans']
Stopping 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_test-tp-xo-java_1 ... 
Stopping 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_xo-tp-java_1 ... 
Attaching to 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_xo-tp-java_1, 5459c35180f3a1eff0d229556e579892c40b0b97b3db022e8ea3c0ba8c41225e_test-tp-xo-java_1
```
This PR attempts to make it a little easier to eyeball the results of a failed test.