### PR TITLE
Return AuthorizationException from Context

### DIFF
--- a/families/smallbank/smallbank_go/src/sawtooth_smallbank/handler/handler.go
+++ b/families/smallbank/smallbank_go/src/sawtooth_smallbank/handler/handler.go
@@ -287,7 +287,7 @@ func loadAccount(customer_id uint32, context *processor.Context) (*smallbank_pb2
 
 	results, err := context.GetState([]string{address})
 	if err != nil {
-		return nil, &processor.InternalError{Msg: fmt.Sprint("Error getting state:", err)}
+		return nil, err
 	}
 
 	if len(string(results[address])) > 0 {
@@ -312,7 +312,7 @@ func saveAccount(account *smallbank_pb2.Account, context *processor.Context) err
 		address: data,
 	})
 	if err != nil {
-		return &processor.InternalError{Msg: fmt.Sprint("Failed to set new Value:", err)}
+		return err
 	}
 
 	if len(addresses) == 0 {

--- a/sdk/examples/intkey_go/src/sawtooth_intkey/handler/handler.go
+++ b/sdk/examples/intkey_go/src/sawtooth_intkey/handler/handler.go
@@ -115,7 +115,7 @@ func (self *IntkeyHandler) Apply(request *processor_pb2.TpProcessRequest, contex
 
 	results, err := context.GetState([]string{address})
 	if err != nil {
-		return &processor.InternalError{Msg: fmt.Sprint("Error getting state:", err)}
+		return err
 	}
 
 	var collisionMap map[string]int
@@ -177,7 +177,7 @@ func (self *IntkeyHandler) Apply(request *processor_pb2.TpProcessRequest, contex
 		address: data,
 	})
 	if err != nil {
-		return &processor.InternalError{Msg: fmt.Sprint("Failed to set new Value:", err)}
+		return err
 	}
 	if len(addresses) == 0 {
 		return &processor.InternalError{Msg: "No addresses in set response"}

--- a/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
+++ b/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
@@ -273,7 +273,7 @@ func loadGame(name string, context *processor.Context) (*Game, error) {
 
 	results, err := context.GetState([]string{address})
 	if err != nil {
-		return nil, &processor.InternalError{Msg: fmt.Sprint("Error getting state:", err)}
+		return nil, err
 	}
 
 	if len(string(results[address])) > 0 {
@@ -303,7 +303,7 @@ func saveGame(game *Game, context *processor.Context) error {
 		address: data,
 	})
 	if err != nil {
-		return &processor.InternalError{Msg: fmt.Sprint("Failed to set new Value:", err)}
+		return err
 	}
 	if len(addresses) == 0 {
 		return &processor.InternalError{Msg: "No addresses in set response"}

--- a/sdk/go/src/sawtooth_sdk/processor/context.go
+++ b/sdk/go/src/sawtooth_sdk/processor/context.go
@@ -104,9 +104,7 @@ func (self *Context) GetState(addresses []string) (map[string][]byte, error) {
 	// Use a switch in case new Status values are added
 	switch response.Status {
 	case state_context_pb2.TpStateGetResponse_AUTHORIZATION_ERROR:
-		return nil, fmt.Errorf(
-			"Tried to get unauthorized address: %v", addresses,
-		)
+		return nil, &AuthorizationException{Msg: fmt.Sprint("Tried to get unauthorized address: ", addresses)}
 	}
 
 	// Construct and return a map
@@ -188,7 +186,7 @@ func (self *Context) SetState(pairs map[string][]byte) ([]string, error) {
 		for a, _ := range pairs {
 			addresses = append(addresses, a)
 		}
-		return nil, fmt.Errorf("Tried to set unauthorized address: %v", addresses)
+		return nil, &AuthorizationException{Msg: fmt.Sprint("Tried to set unauthorized address: ", addresses)}
 	}
 
 	return response.GetAddresses(), nil

--- a/sdk/go/src/sawtooth_sdk/processor/errors.go
+++ b/sdk/go/src/sawtooth_sdk/processor/errors.go
@@ -36,3 +36,12 @@ type InternalError struct {
 func (err *InternalError) Error() string {
 	return fmt.Sprint("Internal error: ", err.Msg)
 }
+
+type AuthorizationException struct {
+	Msg          string
+	ExtendedData []byte
+}
+
+func (err *AuthorizationException) Error() string {
+	return fmt.Sprint("Authorization exception: ", err.Msg)
+}

--- a/sdk/go/src/sawtooth_sdk/processor/worker.go
+++ b/sdk/go/src/sawtooth_sdk/processor/worker.go
@@ -85,6 +85,11 @@ func worker(context *zmq.Context, uri string, queue chan *validator_pb2.Message,
 				response.Status = processor_pb2.TpProcessResponse_INTERNAL_ERROR
 				response.Message = e.Msg
 				response.ExtendedData = e.ExtendedData
+			case *AuthorizationException:
+				logger.Warnf("(%v) %v", id, e)
+				response.Status = processor_pb2.TpProcessResponse_INVALID_TRANSACTION
+				response.Message = e.Msg
+				response.ExtendedData = e.ExtendedData
 			default:
 				logger.Errorf("(%v) Unknown error: %v", id, err)
 				response.Status = processor_pb2.TpProcessResponse_INTERNAL_ERROR

--- a/sdk/javascript/processor/context.js
+++ b/sdk/javascript/processor/context.js
@@ -18,7 +18,7 @@
 'use strict'
 
 const {Entry, TpStateGetRequest, TpStateGetResponse, TpStateSetRequest, TpStateSetResponse, Message} = require('../protobuf')
-const {InvalidTransaction} = require('../processor/exceptions')
+const {AuthorizationException} = require('../processor/exceptions')
 
 const _timeoutPromise = (p, millis) => {
   if (millis !== null && millis !== undefined) {
@@ -55,7 +55,7 @@ class Context {
           results[entry.address] = entry.data
         })
         if (getResponse.status === TpStateGetResponse.Status.AUTHORIZATION_ERROR) {
-          throw new InvalidTransaction(`Tried to get unauthorized address ${addresses}`)
+          throw new AuthorizationException(`Tried to get unauthorized address ${addresses}`)
         }
         return results
       }),
@@ -81,7 +81,7 @@ class Context {
         let setResponse = TpStateSetResponse.decode(buffer)
         if (setResponse.status === TpStateSetResponse.Status.AUTHORIZATION_ERROR) {
           let addresses = Object.keys(addressValuePairs)
-          throw new InvalidTransaction(`Tried to set unauthorized address ${addresses}`)
+          throw new AuthorizationException(`Tried to set unauthorized address ${addresses}`)
         }
         return setResponse.addresses
       }),

--- a/sdk/javascript/processor/exceptions.js
+++ b/sdk/javascript/processor/exceptions.js
@@ -84,8 +84,25 @@ class ValidatorConnectionError extends Error {
   }
 }
 
+/**
+ * Thrown when a authorization error occurs
+ */
+class AuthorizationException extends Error {
+  /**
+   * Construcs a new AuthorizationException
+   *
+   * @param {string} [message] - an optional message, defaults to the empty
+   * string
+   */
+  constructor (message = '') {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
 module.exports = {
   InvalidTransaction,
   InternalError,
-  ValidatorConnectionError
+  ValidatorConnectionError,
+  AuthorizationException
 }

--- a/sdk/javascript/processor/index.js
+++ b/sdk/javascript/processor/index.js
@@ -96,6 +96,13 @@ class TransactionProcessor {
                   })
                 } else if (e instanceof ValidatorConnectionError) {
                   console.log('Validator disconnected.  Ignoring.')
+                } else if (e instanceof AuthorizationException) {
+                  console.log(e)
+                  return TpProcessResponse.create({
+                    status: TpProcessResponse.Status.INVALID_TRANSACTION,
+                    message: e.message,
+                    extendedData: e.extendedData
+                  })
                 } else {
                   console.log('Unhandled exception, returning INTERNAL_ERROR', e)
                   return TpProcessResponse.create({

--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -15,8 +15,8 @@
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 from sawtooth_sdk.protobuf import state_context_pb2
 from sawtooth_sdk.protobuf import events_pb2
-from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
+from sawtooth_sdk.processor.exceptions import AuthorizationException
 
 
 class StateEntry(object):
@@ -56,7 +56,7 @@ class Context(object):
         response.ParseFromString(response_string)
         if response.status == \
                 state_context_pb2.TpStateGetResponse.AUTHORIZATION_ERROR:
-            raise InvalidTransaction(
+            raise AuthorizationException(
                 'Tried to get unauthorized address: {}'.format(addresses))
         entries = response.entries if response is not None else []
         results = [StateEntry(address=e.address, data=e.data)
@@ -87,7 +87,7 @@ class Context(object):
         if response.status == \
                 state_context_pb2.TpStateSetResponse.AUTHORIZATION_ERROR:
             addresses = [e.address for e in entries]
-            raise InvalidTransaction(
+            raise AuthorizationException(
                 'Tried to set unauthorized address: {}'.format(addresses))
         return response.addresses
 
@@ -111,7 +111,7 @@ class Context(object):
                               request).result(timeout).content)
         if response.status == \
                 state_context_pb2.TpStateDeleteResponse.AUTHORIZATION_ERROR:
-            raise InvalidTransaction(
+            raise AuthorizationException(
                 'Tried to delete unauthorized address: {}'.format(addresses))
         return response.addresses
 

--- a/sdk/python/sawtooth_sdk/processor/exceptions.py
+++ b/sdk/python/sawtooth_sdk/processor/exceptions.py
@@ -36,3 +36,7 @@ class InvalidTransaction(_TpResponseError):
 
 class InternalError(_TpResponseError):
     pass
+
+
+class AuthorizationException(Exception):
+    pass


### PR DESCRIPTION
This allows TransactionHandler to return a better error message if an AuthorizationException occurs. If the transaction handler does not handle the AuthorizationException, the transactor processor will return an InvalidTransaction by default. 

This also fixes the issue where if an AuthorizationException occurs in go, many transaction handlers return an InternalError, when it should return an Invalid Transaction error. This is fixed by returning the error received and relying on the defaults to handle the error correctly. 