### PR TITLE
Switch thread pool used for client batch structure verification

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -652,7 +652,7 @@ class Validator(object):
         self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
             structure_verifier.BatchListStructureVerifier(),
-            network_thread_pool)
+            thread_pool)
 
         self._dispatcher.add_handler(
             validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,


### PR DESCRIPTION
Before the network thread pool was being used. It should be using
the client thread pool.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>