### PR TITLE
Create PoET Liveness Test

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -368,6 +368,8 @@ test_integration() {
     copy_coverage .coverage.test_transactor_permissioning
     run_docker_test test_network_permissioning --timeout 800
     copy_coverage .coverage.test_network_permissioning
+    run_docker_test test_poet_liveness
+    copy_coverage .coverage.test_poet_liveness
 }
 
 test_deployment() {

--- a/integration/sawtooth_integration/docker/test_poet_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_poet_liveness.yaml
@@ -1,0 +1,358 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  test-poet-liveness:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -vvvv
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_poet_liveness
+    expose:
+      - 8080
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"
+
+  intkey-workload:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8080
+    command: "bash -c \"\
+      while true; do curl -s http://rest-api-0:8080/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
+      intkey workload --rate 2 --display-frequency 15 --urls http://rest-api-0:8080,http://rest-api-1:8080,http://rest-api-2:8080,http://rest-api-3:8080,http://rest-api-4:8080 \
+      \""
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/sdk/examples/intkey_python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"
+
+  validator-0:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    working_dir: /root
+    command: "bash -c \"\
+        cp /project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/validator-0.toml /etc/sawtooth/validator.toml && \
+        sawtooth admin keygen --force && \
+        sawtooth config genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawtooth config proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm=poet \
+          sawtooth.poet.report_public_key_pem=\
+          \\\"$$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)\\\" \
+          sawtooth.poet.valid_enclave_measurements=$$(poet enclave measurement) \
+          sawtooth.poet.valid_enclave_basenames=$$(poet enclave basename) \
+          -o config.batch && \
+        poet genesis -k /etc/sawtooth/keys/validator.priv -o poet.batch && \
+        sawtooth config proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          $$(/project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/poet-settings.sh) \
+          -o poet-settings.batch && \
+        sawtooth admin genesis \
+          config-genesis.batch config.batch poet.batch poet-settings.batch && \
+        sawtooth-validator -v
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-1:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        cp /project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/validator-1.toml /etc/sawtooth/validator.toml && \
+        sawtooth admin keygen --force && \
+        sawtooth-validator -v
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-2:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        cp /project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/validator-2.toml /etc/sawtooth/validator.toml && \
+        sawtooth admin keygen --force && \
+        sawtooth-validator -v
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-3:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        cp /project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/validator-3.toml /etc/sawtooth/validator.toml && \
+        sawtooth admin keygen --force && \
+        sawtooth-validator -v
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-4:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        cp /project/sawtooth-core/integration/sawtooth_integration/tests/poet_liveness_data/validator-4.toml /etc/sawtooth/validator.toml && \
+        sawtooth admin keygen --force && \
+        sawtooth-validator -v
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  rest-api-0:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api --connect tcp://validator-0:4004 --bind rest-api-0:8080
+    stop_signal: SIGKILL
+
+  rest-api-1:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api --connect tcp://validator-1:4004 --bind rest-api-1:8080
+    stop_signal: SIGKILL
+
+  rest-api-2:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api --connect tcp://validator-2:4004 --bind rest-api-2:8080
+    stop_signal: SIGKILL
+
+  rest-api-3:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api --connect tcp://validator-3:4004 --bind rest-api-3:8080
+    stop_signal: SIGKILL
+
+  rest-api-4:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8080
+    command: sawtooth-rest-api --connect tcp://validator-4:4004 --bind rest-api-4:8080
+    stop_signal: SIGKILL
+
+  intkey-tp-0:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-0:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-1:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-1:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-2:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-2:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-3:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-3:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-4:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-4:4004
+    stop_signal: SIGKILL
+
+  settings-tp-0:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-0:4004
+    stop_signal: SIGKILL
+
+  settings-tp-1:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-1:4004
+    stop_signal: SIGKILL
+
+  settings-tp-2:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-2:4004
+    stop_signal: SIGKILL
+
+  settings-tp-3:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-3:4004
+    stop_signal: SIGKILL
+
+  settings-tp-4:
+    image: sawtooth-settings-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-4:4004
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-0:
+    image: sawtooth-poet-validator-registry-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-0:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-1:
+    image: sawtooth-poet-validator-registry-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-1:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-2:
+    image: sawtooth-poet-validator-registry-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-2:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-3:
+    image: sawtooth-poet-validator-registry-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-3:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-4:
+    image: sawtooth-poet-validator-registry-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-4:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL

--- a/integration/sawtooth_integration/tests/poet_liveness_data/poet-settings.sh
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/poet-settings.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+settings=""
+settings="$settings sawtooth.poet.target_wait_time=5"
+settings="$settings sawtooth.poet.initial_wait_time=25"
+settings="$settings sawtooth.publisher.max_batches_per_block=100"
+
+echo "$settings"

--- a/integration/sawtooth_integration/tests/poet_liveness_data/validator-0.toml
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/validator-0.toml
@@ -1,0 +1,59 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://eth0:8800",
+  "component:tcp://eth0:4004"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "dynamic"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://validator-0:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = []
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+#peers = []
+
+# The type of scheduler to use. The choices are 'serial' or 'parallel'.
+scheduler = 'serial'
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
+# Any off-chain transactor permission roles. The roles should match the roles
+# stored in state for transactor permissioning. Due to the roles having . in the
+# key, the key must be wrapped in quotes so toml can process it. The value
+# should be the file name of a policy stored in the policy_dir.
+[permissions]
+transactor = "policy.example"
+"transactor.transaction_signer" = "policy.example"

--- a/integration/sawtooth_integration/tests/poet_liveness_data/validator-1.toml
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/validator-1.toml
@@ -1,0 +1,59 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://eth0:8800",
+  "component:tcp://eth0:4004"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "dynamic"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://validator-1:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = ["tcp://validator-0:8800"]
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+#peers = []
+
+# The type of scheduler to use. The choices are 'serial' or 'parallel'.
+scheduler = 'serial'
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
+# Any off-chain transactor permission roles. The roles should match the roles
+# stored in state for transactor permissioning. Due to the roles having . in the
+# key, the key must be wrapped in quotes so toml can process it. The value
+# should be the file name of a policy stored in the policy_dir.
+[permissions]
+transactor = "policy.example"
+"transactor.transaction_signer" = "policy.example"

--- a/integration/sawtooth_integration/tests/poet_liveness_data/validator-2.toml
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/validator-2.toml
@@ -1,0 +1,59 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://eth0:8800",
+  "component:tcp://eth0:4004"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "dynamic"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://validator-2:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = ["tcp://validator-0:8800"]
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+#peers = []
+
+# The type of scheduler to use. The choices are 'serial' or 'parallel'.
+scheduler = 'serial'
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
+# Any off-chain transactor permission roles. The roles should match the roles
+# stored in state for transactor permissioning. Due to the roles having . in the
+# key, the key must be wrapped in quotes so toml can process it. The value
+# should be the file name of a policy stored in the policy_dir.
+[permissions]
+transactor = "policy.example"
+"transactor.transaction_signer" = "policy.example"

--- a/integration/sawtooth_integration/tests/poet_liveness_data/validator-3.toml
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/validator-3.toml
@@ -1,0 +1,59 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://eth0:8800",
+  "component:tcp://eth0:4004"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "dynamic"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://validator-3:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = ["tcp://validator-0:8800"]
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+#peers = []
+
+# The type of scheduler to use. The choices are 'serial' or 'parallel'.
+scheduler = 'serial'
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
+# Any off-chain transactor permission roles. The roles should match the roles
+# stored in state for transactor permissioning. Due to the roles having . in the
+# key, the key must be wrapped in quotes so toml can process it. The value
+# should be the file name of a policy stored in the policy_dir.
+[permissions]
+transactor = "policy.example"
+"transactor.transaction_signer" = "policy.example"

--- a/integration/sawtooth_integration/tests/poet_liveness_data/validator-4.toml
+++ b/integration/sawtooth_integration/tests/poet_liveness_data/validator-4.toml
@@ -1,0 +1,59 @@
+#
+# Sawtooth Lake -- Validator Configuration
+#
+
+# This file should exist in the defined config directory and allows
+# validators to be configured without the need for command line options.
+
+# The following is a possible example.
+
+# Bind is used to set the network and component endpoints. It should be a list
+# of strings in the format "option:endpoint", where the options are currently
+# network and component.
+bind = [
+  "network:tcp://eth0:8800",
+  "component:tcp://eth0:4004"
+]
+
+# The type of peering approach the validator should take. Choices are 'static'
+# which only attempts to peer with candidates provided with the peers option,
+# and 'dynamic' which will do topology buildouts. If 'dynamic' is provided,
+# any static peers will be processed first, prior to the topology buildout
+# starting.
+peering = "dynamic"
+
+# Advertised network endpoint URL.
+endpoint = "tcp://validator-4:8800"
+
+# Uri(s) to connect to in order to initially connect to the validator network,
+# in the format tcp://hostname:port. This is not needed in static peering mode
+# and defaults to None.
+seeds = ["tcp://validator-0:8800"]
+
+# A list of peers to attempt to connect to in the format tcp://hostname:port.
+# It defaults to None.
+#peers = []
+
+# The type of scheduler to use. The choices are 'serial' or 'parallel'.
+scheduler = 'serial'
+
+# A Curve ZMQ key pair are used to create a secured network based on side-band
+# sharing of a single network key pair to all participating nodes.
+# Note if the config file does not exist or these are not set, the network
+# will default to being insecure.
+network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+# The type of authorization that must be performed for the different type of
+# roles on the network. The different supported authorization types are "trust"
+# and "challenge". The default is "trust".
+[roles]
+network = "trust"
+
+# Any off-chain transactor permission roles. The roles should match the roles
+# stored in state for transactor permissioning. Due to the roles having . in the
+# key, the key must be wrapped in quotes so toml can process it. The value
+# should be the file name of a policy stored in the policy_dir.
+[permissions]
+transactor = "policy.example"
+"transactor.transaction_signer" = "policy.example"

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -1,0 +1,142 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import unittest
+import logging
+import yaml
+
+import time
+import requests
+
+
+LOGGER = logging.getLogger(__name__)
+
+URL = 'http://rest-api-%d:8080'
+
+# The number of nodes in the test (this needs to match the test's compose file)
+NODES = 5
+
+# Blocks must have between this many batches
+BATCHES_PER_BLOCK_RANGE = (1, 100)
+
+# At the end of the test, this many batches must be in the chain
+MIN_TOTAL_BATCHES = 100
+
+# All nodes must reach this block for the test to pass.
+BLOCK_TO_REACH = 55
+
+# Once all nodes reach the BLOCK_TO_REACH, the test will check for consensus at
+# this block. These are different because PoET occassionally forks.
+BLOCK_TO_CHECK_CONSENSUS = 52
+
+
+class TestPoetLive(unittest.TestCase):
+    def test_poet_liveness(self):
+        """Test that a PoET network publishes blocks and stays in consensus."""
+
+        # Wait until all nodes have reached the minimum block number
+        nodes_reached = set()
+        while len(nodes_reached) < NODES:
+            for i in range(0, NODES):
+                block = get_block(i)
+                if block is not None:
+
+                    # Ensure all blocks have an acceptable number of batches
+                    self.assertTrue(check_block_batch_count(
+                        block, BATCHES_PER_BLOCK_RANGE))
+                    if int(block["header"]["block_num"]) >= BLOCK_TO_REACH:
+                        nodes_reached.add(i)
+
+                    log_block(i, block)
+
+            time.sleep(15)
+
+        chains = [get_chain(i) for node in range(0, NODES)]
+
+        # Ensure all nodes are in consensus on the target block
+        self.assertTrue(check_consensus(chains, BLOCK_TO_CHECK_CONSENSUS))
+
+        # Assert an acceptable number of batches were committed
+        self.assertTrue(check_min_batches(chains[0], MIN_TOTAL_BATCHES))
+
+
+def get_block(node):
+    try:
+        result = requests.get((URL % node)+"/blocks?count=1")
+        result = result.json()
+        try:
+            return result["data"][0]
+        except:
+            LOGGER.warning(result)
+    except:
+        LOGGER.warning("Couldn't connect to REST API %s", node)
+
+
+def get_chain(node):
+    try:
+        result = requests.get((URL % node)+"/blocks")
+        result = result.json()
+        try:
+            return result["data"]
+        except:
+            LOGGER.warning(result)
+    except:
+        LOGGER.warning("Couldn't connect to REST API %s", node)
+
+
+def log_block(node, block):
+    batches = block["header"]["batch_ids"]
+    batches = [b[:6] + '..' for b in batches]
+    LOGGER.warning(
+        "Validator-%s has block %s: %s, batches (%s): %s",
+        node,
+        block["header"]["block_num"],
+        block["header_signature"][:6] + '..',
+        len(batches),
+        batches)
+
+
+def check_block_batch_count(block, batch_range):
+    batches = len(block["header"]["batch_ids"])
+    if batch_range[0] <= batches <= batch_range[1]:
+        return True
+    else:
+        LOGGER.error(
+            "Block (%s, %s) had %s batches in it",
+            block["header"]["block_num"],
+            block["header_signature"],
+            batches)
+
+
+def check_min_batches(chain, min_batches):
+    n = sum([len(block["header"]["batch_ids"]) for block in chain])
+    return n >= min_batches
+
+
+def check_consensus(chains, block_num):
+    blocks = []
+    for chain in chains:
+        if chain is not None:
+            block = chain[-(block_num+1)]
+            blocks.append(block)
+        else:
+            return False
+    b0 = blocks[0]
+    for b in blocks[1:]:
+        if b0["header_signature"] != b["header_signature"]:
+            LOGGER.error("Validators not in consensus on block %s", block_num)
+            LOGGER.error("BLOCK DUMP: %s", blocks)
+            return False
+    return True


### PR DESCRIPTION
The existing PoET Smoke Test is not a sufficient test for gating PRs. This test
simulates the long running network test environment using docker containers and
verifies the validators reach a certain block in consensus within the test
timelimit while ensuring blocks have batches in them.

The PoET settings and validator configuration are identical to the LR1 network
test.

To run the test locally, do:
`./bin/run_docker_test test_poet_liveness`