### PR TITLE
Adds an UNSET option to all protobuf enums

### DIFF
--- a/families/identity/protos/identities.proto
+++ b/families/identity/protos/identities.proto
@@ -20,8 +20,9 @@ option java_package = "sawtooth.identity.protobuf";
 
 message IdentityPayload {
     enum IdentityType {
-      POLICY = 0;
-      ROLE = 1;
+      IDENTITY_TYPE_UNSET = 0;
+      POLICY = 1;
+      ROLE = 2;
     }
 
     // What type of payload this is for

--- a/families/private_utxo/protos/payload.proto
+++ b/families/private_utxo/protos/payload.proto
@@ -19,11 +19,12 @@ syntax = "proto3";
 message PrivateUtxoPayload {
     // The action indicates data is contained within this payload
     enum Action {
-        ISSUE_ASSET = 0;
-        TRANSFER_ASSET = 1;
-        CONVERT_TO_UTXO = 2;
-        CONVERT_FROM_ASSET = 3;
-        UTXO_TRANSFER = 4;
+        ACTION_UNSET = 0;
+        ISSUE_ASSET = 1;
+        TRANSFER_ASSET = 2;
+        CONVERT_TO_UTXO = 3;
+        CONVERT_FROM_ASSET = 4;
+        UTXO_TRANSFER = 5;
     }
 
     // The action of this payload

--- a/families/seth/rpc/src/client.rs
+++ b/families/seth/rpc/src/client.rs
@@ -261,6 +261,7 @@ impl<S: MessageSender> ValidatorClient<S> {
             self.send_request(Message_MessageType::CLIENT_BATCH_SUBMIT_REQUEST, &request)?;
 
         match response.status {
+            ClientBatchSubmitResponse_Status::STATUS_UNSET => Err(Error::ValidatorError),
             ClientBatchSubmitResponse_Status::OK => Ok(txn_signature),
             ClientBatchSubmitResponse_Status::INTERNAL_ERROR => Err(Error::ValidatorError),
             ClientBatchSubmitResponse_Status::INVALID_BATCH => Err(Error::InvalidTransaction),
@@ -357,6 +358,9 @@ impl<S: MessageSender> ValidatorClient<S> {
             self.send_request(Message_MessageType::CLIENT_RECEIPT_GET_REQUEST, &request)?;
 
         let receipts = match response.status {
+            ClientReceiptGetResponse_Status::STATUS_UNSET => {
+                return Err(Error::ValidatorError);
+            },
             ClientReceiptGetResponse_Status::OK => response.receipts,
             ClientReceiptGetResponse_Status::INTERNAL_ERROR => {
                 return Err(Error::ValidatorError);
@@ -394,6 +398,9 @@ impl<S: MessageSender> ValidatorClient<S> {
                 };
 
                 match response.status {
+                    ClientTransactionGetResponse_Status::STATUS_UNSET => {
+                        Err(Error::ValidatorError)
+                    },
                     ClientTransactionGetResponse_Status::INTERNAL_ERROR => {
                         Err(Error::ValidatorError)
                     },
@@ -438,6 +445,9 @@ impl<S: MessageSender> ValidatorClient<S> {
             self.send_request(Message_MessageType::CLIENT_BLOCK_GET_REQUEST, &request)?;
 
         match response.status {
+            ClientBlockGetResponse_Status::STATUS_UNSET=> {
+                Err(Error::ValidatorError)
+            },
             ClientBlockGetResponse_Status::INTERNAL_ERROR => {
                 Err(Error::ValidatorError)
             },
@@ -480,6 +490,9 @@ impl<S: MessageSender> ValidatorClient<S> {
             self.request(Message_MessageType::CLIENT_STATE_GET_REQUEST, &request)?;
 
         let state_data = match response.status {
+            ClientStateGetResponse_Status::STATUS_UNSET => {
+                return Err(String::from("Internal error"));
+            },
             ClientStateGetResponse_Status::OK => response.value,
             ClientStateGetResponse_Status::NO_RESOURCE => {
                 return Ok(None);

--- a/families/seth/src/protos/seth.proto
+++ b/families/seth/src/protos/seth.proto
@@ -56,7 +56,7 @@ message EvmStorage {
 
 message SethTransaction {
     enum TransactionType {
-      DEFAULT = 0;
+      TRANSACTION_TYPE_UNSET = 0;
       CREATE_EXTERNAL_ACCOUNT = 1;
       CREATE_CONTRACT_ACCOUNT = 2;
       MESSAGE_CALL = 3;

--- a/families/settings/protos/settings.proto
+++ b/families/settings/protos/settings.proto
@@ -23,11 +23,13 @@ option java_package = "sawtooth.settings.protobuf";
 message SettingsPayload {
     // The action indicates data is contained within this payload
     enum Action {
+        ACTION_UNSET = 0;
+
         // A proposal action - data will be a SettingProposal
-        PROPOSE = 0;
+        PROPOSE = 1;
 
         // A vote action - data will be a SettingVote
-        VOTE = 1;
+        VOTE = 2;
     }
     // The action of this payload
     Action action = 1;
@@ -58,8 +60,9 @@ message SettingProposal {
 // by its id.
 message SettingVote {
     enum Vote {
-        ACCEPT = 0;
-        REJECT = 1;
+        VOTE_UNSET = 0;
+        ACCEPT = 1;
+        REJECT = 2;
     }
 
     // The id of the proposal, as found in the

--- a/families/smallbank/protos/smallbank.proto
+++ b/families/smallbank/protos/smallbank.proto
@@ -107,12 +107,13 @@ message SmallbankTransactionPayload {
     }
 
     enum PayloadType {
-        CREATE_ACCOUNT = 0;
-        DEPOSIT_CHECKING = 1;
-        WRITE_CHECK = 2;
-        TRANSACT_SAVINGS = 3;
-        SEND_PAYMENT = 4;
-        AMALGAMATE = 5;
+        PAYLOAD_TYPE_UNSET = 0;
+        CREATE_ACCOUNT = 1;
+        DEPOSIT_CHECKING = 2;
+        WRITE_CHECK = 3;
+        TRANSACT_SAVINGS = 4;
+        SEND_PAYMENT = 5;
+        AMALGAMATE = 6;
     }
 
     PayloadType payload_type = 1;
@@ -123,4 +124,3 @@ message SmallbankTransactionPayload {
     SendPaymentTransactionData send_payment = 6;
     AmalgamateTransactionData amalgamate = 7;
 }
-

--- a/families/supplychain/protos/application.proto
+++ b/families/supplychain/protos/application.proto
@@ -28,17 +28,19 @@ message Application {
 
     // Whether this Application is a request for ownership or custodianship
     enum Type {
-        OWNER = 0;
-        CUSTODIAN = 1;
+        TYPE_UNSET = 0;
+        OWNER = 1;
+        CUSTODIAN = 2;
     }
     Type type = 4;
 
     // The current acceptance status
     enum Status {
-        OPEN = 0;
-        CANCELED = 1;
-        REJECTED = 2;
-        ACCEPTED = 3;
+        STATUS_UNSET = 0;
+        OPEN = 1;
+        CANCELED = 2;
+        REJECTED = 3;
+        ACCEPTED = 4;
     }
     Status status = 5;
 
@@ -51,5 +53,3 @@ message ApplicationContainer {
     // List of Applications - more than one implies a state address collision
     repeated Application entries = 1;
 }
-
-

--- a/families/supplychain/protos/payload.proto
+++ b/families/supplychain/protos/payload.proto
@@ -24,13 +24,14 @@ message SupplyChainPayload {
     // Describes the action this payload is initiating.
     // Used to "route" the data to the proper handler.
     enum Action {
-        AGENT_CREATE = 0;
-        APPLICATION_CREATE = 1;
-        APPLICATION_ACCEPT = 2;
-        APPLICATION_REJECT = 3;
-        APPLICATION_CANCEL = 4;
-        RECORD_CREATE = 5;
-        RECORD_FINALIZE = 6;
+        ACTION_UNSET = 0;
+        AGENT_CREATE = 1;
+        APPLICATION_CREATE = 2;
+        APPLICATION_ACCEPT = 3;
+        APPLICATION_REJECT = 4;
+        APPLICATION_CANCEL = 5;
+        RECORD_CREATE = 6;
+        RECORD_FINALIZE = 7;
     }
 
     Action action = 1;

--- a/protos/authorization.proto
+++ b/protos/authorization.proto
@@ -25,24 +25,28 @@ message ConnectionRequest {
 }
 
 enum RoleType {
+  ROLE_TYPE_UNSET = 0;
+
   // A shorthand request for asking for all allowed roles.
-  ALL = 0;
+  ALL = 1;
 
   // Role defining validator to validator communication
-  NETWORK = 1;
+  NETWORK = 2;
 }
 
 message ConnectionResponse {
   // Whether the connection can participate in authorization
   enum Status {
-    OK = 0;
-    ERROR = 1;
+    STATUS_UNSET = 0;
+    OK = 1;
+    ERROR = 2;
   }
 
   //Authorization Type required for the authorization procedure
   enum AuthorizationType {
-    TRUST = 0;
-    CHALLENGE = 1;
+    AUTHORIZATION_TYPE_UNSET = 0;
+    TRUST = 1;
+    CHALLENGE = 2;
   }
 
   message RoleEntry {

--- a/protos/client_batch.proto
+++ b/protos/client_batch.proto
@@ -46,13 +46,14 @@ message ClientBatchListRequest {
 //   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientBatchListResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
-        NO_ROOT = 3;
-        NO_RESOURCE = 4;
-        INVALID_PAGING = 5;
-        INVALID_SORT = 6;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
     }
     Status status = 1;
     repeated Batch batches = 2;
@@ -73,9 +74,10 @@ message ClientBatchGetRequest {
 //   * NO_RESOURCE - no batch with the specified id exists
 message ClientBatchGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NO_RESOURCE = 4;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
     }
     Status status = 1;
     Batch batch = 2;

--- a/protos/client_batch_submit.proto
+++ b/protos/client_batch_submit.proto
@@ -36,10 +36,11 @@ import "batch.proto";
 //     UNKNOWN - no status for the batch could be found (possibly invalid)
 message ClientBatchStatus {
     enum Status {
-        COMMITTED = 0;
-        INVALID = 1;
-        PENDING = 2;
-        UNKNOWN = 3;
+        STATUS_UNSET = 0;
+        COMMITTED = 1;
+        INVALID = 2;
+        PENDING = 3;
+        UNKNOWN = 4;
     }
     message InvalidTransaction {
         string transaction_id = 1;
@@ -63,9 +64,10 @@ message ClientBatchSubmitRequest {
 //   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
 message ClientBatchSubmitResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        INVALID_BATCH = 2;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        INVALID_BATCH = 3;
     }
     Status status = 1;
 }
@@ -88,9 +90,10 @@ message ClientBatchStatusRequest {
 //     no ids were specified in the request
 message ClientBatchStatusResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NO_RESOURCE = 4;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
     }
     Status status = 1;
     repeated ClientBatchStatus batch_statuses = 2;

--- a/protos/client_block.proto
+++ b/protos/client_block.proto
@@ -47,13 +47,14 @@ message ClientBlockListRequest {
 //   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientBlockListResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
-        NO_ROOT = 3;
-        NO_RESOURCE = 4;
-        INVALID_PAGING = 5;
-        INVALID_SORT = 6;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
     }
     Status status = 1;
     repeated Block blocks = 2;
@@ -76,9 +77,10 @@ message ClientBlockGetRequest {
 //   * NO_RESOURCE - no block with the specified id exists
 message ClientBlockGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NO_RESOURCE = 4;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
     }
     Status status = 1;
     Block block = 2;

--- a/protos/client_event.proto
+++ b/protos/client_event.proto
@@ -32,9 +32,10 @@ message ClientEventsSubscribeRequest {
 
 message ClientEventsSubscribeResponse {
     enum Status {
-         OK = 0;
-         INVALID_FILTER = 1;
-         UNKNOWN_BLOCK = 2;
+         STATUS_UNSET = 0;
+         OK = 1;
+         INVALID_FILTER = 2;
+         UNKNOWN_BLOCK = 3;
     }
     Status status = 1;
     // Additional information about the response status
@@ -45,8 +46,9 @@ message ClientEventsUnsubscribeRequest {}
 
 message ClientEventsUnsubscribeResponse {
     enum Status {
-         OK = 0;
-         INTERNAL_ERROR = 1;
+         STATUS_UNSET = 0;
+         OK = 1;
+         INTERNAL_ERROR = 2;
     }
     Status status = 1;
 }
@@ -58,10 +60,11 @@ message ClientEventsGetRequest {
 
 message ClientEventsGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        INVALID_FILTER = 2;
-        UNKNOWN_BLOCK = 3;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        INVALID_FILTER = 3;
+        UNKNOWN_BLOCK = 4;
     }
     Status status = 1;
     repeated Event events = 2;

--- a/protos/client_receipt.proto
+++ b/protos/client_receipt.proto
@@ -35,9 +35,10 @@ message ClientReceiptGetRequest {
 //   * NO_RESOURCE - no receipt exists for the transaction id specified
 message ClientReceiptGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NO_RESOURCE = 4;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
     }
     Status status = 1;
     repeated TransactionReceipt receipts = 2;

--- a/protos/client_state.proto
+++ b/protos/client_state.proto
@@ -33,9 +33,10 @@ message ClientStateCurrentRequest {
 
 message ClientStateCurrentResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
     }
     Status status = 1;
     string merkle_root = 2;
@@ -70,13 +71,14 @@ message ClientStateListRequest {
 
 message ClientStateListResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
-        NO_ROOT = 3;
-        NO_RESOURCE = 4;
-        INVALID_PAGING = 5;
-        INVALID_SORT = 6;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
     }
 
     // An entry in the State
@@ -117,12 +119,13 @@ message ClientStateGetRequest {
 //   * INVALID_ADDRESS - address isn't a valid, i.e. it's a subtree (truncated)
 message ClientStateGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
-        NO_ROOT = 3;
-        NO_RESOURCE = 4;
-        INVALID_ADDRESS = 5;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_ADDRESS = 6;
     }
     Status status = 1;
     bytes value = 2;

--- a/protos/client_transaction.proto
+++ b/protos/client_transaction.proto
@@ -46,13 +46,14 @@ message ClientTransactionListRequest {
 //   * INVALID_SORT - the sorting controls were malformed or invalid
 message ClientTransactionListResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NOT_READY = 2;
-        NO_ROOT = 3;
-        NO_RESOURCE = 4;
-        INVALID_PAGING = 5;
-        INVALID_SORT = 6;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_PAGING = 6;
+        INVALID_SORT = 7;
     }
     Status status = 1;
     repeated Transaction transactions = 2;
@@ -73,9 +74,10 @@ message ClientTransactionGetRequest {
 //   * NO_RESOURCE - no txn with the specified id exists
 message ClientTransactionGetResponse {
     enum Status {
-        OK = 0;
-        INTERNAL_ERROR = 1;
-        NO_RESOURCE = 4;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NO_RESOURCE = 5;
     }
     Status status = 1;
     Transaction transaction = 2;

--- a/protos/events.proto
+++ b/protos/events.proto
@@ -48,10 +48,11 @@ message EventFilter {
     string match_string = 2;
 
     enum FilterType {
-      SIMPLE_ANY = 0;
-      SIMPLE_ALL = 1;
-      REGEX_ANY  = 2;
-      REGEX_ALL  = 3;
+      FILTER_TYPE_UNSET = 0;
+      SIMPLE_ANY = 1;
+      SIMPLE_ALL = 2;
+      REGEX_ANY  = 3;
+      REGEX_ALL  = 4;
     }
     FilterType filter_type = 3;
 }

--- a/protos/identity.proto
+++ b/protos/identity.proto
@@ -21,8 +21,9 @@ option java_package = "sawtooth.identity.protobuf";
 message Policy {
 
   enum Type {
-    PERMIT_KEY = 0;
-    DENY_KEY = 1;
+    TYPE_UNSET = 0;
+    PERMIT_KEY = 1;
+    DENY_KEY = 2;
   }
 
   message Entry {

--- a/protos/network.proto
+++ b/protos/network.proto
@@ -53,8 +53,9 @@ message GossipMessage {
 // receipt
 message NetworkAcknowledgement {
     enum Status {
-        OK = 0;
-        ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
     }
 
     Status status = 1;

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -41,8 +41,9 @@ message TpRegisterRequest {
 // acknowledging the registration
 message TpRegisterResponse {
     enum Status {
-        OK = 0;
-        ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
     }
 
     Status status = 1;
@@ -59,8 +60,9 @@ message TpUnregisterRequest {
 // acknowledging the unregistration
 message TpUnregisterResponse {
     enum Status {
-        OK = 0;
-        ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
     }
 
     Status status = 1;
@@ -81,9 +83,10 @@ message TpProcessRequest {
 // used to respond about the validity of a transaction
 message TpProcessResponse {
     enum Status {
-        OK = 0;
-        INVALID_TRANSACTION = 1;
-        INTERNAL_ERROR = 2;
+        STATUS_UNSET = 0;
+        OK = 1;
+        INVALID_TRANSACTION = 2;
+        INTERNAL_ERROR = 3;
     }
 
     Status status = 1;

--- a/protos/state_context.proto
+++ b/protos/state_context.proto
@@ -36,8 +36,9 @@ message TpStateGetRequest {
 // A response from the contextmanager/validator with a series of State entries
 message TpStateGetResponse {
     enum Status {
-        OK = 0;
-        AUTHORIZATION_ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        AUTHORIZATION_ERROR = 2;
     }
 
     repeated Entry entries = 1;
@@ -53,8 +54,9 @@ message TpStateSetRequest {
 // A response from the contextmanager/validator with the addresses that were set
 message TpStateSetResponse {
   enum Status {
-      OK = 0;
-      AUTHORIZATION_ERROR = 1;
+      STATUS_UNSET = 0;
+      OK = 1;
+      AUTHORIZATION_ERROR = 2;
   }
 
     repeated string addresses = 1;
@@ -70,8 +72,9 @@ message TpStateDeleteRequest {
 // A response form the contextmanager/validator with the addresses that were deleted
 message TpStateDeleteResponse {
     enum Status {
-        OK = 0;
-        AUTHORIZATION_ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        AUTHORIZATION_ERROR = 2;
     }
 
     repeated string addresses = 1;
@@ -91,8 +94,9 @@ message TpReceiptAddDataRequest {
 // data has been appended to a transaction receipt
 message TpReceiptAddDataResponse {
     enum Status {
-        OK = 0;
-        ERROR = 1;
+        STATUS_UNSET = 0;
+        OK = 1;
+        ERROR = 2;
     }
 
     Status status = 2;
@@ -105,8 +109,9 @@ message TpEventAddRequest {
 
 message TpEventAddResponse {
     enum Status {
-      OK = 0;
-      ERROR = 1;
+      STATUS_UNSET = 0;
+      OK = 1;
+      ERROR = 2;
     }
     Status status = 2;
 }

--- a/protos/state_delta.proto
+++ b/protos/state_delta.proto
@@ -63,16 +63,17 @@ message StateDeltaSubscribeRequest {
 // The response to a StateDeltaSubscribeRequest
 message StateDeltaSubscribeResponse {
     enum Status {
+        STATUS_UNSET = 0;
         // returned on successful registration
-        OK = 0;
+        OK = 1;
         // returned on a failed registration, due to
         // an internal validator error
-        INTERNAL_ERROR = 1;
+        INTERNAL_ERROR = 2;
         // returned on a failed registration, due to all
         // last_known_block_ids being unknown.  This could imply
         // that a fork had occurred and been resolved since last
         // unregistration.
-        UNKNOWN_BLOCK = 2;
+        UNKNOWN_BLOCK = 3;
     }
 
     Status status = 1;
@@ -87,11 +88,12 @@ message StateDeltaUnsubscribeRequest {
 
 message StateDeltaUnsubscribeResponse {
     enum Status {
+        STATUS_UNSET = 0;
         // returned on successful registration
-        OK = 0;
+        OK = 1;
         // returned on a failed registration, due to
         // an internal validator error
-        INTERNAL_ERROR = 1;
+        INTERNAL_ERROR = 2;
     }
     Status status = 1;
 }
@@ -114,13 +116,14 @@ message StateDeltaGetEventsRequest {
 // to the validator will result in events.
 message StateDeltaGetEventsResponse {
     enum Status {
+        STATUS_UNSET = 0;
         // returned on a successful request
-        OK = 0;
+        OK = 1;
         // returned on a failed request, due to an internal validator error.
-        INTERNAL_ERROR = 1;
+        INTERNAL_ERROR = 2;
         // return on a bad request, where no block id was provided in the
         // request.
-        NO_VALID_BLOCKS_SPECIFIED = 2;
+        NO_VALID_BLOCKS_SPECIFIED = 3;
     }
     Status status = 1;
     // the events returned for the request.  This may contain only a subset of

--- a/protos/transaction_receipt.proto
+++ b/protos/transaction_receipt.proto
@@ -44,8 +44,9 @@ message TransactionReceipt {
 // DELETE.  Items marked as a DELETE will have no byte value.
 message StateChange {
     enum Type {
-        SET = 0;
-        DELETE = 1;
+        TYPE_UNSET = 0;
+        SET = 1;
+        DELETE = 2;
     }
     string address = 1;
     bytes value = 2;

--- a/sdk/javascript/processor/index.js
+++ b/sdk/javascript/processor/index.js
@@ -76,9 +76,9 @@ class TransactionProcessor {
 
           if (handler) {
             handler.apply(request, context)
-              .then(() => TpProcessResponse.encode({
+              .then(() => TpProcessResponse.create({
                 status: TpProcessResponse.Status.OK
-              }).finish())
+              }))
               .catch((e) => {
                 if (e instanceof InvalidTransaction) {
                   console.log(e)


### PR DESCRIPTION
This will avoid the issues where the default, the first option, is automatically set in a protobuf enum and causes a false positive or negative.

Also, fixes the javascript SDK to set TpProcessResponse status to OK correctly. 
It was working before because of the false positive mentioned above. 