### PR TITLE
Add "sawtooth identity role" to CLI Reference doc

### DIFF
--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -231,10 +231,17 @@ sawtooth identity policy list
   :language: console
   :linenos:
 
+sawtooth identity role
+======================
+
+.. literalinclude:: output/sawtooth_identity_role_usage.out
+  :language: console
+  :linenos:
+
 sawtooth identity role create
 =============================
 
-.. literalinclude:: output/sawtooth_identity_policy_create_usage.out
+.. literalinclude:: output/sawtooth_identity_role_create_usage.out
   :language: console
   :linenos:
 


### PR DESCRIPTION
Also correct the literalinclude line for "sawtooth identity role create"
(it was pulling in the usage output for "sawtooth identity policy create").

Signed-off-by: Anne Chenette <chenette@bitwise.io>