### PR TITLE
State delete in JS and Go

### DIFF
--- a/bin/run_go_fmt
+++ b/bin/run_go_fmt
@@ -10,6 +10,8 @@ $top_dir/sdk/go/src/sawtooth_sdk/processor
 $top_dir/sdk/go/src/sawtooth_sdk/client
 $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey
 $top_dir/sdk/examples/intkey_go/src/sawtooth_intkey/handler
+$top_dir/sdk/examples/xo_go/src/sawtooth_xo
+$top_dir/sdk/examples/xo_go/src/sawtooth_xo/handler
 $top_dir/families/seth/src/sawtooth_seth/processor
 $top_dir/families/seth/src/sawtooth_seth/processor/handler
 $top_dir/families/seth/src/sawtooth_seth/client

--- a/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
@@ -88,6 +88,7 @@ services:
         test_xo_smoke.TestXoSmoke
     stop_signal: SIGKILL
     environment:
+      TP_LANG: "go"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/sdk/examples/xo_python:\
         /project/sawtooth-core/integration:\

--- a/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
@@ -87,6 +87,7 @@ services:
         test_xo_smoke.TestXoSmoke
     stop_signal: SIGKILL
     environment:
+      TP_LANG: "javascript"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/integration:\
         /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
@@ -87,6 +87,7 @@ services:
         test_xo_smoke.TestXoSmoke
     stop_signal: SIGKILL
     environment:
+      TP_LANG: "python"
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
         /project/sawtooth-core/integration:\
         /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -149,6 +149,6 @@ def _send_cmd(cmd_str):
 
 
 def _tp_supports_delete():
-    supported_langs = 'python', 'javascript'
+    supported_langs = 'python', 'javascript', 'go'
 
     return os.getenv('TP_LANG', False) in supported_langs

--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -149,6 +149,6 @@ def _send_cmd(cmd_str):
 
 
 def _tp_supports_delete():
-    supported_langs = 'python',
+    supported_langs = 'python', 'javascript'
 
     return os.getenv('TP_LANG', False) in supported_langs

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -266,6 +266,10 @@ const _handleTake = (context, address, update, player) => (possibleAddressValues
   return _setEntry(context, address, setValue)
 }
 
+const _handleDelete = (context, address) => {
+  return context.deleteState([address])
+}
+
 class XOHandler extends TransactionHandler {
   constructor () {
     super(XO_FAMILY, '1.0', [XO_NAMESPACE])
@@ -296,6 +300,8 @@ class XOHandler extends TransactionHandler {
           handlerFn = _handleCreate
         } else if (update.action === 'take') {
           handlerFn = _handleTake
+        } else if (update.action == 'delete') {
+          handlerFn = _handleDelete
         } else {
           throw new InvalidTransaction(`Action must be create or take not ${update.action}`)
         }

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -124,6 +124,22 @@ def add_take_parser(subparsers, parent_parser):
         help='wait for take to commit, set an integer to specify a timeout')
 
 
+def add_delete_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('delete', parents=[parent_parser])
+
+    parser.add_argument(
+        'name',
+        type=str,
+        help='the identifier for the game to be deleted')
+
+    parser.add_argument(
+        '--wait',
+        nargs='?',
+        const=sys.maxsize,
+        type=int,
+        help='wait for take to commit, set an integer to specify a timeout')
+
+
 def create_parent_parser(prog_name):
     parent_parser = argparse.ArgumentParser(prog=prog_name, add_help=False)
     parent_parser.add_argument(
@@ -186,6 +202,7 @@ def create_parser(prog_name):
     add_list_parser(subparsers, parent_parser)
     add_show_parser(subparsers, parent_parser)
     add_take_parser(subparsers, parent_parser)
+    add_delete_parser(subparsers, parent_parser)
 
     return parser
 
@@ -299,6 +316,28 @@ def do_take(args):
     print("Response: {}".format(response))
 
 
+def do_delete(args):
+    name = args.name
+
+    url = _get_url(args)
+    keyfile = _get_keyfile(args)
+    auth_user, auth_password = _get_auth_info(args)
+
+    client = XoClient(base_url=url, keyfile=keyfile)
+
+    if args.wait and args.wait > 0:
+        response = client.delete(
+            name, wait=args.wait,
+            auth_user=auth_user,
+            auth_password=auth_password)
+    else:
+        response = client.delete(
+            name, auth_user=auth_user,
+            auth_password=auth_password)
+
+    print("Response: {}".format(response))
+
+
 def _get_url(args):
     return DEFAULT_URL if args.url is None else args.url
 
@@ -341,6 +380,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None):
         do_show(args)
     elif args.command == 'take':
         do_take(args)
+    elif args.command == 'delete':
+        do_delete(args)
     else:
         raise XoException("invalid command: {}".format(args.command))
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -61,6 +61,11 @@ class XoClient:
                                  auth_user=auth_user,
                                  auth_password=auth_password)
 
+    def delete(self, name, wait=None, auth_user=None, auth_password=None):
+        return self._send_xo_txn(name, "delete", wait=wait,
+                                 auth_user=auth_user,
+                                 auth_password=auth_password)
+
     def take(self, name, space, wait=None, auth_user=None, auth_password=None):
         return self._send_xo_txn(name, "take", space, wait=wait,
                                  auth_user=auth_user,

--- a/sdk/go/src/sawtooth_sdk/processor/context.go
+++ b/sdk/go/src/sawtooth_sdk/processor/context.go
@@ -192,6 +192,69 @@ func (self *Context) SetState(pairs map[string][]byte) ([]string, error) {
 	return response.GetAddresses(), nil
 }
 
+// DeleteState requests that each address in the validator state be
+// deleted from state. A slice of addresses deleted is returned or an
+// error if there was a problem deleting the addresses. For example:
+//
+//     responses, err := context.DeleteState(dataMap)
+//     if err != nil {
+//         fmt.Println("Error deleting addresses!")
+//     }
+//     delete, ok := results[address]
+//     if !ok {
+//         fmt.Prinln("Address was not deleted!")
+//     }
+//
+func (self *Context) DeleteState(addresses []string) ([]string, error) {
+	// Construct the message
+	request := &state_context_pb2.TpStateDeleteRequest{
+		ContextId: self.contextId,
+		Addresses: addresses,
+	}
+
+	bytes, err := proto.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal TpStateDeleteRequest: %v", err)
+	}
+
+	// Send the message and get the response
+	corrId, err := self.connection.SendNewMsg(
+		validator_pb2.Message_TP_STATE_DELETE_REQUEST, bytes,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to send TpStateDeleteRequest: %v", err)
+	}
+
+	_, msg, err := self.connection.RecvMsgWithId(corrId)
+	if msg.GetCorrelationId() != corrId {
+		return nil, fmt.Errorf(
+			"Expected message with correlation id %v but got %v",
+			corrId, msg.GetCorrelationId(),
+		)
+	}
+
+	if msg.GetMessageType() != validator_pb2.Message_TP_STATE_DELETE_RESPONSE {
+		return nil, fmt.Errorf(
+			"Expected TpStateDeleteResponse but got %v", msg.GetMessageType(),
+		)
+	}
+
+	// Parse the result
+	response := &state_context_pb2.TpStateDeleteResponse{}
+	err = proto.Unmarshal(msg.GetContent(), response)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal TpStatedDeleteResponse: %v", err)
+	}
+
+	// Use a switch in case new Status values are added
+	switch response.Status {
+	case state_context_pb2.TpStateDeleteResponse_AUTHORIZATION_ERROR:
+		return nil, &AuthorizationException{Msg: fmt.Sprint("Tried to get unauthorized address: ", addresses)}
+	}
+
+	return response.GetAddresses(), nil
+}
+
 func (self *Context) Get(addresses []string) (map[string][]byte, error) {
 	return self.GetState(addresses)
 }

--- a/sdk/javascript/protobuf/index.js
+++ b/sdk/javascript/protobuf/index.js
@@ -36,6 +36,9 @@ TpStateSetResponse.Status = TpStateSetResponse.nested.Status.values
 const TpStateGetResponse = root.lookup('TpStateGetResponse')
 TpStateGetResponse.Status = TpStateGetResponse.nested.Status.values
 
+const TpStateDeleteResponse = root.lookup('TpStateDeleteResponse')
+TpStateDeleteResponse.Status = TpStateDeleteResponse.nested.Status.values
+
 const PingResponse = root.lookup('PingResponse')
 
 const Message = root.lookup('Message')
@@ -78,6 +81,10 @@ module.exports = {
   TpStateSetRequest: root.lookup('TpStateSetRequest'),
 
   TpStateSetResponse,
+
+  TpStateDeleteRequest: root.lookup('TpStateDeleteRequest'),
+
+  TpStateDeleteResponse,
 
   //
   // Transactions


### PR DESCRIPTION
This PR adds state delete to the Go and JS SDKs. It also adds a game delete transaction to xo in order to test state deletes. (This transaction is not in the xo transaction family spec, so it should be considered a nonstandard extension for now.)