### PR TITLE
Remove Data from TransactionReciept and replace with bytes

### DIFF
--- a/docs/source/architecture/events_and_transactions_receipts.rst
+++ b/docs/source/architecture/events_and_transactions_receipts.rst
@@ -290,18 +290,13 @@ list of Event messages, and a list of TransactionReceipt.Data messages:
 .. code-block:: protobuf
 
   message TransactionReceipt {
-    message Data {
-      // Interpretation left to transaction family
-      string data_type = 1;
-      bytes data = 2;
-    }
     // State changes made by this transaction
     // StateChange is already defined in protos/state_delta.proto
     repeated StateChange state_changes = 1;
     // Events fired by this transaction
     repeated Event events = 2;
     // Transaction family defined data
-    repeated Data data = 3;
+    repeated bytes data = 3;
 
     string transaction_id = 4;
   }

--- a/families/seth/rpc/src/transactions.rs
+++ b/families/seth/rpc/src/transactions.rs
@@ -31,7 +31,7 @@ use sawtooth_sdk::messages::transaction::{
     Transaction as TransactionPb,
     TransactionHeader,
 };
-use sawtooth_sdk::messages::transaction_receipt::{TransactionReceipt, TransactionReceipt_Data};
+use sawtooth_sdk::messages::transaction_receipt::{TransactionReceipt};
 use sawtooth_sdk::messages::events::{Event, Event_Attribute};
 
 use client::{
@@ -206,10 +206,9 @@ pub struct SethReceipt {
 impl SethReceipt {
     pub fn from_receipt_pb(receipt: &TransactionReceipt) -> Result<SethReceipt, Error>{
         let seth_receipt_pbs: Vec<SethTransactionReceipt> = receipt.get_data().iter()
-            .filter(|d: &&TransactionReceipt_Data| d.data_type == "seth_receipt")
-            .map(|d: &TransactionReceipt_Data| {
+             .map(|d: &Vec<u8>| {
                 let r: Result<SethTransactionReceipt, Error> =
-                    protobuf::parse_from_bytes(d.data.as_slice())
+                    protobuf::parse_from_bytes(d.as_slice())
                         .map_err(|error|
                             Error::ParseError(format!(
                                 "Failed to deserialize Seth receipt: {:?}", error)));

--- a/families/seth/rpc/tests/test_seth_rpc.py
+++ b/families/seth/rpc/tests/test_seth_rpc.py
@@ -1040,14 +1040,12 @@ class SethRpcTest(unittest.TestCase):
 
         receipts = [
             TransactionReceipt(
-                data=[TransactionReceipt.Data(
-                    data_type="seth_receipt",
-                    data=SethTransactionReceipt(
-                        gas_used=self.gas,
-                        return_value=self.return_value_b,
-                        contract_address=self.contract_address_b,
+                data=[SethTransactionReceipt(
+                    gas_used=self.gas,
+                    return_value=self.return_value_b,
+                    contract_address=self.contract_address_b,
                     ).SerializeToString(),
-                )],
+                ],
                 events=[Event(
                     event_type="seth_log_event",
                     attributes=[
@@ -1059,14 +1057,12 @@ class SethRpcTest(unittest.TestCase):
                 transaction_id=txn_ids[0],
             ),
             TransactionReceipt(
-                data=[TransactionReceipt.Data(
-                    data_type="seth_receipt",
-                    data=SethTransactionReceipt(
-                        gas_used=self.gas,
-                        return_value=self.return_value_b,
-                        contract_address=self.contract_address_b,
+                data=[SethTransactionReceipt(
+                    gas_used=self.gas,
+                    return_value=self.return_value_b,
+                    contract_address=self.contract_address_b,
                     ).SerializeToString(),
-                )],
+                ],
                 events=[Event(
                     event_type="seth_log_event",
                     attributes=[
@@ -1175,14 +1171,12 @@ class SethRpcTest(unittest.TestCase):
     def _send_receipts_back(self, msg, receipts=None):
         if receipts is None:
             receipts = [TransactionReceipt(
-                data=[TransactionReceipt.Data(
-                    data_type="seth_receipt",
-                    data=SethTransactionReceipt(
-                        gas_used=self.gas,
-                        return_value=self.return_value_b,
-                        contract_address=self.contract_address_b,
+                data=[SethTransactionReceipt(
+                    gas_used=self.gas,
+                    return_value=self.return_value_b,
+                    contract_address=self.contract_address_b,
                     ).SerializeToString(),
-                )],
+                ],
                 events=[Event(
                     event_type="seth_log_event",
                     attributes=[

--- a/families/seth/src/sawtooth_seth/client/client.go
+++ b/families/seth/src/sawtooth_seth/client/client.go
@@ -480,7 +480,7 @@ func (c *Client) GetEvents(txnID string) (*ClientResult, error) {
 
 func (c *Client) parseTransactionReceipt(receipt *TransactionReceipt) (*SethTransactionReceipt, []Event) {
 	sethReceipt := &SethTransactionReceipt{}
-	buf, err := base64.StdEncoding.DecodeString(receipt.Data[0].Data)
+	buf, err := base64.StdEncoding.DecodeString(receipt.Data[0])
 	if err != nil {
 		logger.Debugf("Receipt not available")
 		sethReceipt = nil

--- a/families/seth/src/sawtooth_seth/client/response.go
+++ b/families/seth/src/sawtooth_seth/client/response.go
@@ -99,10 +99,7 @@ type TransactionReceipt struct {
 		Address string
 	}
 	Events []Event
-	Data   []struct {
-		Data     string
-		DataType string
-	}
+	Data   []string
 }
 type Event struct {
 	EventType  string

--- a/families/seth/src/sawtooth_seth/processor/handler/handler.go
+++ b/families/seth/src/sawtooth_seth/processor/handler/handler.go
@@ -121,7 +121,7 @@ func (self *BurrowEVMHandler) Apply(request *processor_pb2.TpProcessRequest, con
 			"Couldn't marshal receipt: %v", err,
 		)}
 	}
-	err = context.AddReceiptData("seth_receipt", bytes)
+	err = context.AddReceiptData(bytes)
 	if err != nil {
 		return &processor.InternalError{Msg: fmt.Sprintf(
 			"Couldn't set receipt data: %v", err,

--- a/protos/identity.proto
+++ b/protos/identity.proto
@@ -20,15 +20,15 @@ option java_package = "sawtooth.identity.protobuf";
 
 message Policy {
 
-  enum Type {
-    TYPE_UNSET = 0;
+  enum EntryType {
+    ENTRY_TYPE_UNSET = 0;
     PERMIT_KEY = 1;
     DENY_KEY = 2;
   }
 
   message Entry {
     // Whether this is a Permit_KEY or Deny_KEY entry
-    Type type = 1;
+    EntryType type = 1;
 
     // This should be a list of public keys or * to refer to all participants.
     // If using *, it should be the only key in the list.

--- a/protos/state_context.proto
+++ b/protos/state_context.proto
@@ -84,9 +84,8 @@ message TpStateDeleteResponse {
 // The request from the transaction processor to the validator append data
 // to a transaction receipt
 message TpReceiptAddDataRequest {
-    // The context id that references a context in the contextmanager
+    // The context id that references a context in the context manager
     string context_id = 1;
-    string data_type = 2;
     bytes data = 3;
 }
 

--- a/protos/transaction_receipt.proto
+++ b/protos/transaction_receipt.proto
@@ -23,18 +23,13 @@ import "events.proto";
 
 
 message TransactionReceipt {
-  message Data {
-    // Interpretation left to transaction family
-    string data_type = 1;
-    bytes data = 2;
-  }
   // State changes made by this transaction
   // StateChange is already defined in protos/state_delta.proto
   repeated StateChange state_changes = 1;
   // Events fired by this transaction
   repeated Event events = 2;
   // Transaction family defined data
-  repeated Data data = 3;
+  repeated bytes data = 3;
 
   string transaction_id = 4;
 }

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -677,12 +677,8 @@ definitions:
       data:
         type: array
         items:
-          properties:
-            data_type:
-              type: string
-            data:
-              type: string
-              format: binary
+          type: string
+          format: binary
   TransactionReceipts:
     type: array
     items:

--- a/sdk/go/src/sawtooth_sdk/processor/context.go
+++ b/sdk/go/src/sawtooth_sdk/processor/context.go
@@ -200,11 +200,10 @@ func (self *Context) Set(pairs map[string][]byte) ([]string, error) {
 	return self.SetState(pairs)
 }
 
-func (self *Context) AddReceiptData(data_type string, data []byte) error {
+func (self *Context) AddReceiptData(data []byte) error {
 	// Append the data to the transaction receipt and set the type
 	request := &state_context_pb2.TpReceiptAddDataRequest{
 		ContextId: self.contextId,
-		DataType:  data_type,
 		Data:      data,
 	}
 	bytes, err := proto.Marshal(request)

--- a/sdk/go/tests/state_test.go
+++ b/sdk/go/tests/state_test.go
@@ -110,7 +110,6 @@ func TestReceiptData(t *testing.T) {
 
   request := &state_context_pb2.TpReceiptAddDataRequest{
     ContextId: "qwerty",
-    DataType: "test",
     Data: []byte("receiptdata"),
   }
   bytes, _ := proto.Marshal(request)
@@ -118,5 +117,5 @@ func TestReceiptData(t *testing.T) {
   mock_connection.EXPECT().SendNewMsg(validator_pb2.Message_TP_RECEIPT_ADD_DATA_REQUEST, bytes)
   mock_connection.EXPECT().RecvMsgWithId("")
 
-  context.AddReceiptData("test", []byte("receiptdata"))
+  context.AddReceiptData([]byte("receiptdata"))
 }

--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -109,16 +109,14 @@ class Context(object):
                 'Tried to delete unauthorized address: {}'.format(addresses))
         return response.addresses
 
-    def add_receipt_data(self, data_type, data, timeout=None):
+    def add_receipt_data(self, data, timeout=None):
         """Add a blob to the execution result for this transaction.
 
         Args:
-            data_type (str): Transparent hint for decoding the data.
             data (bytes): The data to add.
         """
         request = state_context_pb2.TpReceiptAddDataRequest(
             context_id=self._context_id,
-            data_type=data_type,
             data=data).SerializeToString()
         response = state_context_pb2.TpReceiptAddDataResponse()
         response.ParseFromString(
@@ -127,7 +125,7 @@ class Context(object):
                 request).result(timeout).content)
         if response.status == state_context_pb2.TpReceiptAddDataResponse.ERROR:
             raise InternalError(
-                "Failed to add receipt data: {}".format((data_type, data)))
+                "Failed to add receipt data: {}".format((data)))
 
     def add_event(self, event_type, attributes=None, data=None, timeout=None):
         """Add a new event to the execution result for this transaction.

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -117,13 +117,12 @@ class ContextTest(unittest.TestCase):
             content=TpReceiptAddDataResponse(
                 status=TpReceiptAddDataResponse.OK).SerializeToString())
 
-        self.context.add_receipt_data("test", b"test")
+        self.context.add_receipt_data(b"test")
 
         self.mock_stream.send.assert_called_with(
             Message.TP_RECEIPT_ADD_DATA_REQUEST,
             TpReceiptAddDataRequest(
                 context_id=self.context_id,
-                data_type="test",
                 data=b"test").SerializeToString())
 
     def test_add_event(self):

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -428,7 +428,7 @@ class ContextManager(object):
         self._address_queue.put_nowait(_SHUTDOWN_SENTINEL)
         self._inflated_addresses.put_nowait(_SHUTDOWN_SENTINEL)
 
-    def add_execution_data(self, context_id, data_type, data):
+    def add_execution_data(self, context_id, data):
         """Within a context, append data to the execution result.
 
         Args:
@@ -445,7 +445,7 @@ class ContextManager(object):
             return False
 
         context = self._contexts.get(context_id)
-        context.add_execution_data(data_type, data)
+        context.add_execution_data(data)
         return True
 
     def add_execution_event(self, context_id, event):

--- a/validator/sawtooth_validator/execution/execution_context.py
+++ b/validator/sawtooth_validator/execution/execution_context.py
@@ -351,9 +351,9 @@ class ExecutionContext(object):
         if not any(address.startswith(ns) for ns in self._read_list):
             raise AuthorizationException(address=address)
 
-    def add_execution_data(self, data_type, data):
+    def add_execution_data(self, data):
         with self._lock:
-            self._execution_data.append((data_type, data))
+            self._execution_data.append(data)
 
     def get_execution_data(self):
         with self._lock:

--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -153,7 +153,6 @@ class TpReceiptAddDataHandler(Handler):
 
         success = self._context_manager.add_execution_data(
             add_receipt_data_request.context_id,
-            add_receipt_data_request.data_type,
             add_receipt_data_request.data)
 
         ack = state_context_pb2.TpReceiptAddDataResponse()

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -931,11 +931,7 @@ class ChainController(object):
         receipts = []
         for result in results:
             receipt = TransactionReceipt()
-            receipt.data.extend([
-                TransactionReceipt.Data(
-                    data_type=data_type, data=data)
-                for data_type, data in result.data
-            ])
+            receipt.data.extend([data for data in result.data])
             receipt.state_changes.extend(result.state_changes)
             receipt.events.extend(result.events)
             receipt.transaction_id = result.signature

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -287,7 +287,6 @@ def main(args=None):
         LOGGER.error("Initialization errors occurred (see previous log "
                      "ERROR messages), shutting down.")
         sys.exit(1)
-
     bind_network = validator_config.bind_network
     bind_component = validator_config.bind_component
 

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -200,7 +200,7 @@ class TestContextManager(unittest.TestCase):
             attributes=[Event.Attribute(key=teststr, value=teststr)],
             data=teststr.encode()) for teststr in ("test1", "test2")]
         deletes = {addr2: None}
-        data = [(teststr, teststr.encode()) for teststr in ("test1", "test2")]
+        data = [(teststr.encode()) for teststr in ("test1", "test2")]
 
         self.context_manager.set(context_id, [sets])
         for event in events:
@@ -209,7 +209,7 @@ class TestContextManager(unittest.TestCase):
         self.context_manager.delete(context_id, deletes)
         for datum in data:
             self.context_manager.add_execution_data(
-                context_id, datum[0], datum[1])
+                context_id, datum)
 
 
         results = self.context_manager.get_execution_results(context_id)

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -66,9 +66,7 @@ class ReceiptStoreTest(unittest.TestCase):
                     event_type="test",
                     data=byte,
                     attributes=[Event.Attribute(key=string, value=string)]))
-                data.append(TransactionReceipt.Data(
-                    data_type="test",
-                    data=byte))
+                data.append(byte)
 
             receipts.append(TransactionReceipt(
                 state_changes=state_changes,
@@ -101,8 +99,7 @@ class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
         receipt_store = TransactionReceiptStore(DictDatabase())
 
         receipt = TransactionReceipt(
-            data=[TransactionReceipt.Data(
-                data_type="dead", data="beef".encode())])
+            data=["beef".encode()])
 
         receipt_store.put("deadbeef", receipt)
 
@@ -131,8 +128,7 @@ class TpReceiptAddDataHandlerTest(unittest.TestCase):
     def test_add_event(self):
         mock_add_receipt_data = Mock()
         handler = TpReceiptAddDataHandler(mock_add_receipt_data)
-        request = TpReceiptAddDataRequest(
-            data_type="test").SerializeToString()
+        request = TpReceiptAddDataRequest().SerializeToString()
 
         response = handler.handle("test_conn_id", request)
 


### PR DESCRIPTION
Also, changes Type in Policy to EntryType.

Removing Data from TransactionReceipt removes extra info and remove the awkward to need to do TransactionReceipt.data[0].data