### PR TITLE
Make TpProcessRequest header unserialized

### DIFF
--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -28,7 +28,6 @@ from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.setting_pb2 import Setting
 
 from sawtooth_poet_common import sgx_structs
@@ -463,8 +462,7 @@ class ValidatorRegistryTransactionHandler(TransactionHandler):
                         val_reg_payload.signup_info.nonce))
 
     def apply(self, transaction, context):
-        txn_header = TransactionHeader()
-        txn_header.ParseFromString(transaction.header)
+        txn_header = transaction.header
         public_key = txn_header.signer_public_key
 
         val_reg_payload = ValidatorRegistryPayload()

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -245,8 +245,7 @@ an empty string if the action isn't 'take'). So our {% if language == 'JavaScrip
 .. code-block:: python
 
     def _unpack_transaction(self, transaction):
-        header = TransactionHeader()
-        header.ParseFromString(transaction.header)
+        header = transaction.header
         signer = header.signer
 
         try:

--- a/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
+++ b/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
@@ -18,7 +18,6 @@ import re
 import json
 import hashlib
 
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
 
@@ -36,8 +35,7 @@ class BattleshipTransaction:
             transaction: Dictionary of values for transaction fields.
         """
 
-        header = TransactionHeader()
-        header.ParseFromString(transaction.header)
+        header = transaction.header
 
         try:
             payload = json.loads(

--- a/families/identity/sawtooth_identity/processor/handler.py
+++ b/families/identity/sawtooth_identity/processor/handler.py
@@ -21,7 +21,6 @@ from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.setting_pb2 import Setting
 
 from sawtooth_identity.protobuf.identity_pb2 import Policy
@@ -120,8 +119,7 @@ class IdentityTransactionHandler(TransactionHandler):
 
 
 def _check_allowed_transactor(transaction, context):
-    header = TransactionHeader()
-    header.ParseFromString(transaction.header)
+    header = transaction.header
 
     entries_list = _get_data(ALLOWED_SIGNER_ADDRESS, context)
     if not entries_list:

--- a/families/seth/src/sawtooth_seth/processor/handler/handler.go
+++ b/families/seth/src/sawtooth_seth/processor/handler/handler.go
@@ -69,7 +69,7 @@ func (self *BurrowEVMHandler) Apply(request *processor_pb2.TpProcessRequest, con
 	}
 
 	// Unpack and validate header
-	header, err := unpackHeader(request.GetHeader())
+	header, err := unpackHeader(request)
 	if err != nil {
 		return err
 	}
@@ -177,14 +177,8 @@ func unpackPayload(payload []byte) (*SethTransaction, error) {
 	return transaction, nil
 }
 
-func unpackHeader(headerBytes []byte) (*transaction_pb2.TransactionHeader, error) {
-	header := &transaction_pb2.TransactionHeader{}
-	err := proto.Unmarshal(headerBytes, header)
-	if err != nil {
-		return nil, &processor.InvalidTransactionError{
-			Msg: "Malformed request header",
-		}
-	}
+func unpackHeader(request *processor_pb2.TpProcessRequest) (*transaction_pb2.TransactionHeader, error) {
+	header := request.GetHeader()
 
 	if header.GetSignerPublicKey() == "" {
 		return nil, &processor.InvalidTransactionError{Msg: "Public Key not set"}

--- a/families/settings/sawtooth_settings/processor/handler.py
+++ b/families/settings/sawtooth_settings/processor/handler.py
@@ -23,7 +23,6 @@ from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.messaging.future import FutureTimeoutError
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 
 from sawtooth_settings.protobuf.settings_pb2 import SettingsPayload
 from sawtooth_settings.protobuf.settings_pb2 import SettingProposal
@@ -58,8 +57,7 @@ class SettingsTransactionHandler(TransactionHandler):
 
     def apply(self, transaction, context):
 
-        txn_header = TransactionHeader()
-        txn_header.ParseFromString(transaction.header)
+        txn_header = transaction.header
         public_key = txn_header.signer_public_key
 
         auth_keys = _get_auth_keys(context)

--- a/families/smallbank/smallbank_go/src/sawtooth_smallbank/handler/handler.go
+++ b/families/smallbank/smallbank_go/src/sawtooth_smallbank/handler/handler.go
@@ -26,7 +26,6 @@ import (
 	"sawtooth_sdk/logging"
 	"sawtooth_sdk/processor"
 	"sawtooth_sdk/protobuf/processor_pb2"
-	"sawtooth_sdk/protobuf/transaction_pb2"
 	"strings"
 )
 
@@ -260,16 +259,6 @@ func unpackPayload(payloadData []byte) (*smallbank_pb2.SmallbankTransactionPaylo
 			Msg: fmt.Sprint("Failed to unmarshal SmallbankTransaction: %v", err)}
 	}
 	return payload, nil
-}
-
-func unpackHeader(headerData []byte) (*transaction_pb2.TransactionHeader, error) {
-	header := &transaction_pb2.TransactionHeader{}
-	err := proto.Unmarshal(headerData, header)
-	if err != nil {
-		return nil, &processor.InternalError{
-			Msg: fmt.Sprint("Failed to unmarshal TransactionHeader: %v", err)}
-	}
-	return header, nil
 }
 
 func unpackAccount(accountData []byte) (*smallbank_pb2.Account, error) {

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -18,6 +18,9 @@ option java_multiple_files = true;
 option java_package = "sawtooth.sdk.protobuf";
 option go_package = "processor_pb2";
 
+import "transaction.proto";
+
+
 // The registration request from the transaction processor to the
 // validator/executor
 message TpRegisterRequest {
@@ -72,7 +75,7 @@ message TpUnregisterResponse {
 // The request from the validator/executor of the transaction processor
 // to verify a transaction.
 message TpProcessRequest {
-    bytes header = 1;  // The transaction header
+    TransactionHeader header = 1;  // The transaction header
     bytes payload = 2;  // The transaction payload
     string signature = 3;  // The transaction header_signature
     string context_id = 4; // The context_id for state requests.

--- a/sdk/cxx/include/sawtooth/transaction_handler.h
+++ b/sdk/cxx/include/sawtooth/transaction_handler.h
@@ -32,11 +32,10 @@ typedef std::shared_ptr<std::string> StringPtr;
 // The transaction data for a Transaction Processing request.
 class Transaction final {
  public:
-    Transaction(StringPtr header, StringPtr payload, StringPtr signature):
+    Transaction(TransactionHeader* header, StringPtr payload, StringPtr signature):
             payload_(payload), signature_(signature) {
-        this->header_.ParseFromArray(header->c_str(),
-            header->length());
     }
+
     Transaction (const Transaction&) = delete;
     Transaction (const Transaction&&) = delete;
     Transaction& operator= (const Transaction&) = delete;

--- a/sdk/cxx/src/transaction_processor.cpp
+++ b/sdk/cxx/src/transaction_processor.cpp
@@ -87,15 +87,17 @@ void TransactionProcessor::HandleProcessingRequest(const void* msg,
     try {
         request.ParseFromArray(msg, msg_size);
 
-        StringPtr header_data(request.release_header());
+        TransactionHeader* txn_header(request.release_header());
+
         StringPtr payload_data(request.release_payload());
         StringPtr signature_data(request.release_signature());
 
-        TransactionUPtr txn(new Transaction( header_data,
+        TransactionUPtr txn(new Transaction( txn_header,
             payload_data,
             signature_data));
-        const TransactionHeader& txn_header = txn->header();
-        const std::string& family = txn_header.family_name();
+
+        const std::string& family = txn_header->family_name();
+
         auto iter = this->handlers.find(family);
         if (iter != this->handlers.end()) {
             // TBD match version
@@ -216,4 +218,3 @@ void TransactionProcessor::Run() {
 }
 
 }  // namespace sawtooth
-

--- a/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
+++ b/sdk/examples/xo_go/src/sawtooth_xo/handler/handler.go
@@ -22,11 +22,9 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
-	"github.com/golang/protobuf/proto"
 	"sawtooth_sdk/logging"
 	"sawtooth_sdk/processor"
 	"sawtooth_sdk/protobuf/processor_pb2"
-	"sawtooth_sdk/protobuf/transaction_pb2"
 	"strconv"
 	"strings"
 )
@@ -66,10 +64,7 @@ func (self *XoHandler) Apply(request *processor_pb2.TpProcessRequest, context *p
 	// The xo player is defined as the signer of the transaction, so we unpack
 	// the transaction header to obtain the signer's public key, which will be
 	// used as the player's identity.
-	header, err := unpackHeader(request.Header)
-	if err != nil {
-		return err
-	}
+	header := request.GetHeader()
 	player := header.GetSignerPublicKey()
 
 	// The payload is sent to the transaction processor as bytes (just as it
@@ -229,16 +224,6 @@ func unpackPayload(payloadData []byte) (*XoPayload, error) {
 	}
 
 	return &payload, nil
-}
-
-func unpackHeader(headerData []byte) (*transaction_pb2.TransactionHeader, error) {
-	header := &transaction_pb2.TransactionHeader{}
-	err := proto.Unmarshal(headerData, header)
-	if err != nil {
-		return nil, &processor.InternalError{
-			Msg: fmt.Sprint("Failed to unmarshal TransactionHeader: %v", err)}
-	}
-	return header, nil
 }
 
 func unpackGame(gameData []byte) (*Game, error) {

--- a/sdk/examples/xo_java/XoHandler.java
+++ b/sdk/examples/xo_java/XoHandler.java
@@ -107,12 +107,9 @@ public class XoHandler implements TransactionHandler {
 
     // The transaction signer is the player
     String player;
-    try {
-      TransactionHeader header = TransactionHeader.parseFrom(transactionRequest.getHeader());
-      player = header.getSignerPublicKey();
-    } catch (InvalidProtocolBufferException e) {
-      throw new InternalError("Protocol Buffer Error: " + e.toString());
-    }
+    TransactionHeader header = transactionRequest.getHeader();
+    player = header.getSignerPublicKey();
+
     if (transactionData.gameName.equals("")) {
       throw new InvalidTransactionException("Name is required");
     }
@@ -233,7 +230,7 @@ public class XoHandler implements TransactionHandler {
       }
       stateEntry = StringUtils.join(dataList, "|");
     }
-    
+
     ByteString csvByteString = ByteString.copyFromUtf8(stateEntry);
     Map.Entry<String, ByteString> entry = new AbstractMap.SimpleEntry<>(address, csvByteString);
     Collection<Map.Entry<String, ByteString>> addressValues = Collections.singletonList(entry);

--- a/sdk/examples/xo_javascript/xo_handler.js
+++ b/sdk/examples/xo_javascript/xo_handler.js
@@ -18,7 +18,6 @@
 'use strict'
 
 const {TransactionHandler} = require('sawtooth-sdk/processor')
-const {TransactionHeader} = require('sawtooth-sdk/protobuf')
 const {InvalidTransaction, InternalError} = require('sawtooth-sdk/processor/exceptions')
 
 const crypto = require('crypto')
@@ -279,7 +278,7 @@ class XOHandler extends TransactionHandler {
     return _decodeRequest(transactionProcessRequest.payload)
       .catch(_toInternalError)
       .then((update) => {
-        let header = TransactionHeader.decode(transactionProcessRequest.header)
+        let header = transactionProcessRequest.header
         let player = header.signerPublicKey
         if (!update.name) {
           throw new InvalidTransaction('Name is required')

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -20,7 +20,6 @@ import logging
 from sawtooth_sdk.processor.handler import TransactionHandler
 from sawtooth_sdk.processor.exceptions import InvalidTransaction
 from sawtooth_sdk.processor.exceptions import InternalError
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 
 LOGGER = logging.getLogger(__name__)
 
@@ -84,8 +83,7 @@ class XoTransactionHandler(TransactionHandler):
 
 
 def _unpack_transaction(transaction):
-    header = TransactionHeader()
-    header.ParseFromString(transaction.header)
+    header = transaction.header
 
     # The transaction signer is the player
     signer = header.signer_public_key

--- a/sdk/go/src/sawtooth_sdk/processor/worker.go
+++ b/sdk/go/src/sawtooth_sdk/processor/worker.go
@@ -49,13 +49,7 @@ func worker(context *zmq.Context, uri string, queue chan *validator_pb2.Message,
 			break
 		}
 
-		header := &transaction_pb2.TransactionHeader{}
-		err = proto.Unmarshal(request.Header, header)
-		if err != nil {
-			logger.Errorf(
-				"(%v) Failed to unmarshal TransactionHeader: %v", id, err)
-			break
-		}
+		header := request.GetHeader()
 
 		// Try to find a handler
 		handler, err := findHandler(handlers, header)

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/TransactionProcessor.java
@@ -177,8 +177,7 @@ public class TransactionProcessor implements Runnable {
     try {
       TpProcessRequest transactionRequest = TpProcessRequest
               .parseFrom(this.currentMessage.getContent());
-      TransactionHeader header = TransactionHeader
-              .parseFrom(transactionRequest.getHeader());
+      TransactionHeader header = transactionRequest.getHeader();
       for (int  i = 0; i < this.handlers.size(); i++) {
         TransactionHandler handler = this.handlers.get(i);
         if (header.getFamilyName().equals(handler.transactionFamilyName())

--- a/sdk/javascript/processor/index.js
+++ b/sdk/javascript/processor/index.js
@@ -24,7 +24,6 @@ const {
   TpProcessRequest,
   TpProcessResponse,
   PingResponse,
-  TransactionHeader,
   Message
 } = require('../protobuf')
 
@@ -69,7 +68,7 @@ class TransactionProcessor {
         const context = new Context(this._stream, request.contextId)
 
         if (this._handlers.length > 0) {
-          let txnHeader = TransactionHeader.decode(request.header)
+          let txnHeader = request.header
 
           let handler = this._handlers.find((candidate) =>
              candidate.transactionFamilyName === txnHeader.familyName &&

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -138,7 +138,7 @@ class MessageFactory(object):
             batcher_public_key=pub_key,
             nonce=nonce
         )
-        return header.SerializeToString()
+        return header
 
     def _create_signature(self, header):
         return _sign(header, self._private)
@@ -147,7 +147,7 @@ class MessageFactory(object):
                                set_nonce=True, batcher=None):
         header = self._create_transaction_header(
             payload, inputs, outputs, deps, set_nonce, batcher)
-        signature = self._create_signature(header)
+        signature = self._create_signature(header.SerializeToString())
         return header, signature
 
     def create_transaction(self, payload, inputs, outputs, deps,
@@ -156,7 +156,7 @@ class MessageFactory(object):
             payload, inputs, outputs, deps, batcher=batcher)
 
         return Transaction(
-            header=header,
+            header=header.SerializeToString(),
             payload=payload,
             header_signature=signature)
 

--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -36,7 +36,6 @@ from sawtooth_sdk.protobuf.processor_pb2 import TpUnregisterResponse
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessRequest
 from sawtooth_sdk.protobuf.processor_pb2 import TpProcessResponse
 from sawtooth_sdk.protobuf.network_pb2 import PingResponse
-from sawtooth_sdk.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
 
@@ -110,8 +109,7 @@ class TransactionProcessor(object):
         request = TpProcessRequest()
         request.ParseFromString(msg.content)
         state = Context(self._stream, request.context_id)
-        header = TransactionHeader()
-        header.ParseFromString(request.header)
+        header = request.header
         try:
             if not self._stream.is_ready():
                 raise ValidatorConnectionError()

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -241,7 +241,7 @@ class TransactionExecutorThread(object):
                     context_id=None)
                 continue
             content = processor_pb2.TpProcessRequest(
-                header=txn.header,
+                header=header,
                 payload=txn.payload,
                 signature=txn.header_signature,
                 context_id=context_id).SerializeToString()


### PR DESCRIPTION
Previously the header was bytes, requiring TP handlers to go through
the extra step of deserializing it before being able to access it.

Addresses https://jira.hyperledger.org/browse/STL-817