### PR TITLE
Implement catchup for EventBroadcaster

### DIFF
--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -67,6 +67,75 @@ class TestEventsAndReceipts(unittest.TestCase):
 
         self._unsubscribe()
 
+    def test_get_events(self):
+        """Tests that block commit events are properly received on block
+        boundaries."""
+        self._subscribe()
+
+        self.batch_submitter.submit_next_batch()
+        msg = self.stream.receive().result()
+        self._unsubscribe()
+
+        event_list = events_pb2.EventList()
+        event_list.ParseFromString(msg.content)
+        events = event_list.events
+        block_commit_event = events[0]
+        block_id = list(filter(
+            lambda attr: attr.key == "block_id",
+            block_commit_event.attributes))[0].value
+        block_num = list(filter(
+            lambda attr: attr.key == "block_num",
+            block_commit_event.attributes))[0].value
+
+        response = self._get_events(
+            block_id,
+            [events_pb2.EventSubscription(event_type="block_commit")])
+        events = self.assert_events_get_response(response)
+        self.assert_block_commit_event(events[0], block_num)
+
+    def test_catchup(self):
+        """Tests that a subscriber correctly receives catchup events."""
+        self._subscribe()
+
+        blocks = []
+        for i in range(4):
+            self.batch_submitter.submit_next_batch()
+            msg = self.stream.receive().result()
+            event_list = events_pb2.EventList()
+            event_list.ParseFromString(msg.content)
+            events = event_list.events
+            block_commit_event = events[0]
+            block_id = list(filter(
+                lambda attr: attr.key == "block_id",
+                block_commit_event.attributes))[0].value
+            block_num = list(filter(
+                lambda attr: attr.key == "block_num",
+                block_commit_event.attributes))[0].value
+            blocks.append((block_num, block_id))
+
+        self._unsubscribe()
+
+        self.assert_subscribe_response(
+            self._subscribe(last_known_block_ids=[blocks[0][1]]))
+        LOGGER.warning("Waiting for catchup events")
+        msg = self.stream.receive().result()
+        LOGGER.warning("Got catchup events")
+        event_list = events_pb2.EventList()
+        event_list.ParseFromString(msg.content)
+        events = event_list.events
+        self.assertEqual(len(events), 3)
+        for i in range(3):
+            block_commit_event = events[i]
+            block_id = list(filter(
+                lambda attr: attr.key == "block_id",
+                block_commit_event.attributes))[0].value
+            block_num = list(filter(
+                lambda attr: attr.key == "block_num",
+                block_commit_event.attributes))[0].value
+            self.assertEqual((block_num, block_id), blocks[i+1])
+
+        self._unsubscribe()
+
     def test_receipt_stored(self):
         """Tests that receipts are stored successfully when a block is
         committed."""
@@ -108,13 +177,25 @@ class TestEventsAndReceipts(unittest.TestCase):
             request.SerializeToString()).result()
         return response
 
-    def _subscribe(self, subscriptions=None):
+    def _get_events(self, block_id, subscriptions):
+        request = client_event_pb2.ClientEventsGetRequest(
+            block_ids=[block_id],
+            subscriptions=subscriptions)
+        response = self.stream.send(
+            validator_pb2.Message.CLIENT_EVENTS_GET_REQUEST,
+            request.SerializeToString()).result()
+        return response
+
+    def _subscribe(self, subscriptions=None, last_known_block_ids=None):
         if subscriptions is None:
             subscriptions = [
                 events_pb2.EventSubscription(event_type="block_commit"),
             ]
+        if last_known_block_ids is None:
+            last_known_block_ids = []
         request = client_event_pb2.ClientEventsSubscribeRequest(
-            subscriptions=subscriptions)
+            subscriptions=subscriptions,
+            last_known_block_ids=last_known_block_ids)
         response = self.stream.send(
             validator_pb2.Message.CLIENT_EVENTS_SUBSCRIBE_REQUEST,
             request.SerializeToString()).result()
@@ -155,6 +236,20 @@ class TestEventsAndReceipts(unittest.TestCase):
             client_receipt_pb2.ClientReceiptGetResponse.OK)
 
         return receipt_response.receipts
+
+    def assert_events_get_response(self, msg):
+        self.assertEqual(
+            msg.message_type,
+            validator_pb2.Message.CLIENT_EVENTS_GET_RESPONSE)
+
+        events_response = client_event_pb2.ClientEventsGetResponse()
+        events_response.ParseFromString(msg.content)
+
+        self.assertEqual(
+            events_response.status,
+            client_event_pb2.ClientEventsGetResponse.OK)
+
+        return events_response.events
 
     def assert_subscribe_response(self, msg):
         self.assertEqual(

--- a/validator/sawtooth_validator/server/events/broadcaster.py
+++ b/validator/sawtooth_validator/server/events/broadcaster.py
@@ -28,6 +28,10 @@ from sawtooth_validator.journal.event_extractors \
 LOGGER = logging.getLogger(__name__)
 
 
+class NoKnownBlockError(Exception):
+    pass
+
+
 class EventBroadcaster(ChainObserver):
     def __init__(self, service, block_store, receipt_store):
         self._subscribers = {}
@@ -37,18 +41,54 @@ class EventBroadcaster(ChainObserver):
         self._receipt_store = receipt_store
 
     def add_subscriber(self, connection_id, subscriptions,
-                       last_known_block_ids):
+                       last_known_block_id):
         """Register the subscriber for the given event subscriptions.
 
-        Raises an exception if:
-        1. The subscription is unsuccessful.
-        2. None of the block ids in last_known_block_ids are part of the
-           current chain.
+        Raises:
+            InvalidFilterError
+                One of the filters in the subscriptions is invalid.
         """
         with self._subscribers_cv:
             self._subscribers[connection_id] = \
                 EventSubscriber(
-                    connection_id, subscriptions, last_known_block_ids)
+                    connection_id, subscriptions, last_known_block_id)
+
+        LOGGER.debug(
+            'Added Subscriber %s for %s', connection_id, subscriptions)
+
+    def catchup_subscriber(self, connection_id):
+        """Send an event list with all events that are in the given
+        subscriptions from all blocks since that latest block in the current
+        chain that is in the given last known block ids.
+
+        Raises:
+            PossibleForkDetectedError
+                A possible fork was detected while building the event list
+            NoKnownBlockError
+                None of the last known blocks were in the current chain
+            KeyError
+                Unknown connection_id
+        """
+        with self._subscribers_cv:
+            subscriber = self._subscribers[connection_id]
+            last_known_block_id = subscriber.get_last_known_block_id()
+            subscriptions = subscriber.subscriptions
+
+        if last_known_block_id is not None:
+            LOGGER.debug(
+                'Catching up Subscriber %s from %s',
+                connection_id, last_known_block_id)
+            catchup_blocks = self.get_catchup_blocks(last_known_block_id)
+            if not catchup_blocks:
+                return
+
+            catchup_events = self.get_events_for_blocks(
+                catchup_blocks, subscriptions)
+            if not catchup_events:
+                return
+
+            event_list = EventList(events=catchup_events)
+            self._send(connection_id, event_list.SerializeToString())
 
     def enable_subscriber(self, connection_id):
         """Start sending events to the subscriber.
@@ -70,6 +110,48 @@ class EventBroadcaster(ChainObserver):
             if connection_id in self._subscribers:
                 del self._subscribers[connection_id]
 
+    def get_catchup_blocks(self, last_known_block_id):
+        '''
+        Raises:
+            PossibleForkDetectedError
+        '''
+        # If latest known block is not the current chain head, catch up
+        catchup_up_blocks = []
+        if last_known_block_id != self._block_store.chain_head.identifier:
+            # Start from the chain head and get blocks until we reach the
+            # known block
+            for block in self._block_store.get_predecessor_iter():
+                if block.identifier == last_known_block_id:
+                    break
+                catchup_up_blocks.append(block)
+
+        return list(reversed(catchup_up_blocks))
+
+    def get_latest_known_block_id(self, last_known_block_ids):
+        '''
+        Raises:
+            NoKnownBlockError
+        '''
+        # Filter known blocks to contain only blocks in the current chain
+        blocks = []
+        if last_known_block_ids:
+            for block_id in last_known_block_ids:
+                try:
+                    block = self._block_store[block_id]
+                except KeyError:
+                    continue
+                block_num = block.block_num
+                blocks.append((block_num, block_id))
+
+        # No known blocks in the current chain
+        if not blocks:
+            raise NoKnownBlockError()
+
+        # Sort by block num and get the block id of the latest known block
+        blocks.sort()
+        block_id = blocks[-1][1]
+        return block_id
+
     def get_events_for_block_ids(self, block_ids, subscriptions):
         """Get a list of events associated with all the block ids.
 
@@ -81,15 +163,33 @@ class EventBroadcaster(ChainObserver):
 
         Returns (list of Events): The Events associated which each block id.
 
-        Raises: KeyError A block id isn't found within the block store.
+        Raises:
+            KeyError
+                A block id isn't found within the block store or a transaction
+                is missing from the receipt store.
+        """
 
+        blocks = [self._block_store[block_id] for block_id in block_ids]
+        return self.get_events_for_blocks(blocks, subscriptions)
+
+    def get_events_for_blocks(self, blocks, subscriptions):
+        """Get a list of events associated with all the blocks.
+
+        Args:
+            blocks (list of BlockWrapper): The blocks to search for events that
+                match each subscription.
+            subscriptions (list of EventSubscriptions): EventFilter and
+                event type to filter events.
+
+        Returns (list of Events): The Events associated which each block id.
+
+        Raises:
+            KeyError A receipt is missing from the receipt store.
         """
 
         events = []
-
         extractors = []
-        for block_id in block_ids:
-            blk_w = self._block_store[block_id]
+        for blk_w in blocks:
             extractors.append(BlockEventExtractor(blk_w))
             receipts = []
             for batch in blk_w.block.batches:
@@ -103,7 +203,7 @@ class EventBroadcaster(ChainObserver):
                             " while looking"
                             " up events for block id %s",
                             txn.header_signature[:10],
-                            block_id[:10])
+                            blk_w.identifier[:10])
             extractors.append(ReceiptEventExtractor(receipts=receipts))
 
         for extractor in extractors:
@@ -133,8 +233,14 @@ class EventBroadcaster(ChainObserver):
 
     def broadcast_events(self, events):
         LOGGER.debug("Broadcasting events: %s", events)
-        if self._subscribers:
-            for connection_id, subscriber in self._subscribers.items():
+        with self._subscribers_cv:
+            # Copy the subscribers
+            subscribers = {
+                conn: sub.copy() for conn, sub in self._subscribers.items()
+            }
+
+        if subscribers:
+            for connection_id, subscriber in subscribers.items():
                 if subscriber.is_listening():
                     subscriber_events = [event for event in events
                                          if subscriber.is_subscribed(event)]
@@ -148,11 +254,12 @@ class EventBroadcaster(ChainObserver):
 
 
 class EventSubscriber:
-    def __init__(self, connection_id, subscriptions, last_known_block_ids):
+    def __init__(self, connection_id, subscriptions, last_known_block,
+                 listening=False):
         self._connection_id = connection_id
         self._subscriptions = subscriptions
-        self._listening = False
-        self._last_known_block_ids = last_known_block_ids
+        self._listening = listening
+        self._last_known_block = last_known_block
 
     def start_listening(self):
         self._listening = True
@@ -173,3 +280,16 @@ class EventSubscriber:
     @property
     def subscriptions(self):
         return self._subscriptions.copy()
+
+    def get_last_known_block_id(self):
+        return self._last_known_block
+
+    def set_last_known_block_id(self):
+        return self._last_known_block
+
+    def copy(self):
+        return self.__class__(
+            self._connection_id,
+            self._subscriptions,
+            self._last_known_block,
+            self._listening)

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -156,6 +156,8 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
         """
 
         mock_event_broadcaster = Mock()
+        mock_event_broadcaster.get_latest_known_block_id.return_value = \
+            "0" * 128
         handler = \
             ClientEventsSubscribeValidationHandler(mock_event_broadcaster)
         request = client_event_pb2.ClientEventsSubscribeRequest(
@@ -174,7 +176,7 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
                 event_type="test_event",
                 filters=[
                     FILTER_FACTORY.create(key="test", match_string="test")])],
-            ["0" * 128])
+            "0" * 128)
         self.assertEqual(HandlerStatus.RETURN_AND_PASS, response.status)
         self.assertEqual(client_event_pb2.ClientEventsSubscribeResponse.OK,
                          response.message_out.status)


### PR DESCRIPTION
The StateDeltaProcessor would send events to a client since the last block they knew about. This PR adds similar functionality to the EventBroadcaster for events.