### PR TITLE
Fix memory leak in schedulers when .cancel is called

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -319,8 +319,13 @@ class SerialScheduler(Scheduler):
 
     def cancel(self):
         with self._condition:
-            self._cancelled = True
-            self._condition.notify_all()
+            if not self._cancelled and not self._final \
+                    and self._previous_context_id:
+                self._squash(state_root=self._previous_state_hash,
+                             context_ids=[self._previous_context_id],
+                             persist=False, clean_up=True)
+                self._cancelled = True
+                self._condition.notify_all()
 
     def is_cancelled(self):
         with self._condition:


### PR DESCRIPTION
Cancel is called when, during block publishing, the validator receives
a new chain head and stops the construction of that candidate block
because the predecessor is a different block, with a different state
root hash. No new merkle root will be constructed out of contexts
in the context manager, but they need to be cleaned up. This commit
adds a call to squash with persist=False, and cleanup=True in .cancel.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>