### PR TITLE
Update settings log formatting to match validator

### DIFF
--- a/families/settings/sawtooth_settings/processor/main.py
+++ b/families/settings/sawtooth_settings/processor/main.py
@@ -31,7 +31,8 @@ DISTRIBUTION_NAME = 'sawtooth-settings'
 def create_console_handler(verbose_level):
     clog = logging.StreamHandler()
     formatter = ColoredFormatter(
-        "%(log_color)s[%(asctime)s %(levelname)-8s%(module)s]%(reset)s "
+        "%(log_color)s[%(asctime)s.%(msecs)03d "
+        "%(levelname)-8s %(module)s]%(reset)s "
         "%(white)s%(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
         reset=True,


### PR DESCRIPTION
settings_tp wasn't printing microseconds so its messages weren't aligned
with validator logging. This is the worst travesty to befall any
codebase ever, but I fixed it. Probably.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>