### PR TITLE
Fix docker CMDs to use connection flag

### DIFF
--- a/docker/sawtooth-int-identity-tp
+++ b/docker/sawtooth-int-identity-tp
@@ -48,4 +48,4 @@ RUN apt-get install -y -q --allow-unauthenticated \
 
 EXPOSE 4004/tcp
 
-CMD ["identity-tp", "tcp://validator:4004"]
+CMD ["identity-tp", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-intkey-tp-cxx
+++ b/docker/sawtooth-int-intkey-tp-cxx
@@ -55,5 +55,5 @@ RUN mkdir -p /project/sawtooth-core/ \
 ENV PATH=$PATH:/project/sawtooth-core/sdk/cxx/build/bin
 
 WORKDIR /project/sawtooth-core
-CMD ["intkey_cxx", "tcp://validator:4004"]
+CMD ["intkey_cxx", "-C", "tcp://validator:4004"]
 

--- a/docker/sawtooth-int-intkey-tp-go
+++ b/docker/sawtooth-int-intkey-tp-go
@@ -37,4 +37,4 @@ COPY intkey-tp-go /usr/bin/intkey-tp-go
 
 EXPOSE 4004/tcp
 
-CMD ["intkey-tp-go", "tcp://validator:4004"]
+CMD ["intkey-tp-go", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-intkey-tp-python
+++ b/docker/sawtooth-int-intkey-tp-python
@@ -48,4 +48,4 @@ RUN apt-get install -y -q --allow-unauthenticated \
 
 EXPOSE 4004/tcp
 
-CMD ["intkey-tp-python", "tcp://validator:4004"]
+CMD ["intkey-tp-python", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-noop-tp-go
+++ b/docker/sawtooth-int-noop-tp-go
@@ -37,4 +37,4 @@ COPY noop-tp-go /usr/bin/noop-tp-go
 
 EXPOSE 4004/tcp
 
-CMD ["noop-tp-go", "tcp://validator:4004"]
+CMD ["noop-tp-go", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-poet-validator-registry-tp
+++ b/docker/sawtooth-int-poet-validator-registry-tp
@@ -48,4 +48,4 @@ RUN apt-get install -y -q --allow-unauthenticated \
 
 EXPOSE 4004/tcp
 
-CMD ["poet-validator-registry-tp", "tcp://validator:4004"]
+CMD ["poet-validator-registry-tp", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-settings-tp
+++ b/docker/sawtooth-int-settings-tp
@@ -48,4 +48,4 @@ RUN apt-get install -y -q --allow-unauthenticated \
 
 EXPOSE 4004/tcp
 
-CMD ["settings-tp", "tcp://validator:4004"]
+CMD ["settings-tp", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-smallbank-tp-go
+++ b/docker/sawtooth-int-smallbank-tp-go
@@ -36,4 +36,4 @@ COPY smallbank-tp-go /usr/bin/smallbank-tp-go
 
 EXPOSE 4004/tcp
 
-CMD ["smallbank-tp-go", "tcp://validator:4004"]
+CMD ["smallbank-tp-go", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-xo-tp-go
+++ b/docker/sawtooth-int-xo-tp-go
@@ -37,4 +37,4 @@ COPY xo-tp-go /usr/bin/xo-tp-go
 
 EXPOSE 4004/tcp
 
-CMD ["xo-tp-go", "tcp://validator:4004"]
+CMD ["xo-tp-go", "-C", "tcp://validator:4004"]

--- a/docker/sawtooth-int-xo-tp-python
+++ b/docker/sawtooth-int-xo-tp-python
@@ -48,4 +48,4 @@ RUN apt-get install -y -q --allow-unauthenticated \
 
 EXPOSE 4004/tcp
 
-CMD ["xo-tp-python", "tcp://validator:4004"]
+CMD ["xo-tp-python", "-C", "tcp://validator:4004"]


### PR DESCRIPTION
The CLIs were updated to use -C ahead of the validator connection
string. Update the dockerfile default commands to include that flag.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>