### PR TITLE
Renamed state_context Entry to TpStateEntry

### DIFF
--- a/protos/state_context.proto
+++ b/protos/state_context.proto
@@ -21,7 +21,7 @@ option go_package = "state_context_pb2";
 import "events.proto";
 
 // An entry in the State
-message Entry {
+message TpStateEntry {
     string address = 1;
     bytes data = 2;
 }
@@ -41,14 +41,14 @@ message TpStateGetResponse {
         AUTHORIZATION_ERROR = 2;
     }
 
-    repeated Entry entries = 1;
+    repeated TpStateEntry entries = 1;
     Status status = 2;
 }
 
 // A request from the handler/tp to put entries in the state of a context
 message TpStateSetRequest {
     string context_id = 1;
-    repeated Entry entries = 2;
+    repeated TpStateEntry entries = 2;
 }
 
 // A response from the contextmanager/validator with the addresses that were set

--- a/sdk/cxx/src/global_state.cpp
+++ b/sdk/cxx/src/global_state.cpp
@@ -92,7 +92,7 @@ void GlobalState::Set(const std::vector<KeyValue>& kv_pairs) const {
     TpStateSetResponse response;
     request.set_context_id(this->context_id);
     for (auto kv : kv_pairs) {
-        Entry* ent = request.add_entries();
+        TpStateEntry* ent = request.add_entries();
         ent->set_address(kv.first);
         ent->set_data(kv.second);
     }

--- a/sdk/go/src/sawtooth_sdk/processor/context.go
+++ b/sdk/go/src/sawtooth_sdk/processor/context.go
@@ -133,9 +133,9 @@ func (self *Context) GetState(addresses []string) (map[string][]byte, error) {
 //
 func (self *Context) SetState(pairs map[string][]byte) ([]string, error) {
 	// Construct the message
-	entries := make([]*state_context_pb2.Entry, 0, len(pairs))
+	entries := make([]*state_context_pb2.TpStateEntry, 0, len(pairs))
 	for address, data := range pairs {
-		entries = append(entries, &state_context_pb2.Entry{
+		entries = append(entries, &state_context_pb2.TpStateEntry{
 			Address: address,
 			Data:    data,
 		})

--- a/sdk/java/src/main/java/sawtooth/sdk/processor/State.java
+++ b/sdk/java/src/main/java/sawtooth/sdk/processor/State.java
@@ -22,8 +22,8 @@ import sawtooth.sdk.messaging.Stream;
 import sawtooth.sdk.processor.exceptions.InternalError;
 import sawtooth.sdk.processor.exceptions.InvalidTransactionException;
 import sawtooth.sdk.processor.exceptions.ValidatorConnectionError;
-import sawtooth.sdk.protobuf.Entry;
 import sawtooth.sdk.protobuf.Message;
+import sawtooth.sdk.protobuf.TpStateEntry;
 import sawtooth.sdk.protobuf.TpStateGetRequest;
 import sawtooth.sdk.protobuf.TpStateGetResponse;
 import sawtooth.sdk.protobuf.TpStateSetRequest;
@@ -83,7 +83,7 @@ public class State {
         throw new InvalidTransactionException(
           "Tried to get unauthorized address " + addresses.toString()) ;
       }
-      for (Entry entry : getResponse.getEntriesList()) {
+      for (TpStateEntry entry : getResponse.getEntriesList()) {
         results.put(entry.getAddress(), entry.getData());
       }
     }
@@ -104,13 +104,13 @@ public class State {
    */
   public Collection<String> set(Collection<java.util.Map.Entry<String,
           ByteString>> addressValuePairs) throws InternalError, InvalidTransactionException {
-    ArrayList<Entry> entryArrayList = new ArrayList<Entry>();
+    ArrayList<TpStateEntry> entryArrayList = new ArrayList<TpStateEntry>();
     for (Map.Entry<String, ByteString> entry : addressValuePairs) {
-      Entry ourEntry = Entry.newBuilder()
+      TpStateEntry ourTpStateEntry = TpStateEntry.newBuilder()
               .setAddress(entry.getKey())
               .setData(entry.getValue())
               .build();
-      entryArrayList.add(ourEntry);
+      entryArrayList.add(ourTpStateEntry);
     }
     TpStateSetRequest setRequest = TpStateSetRequest.newBuilder()
             .addAllEntries(entryArrayList)

--- a/sdk/javascript/processor/context.js
+++ b/sdk/javascript/processor/context.js
@@ -17,7 +17,7 @@
 
 'use strict'
 
-const {Entry, TpStateGetRequest, TpStateGetResponse, TpStateSetRequest, TpStateSetResponse, TpStateDeleteRequest, TpStateDeleteResponse, Message} = require('../protobuf')
+const {TpStateEntry, TpStateGetRequest, TpStateGetResponse, TpStateSetRequest, TpStateSetResponse, TpStateDeleteRequest, TpStateDeleteResponse, Message} = require('../protobuf')
 const {AuthorizationException} = require('../processor/exceptions')
 
 const _timeoutPromise = (p, millis) => {
@@ -70,7 +70,7 @@ class Context {
    */
   setState (addressValuePairs, timeout = null) {
     let entries = Object.keys(addressValuePairs).map((address) =>
-      Entry.create({address, data: addressValuePairs[address]}))
+      TpStateEntry.create({address, data: addressValuePairs[address]}))
 
     let setRequest = TpStateSetRequest.create({entries, contextId: this._contextId})
     let future = this._stream.send(Message.MessageType.TP_STATE_SET_REQUEST,

--- a/sdk/javascript/protobuf/index.js
+++ b/sdk/javascript/protobuf/index.js
@@ -72,7 +72,7 @@ module.exports = {
 
   //
   // State
-  Entry: root.lookup('Entry'),
+  TpStateEntry: root.lookup('TpStateEntry'),
 
   TpStateGetRequest: root.lookup('TpStateGetRequest'),
 

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -38,7 +38,7 @@ from sawtooth_sdk.protobuf.state_context_pb2 import TpStateDeleteResponse
 from sawtooth_sdk.protobuf.state_context_pb2 import TpStateDeleteRequest
 from sawtooth_sdk.protobuf.state_context_pb2 import TpEventAddRequest
 from sawtooth_sdk.protobuf.state_context_pb2 import TpEventAddResponse
-from sawtooth_sdk.protobuf.state_context_pb2 import Entry
+from sawtooth_sdk.protobuf.state_context_pb2 import TpStateEntry
 
 from sawtooth_sdk.protobuf.events_pb2 import Event
 
@@ -209,19 +209,19 @@ class MessageFactory(object):
 
     def create_get_response(self, address_data_map):
 
-        # Each Entry has an address, and data.
+        # Each TpStateEntry has an address, and data.
         # Data can be anything, but transaction processors may assum a
         # certain data type. For example, intkey assumes a dictionary
         # with "Name" in it and stores the "Value". A dictionary is
         # used to deal with hash collisions.
 
-        # GetResponse object has a list of Entry objects
+        # GetResponse object has a list of TpStateEntry objects
 
         self._validate_addresses(
             [address for address, _ in address_data_map.items()])
 
         entries = [
-            Entry(address=address, data=data)
+            TpStateEntry(address=address, data=data)
             for address, data in address_data_map.items()
         ]
 
@@ -235,7 +235,7 @@ class MessageFactory(object):
             [address for address, _ in address_data_map.items()])
 
         entries = [
-            Entry(address=address, data=data)
+            TpStateEntry(address=address, data=data)
             for address, data in address_data_map.items()
         ]
 

--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -68,7 +68,7 @@ class Context(object):
             addresses (list): a list of addresses that were set
 
         """
-        state_entries = [state_context_pb2.Entry(
+        state_entries = [state_context_pb2.TpStateEntry(
             address=e,
             data=entries[e]) for e in entries]
         request = state_context_pb2.TpStateSetRequest(

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -23,7 +23,7 @@ from sawtooth_sdk.messaging.future import Future
 from sawtooth_sdk.messaging.future import FutureResult
 
 from sawtooth_sdk.protobuf.validator_pb2 import Message
-from sawtooth_sdk.protobuf.state_context_pb2 import Entry
+from sawtooth_sdk.protobuf.state_context_pb2 import TpStateEntry
 from sawtooth_sdk.protobuf.state_context_pb2 import TpStateGetRequest
 from sawtooth_sdk.protobuf.state_context_pb2 import TpStateGetResponse
 from sawtooth_sdk.protobuf.state_context_pb2 import TpStateSetRequest
@@ -54,7 +54,7 @@ class ContextTest(unittest.TestCase):
 
     def _make_entries(self, protobuf=True):
         if protobuf:
-            return [Entry(address=a, data=d)
+            return [TpStateEntry(address=a, data=d)
                     for a, d in zip(self.addresses, self.data)]
 
         entries = OrderedDict()

--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -47,8 +47,8 @@ class TpStateGetHandler(Handler):
 
         return_list = return_values if return_values is not None else []
         LOGGER.debug("GET: %s", return_list)
-        entry_list = [state_context_pb2.Entry(address=a,
-                                              data=d) for a, d in return_list]
+        entry_list = [state_context_pb2.TpStateEntry(address=a, data=d)
+                      for a, d in return_list]
         response = state_context_pb2.TpStateGetResponse(
             status=state_context_pb2.TpStateGetResponse.OK)
         response.entries.extend(entry_list)


### PR DESCRIPTION
The change makes the Entry message consistently named with the `TpState-` prefix that the rest of the messages in `state_context`