### PR TITLE
Set CREATE_ACCOUNT payload type for smallbank workload

### DIFF
--- a/perf/smallbank_workload/src/playlist.rs
+++ b/perf/smallbank_workload/src/playlist.rs
@@ -244,6 +244,7 @@ impl Iterator for SmallbankGeneratingIter {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_account < self.num_accounts {
             let mut payload =  SmallbankTransactionPayload::new();
+            payload.set_payload_type(SBPayloadType::CREATE_ACCOUNT);
 
             let mut create_account = smallbank::SmallbankTransactionPayload_CreateAccountTransactionData::new();
             create_account.set_customer_id(self.current_account as u32);


### PR DESCRIPTION
Fixes issue generating smallbank playlist of transactions where the initial account creation txn does not have its type set, causing this error:
```
$ smallbank_workload playlist create -a 3 -n 1 -o smallbank_playlist.yaml
thread 'main' panicked at 'Unset payload type: create_account {customer_name: "customer_000000" initial_savings_balance: 1000000 initial_checking_balance: 1000000}', src/playlist.rs:358:16
stack backtrace:
   0: std::sys::imp::backtrace::tracing::imp::unwind_backtrace
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::begin_panic
   5: std::panicking::begin_panic_fmt
   6: <core::iter::Map<I, F> as core::iter::iterator::Iterator>::next
   7: smallbank_workload::main
   8: __rust_maybe_catch_panic
   9: std::rt::lang_start
```