### PR TITLE
Fix top comment in config files

### DIFF
--- a/consensus/poet/sgx/packaging/poet_enclave_sgx.toml.example
+++ b/consensus/poet/sgx/packaging/poet_enclave_sgx.toml.example
@@ -1,3 +1,7 @@
+#
+# Sawtooth -- PoET SGX Enclave Configuration
+#
+
 # spid is a 32-digit hex string tied to the enclave implementation
 
 spid = 'DEADBEEF00000000DEADBEEF00000000'

--- a/rest_api/packaging/rest_api.toml.example
+++ b/rest_api/packaging/rest_api.toml.example
@@ -1,5 +1,5 @@
 #
-# Sawtooth Lake -- REST API Configuration
+# Sawtooth -- REST API Configuration
 #
 
 # The port and host for the api to run on

--- a/validator/packaging/path.toml.example
+++ b/validator/packaging/path.toml.example
@@ -1,5 +1,5 @@
 #
-# Sawtooth Lake -- Path Configuration
+# Sawtooth -- Path Configuration
 #
 
 
@@ -54,7 +54,7 @@
 #   policy_dir  = base_dir\policy\
 
 #
-# For example, if Sawtooth Lake is installed in C:\sawtooth\, the validator
+# For example, if Sawtooth is installed in C:\sawtooth\, the validator
 # executable would be C:\sawtooth\bin\validator.exe and the data directory
 # would be C:\sawtooth\data\.
 

--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -1,5 +1,5 @@
 #
-# Sawtooth Lake -- Validator Configuration
+# Sawtooth -- Validator Configuration
 #
 
 # This file should exist in the defined config directory and allows


### PR DESCRIPTION
- Change "Sawtooth Lake" to "Sawtooth".
- Add a "title" comment to poet_enclave_sgx.toml.example
  to match the others.

Signed-off-by: Anne Chenette <chenette@bitwise.io>