### PR TITLE
Revert "Skip batch validation if not committing a fork"

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -279,7 +279,7 @@ class BlockValidator(object):
             return self._validation_rule_enforcer.validate(blkw, state_root)
         return True
 
-    def validate_block(self, blkw, skip_batches=False):
+    def validate_block(self, blkw):
         # pylint: disable=broad-except
         try:
             if blkw.status == BlockStatus.Valid:
@@ -303,10 +303,7 @@ class BlockValidator(object):
                 if valid:
                     valid = self._validate_on_chain_rules(blkw)
 
-                # If skip_batches is true, the block is validated except for
-                # batches. In this case, the block is marked as invalid if any
-                # of the checks fail, but will never be marked as valid.
-                if valid and not skip_batches:
+                if valid:
                     valid = self._verify_block_batches(blkw)
 
                 # since changes to the chain-head can change the state of the
@@ -317,12 +314,8 @@ class BlockValidator(object):
                         block_store.chain_head.identifier:
                     raise ChainHeadUpdated()
 
-                if valid:
-                    if not skip_batches:
-                        blkw.status = BlockStatus.Valid
-                else:
-                    blkw.status = BlockStatus.Invalid
-
+                blkw.status = BlockStatus.Valid if\
+                    valid else BlockStatus.Invalid
                 return valid
         except ChainHeadUpdated:
             raise
@@ -462,17 +455,7 @@ class BlockValidator(object):
             self._find_common_ancestor(new_blkw, cur_blkw,
                                        new_chain, cur_chain)
 
-            # 3) Evaluate the 2 chains to see if the new chain should be
-            # committed
-            commit_new_chain = self._test_commit_new_chain()
-
-            # If we're not going to commit this fork and it is only a single
-            # block fork, we can skip validating the batches as an optimization
-            skip = (not commit_new_chain) and (
-                self._new_block.previous_block_id ==
-                self._chain_head.identifier)
-
-            # 4) Determine the validity of the new fork
+            # 3) Determine the validity of the new fork
             # build the transaction cache to simulate the state of the
             # chain at the common root.
             self._chain_commit_state = ChainCommitState(
@@ -481,7 +464,7 @@ class BlockValidator(object):
             valid = True
             for block in reversed(new_chain):
                 if valid:
-                    if not self.validate_block(block, skip_batches=skip):
+                    if not self.validate_block(block):
                         LOGGER.info("Block validation failed: %s", block)
                         valid = False
                 else:
@@ -492,6 +475,10 @@ class BlockValidator(object):
             if not valid:
                 self._done_cb(False, self._result)
                 return
+
+            # 4) Evaluate the 2 chains to see if the new chain should be
+            # committed
+            commit_new_chain = self._test_commit_new_chain()
 
             # 5) Consensus to compute batch sets (only if we are switching).
             if commit_new_chain:

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -118,10 +118,7 @@ class ForkResolver(ForkResolverInterface):
         new_num = new_fork_head.block_num
         new_weight = 0
         if new_fork_head.consensus:
-            try:
-                new_weight = int(new_fork_head.consensus.decode().split(':')[1])
-            except IndexError:
-                return False
+            new_weight = int(new_fork_head.consensus.decode().split(':')[1])
         cur_num = cur_fork_head.block_num
         cur_weight = 0
         if cur_fork_head.consensus:

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -588,7 +588,7 @@ class TestBlockValidator(unittest.TestCase):
 
     def test_block_bad_consensus(self):
         """
-        Test the case where the new block has invalid consensus
+        Test the case where the new block has a bad batch
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})


### PR DESCRIPTION
This reverts commit 7aa1248e88aabac59a7a3cfa7ea6644045008c1f.

An intermittent bug was discovered on LR7 after this commit was merged into
master.