### PR TITLE
Document config files in new "Configuring Sawtooth" section

### DIFF
--- a/docs/source/architecture/validator_network.rst
+++ b/docs/source/architecture/validator_network.rst
@@ -288,6 +288,8 @@ role.
 In the future, RoleType will include other roles such as CLIENT, STATE_DELTA,
 and TP.
 
+.. _Authorization_Types:
+
 Authorization Types
 -------------------
 Presented here are the two authorization types that will be implemented

--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -8,7 +8,7 @@ System Administrator's Guide
 
    sysadmin_guide/installation
    sysadmin_guide/systemd
-   sysadmin_guide/log_configuration
+   sysadmin_guide/configuring_sawtooth
    sysadmin_guide/rest_auth_proxy
    sysadmin_guide/permissioning
    sysadmin_guide/configure_sgx

--- a/docs/source/sysadmin_guide/configuring_sawtooth.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth.rst
@@ -1,0 +1,38 @@
+********************
+Configuring Sawtooth
+********************
+
+Each Sawtooth component, such as the validator or the REST API, has an optional
+configuration file that controls the component's behavior. You can also specify
+configuration options on the command line when starting the component. For more
+information, see :doc:`/cli`.
+
+When a Sawtooth component starts, it looks for a
+`TOML <https://github.com/toml-lang/toml>`_ configuration file in the config
+directory (``config_dir``). By default, configuration files are stored in
+``/etc/sawtooth``; see :doc:`configuring_sawtooth/path_configuration_file` for
+more information on the config directory location.
+
+.. Note::
+
+  Sawtooth also includes a deprecated set of configuration files in
+  ``/etc/default``. These files have the same name as the component they
+  configure and contain the command-line arguments passed when the service
+  is started.
+
+In addition, the Sawtooth log output can be configured with a log config file
+in `TOML <https://github.com/toml-lang/toml>`_ or `YAML <http://yaml.org>`_
+format. By default, Sawtooth stores error and debug log messages
+for each component in the log directory. For more information,
+see :doc:`log_configuration`.
+
+The following sections describe each component's configuration file.
+
+.. toctree::
+   :maxdepth: 1
+
+   configuring_sawtooth/validator_configuration_file
+   configuring_sawtooth/rest_api_configuration_file
+   configuring_sawtooth/poet_sgx_enclave_configuration_file
+   configuring_sawtooth/path_configuration_file
+   log_configuration

--- a/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
@@ -1,0 +1,62 @@
+-----------------------
+Path Configuration File
+-----------------------
+
+.. Important::
+
+  Changing the path settings in this file is usually unnecessary.
+  For non-standard directory paths, use the ``SAWTOOTH_HOME`` environment
+  variable instead of this configuration file.
+
+The ``path.toml`` configuration changes the Sawtooth ``data_dir`` directory.
+This file should be used only when installing on an operating system
+distribution where the  default paths are not appropriate. For example, some
+Unix-based operating systems do not use ``/var/lib``, so it would be appropriate
+to use this file to set ``data_dir`` to the natural operating system default
+path for application data.
+
+This file configures the following settings:
+
+- ``key_dir`` = `path`
+
+  Directory path to use when loading key files
+
+- ``data_dir`` = `path`
+
+  Directory path for storing data files such as the block store
+
+- ``log_dir`` = `path`
+
+  Directory path to use to write log files
+  (by default, an error log and a debug log; see :doc:`../log_configuration`).
+
+- ``policy_dir`` = `path`
+
+  Directory path for storing policies
+
+The default directory paths depend on whether the ``SAWTOOTH_HOME`` environment
+variable is set. When ``SAWTOOTH_HOME`` is set, the default paths are:
+
+- ``key_dir`` = ``SAWTOOTH_HOME/keys/``
+- ``data_dir`` = ``SAWTOOTH_HOME/data/``
+- ``log_dir`` = ``SAWTOOTH_HOME/logs/``
+- ``policy_dir`` = ``SAWTOOTH_HOME/policy/``
+
+For example, if ``SAWTOOTH_HOME`` is set to ``/tmp/testing``, the default path
+for ``data_dir`` is ``/tmp/testing/data/``.
+
+When ``SAWTOOTH_HOME`` is not set, the operating system defaults are used.
+On Linux, the default path settings are:
+
+- ``key_dir`` = ``/etc/sawtooth/keys``
+- ``data_dir`` = ``/var/lib/sawtooth``
+- ``log_dir`` = ``/var/log/sawtooth``
+- ``policy_dir`` = ``/etc/sawtooth/policy``
+
+Sawtooth also uses ``config_dir`` to determine the directory path containing the
+configuration files. Note that this directory is fixed; it cannot be changed in
+the ``path.toml`` configuration file.
+
+- If ``SAWTOOTH_HOME`` is set, ``conf_dir`` = ``SAWTOOTH_HOME/etc/``
+
+- If ``SAWTOOTH_HOME`` is not set, ``conf_dir`` = ``/etc/sawtooth``

--- a/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
@@ -1,0 +1,51 @@
+-----------------------------------
+PoET SGX Enclave Configuration File
+-----------------------------------
+
+This configuration file specifies configuration settings for a PoET SGX enclave.
+
+If the config directory contains a file named ``poet_enclave_sgx.toml``, the
+configuration settings are applied when the component starts. (By default, the
+config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
+more information.) Specifying a command-line option will override the setting
+in the configuration file.
+
+An example configuration file is in
+``/sawtooth-core/consensus/poet/sgx/packaging/poet_enclave_sgx.toml.example``.
+To create a PoET SGX enclave configuration file, copy the example file to the
+config directory and name it ``poet_enclave_sgx.toml``. Then edit the file to
+change the example configuration options as necessary for your system.
+
+.. Note::
+
+  See :doc:`../configure_sgx` for an example of changing settings in
+  ``poet_enclave_sgx.toml`` when configuring Sawtooth with the SGX
+  implementation of PoET.
+
+The ``poet_enclave_sgx.toml`` configuration file has the following options:
+
+- ``spid`` = '`string`'
+
+  Specifies the Service Provider ID (SPID), which is linked to the key pair used
+  to authenticate with the attestation service. Default: none. The SPID value
+  is a 32-digit hex string tied to the enclave implementation; for example:
+
+  .. code-block:: none
+
+    spid = 'DEADBEEF00000000DEADBEEF00000000'
+
+- ``ias_url`` = '`URL`'
+
+  Specifies the URL of the Intel Attestation Service (IAS) server. Default:
+  none. Note that the URL shown in ``poet_enclave_sgx.toml.example`` is an
+  example server for debug enclaves only:
+
+  .. code-block:: none
+
+    ias_url = 'https://test-as.sgx.trustedservices.intel.com:443'
+
+- ``spid_cert_file`` = '`/full/path/to/certificate.pem`'
+
+  Identifies the PEM-encoded certificate file that was submitted to Intel in
+  order to obtain a SPID. Default: none. Specify the full path to the
+  certificate file.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -1,0 +1,63 @@
+---------------------------
+REST API Configuration File
+---------------------------
+
+The REST API configuration file specifies network connection settings and an
+optional timeout value.
+
+If the config directory contains a file named ``rest_api.toml``, the
+configuration settings are applied when the REST API starts.  (By default, the
+config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
+more information.) Specifying a command-line option will override the setting
+in the configuration file.
+
+An example configuration file is in
+``/sawtooth-core/rest_api/packaging/rest_api.toml.example``.
+To create a REST API configuration file, copy the example file to the config
+directory and name it ``rest_api.toml``. Then edit the file to change the
+example configuration options as necessary for your system.
+
+The ``rest_api.toml`` configuration file has the following options:
+
+- ``bind`` = ["`HOST:PORT`"]
+
+  Sets the port and host for the REST API to run on.
+  Default: ``127.0.0.1:8080``. For example:
+
+  .. code-block:: none
+
+    bind = ["127.0.0.1:8080"]
+
+- ``connect`` = "`URL`"
+
+  Identifies the URL of a running validator. Default: ``tcp://localhost:4004``.
+  For example:
+
+  .. code-block:: none
+
+    connect = "tcp://localhost:4004"
+
+- ``timeout`` = `value`
+
+  Specifies the time, in seconds, to wait for a validator response.
+  Default: 300. For example:
+
+  .. code-block:: none
+
+    timeout = 900
+
+- ``opentsdb_url`` = "`value`"
+
+  Sets the host and port for Open TSDB database (used for metrics).
+
+- ``opentsdb_db`` = "`name`"
+
+  Sets the name of the Open TSDB database. Default: none.
+
+- ``opentsdb_username`` = `username`
+
+  Sets the username for the Open TSDB database. Default: none.
+
+- ``opentsdb_password`` = `password`
+
+  Sets the password for the Open TSDB database. Default: none.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -1,0 +1,193 @@
+----------------------------
+Validator Configuration File
+----------------------------
+
+The validator configuration file specifies network information that allows
+the validator to advertise itself properly and search for peers. This file
+also contains settings for optional authorization roles and transactor
+permissions.
+
+If the config directory contains a file named ``validator.toml``, the
+configuration settings are applied when the validator starts. (By default, the
+config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
+more information.) Specifying an option on the command line overrides the
+setting in the configuration file.
+
+An example configuration file is in
+``/sawtooth-core/packaging/validator.toml.example``.
+To create a validator configuration file, copy the example file to the config
+directory and name it ``validator.toml``. Then edit the file to change the
+example configuration options as necessary for your system.
+
+.. Note::
+
+  See :doc:`../configure_sgx` for an example of changing the settings in
+  ``validator.toml`` when configuring Sawtooth with the SGX implementation of
+  PoET.
+
+The ``validator.toml`` configuration file has the following options:
+
+- ``bind`` = [ "``endpoint``", "``endpoint``" ]
+
+  Sets the network and component endpoints. Default network bind interface:
+  ``tcp://127.0.0.1:8800``. Default component bind interface:
+  ``tcp://127.0.0.1:4004``.
+
+  Each string has the format ``{option}:{endpoint}``, where
+  ``{option}`` is either ``network`` or ``component``. For example:
+
+  .. code-block:: none
+
+    bind = [
+      "network:tcp://127.0.0.1:8800",
+      "component:tcp://127.0.0.1:4004"
+    ]
+
+- ``peering = "{static,dynamic}"``
+
+  Specifies the type of peering approach the validator should take: static
+  or dynamic.  Default: ``static``.
+
+  Static peering attempts to peer only with the candidates provided with the
+  peers option. For example:
+
+  .. code-block:: none
+
+    peering = "static"
+
+  Dynamic peering first processes any static peers, starts topology buildouts,
+  then uses the URLs specified by the seeds option for the initial connection
+  to the validator network.
+
+  .. code-block:: none
+
+    peering = "dynamic"
+
+- ``endpoint = "URL"``
+
+  Sets the advertised network endpoint URL. Default: tcp://127.0.0.1:8800.
+  Replace the external interface and port values with either the
+  publicly-addressable IP address and port or with the NAT values for your
+  validator. For example:
+
+  .. code-block:: none
+
+    endpoint = "tcp://127.0.0.1:8800"
+
+- ``seeds`` = [``URI``]
+
+  (Dynamic peering only.) Specifies the URI or URIs for the initial connection
+  to the validator network.  Specify multiple URIs in a comma-separated list;
+  each URI must be enclosed in double quotes.  Default: none.
+
+  Note that this option is not needed in static peering mode.
+
+  Replace the seed address and port values with either the publicly-addressable
+  IP address and port or with the NAT values for the other nodes in your
+  network. For example:
+
+  .. code-block:: none
+
+    seeds = ["tcp://127.0.0.1:8801"]
+
+- ``peers`` = ["`URL`"]
+
+  Specifies a static list of peers to attempt to connect to. Default: none.
+
+  .. code-block:: none
+
+    peers = ["tcp://127.0.0.1:8801"]
+
+- ``scheduler`` = '`type`'
+
+  Determines the type of scheduler to use: serial or parallel. Default:
+  ``serial``. For example:
+
+  .. code-block:: none
+
+    scheduler = 'serial'
+
+- ``network_public_key`` and ``network_private_key``
+
+  Specifies the curve ZMQ key pair used to create a secured network based on
+  side-band sharing of a single network key pair to all participating nodes.
+  Default: none.
+
+  Enclose the key in single quotes; for example:
+
+  .. code-block:: none
+
+    network_public_key = 'wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)'
+    network_private_key = 'r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*'
+
+  .. Important::
+
+    If these options are not set or the configuration file does not exist, the
+    network will default to being insecure.
+
+- ``opentsdb_url`` = "`value`"
+
+  Sets the host and port for Open TSDB database (used for metrics).
+  Default: none.
+
+- ``opentsdb_db`` = "`name`"
+
+  Sets the name of the Open TSDB database. Default: none.
+
+- ``opentsdb_username`` = `username`
+
+  Sets the username for the Open TSDB database. Default: none.
+
+- ``opentsdb_password`` = `password`
+
+  Sets the password for the Open TSDB database. Default: none.
+
+- ``network = "{trust,challenge}"``
+
+  Specifies the type of authorization that must be performed for the different
+  type of authorization roles on the network: trust or challenge.
+  Default: trust.
+
+  This option must be in the ``[roles]`` section of the file.
+  For example:
+
+  .. code-block:: none
+
+    [roles]
+    network = "trust"
+
+  For more information, see :ref:`Authorization_Types`.
+
+- "`role`" = "`policy`"
+
+  Sets the off-chain transactor permissions for the role or roles that specify
+  which transactors are allowed to sign batches on the system. Multiple roles
+  can be defined, using one "`role`" = "`policy`" entry per line. Default: none.
+
+  The role names specified in this config file must match the roles stored in
+  state for transactor permissioning. For example:
+
+  - ``transactor``
+  - ``transactor.transaction_signer``
+  - ``transactor.transaction_signer.{tp_name}``
+  - ``transactor.batch_signer``
+
+  For `policy`, specify a policy file in ``policy_dir`` (by default,
+  ``/etc/sawtooth/``). Each policy file contains permit and deny rules for the
+  transactors; see :ref:`Off-Chain_Transactor_Permissioning`.
+
+  Because transactor roles and policy files can have a period in the name, use
+  double-quotes so that TOML can process these settings. For example:
+
+  .. code-block:: none
+
+    [permissions]
+    "transactor" = "policy.example"
+    "transactor.transaction_signer" = "policy.example"
+
+  .. Note::
+
+    The ``default`` role cannot be set in the configuration file. Use the
+    ``sawtooth identity`` CLI to change this on-chain-only setting.
+
+  See :doc:`../permissioning` for more information on roles and permissions.

--- a/docs/source/sysadmin_guide/log_configuration.rst
+++ b/docs/source/sysadmin_guide/log_configuration.rst
@@ -4,76 +4,71 @@ Log Configuration
 
 Overview
 ========
-The validator and the Python SDK make it easy to customize the logging output.
-This is done by creating a TOML (`<https://github.com/toml-lang/toml>`_)
-formatted log config file and passing it to the built-in Python logging module.
+The validator and the Python SDK make it easy to customize the
+logging output.  This is done by creating a log config file in
+`TOML <https://github.com/toml-lang/toml>`_ or `YAML <http://yaml.org>`_
+format and passing it to the built-in Python logging module.
 
-Default
-=======
+.. Note::
+
+  Use YAML to configure a remote syslog service. Due to a limitation in
+  the TOML spec, you cannot configure a remote syslog service using TOML.
+
+Log Files
+=========
 
 If there is no log configuration file provided, the default is to create an
-error log and a debug log. Theses files will be stored in the log directory that
-is configured by the SAWTOOTH_HOME environment variable. For example, if
-`SAWTOOTH_HOME="/home/ubuntu/sawtooth"`, the logs will be written
-to `/home/ubuntu/sawtooth/logs`.
+error log and a debug log. Theses files will be stored in the log directory
+(``log_dir``) in a location determined by the ``SAWTOOTH_HOME`` environment
+variable. For more information, see
+:doc:`configuring_sawtooth/path_configuration_file`.
 
-If SAWTOOTH_HOME is not set, the default location is OS-specific. On Linux,
-it's `/var/log/sawtooth`. On Windows, it is one level up from the where the
-command is installed. For example, if `C:\\sawtooth\\bin\\validator.exe`
-starts the validator, the log directory is `C:\\sawtooth\\logs\\`. The log
-directory can also be set in the path.toml file, however, this file should
-rarely be used.
+The names of the validator log files are:
 
-The validator logs names are:
-
-- validator-debug.log
-- validator-error.log
+- ``validator-debug.log``
+- ``validator-error.log``
 
 For Python transaction processors, the author determines the name of the log
 file. It is highly encouraged that the file names are unique for each running
 processor to avoid naming conflicts.  The example transaction processors
-provided with the SDK uses the following:
+provided with the SDK uses the following naming convention:
 
-- {tp_name}-{zmq_identity}-debug.log
-- {tp_name}-{zmq_identity}-error.log
+- ``{TPname}-{zmqID}-debug.log``
+- ``{TPname}-{zmqID}-error.log``
 
 Examples:
 
--  *intkey-18670799cbbe4367-debug.log*
--  *intkey-18670799cbbe4367-error.log*
+-  ``intkey-18670799cbbe4367-debug.log``
+-  ``intkey-18670799cbbe4367-error.log``
 
-Configuration
-=============
+Log Configuration
+=================
 
-To change the default behavior, a log configuration file can be placed in the
-config directory (see below).
+To change the default logging behavior of a Sawtooth component, such as the
+validator, put a log configuration file in the config directory (see
+:doc:`configuring_sawtooth/path_configuration_file`).
 
-The validator log config file should be named `log_config.toml`.
+The validator log config file should be named ``log_config.toml``.
 
-Each transaction processor may also define its own config file. The name of
+Each transaction processor can define its own config file. The name of
 this file is determined by the author. The transaction processors included in
-the Python SDK follow the convention `{Transaction_Family_Name}_log_config.toml`.
-For example, the intkey (IntegerKey) log configuration file is `intkey_log_config.toml`.
+the Python SDK use the following naming convention:
 
-Config Directory
-----------------
+ - ``{TransactionFamilyName}_log_config.toml``
 
-If `$SAWTOOTH_HOME` is set the config directory is found at
-`$SAWTOOTH_HOME/etc/` . Otherwise it is defined by the OS being used. On Linux the
-config directory is located at `/etc/sawtooth`. On Windows, the config
-directory is located one directory up from where the command is installed.
-For example, if `C:\\sawtooth\\bin\\validator.exe` starts the validator, the config
-directory is `C:\\sawtooth\\conf\\`. As long as the log configuration file is
-present, the validator and transaction processors will automatically find it
-and load the configuration.
+For example, the IntegerKey (``intkey``) log configuration file is
+``intkey_log_config.toml``.
 
 Examples
 ========
 
-Configure Specific Logger
--------------------------
+Configure a Specific Logger
+---------------------------
 If the default logs give too much information, you can configure a specific
 logger that will only report on the area of the code you are interested in.
+
+This example ``log_config.toml`` file creates a handler that only writes
+interconnect logs to the directory and file specified.
 
 .. code-block:: none
 
@@ -95,15 +90,13 @@ logger that will only report on the area of the code you are interested in.
   propagate = true
   handlers = [ "interconnect"]
 
-The above log_config.toml file creates a handler that only writes
-interconnect logs to the directory and file specified. The formatter and log level
-can also be specified to provide the exact information you want in your logs.
-
+The formatter and log level can also be specified to provide the exact
+information you want in your logs.
 
 Rotating File Handler
 ---------------------
 Below is an example of how to setup rotating logs. This is useful when the logs
-may grow very large, such as with a long running network.
+may grow very large, such as with a long-running network. For example:
 
 .. code-block:: none
 
@@ -124,11 +117,11 @@ may grow very large, such as with a long running network.
   propagate = true
   handlers = [ "interconnect"]
 
-If one file exceeds the maxBytes set in the config file, that file will be
-renamed to filename.log.1 and a new filename.log will be written to. This
-process continues for the number of files plus one set in the backupCount.
-After that point, the file that is being written to is rotated. The current
-file being written to is always filename.log.
+If one file exceeds the ``maxBytes`` set in the config file, that file will be
+renamed to ``filename.log.1`` and a new ``filename.log`` will be written to.
+This process continues for the number of files plus one set in the
+``backupCount``. After that point, the file that is being written to is rotated.
+The current file being written to is always ``filename.log``.
 
-For further configuration options see the Python docs:
-`<https://docs.python.org/3/library/logging.config.html>`_
+For more Python configuration options, see the Python documentation at
+`<https://docs.python.org/3/library/logging.config.html>`_.

--- a/docs/source/sysadmin_guide/permissioning.rst
+++ b/docs/source/sysadmin_guide/permissioning.rst
@@ -34,6 +34,8 @@ the transactor permissions have been updated to no longer allow a batch signer
 or a transaction signer that is being included in a block. For this reason, the
 allowed transactor roles will also need to be checked on block validation.
 
+.. _Off-Chain_Transactor_Permissioning:
+
 Off-Chain Transactor Permissioning
 ----------------------------------
 Validators can be locally configured by creating a validator.toml file and

--- a/docs/source/sysadmin_guide/systemd.rst
+++ b/docs/source/sysadmin_guide/systemd.rst
@@ -1,5 +1,5 @@
 *****************************
-Running Sawtooth As A Service
+Running Sawtooth as a Service
 *****************************
 
 When installing Sawtooth using apt-get, *systemd* units are added for the
@@ -74,10 +74,3 @@ Likewise, to stop a component run:
 .. code-block:: console
 
   $ sudo systemctl stop sawtooth-COMPONENT
-
-Configuring Sawtooth
---------------------
-
-Configuration for each of the components is handled by a set of files in
-`/etc/default`. These files have the same name as the component they configure
-and contain the command line arguments passed when the service is started.


### PR DESCRIPTION
- Added new "Configuring Sawtooth" section to the sys admin guide.
  This section currently documents the validator, REST API,
  PoET SGX enclave, and path config files.

- Changed "Log Configuration" to point to the path config info;
  removed duplicated path & config info, deleted obsolete Windows
  info, and edited wording and formatting.

- Moved text about the old-style /etc/default config files from "Running Sawtooth As A Service" 
  (systemd.rst) to the "Configuring Sawtooth" intro (configuring_sawtooth.rst).

Signed-off-by: Anne Chenette <chenette@bitwise.io>