### PR TITLE
Add generated API docs to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,15 +32,6 @@
 /families/settings/sawtooth_settings/protobuf/
 /families/smallbank/smallbank_go/src/protobuf/
 /families/smallbank/smallbank_go/bin/
-/families/supplychain/python/sawtooth_supplychain/protobuf
-/families/supplychain/python/build/
-/families/track_and_trade/**/node_modules
-/families/track_and_trade/**/package-lock.json
-/families/track_and_trade/processor/sawtooth_track_and_trade/protobuf
-/families/track_and_trade/client/public/dist
-/families/track_and_trade/client/src/protos.json
-/families/track_and_trade/server/rethinkdb_data
-/families/track_and_trade/server/fish.batch
 /families/block_info/sawtooth_block_info/protobuf
 /families/identity/sawtooth_identity/protobuf
 
@@ -52,11 +43,7 @@
 /docs/source/_autogen/
 /docs/source/cli/output/
 
-/extensions/arcade/sawtooth_arcade.egg-info/
-
 /integration/**/__pycache__/
-
-/manage/**/__pycache__/
 
 /rest_api/build/
 /rest_api/sawtooth_rest_api/protobuf/
@@ -72,7 +59,6 @@
 /sdk/examples/xo_javascript/node_modules/
 /sdk/examples/xo_javascript/package-lock.json
 /sdk/examples/intkey_python/**/__pycache__/
-/sdk/examples/supplychain/python/**/__pycache__/
 /sdk/examples/intkey_javascript/node_modules/
 /sdk/examples/intkey_javascript/package-lock.json
 /sdk/examples/intkey_java/dependency-reduced-pom.xml
@@ -91,13 +77,6 @@
 /sdk/go/pkg/
 /sdk/go/src/golang.org/
 /sdk/go/src/gopkg.in/
-/families/seth/bin/
-/families/seth/src/sawtooth_seth/protobuf/
-/families/seth/rpc/Cargo.lock
-/families/seth/rpc/target/
-/families/seth/rpc/src/messages/*.rs
-!/families/seth/rpc/src/messages/mod.rs
-/families/seth/rpc/tests/protobuf/
 /sdk/rust/target
 /sdk/rust/Cargo.lock
 /sdk/rust/src/messages/*.rs

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -36,6 +36,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     git \
     libffi-dev \
     libssl-dev \
+    golang-golang-x-tools \
     pep8 \
     python3-aiodns=1.1.1-1 \
     python3-aiohttp=1.3.5-1 \
@@ -74,6 +75,19 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     pylint \
     bandit
 
+# Install jsdoc
+RUN apt-get update && apt-get install -y -q --no-install-recommends \
+    curl \
+ && curl -s -S -o /tmp/setup-node.sh https://deb.nodesource.com/setup_6.x \
+ && chmod 755 /tmp/setup-node.sh \
+ && /tmp/setup-node.sh \
+ && apt-get install nodejs -y -q \
+ && rm /tmp/setup-node.sh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && npm install -g \
+    jsdoc
+
 RUN apt-get update && apt-get install -y -q \
     dvipng \
     make \
@@ -90,6 +104,9 @@ RUN apt-get update && apt-get install -y -q \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \
     sphinx_rtd_theme
+
+ENV GOPATH=/go:/project/sawtooth-core/sdk/go \
+    PYTHONPATH=/project/sawtooth-core/sdk/python
 
 WORKDIR /project/sawtooth-core/docs
 CMD make html latexpdf

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,9 +8,12 @@ SPHINXAPIDOC  = sphinx-apidoc
 PAPER         =
 BUILDDIR      = build
 
+HTMLDIR       = $(BUILDDIR)/html
+SAWTOOTH      = ..
+
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error "The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/")
 endif
 
 # Internal variables.
@@ -20,7 +23,7 @@ ALLSPHINXOPTS   = -W -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) 
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-.PHONY: help clean templates html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext cli
+.PHONY: help clean templates html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext cli python go javascript
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -54,17 +57,34 @@ clean:
 
 templates:
 	@mkdir -p source/_autogen
-	@../bin/make_templated_docs
+	@$(SAWTOOTH)/bin/make_templated_docs
 
 cli:
-	../bin/generate_cli_output
+	$(SAWTOOTH)/bin/generate_cli_output
 
-html: templates cli
+python:
+    # pydoc doesn't allow specifying an output directory, so make the
+    # files first and then move them.
+	mkdir -p $(HTMLDIR)/python_sdk/processor
+	pydoc3 -w sawtooth_sdk.processor.core
+	pydoc3 -w sawtooth_sdk.processor.context
+	pydoc3 -w sawtooth_sdk.processor.handler
+	mv sawtooth_sdk.processor*.html $(HTMLDIR)/python_sdk/processor
+
+go:
+	mkdir -p $(HTMLDIR)/go_sdk/
+	godoc -html sawtooth_sdk/processor > $(HTMLDIR)/go_sdk/processor.html
+
+javascript:
+	mkdir -p $(HTMLDIR)/javascript_sdk/
+	jsdoc $(SAWTOOTH)/sdk/javascript/processor/ -d $(HTMLDIR)/javascript_sdk/processor/
+
+html: templates cli python go javascript
 	@mkdir -p source/_static
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(HTMLDIR)
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-	@cp ../docker/compose/sawtooth-default.yaml $(BUILDDIR)/html/app_developers_guide/sawtooth-default.yaml
+	@echo "Build finished. The HTML pages are in $(HTMLDIR)."
+	@cp $(SAWTOOTH)/docker/compose/sawtooth-default.yaml $(HTMLDIR)/app_developers_guide/sawtooth-default.yaml
 
 dirhtml: templates cli
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml


### PR DESCRIPTION
This PR adds generated HTML pages for the Python, Go, and JS SDKs to the build process. This requires modifying both the Makefile and the docs Docker file. I know little about either of these, so there are almost certainly errors here.

Note that the API docs are just generated and stored in the `build` directory, not integrated into the published docs.

Unrelated to docs, I found that the `.gitignore` file had old entries in it. Those bothered me, so I took them out.