### PR TITLE
Remove CORS handlers from REST API

### DIFF
--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -86,12 +86,6 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-async def cors_handler(request):
-    headers = {}
-    RouteHandler.add_cors_headers(request, headers)
-    return web.Response(headers=headers)
-
-
 def start_rest_api(host, port, connection, timeout, registry):
     """Builds the web app, adds route handlers, and finally starts the app.
     """
@@ -104,8 +98,6 @@ def start_rest_api(host, port, connection, timeout, registry):
     LOGGER.info('Creating handlers for validator at %s', connection.url)
 
     handler = RouteHandler(loop, connection, timeout, registry)
-
-    app.router.add_route('OPTIONS', '/{route_name}', cors_handler)
 
     app.router.add_post('/batches', handler.submit_batches)
     app.router.add_get('/batch_status', handler.list_statuses)

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -655,14 +655,6 @@ class RouteHandler(object):
                 trap.check(content.status)
 
     @staticmethod
-    def add_cors_headers(request, headers):
-        if 'Origin' in request.headers:
-            headers['Access-Control-Allow-Origin'] = request.headers['Origin']
-            headers["Access-Control-Allow-Methods"] = "GET,POST"
-            headers["Access-Control-Allow-Headers"] =\
-                "Origin, X-Requested-With, Content-Type, Accept"
-
-    @staticmethod
     def _wrap_response(request, data=None, metadata=None, status=200):
         """Creates the JSON response envelope to be sent back to the client.
         """
@@ -671,13 +663,9 @@ class RouteHandler(object):
         if data is not None:
             envelope['data'] = data
 
-        headers = {}
-        RouteHandler.add_cors_headers(request, headers)
-
         return web.Response(
             status=status,
             content_type='application/json',
-            headers=headers,
             text=json.dumps(
                 envelope,
                 indent=2,


### PR DESCRIPTION
Blanket CORS approval represents a security vulnerability and
should be removed previous to 1.0. The REST API is intended to
be lightweight, and features like authentication or CORS should
be handled by a proxy server when needed.