### PR TITLE
Reduce default page size

### DIFF
--- a/docker/compose/sawtooth-local.yaml
+++ b/docker/compose/sawtooth-local.yaml
@@ -65,8 +65,8 @@ services:
       - "4004:4004"
     # start the validator with an empty genesis batch
     command: "bash -c \"\
-        sawtooth admin keygen && \
-        sawtooth admin genesis && \
+        sawadm keygen && \
+        sawadm genesis && \
         sawtooth-validator -vv \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -46,6 +46,7 @@ from sawtooth_validator.protobuf import validator_pb2
 LOGGER = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 300
 MAX_PAGE_SIZE = 1000
+DEFAULT_PAGE_SIZE = 100
 
 
 class _ResponseFailed(BaseException):
@@ -304,7 +305,7 @@ class _Pager(object):
                         total_resources=0))
 
         paging = request.paging
-        count = min(paging.count, MAX_PAGE_SIZE) or MAX_PAGE_SIZE
+        count = min(paging.count, MAX_PAGE_SIZE) or DEFAULT_PAGE_SIZE
 
         # Find the start index from the location marker sent
         try:
@@ -715,7 +716,7 @@ class BlockListRequest(_ClientRequestHandler):
             paging = request.paging
             sort_reverse = BlockListRequest.is_reverse(
                 request.sorting, self._status.INVALID_SORT)
-            count = min(paging.count, MAX_PAGE_SIZE) or MAX_PAGE_SIZE
+            count = min(paging.count, MAX_PAGE_SIZE) or DEFAULT_PAGE_SIZE
             iterargs = {
                 'reverse': not sort_reverse
             }


### PR DESCRIPTION
Reduce the default page size for client list requests to 100.  This will improve the perceived experience of list calls by reducing the amount of objects that have to be deserialized in a given request. 1000 items is still the max page size.