### PR TITLE
Cleanup crates

### DIFF
--- a/perf/sawtooth_perf/Cargo.toml
+++ b/perf/sawtooth_perf/Cargo.toml
@@ -6,11 +6,7 @@ authors = ["Intel Corporation"]
 [dependencies]
 sawtooth_sdk = { path = "../../sdk/rust" }
 protobuf = "1.4.1"
-clap = "2.26.0"
 futures = "0.1"
 hyper = "0.11"
 tokio-core = "0.1"
 tokio-timer = "0.1"
-yaml-rust = "0.3.5"
-rand = "0.3.16"
-rust-crypto = "0.2.36"

--- a/perf/sawtooth_workload/Cargo.toml
+++ b/perf/sawtooth_workload/Cargo.toml
@@ -7,10 +7,3 @@ sawtooth_sdk = { path = "../../sdk/rust" }
 sawtooth_perf = { path = "../sawtooth_perf" }
 protobuf = "1.4.1"
 clap = "2.26.0"
-futures = "0.1"
-hyper = "0.11"
-tokio-core = "0.1"
-tokio-timer = "0.1"
-yaml-rust = "0.3.5"
-rand = "0.3.16"
-rust-crypto = "0.2.36"

--- a/perf/smallbank_workload/Cargo.toml
+++ b/perf/smallbank_workload/Cargo.toml
@@ -7,10 +7,6 @@ sawtooth_sdk = { path = "../../sdk/rust" }
 sawtooth_perf = { path = "../sawtooth_perf" }
 protobuf = "1.4.1"
 clap = "2.26.0"
-futures = "0.1"
-hyper = "0.11"
-tokio-core = "0.1"
-tokio-timer = "0.1"
 yaml-rust = "0.3.5"
 rand = "0.3.16"
 rust-crypto = "0.2.36"


### PR DESCRIPTION
Remove extraneous dependencies from rust performance projects.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>