### PR TITLE
Remove the use of CBOR in Merkle Trie

### DIFF
--- a/protos/merkle.proto
+++ b/protos/merkle.proto
@@ -1,0 +1,44 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "merkle_pb2";
+
+// A node in the merkle trie
+message MerkleNode {
+    enum ValueState {
+        VALUE_UNSET = 0;
+        VALUE_SET = 1;
+    }
+    // The value at a given node. Generally this is empty, except in the case
+    // of leaf nodes
+    bytes value = 1;
+    // Indicates whether or not the value is actually set
+    ValueState value_state = 2;
+    // list of path children of this node
+    repeated MerklePath children = 3;
+}
+
+// A Path entry.  This this made up of a portion of the path and the hash of
+// the remaining entries along the rest of the path.
+message MerklePath {
+    // The path branch is a portion of the address at given trie.
+    string path_branch = 1;
+    // the hash of all elements below this path in the trie
+    string hash_key = 2;
+}

--- a/validator/sawtooth_validator/database/indexed_database.py
+++ b/validator/sawtooth_validator/database/indexed_database.py
@@ -25,6 +25,14 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_SIZE = 1024**4
 
 
+def _identity_serializer(byte_input):
+    return byte_input
+
+
+def _identity_deserializer(byte_output):
+    return byte_output
+
+
 class IndexOutOfSyncError(Exception):
     pass
 
@@ -37,7 +45,9 @@ class IndexedDatabase(database.Database):
     It must be provided with a serializer and a deserializer.
     """
 
-    def __init__(self, filename, serializer, deserializer,
+    def __init__(self, filename,
+                 serializer=_identity_serializer,
+                 deserializer=_identity_deserializer,
                  indexes=None,
                  flag=None,
                  _size=DEFAULT_SIZE):
@@ -45,8 +55,10 @@ class IndexedDatabase(database.Database):
 
         Args:
             filename (str): The filename of the database file.
-            serializer (function): converts entries to bytes
-            deserializer (function): restores items from bytes
+            serializer (function:optional): converts entries to bytes; defaults
+                to the identity function
+            deserializer (function:optional): restores items from bytes
+                defaults to the identity function
             indexes (dict:(str,function):optional): dict of index names to key
                 functions.  The key functions use the deserialized value and
                 produce n index keys, that will reference the items primary

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -116,8 +116,8 @@ class Validator(object):
         LOGGER.debug('block store file is %s', block_db_filename)
         block_db = IndexedDatabase(
             block_db_filename,
-            BlockStore.serialize_block,
-            BlockStore.deserialize_block,
+            serializer=BlockStore.serialize_block,
+            deserializer=BlockStore.deserialize_block,
             flag='c',
             indexes=BlockStore.create_index_configuration())
         block_store = BlockStore(block_db)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -107,7 +107,7 @@ class Validator(object):
         receipt_db_filename = os.path.join(
             data_dir, 'txn_receipts-{}.lmdb'.format(bind_network[-2:]))
         LOGGER.debug('txn receipt store file is %s', receipt_db_filename)
-        receipt_db = LMDBNoLockDatabase(receipt_db_filename, 'c')
+        receipt_db = IndexedDatabase(receipt_db_filename, flag='c')
         receipt_store = TransactionReceiptStore(receipt_db)
 
         # -- Setup Block Store -- #

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -118,7 +118,7 @@ def make_db_and_store(size=3, start='a'):
         * 2 - {'a': b'3', 'b': b'5', 'c': b'7'}
     """
     database = DictDatabase()
-    store = MockBlockStore(size=0);
+    store = MockBlockStore(size=0)
     roots = []
 
     merkle = MerkleDatabase(database)

--- a/validator/tests/test_duplicate_handler/mock.py
+++ b/validator/tests/test_duplicate_handler/mock.py
@@ -19,11 +19,9 @@ class MockCompleter:
         self.batches = {}
 
     def get_block(self, block_id):
-        print(self.blocks)
         return self.blocks.get(block_id)
 
     def get_batch(self, batch_id):
-        print(self.batches)
         return self.batches.get(batch_id)
 
     def add_block(self, block_id):
@@ -38,7 +36,6 @@ class MockChainController:
         self.blocks = {}
 
     def has_block(self, block_id):
-        print(self.blocks)
         if block_id in self.blocks:
             return True
         return False
@@ -51,7 +48,6 @@ class MockPublisher:
         self.batches = []
 
     def has_batch(self, batch_id):
-        print(self.batches)
         if batch_id in self.batches:
             return True
         return False


### PR DESCRIPTION
Remove the reliance on CBOR and encode the merkle nodes using protocol
buffers. Introduces the messages `MerkleNode` and `MerklePath`, which
provide the serializable containers for what is stored in the dict
version of the nodes.

This only replaces the nodes at the serialization seam.  The nodes
during the operation of the trie are materialized into standard python
dicts, as per previous operation.