### PR TITLE
Rename REST API's /batch_status to /batch_statuses

### DIFF
--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -70,7 +70,7 @@ class RestClient(object):
         Returns:
             list of dict: Dicts with 'id' and 'status' properties
         """
-        return self._post('/batch_status', batch_ids, wait=wait)['data']
+        return self._post('/batch_statuses', batch_ids, wait=wait)['data']
 
     def send_batches(self, batch_list):
         """Sends a list of batches to the validator.

--- a/docs/source/architecture/rest_api.rst
+++ b/docs/source/architecture/rest_api.rst
@@ -244,7 +244,7 @@ only once the batches are committed.
 
    * **/batches** - accepts a ``POST`` request with a body of a binary
      BatchList of batches to be submitted
-   * **/batch_status** - fetches the committed status of one or more batches
+   * **/batch_statuses** - fetches the committed status of one or more batches
 
      *Example batch status response:*
 

--- a/families/battleship/sawtooth_battleship/battleship_client.py
+++ b/families/battleship/sawtooth_battleship/battleship_client.py
@@ -226,7 +226,7 @@ class BattleshipClient:
     def _get_status(self, batch_id, wait):
         try:
             result = self._send_request(
-                'batch_status?id={}&wait={}'.format(batch_id, wait))
+                'batch_statuses?id={}&wait={}'.format(batch_id, wait))
             return yaml.safe_load(result)['data'][0]['status']
         except BaseException as err:
             raise BattleshipException(err)

--- a/integration/sawtooth_integration/tests/intkey_client.py
+++ b/integration/sawtooth_integration/tests/intkey_client.py
@@ -61,7 +61,7 @@ class IntkeyClient(RestClient):
         while time_waited < self.wait:
 
             res = self._get(
-                '/batch_status',
+                '/batch_statuses',
                 id=','.join(batch_ids), wait=(self.wait - time_waited))
 
             if 'PENDING' not in [data['status'] for data in res['data']]:

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -285,7 +285,7 @@ class BatchSubmitter:
     def _post_batch(self, batch):
         headers = {'Content-Type': 'application/octet-stream'}
         response = self._query_rest_api(
-            '/batches?wait={}'.format(self.timeout),
+            '/batches',
             data=batch,
             headers=headers,
             expected_code=202)

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -29,7 +29,6 @@ paths:
           schema:
             $ref: "#/definitions/BatchList"
           required: true
-        - $ref: "#/parameters/wait"
       responses:
         202:
           description: Batches submitted for validation, but not yet committed

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -18,7 +18,7 @@ paths:
         file and submits it to the validator to be committed.
 
         The API will return immediately with a status of `202`. There will be
-        no `data` object, only a `link` to a `/batch_status` endpoint to be
+        no `data` object, only a `link` to a `/batch_statuses` endpoint to be
         polled to check the status of submitted batches.
       consumes:
         - application/octet-stream
@@ -100,7 +100,7 @@ paths:
         503:
           $ref: "#/responses/503ServiceUnavailable"
 
-  /batch_status:
+  /batch_statuses:
     get:
       summary: Fetches the committed statuses for a set of batches
       description: |
@@ -144,7 +144,7 @@ paths:
     post:
       summary: Fetches the committed statuses for a set of batches
       description: |
-        Identical to `GET /batch_status`, but takes ids of batches as a JSON
+        Identical to `GET /batch_statuses`, but takes ids of batches as a JSON
         formatted POST body rather than a query parameter. This allows for many
         more batches to be checked and should be used for more than 15 ids.
 

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -100,8 +100,8 @@ def start_rest_api(host, port, connection, timeout, registry):
     handler = RouteHandler(loop, connection, timeout, registry)
 
     app.router.add_post('/batches', handler.submit_batches)
-    app.router.add_get('/batch_status', handler.list_statuses)
-    app.router.add_post('/batch_status', handler.list_statuses)
+    app.router.add_get('/batch_statuses', handler.list_statuses)
+    app.router.add_post('/batch_statuses', handler.list_statuses)
 
     app.router.add_get('/state', handler.list_state)
     app.router.add_get('/state/{address}', handler.fetch_state)

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -126,7 +126,7 @@ class RouteHandler(object):
         Response:
             status:
                  - 202: Batches submitted and pending
-            link: /batches or /batch_status link for submitted batches
+            link: /batches or /batch_statuses link for submitted batches
 
         """
         timer_ctx = self._post_batches_total_time.time()
@@ -170,7 +170,7 @@ class RouteHandler(object):
         id_string = ','.join(b.header_signature for b in batch_list.batches)
 
         status = 202
-        link = self._build_url(request, path='/batch_status', id=id_string)
+        link = self._build_url(request, path='/batch_statuses', id=id_string)
 
         retval = self._wrap_response(
             request,
@@ -191,7 +191,7 @@ class RouteHandler(object):
 
         Response:
             data: A JSON object, with batch ids as keys, and statuses as values
-            link: The /batch_status link queried (if GET)
+            link: The /batch_statuses link queried (if GET)
         """
         error_traps = [error_handlers.StatusResponseMissing]
 

--- a/rest_api/tests/unit/test_receipt_requests.py
+++ b/rest_api/tests/unit/test_receipt_requests.py
@@ -126,7 +126,7 @@ class ReceiptGetRequestTests(BaseApiTest):
         self.assert_receipts_match(receipts, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_as_post(self):
+    async def test_batch_statuses_as_post(self):
         """Verifies a POST to /receipts with many ids works properly.
 
         It will receive a Protobuf response with receipts with ids:

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -46,7 +46,7 @@ class PostBatchTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 202
             - no data property
-            - a link property that ends in '/batch_status?id=a'
+            - a link property that ends in '/batch_statuses?id=a'
         """
         batches = Mocks.make_batches('a')
         self.connection.preset_response()
@@ -57,7 +57,7 @@ class PostBatchTests(BaseApiTest):
 
         response = await request.json()
         self.assertNotIn('data', response)
-        self.assert_has_valid_link(response, '/batch_status?id=a')
+        self.assert_has_valid_link(response, '/batch_statuses?id=a')
 
     @unittest_run_loop
     async def test_post_batch_with_validator_error(self):
@@ -129,7 +129,7 @@ class PostBatchTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 202
             - no data property
-            - a link property that ends in '/batch_status?id=a,b,c'
+            - a link property that ends in '/batch_statuses?id=a,b,c'
         """
         batches = Mocks.make_batches('a', 'b', 'c')
         self.connection.preset_response()
@@ -140,7 +140,7 @@ class PostBatchTests(BaseApiTest):
 
         response = await request.json()
         self.assertNotIn('data', response)
-        self.assert_has_valid_link(response, '/batch_status?id=a,b,c')
+        self.assert_has_valid_link(response, '/batch_statuses?id=a,b,c')
 
     @unittest_run_loop
     async def test_post_no_batches(self):
@@ -166,11 +166,11 @@ class ClientBatchStatusTests(BaseApiTest):
             client_batch_submit_pb2.ClientBatchStatusResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        return self.build_app(self.loop, '/batch_status', handlers.list_statuses)
+        return self.build_app(self.loop, '/batch_statuses', handlers.list_statuses)
 
     @unittest_run_loop
-    async def test_batch_status_with_one_id(self):
-        """Verifies a GET /batch_status with one id works properly.
+    async def test_batch_statuses_with_one_id(self):
+        """Verifies a GET /batch_statuses with one id works properly.
 
         It will receive a Protobuf response with:
             - batch statuses of {batch_id: 'pending',  status: PENDING}
@@ -180,22 +180,22 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a link property that ends in '/batch_status?id=pending'
+            - a link property that ends in '/batch_statuses?id=pending'
             - a data property matching the batch statuses received
         """
         statuses = [ClientBatchStatus(
             batch_id='pending', status=ClientBatchStatus.PENDING)]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_status?id=pending')
+        response = await self.get_assert_200('/batch_statuses?id=pending')
         self.connection.assert_valid_request_sent(batch_ids=['pending'])
 
-        self.assert_has_valid_link(response, '/batch_status?id=pending')
+        self.assert_has_valid_link(response, '/batch_statuses?id=pending')
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_with_invalid_data(self):
-        """Verifies a GET /batch_status with fetched invalid data works.
+    async def test_batch_statuses_with_invalid_data(self):
+        """Verifies a GET /batch_statuses with fetched invalid data works.
 
         It will receive a Protobuf response with:
             - batch_id: 'bad-batch'
@@ -209,7 +209,7 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a link property that ends in '/batch_status?id=bad'
+            - a link property that ends in '/batch_statuses?id=bad'
             - a data property matching the batch statuses received
         """
         statuses = [ClientBatchStatus(
@@ -221,15 +221,15 @@ class ClientBatchStatusTests(BaseApiTest):
                 extended_data=b'error data')])]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_status?id=bad')
+        response = await self.get_assert_200('/batch_statuses?id=bad')
         self.connection.assert_valid_request_sent(batch_ids=['bad'])
 
-        self.assert_has_valid_link(response, '/batch_status?id=bad')
+        self.assert_has_valid_link(response, '/batch_statuses?id=bad')
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_with_validator_error(self):
-        """Verifies a GET /batch_status with a validator error breaks properly.
+    async def test_batch_statuses_with_validator_error(self):
+        """Verifies a GET /batch_statuses with a validator error breaks properly.
 
         It will receive a Protobuf response with:
             - a status of INTERNAL_ERROR
@@ -240,13 +240,13 @@ class ClientBatchStatusTests(BaseApiTest):
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
         response = await self.get_assert_status(
-            '/batch_status?id=pending', 500)
+            '/batch_statuses?id=pending', 500)
 
         self.assert_has_valid_error(response, 10)
 
     @unittest_run_loop
-    async def test_batch_status_with_missing_statuses(self):
-        """Verifies a GET /batch_status with no statuses breaks properly.
+    async def test_batch_statuses_with_missing_statuses(self):
+        """Verifies a GET /batch_statuses with no statuses breaks properly.
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
@@ -257,13 +257,13 @@ class ClientBatchStatusTests(BaseApiTest):
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
         response = await self.get_assert_status(
-            '/batch_status?id=pending', 500)
+            '/batch_statuses?id=pending', 500)
 
         self.assert_has_valid_error(response, 27)
 
     @unittest_run_loop
-    async def test_batch_status_with_wait(self):
-        """Verifies a GET /batch_status with a wait set works properly.
+    async def test_batch_statuses_with_wait(self):
+        """Verifies a GET /batch_statuses with a wait set works properly.
 
         It will receive a Protobuf response with:
             - batch statuses of {batch_id: 'pending', status: COMMITTED}
@@ -275,25 +275,25 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a link property that ends in '/batch_status?id=pending&wait'
+            - a link property that ends in '/batch_statuses?id=pending&wait'
             - a data property matching the batch statuses received
         """
         statuses = [ClientBatchStatus(
             batch_id='pending', status=ClientBatchStatus.COMMITTED)]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_status?id=pending&wait')
+        response = await self.get_assert_200('/batch_statuses?id=pending&wait')
         self.connection.assert_valid_request_sent(
             batch_ids=['pending'],
             wait=True,
             timeout=4)
 
-        self.assert_has_valid_link(response, '/batch_status?id=pending&wait')
+        self.assert_has_valid_link(response, '/batch_statuses?id=pending&wait')
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_with_many_ids(self):
-        """Verifies a GET /batch_status with many ids works properly.
+    async def test_batch_statuses_with_many_ids(self):
+        """Verifies a GET /batch_statuses with many ids works properly.
 
         It will receive a Protobuf response with:
             - batch statuses of:
@@ -306,7 +306,7 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/batch_status?id=committed,unknown,bad'
+            - link property ending in '/batch_statuses?id=committed,unknown,bad'
             - a data property matching the batch statuses received
         """
         statuses = [
@@ -319,30 +319,30 @@ class ClientBatchStatusTests(BaseApiTest):
         self.connection.preset_response(batch_statuses=statuses)
 
         response = await self.get_assert_200(
-            '/batch_status?id=committed,unknown,bad')
+            '/batch_statuses?id=committed,unknown,bad')
         self.connection.assert_valid_request_sent(
             batch_ids=['committed', 'unknown', 'bad'])
 
         self.assert_has_valid_link(
             response,
-            '/batch_status?id=committed,unknown,bad')
+            '/batch_statuses?id=committed,unknown,bad')
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_with_no_id(self):
-        """Verifies a GET /batch_status with no id breaks properly.
+    async def test_batch_statuses_with_no_id(self):
+        """Verifies a GET /batch_statuses with no id breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 66
         """
-        response = await self.get_assert_status('/batch_status', 400)
+        response = await self.get_assert_status('/batch_statuses', 400)
 
         self.assert_has_valid_error(response, 66)
 
     @unittest_run_loop
-    async def test_batch_status_as_post(self):
-        """Verifies a POST to /batch_status works properly.
+    async def test_batch_statuses_as_post(self):
+        """Verifies a POST to /batch_statuses works properly.
 
         It will receive a Protobuf response with:
             - batch statuses of:
@@ -368,7 +368,7 @@ class ClientBatchStatusTests(BaseApiTest):
         self.connection.preset_response(batch_statuses=statuses)
 
         request = await self.client.post(
-            '/batch_status',
+            '/batch_statuses',
             data=json.dumps(['committed', 'pending', 'bad']).encode(),
             headers={'content-type': 'application/json'})
         self.connection.assert_valid_request_sent(
@@ -380,15 +380,15 @@ class ClientBatchStatusTests(BaseApiTest):
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
-    async def test_batch_status_wrong_post_type(self):
-        """Verifies a bad POST to /batch_status breaks properly.
+    async def test_batch_statuses_wrong_post_type(self):
+        """Verifies a bad POST to /batch_statuses breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 43
         """
         request = await self.client.post(
-            '/batch_status',
+            '/batch_statuses',
             data=json.dumps(['a', 'b', 'c']).encode(),
             headers={'content-type': 'application/octet-stream'})
         self.assertEqual(400, request.status)
@@ -397,15 +397,15 @@ class ClientBatchStatusTests(BaseApiTest):
         self.assert_has_valid_error(response, 43)
 
     @unittest_run_loop
-    async def test_batch_status_as_bad_post(self):
-        """Verifies an empty POST to /batch_status breaks properly.
+    async def test_batch_statuses_as_bad_post(self):
+        """Verifies an empty POST to /batch_statuses breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 46
         """
         request = await self.client.post(
-            '/batch_status',
+            '/batch_statuses',
             data=json.dumps('bad body').encode(),
             headers={'content-type': 'application/json'})
         self.assertEqual(400, request.status)
@@ -414,15 +414,15 @@ class ClientBatchStatusTests(BaseApiTest):
         self.assert_has_valid_error(response, 46)
 
     @unittest_run_loop
-    async def test_batch_status_as_empty_post(self):
-        """Verifies an empty POST to /batch_status breaks properly.
+    async def test_batch_statuses_as_empty_post(self):
+        """Verifies an empty POST to /batch_statuses breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 46
         """
         request = await self.client.post(
-            '/batch_status',
+            '/batch_statuses',
             data=json.dumps([]).encode(),
             headers={'content-type': 'application/json'})
         self.assertEqual(400, request.status)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
@@ -91,7 +91,7 @@ class IntkeyClient:
     def _get_status(self, batch_id, wait):
         try:
             result = self._send_request(
-                'batch_status?id={}&wait={}'.format(batch_id, wait),)
+                'batch_statuses?id={}&wait={}'.format(batch_id, wait),)
             return yaml.safe_load(result)['data'][0]['status']
         except BaseException as err:
             raise IntkeyClientException(err)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
@@ -204,7 +204,7 @@ class WorkloadGenerator(object):
 
         try:
             result = requests.post(
-                url + '/batch_status', data=data, headers=headers)
+                url + '/batch_statuses', data=data, headers=headers)
 
             code, json_result = \
                 result.status_code, result.json()

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -105,7 +105,7 @@ class XoClient:
     def _get_status(self, batch_id, wait, auth_user=None, auth_password=None):
         try:
             result = self._send_request(
-                'batch_status?id={}&wait={}'.format(batch_id, wait),
+                'batch_statuses?id={}&wait={}'.format(batch_id, wait),
                 auth_user=auth_user,
                 auth_password=auth_password)
             return yaml.safe_load(result)['data'][0]['status']

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -41,7 +41,7 @@ class TestBatchSubmitFinisher(ClientHandlerTestCase):
 
         Expects to find:
             - a response status of OK
-            - no batch_statusus
+            - no batch_statuses
         """
         response = self.make_request(batches=[make_mock_batch('new')])
 
@@ -69,7 +69,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
             store=store,
             tracker=tracker)
 
-    def test_batch_status_in_store(self):
+    def test_batch_statuses_in_store(self):
         """Verifies requests for status of a batch in the block store work.
 
         Queries the default mock block store with three blocks/batches:
@@ -88,7 +88,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.COMMITTED)
 
-    def test_batch_status_bad_request(self):
+    def test_batch_statuses_bad_request(self):
         """Verifies bad requests for status of a batch break properly.
 
         Expects to find:
@@ -98,7 +98,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
 
-    def test_batch_status_when_empty(self):
+    def test_batch_statuses_when_empty(self):
         """Verifies requests for batch statuses with no ids break properly.
 
         Expects to find:
@@ -110,7 +110,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.batch_statuses)
 
-    def test_invalid_batch_status(self):
+    def test_invalid_batch_statuses(self):
         """Verifies batch status requests marked INVALID by the tracker work.
 
         Queries the default mock batch tracker with invalid batch ids of:
@@ -137,7 +137,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(invalid_txn.message, 'error message')
         self.assertEqual(invalid_txn.extended_data, b'error data')
 
-    def test_pending_batch_status(self):
+    def test_pending_batch_statuses(self):
         """Verifies batch status requests marked PENDING by the tracker work.
 
         Queries the default mock batch tracker with pending batch ids of:
@@ -154,7 +154,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.PENDING)
 
-    def test_batch_status_when_missing(self):
+    def test_batch_statuses_when_missing(self):
         """Verifies requests for status of a batch that is not found work.
 
         Expects to find:
@@ -168,7 +168,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.UNKNOWN)
 
-    def test_batch_status_for_many_batches(self):
+    def test_batch_statuses_for_many_batches(self):
         """Verifies requests for status of many batches work properly.
 
         Queries the default mock block store with three blocks/batches:
@@ -199,7 +199,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[3].status,
                          ClientBatchStatus.UNKNOWN)
 
-    def test_batch_status_with_wait(self):
+    def test_batch_statuses_with_wait(self):
         """Verifies requests for status that wait for commit work properly.
 
         Queries the default mock block store which will have no block with
@@ -230,7 +230,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.COMMITTED)
 
-    def test_batch_status_with_committed_wait(self):
+    def test_batch_statuses_with_committed_wait(self):
         """Verifies requests for status that wait for commit work properly,
         when the batch is already committed.
 


### PR DESCRIPTION
This change to the API better reflects both RESTful expectations and the nature of the route, which is to return multiple BatchStatus resources.