### PR TITLE
Add TP cmds to CLI reference; edit doc-only text

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -19,6 +19,19 @@
 CLI Reference
 *************
 
+The Sawtooth command-line interface provides a set of commands to interact with
+Sawtooth services.
+
+This chapter shows the available options and arguments for each command and
+subcommand. The synopsis for each command shows its parameters and their usage.
+
+- Optional parameters are shown in square brackets
+- Choices are shown in curly braces.
+- User-supplied values are shown in angle brackets.
+
+This usage information is also available on the command line by using the
+``-h`` or`` --help`` option.
+
 .. toctree::
    :maxdepth: 2
 
@@ -30,3 +43,5 @@ CLI Reference
    cli/rest_api.rst
    cli/intkey.rst
    cli/xo.rst
+   cli/settings-tp.rst
+   cli/identity-tp.rst

--- a/docs/source/cli/identity-tp.rst
+++ b/docs/source/cli/identity-tp.rst
@@ -1,0 +1,39 @@
+..
+   Copyright 2017 Intel Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+************************************************
+Identity Transaction Processor CLI (identity-tp)
+************************************************
+
+The Identity transaction processor CLI, ``sawtooth-identity``, handles
+on-chain permissioning for transactor and validator keys to streamline
+managing identities for lists of public keys.
+
+The Settings transaction processor is required when using the Identity
+transaction processor.
+
+identity-tp
+===========
+
+The ``identity-tp`` command starts an Identity transition processor, which
+is responsible for applying the changes to on-chain permissions that are used
+by the Sawtooth platform.
+
+In order to send identity transactions, your public key
+must be stored in ``sawtooth.identity.allowed_keys``.
+
+.. literalinclude:: output/identity-tp_usage.out
+   :language: console
+   :linenos:

--- a/docs/source/cli/intkey.rst
+++ b/docs/source/cli/intkey.rst
@@ -15,14 +15,17 @@
 
 .. _intkey-cli-reference-label:
 
-**************
-IntegerKey CLI
-**************
+***********************
+IntegerKey CLI (intkey)
+***********************
+
+The IntegerKey CLI, ``intkey``, provides functions that can be used to test
+deployed ledgers.
 
 intkey
 ======
 
-The IntegerKey transaction family allows users to set, increment, and
+The ``intkey`` command provides subcommands to set, increment, and
 decrement the value of entries stored in a state dictionary.
 
 .. literalinclude:: output/intkey_usage.out
@@ -32,9 +35,9 @@ decrement the value of entries stored in a state dictionary.
 intkey set
 ==========
 
-Sends a transaction to set ``<name>`` to ``<value>``. This transaction
-will fail if ``<value>`` is less than 0 or greater than 2\
-:sup:`32` - 1.
+The ``intkey set`` subcommand sets a key (`name`) to the specified value.
+This transaction will fail if the value is less than 0 or greater than
+2\ :sup:`32` - 1.
 
 .. literalinclude:: output/intkey_set_usage.out
    :language: console
@@ -43,9 +46,9 @@ will fail if ``<value>`` is less than 0 or greater than 2\
 intkey inc
 ==========
 
-Sends a transaction to increment ``<name>`` by ``<value>``. This
-transaction will fail if ``<name>`` is not set or if the resulting
-value would exceed 2\ :sup:`32` - 1.
+The ``intkey inc`` subcommand increments a key (`name`) by the specified value.
+This transaction will fail if the key is not set or if the resulting value
+would exceed 2\ :sup:`32` - 1.
 
 .. literalinclude:: output/intkey_inc_usage.out
    :language: console
@@ -54,9 +57,9 @@ value would exceed 2\ :sup:`32` - 1.
 intkey dec
 ==========
 
-Sends a transaction to increment ``<name>`` by ``<value>``. This
-transaction will fail if ``<name>`` is not set or if the resulting
-value would be less than 0.
+The ``intkey dec`` subcommand decrements a key (`name`) by the specified value.
+This transaction will fail if the key is not set or if the resulting value
+would be less than 0.
 
 .. literalinclude:: output/intkey_dec_usage.out
    :language: console
@@ -65,7 +68,7 @@ value would be less than 0.
 intkey show
 ===========
 
-Displays the value of the intkey entry ``<name>``.
+The ``intkey show`` subcommand displays the value of the specified key (`name`).
 
 .. literalinclude:: output/intkey_show_usage.out
    :language: console
@@ -74,7 +77,7 @@ Displays the value of the intkey entry ``<name>``.
 intkey list
 ===========
 
-Displays the value of all intkey entries in state.
+The ``intkey list`` subcommand displays the value of all keys.
 
 .. literalinclude:: output/intkey_list_usage.out
    :language: console

--- a/docs/source/cli/poet.rst
+++ b/docs/source/cli/poet.rst
@@ -27,10 +27,8 @@ Batch for the genesis block. For more information, see
 poet
 ====
 
-The ``poet`` command generates information for configuring a node to
-use Sawtooth with the PoET consensus method. The genesis subcommand
-creates a Batch for the genesis block. The enclave subcommand
-generates enclave setup information.
+The ``poet`` command provides subcommands for configuring a node to use
+Sawtooth with the PoET consensus method.
 
 .. literalinclude:: output/poet_usage.out
    :language: console

--- a/docs/source/cli/rest_api.rst
+++ b/docs/source/cli/rest_api.rst
@@ -15,11 +15,11 @@
 
 .. _rest-api-cli-reference-label:
 
-************
-REST API CLI
-************
+********************************
+REST API CLI (sawtooth-rest-api)
+********************************
 
-The Sawtooth REST API is designed to run alongside a validator,
+The REST API, ``sawtooth-rest-api``, is designed to run alongside a validator,
 providing potential clients access to blockchain and state data
 through common HTTP/JSON standards. It is a stateless process, and
 does not store any part of the blockchain or blockchain state. Instead

--- a/docs/source/cli/sawadm.rst
+++ b/docs/source/cli/sawadm.rst
@@ -15,9 +15,11 @@
 
 .. _sawadm-reference-label:
 
-******************
-Sawtooth Admin CLI
-******************
+***************************
+Sawtooth Admin CLI (sawadm)
+***************************
+
+The Sawtooth admin CLI, ``sawadm`` is used for Sawtooth administration tasks.
 
 sawadm
 ======
@@ -33,60 +35,48 @@ initializing a validator.
 sawadm genesis
 ==============
 
-Overview
---------
-
-The genesis CLI tool produces a file for use during initialization of
-a validator. A network requires an initial block (known as the genesis
-block) whose signature will determine the block chain id. This initial
+The ``sawadm genesis`` subcommand produces a file for use during the
+initialization of a validator. A network requires an initial block (known as the
+`genesis block`) whose signature will determine the block chain id. This initial
 block is produced from a list of batches, which will be applied at
-genesis time. The input to the command is a set of zero or more files
-containing serialized ``BatchList`` protobuf messages. The output is a
-file containing a serialized ``GenesisData`` protobuf message. This
-file, when placed at ``<sawtooth_data>/genesis.batch``, will trigger
+genesis time.
+
+The optional argument `input_file` specifies one or more files containing
+serialized ``BatchList`` protobuf messages to add to the genesis data. (Use a
+space to separate multiple files.) If no input file is specified,
+``sawadm keygen`` produces an empty genesis block.
+
+The output is a file containing a serialized ``GenesisData`` protobuf message.
+This file, when placed at `sawtooth_data`/``genesis.batch``, will trigger
 the genesis process.
 
-The location ``sawtooth_data`` depends on whether or not the
-environment variable ``SAWTOOTH_HOME`` is set. If it is, then
-``sawtooth_data`` is located at ``<SAWTOOTH_HOME>/data``. If it is
-not, then ``sawtooth_data`` is located at ``/var/lib/sawtooth``.
+.. Note::
 
-Usage
------
+  The location of `sawtooth_data` depends on whether the
+  environment variable ``SAWTOOTH_HOME`` is set. If it is, then
+  `sawtooth_data` is located at ``SAWTOOTH_HOME/data``. If it is
+  not, then `sawtooth_data` is located at ``/var/lib/sawtooth``.
+
+When ``sawadm genesis`` runs, it displays the path and filename of the
+target file where the serialized ``GenesisData`` is written. (Default:
+`sawtooth_data`/``genesis.batch``.) For example:
+
+.. code-block:: console
+
+    $ sawadm genesis config.batch mktplace.batch
+    Generating /var/lib/sawtooth/genesis.batch
+
+Use ``--output`` `filename` to specify a different name for the target file.
 
 .. literalinclude:: output/sawadm_genesis_usage.out
    :language: console
    :linenos:
 
-Arguments
-^^^^^^^^^
-
-- ``input_batch_file`` - a repeated list of files containing a
-  serialized ``BatchList`` message. This may be empty, which will
-  produce an empty genesis block.
-
-- ``--output <filename>`` - a target file where the serialized
-  ``GenesisData`` will be written. Defaults to
-  ``<sawtooth_data>/genesis.batch``.
-
-Output
-^^^^^^
-
-The output of the command displays a message where the output
-``GenesisData`` is written.
-
-Example
-^^^^^^^
-
-.. code-block:: console
-
-    > sawadm genesis config.batch mktplace.batch
-    Generating /var/lib/sawtooth/genesis.batch
 
 sawadm keygen
 =============
 
-The ``sawadm keygen`` command generates keys that the validator uses to
+The ``sawadm keygen`` subcommand generates keys that the validator uses to
 sign blocks. This system-wide key must be created during Sawtooth
 configuration.
 

--- a/docs/source/cli/sawset.rst
+++ b/docs/source/cli/sawset.rst
@@ -15,16 +15,18 @@
 
 .. _sawset-reference-label:
 
-*******************
-Sawtooth Config CLI
-*******************
+****************************
+Sawtooth Config CLI (sawset)
+****************************
+
+The Sawtooth Config CLI, ``sawset``, is used to work with settings proposals.
 
 sawset
 ======
 
 Sawtooth supports storing settings on-chain. The ``sawset``
 subcommands can be used to view the current proposals, create
-proposals and vote on existing proposals, and produce setting values
+proposals, vote on existing proposals, and produce setting values
 that will be set in the genesis block.
 
 .. literalinclude:: output/sawset_usage.out

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -19,10 +19,23 @@
 Sawtooth CLI
 ************
 
+The Sawtooth CLI is the usual way to interact with validators or
+validator networks.
+
+This CLI has a multi-level structure. It starts with the base call to
+``sawtooth``. Next is a top-level subcommand such as ``block`` or ``state``.
+Each top-level subcommand has additional subcommands that specify the
+operation to perform, such as ``list`` or ``create``.  The subcommands have
+options and arguments that control their behavior. For example:
+
+.. code-block:: console
+
+  $ sawtooth state list --format csv
+
 sawtooth
 ========
 
-The Sawtooth CLI has a large set of subcommands that are used to
+The ``sawtooth`` command provides a set of subcommands that are used to
 configure, manage, and interact with the components of Sawtooth.
 
 .. literalinclude:: output/sawtooth_usage.out
@@ -67,12 +80,12 @@ sawtooth batch show
 The ``sawtooth batch show`` subcommand queries the Sawtooth REST API
 for a specific batch in the current blockchain. It returns complete
 information for this batch in either YAML (default) or JSON format.
-Using the ``--key`` option, it is possible to narrow the returned
+Use the ``--key`` option to narrow the returned
 information to just the value of a single key, either from the batch
 or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -93,7 +106,7 @@ until processing is complete, with an optional timeout value specified
 in seconds.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_batch_status_usage.out
@@ -111,7 +124,7 @@ contain one or more batches with any number of transactions. The
 processing is complete, with an optional timeout specified in seconds.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -158,7 +171,7 @@ information to just the value of a single key, either from the block,
 or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -269,7 +282,7 @@ processing.
 sawtooth keygen
 ===============
 
-The keygen subcommand generates a private key file and a public key
+The ``sawtooth keygen`` subcommand generates a private key file and a public key
 file so that users can sign Sawtooth transactions and batches. These
 files are stored in the ``<key-dir>`` directory in ``<key_name>.priv``
 and ``<key_dir>/<key_name>.pub``. By default, ``<key_dir>`` is
@@ -313,12 +326,12 @@ sawtooth state list
 ===================
 
 The ``sawtooth state list`` subcommand queries the Sawtooth REST API
-for a list of all state entries in the current blockchain state. It
+for a list of all state entries in the current blockchain state. This subcommand
 returns the address of each entry, its size in bytes, and the
 byte-encoded data it contains. It also returns the head block for
 which this data is valid.
 
-The state that is returned can be controlled using the subtree
+To control the state that is returned, use the ``subtree``
 argument to specify an address prefix as a filter or a block id to use
 as the chain head.
 
@@ -328,7 +341,7 @@ and YAML) are available and can be piped into a file for further
 processing.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_state_list_usage.out
@@ -346,7 +359,7 @@ the logic of the transaction family that created it, and must be
 decoded using that same logic.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_state_show_usage.out
@@ -387,12 +400,12 @@ sawtooth transaction show
 The ``sawtooth transaction show`` subcommand queries the Sawtooth REST
 API for a specific transaction in the current blockchain. It returns
 complete information for this transaction in either YAML (default) or
-JSON format. Using the --key option, it is possible to narrow the
+JSON format. Use the ``--key`` option to narrow the
 returned information to just the value of a single key, either from
 the transaction or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a username:password
+``http://localhost:8080``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_transaction_show_usage.out

--- a/docs/source/cli/settings-tp.rst
+++ b/docs/source/cli/settings-tp.rst
@@ -1,0 +1,47 @@
+..
+   Copyright 2017 Intel Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+******************************************************
+Settings Transaction Processor CLI (sawtooth-settings)
+******************************************************
+
+The Settings transaction processor CLI, ``sawtooth-settings``, starts
+starts a Settings transaction processor. This transaction family provides
+a methodology for storing on-chain configuration settings.
+
+The settings stored in state as a result of this transaction family play a
+critical role in the operation of a validator. For example, the consensus module
+uses these settings. In the case of PoET, one cross-network setting is target
+wait time (which must be the same across validators), that is stored as
+``sawtooth.poet.target_wait_time``. Other parts of the system use these settings
+similarly; for example, the list of enabled transaction families is used by the
+transaction processing platform. In addition, pluggable components such as
+transaction family implementations can use the settings during their execution.
+
+This design supports two authorization options: either a single authorized key
+that can make changes or multiple authorized keys. In the case of multiple keys,
+a percentage of votes signed by the keys is required to make a change. Note that
+only the keys in ``sawtooth.settings.vote.authorized_keys`` are allowed to
+submit setting transactions.
+
+settings-tp
+===========
+
+The ``settings-tp`` command starts a Settings transaction processor,
+which is required in order to apply changes to on-chain settings.
+
+.. literalinclude:: output/settings-tp_usage.out
+   :language: console
+   :linenos:

--- a/docs/source/cli/validator.rst
+++ b/docs/source/cli/validator.rst
@@ -15,11 +15,11 @@
 
 .. _validator-cli-reference-label:
 
-*************
-Validator CLI
-*************
+**********************************
+Validator CLI (sawtooth-validator)
+**********************************
 
-The Validator CLI (the sawtooth-validator command) controls the
+The validator CLI, ``sawtooth-validator``, controls the
 behavior of the validator.
 
 A validator is the component ultimately responsible for validating
@@ -41,7 +41,7 @@ validator.
 
   - If set to ``static``, use the ``--peers`` option to list the URLs
     of all peers that the validator should connect to, using the
-    format tcp://hostname:port. Specify multiple peer URLs in a
+    format ``tcp``://`hostname`:`port`. Specify multiple peer URLs in a
     comma-separated list.
 
   - If set to ``dynamic``, any static peers will be processed first,

--- a/docs/source/cli/xo.rst
+++ b/docs/source/cli/xo.rst
@@ -19,11 +19,21 @@
 XO CLI
 ******
 
+The XO CLI demonstrates an example client that uses the XO transaction family
+to play a simple game of Tic-tac-toe (also known as Noughts and Crosses,
+or X's and O's). This CLI handles the construction and submission of
+transactions to a running validator via the URL of the validator's REST API.
+
+Before playing a game, you must start a validator, the XO transaction processor,and the REST API. The XO client sends requests to update and query the
+blockchain to the URL of the REST API (by default, ``http://127.0.0.1:8080``).
+
+For more information on requirements and game rules, see
+:doc:`../app_developers_guide/intro_xo_transaction_family`.
+
 xo
 ==
 
-The ``xo`` command allows users to play a simple board game known
-variously as tic-tac-toe, noughts and crosses, and XO.
+The ``xo`` command provides subcommands for playing XO on the command line.
 
 .. literalinclude:: output/xo_usage.out
    :language: console
@@ -32,9 +42,7 @@ variously as tic-tac-toe, noughts and crosses, and XO.
 xo create
 =========
 
-Sends a transaction to start an xo game with the identifier
-``<name>``. This transaction will fail if a game already exists with
-the name ``<name>``.
+The ``xo create`` subcommand starts an XO game with the specified name.
 
 .. literalinclude:: output/xo_create_usage.out
    :language: console
@@ -43,8 +51,7 @@ the name ``<name>``.
 xo list
 =======
 
-Displays information for all xo games in state, showing the players,
-the game state, and the board for each game.
+The ``xo list`` subcommand displays information for all XO games in state.
 
 .. literalinclude:: output/xo_list_usage.out
    :language: console
@@ -53,8 +60,7 @@ the game state, and the board for each game.
 xo show
 =======
 
-Displays the xo game ``<name>``, showing the players, the game state,
-and the board.
+The ``xo show`` subcommand displays information about the specified XO game.
 
 .. literalinclude:: output/xo_show_usage.out
    :language: console
@@ -63,9 +69,8 @@ and the board.
 xo take
 =======
 
-Sends a transaction to make a move in the xo game ``<name>``, taking
-``<space>``. This transaction will fail if the game ``<name>`` does
-not exist, if it is not the sender’s turn, or if ``<space>`` is
+The ``xo take`` subcommand makes a move in an XO game by sending a transaction
+to take the identified space.  This transaction will fail if the game `name` does not exist, if it is not the sender’s turn, or if `space` is
 already taken.
 
 .. literalinclude:: output/xo_take_usage.out


### PR DESCRIPTION
- Add sections for settings-tp and identity-tp

- Edit the doc-only text for consistency and clarity

- Add the command name to section title if significantly different

- Remove subsections from "sawadm genesis" (Overview, Output etc.)
  to be consistent - the other commands don't have subsections

Signed-off-by: Anne Chenette <chenette@bitwise.io>