### PR TITLE
Switch default REST API port from 8080 to 8008

### DIFF
--- a/ci/sawtooth-all
+++ b/ci/sawtooth-all
@@ -52,6 +52,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/0.8/stable xenial universe" >> /etc
  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 4004/tcp
-EXPOSE 8080
+EXPOSE 8008
 
 # Entrypoint is left up to user

--- a/ci/sawtooth-rest-api
+++ b/ci/sawtooth-rest-api
@@ -38,6 +38,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/0.8/stable xenial universe" >> /etc
  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 4004/tcp
-EXPOSE 8080
+EXPOSE 8008
 
 CMD ["sawtooth-rest-api"]

--- a/cli/sawtooth_cli/config.py
+++ b/cli/sawtooth_cli/config.py
@@ -548,7 +548,7 @@ def create_parser(prog_name):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     prop_parser.add_argument(
         'setting',
@@ -567,7 +567,7 @@ def create_parser(prog_name):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     proposal_list_parser.add_argument(
         '--public-key',
@@ -598,7 +598,7 @@ def create_parser(prog_name):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     vote_parser.add_argument(
         '-k', '--key',

--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -108,7 +108,7 @@ def add_identity_parser(subparsers, parent_parser):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     create_parser.add_argument(
         '--wait',
@@ -139,7 +139,7 @@ def add_identity_parser(subparsers, parent_parser):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     list_parser.add_argument(
         '--format',
@@ -191,7 +191,7 @@ def add_identity_parser(subparsers, parent_parser):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     create_parser.add_argument(
         'name',
@@ -213,7 +213,7 @@ def add_identity_parser(subparsers, parent_parser):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     list_parser.add_argument(
         '--format',

--- a/cli/sawtooth_cli/parent_parsers.py
+++ b/cli/sawtooth_cli/parent_parsers.py
@@ -28,7 +28,7 @@ def base_http_parser():
     base_parser.add_argument(
         '--url',
         type=str,
-        default='http://localhost:8080',
+        default='http://localhost:8008',
         help="the URL of the validator's REST API")
     base_parser.add_argument(
         '-u', '--user',

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -26,7 +26,7 @@ from sawtooth_cli.exceptions import CliException
 
 class RestClient(object):
     def __init__(self, base_url=None, user=None):
-        self._base_url = base_url or 'http://localhost:8080'
+        self._base_url = base_url or 'http://localhost:8008'
 
         if user:
             b64_string = b64encode(user.encode()).decode()

--- a/cli/sawtooth_cli/settings.py
+++ b/cli/sawtooth_cli/settings.py
@@ -66,7 +66,7 @@ def add_settings_parser(subparsers, parent_parser):
         '--url',
         type=str,
         help="the URL of a validator's REST API",
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     list_parser.add_argument(
         '--filter',

--- a/docker/apache-basic_auth_proxy
+++ b/docker/apache-basic_auth_proxy
@@ -16,7 +16,7 @@
 # Description:
 #   Builds an image to be used in testing REST API behavior behind a proxy with
 #   Basic Authentication. Redirects from 'basic_auth_proxy/sawtooth' to
-#   'rest-api:8080' with both HTTP and HTTPS.
+#   'rest-api:8008' with both HTTP and HTTPS.
 #
 # Build:
 #   $ cd sawtooth-core/docker
@@ -72,14 +72,14 @@ RUN echo "\
         Require all denied\n\
 </Location>\n\
 \n\
-ProxyPass /sawtooth http://rest-api:8080\n\
-ProxyPassReverse /sawtooth http://rest-api:8080\n\
+ProxyPass /sawtooth http://rest-api:8008\n\
+ProxyPassReverse /sawtooth http://rest-api:8008\n\
 RequestHeader set X-Forwarded-Path \"/sawtooth\"\n\
 \n\
 " >/etc/apache2/sites-enabled/000-default.conf
 
 EXPOSE 80
 EXPOSE 443
-EXPOSE 8080
+EXPOSE 8008
 
 CMD ["apachectl start"]

--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -68,18 +68,18 @@ services:
     container_name: sawtooth-rest-api-default
     expose:
       - 4004
-      - 8080
+      - 8008
     ports:
-      - "8080:8080"
+      - "8008:8008"
     depends_on:
       - validator
-    entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8080
+    entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8008
 
   client:
     image: hyperledger/sawtooth-all:latest
     container_name: sawtooth-client-default
     expose:
-      - 8080
+      - 8008
       - 4004
     depends_on:
       - rest-api

--- a/docker/compose/sawtooth-local.yaml
+++ b/docker/compose/sawtooth-local.yaml
@@ -81,12 +81,12 @@ services:
       - ../../:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     ports:
-      - "8080:8080"
+      - "8008:8008"
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   client:
@@ -95,7 +95,7 @@ services:
     volumes:
       - ../../:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
       - 4004
     depends_on:
       - rest-api

--- a/docker/compose/sawtooth-xo.yaml
+++ b/docker/compose/sawtooth-xo.yaml
@@ -94,12 +94,12 @@ services:
       - ../../:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     ports:
-      - 8080
+      - 8008
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   xo-client:
@@ -108,7 +108,7 @@ services:
     volumes:
       - ../../:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/docker/compose/smallbank-local-installed.yaml
+++ b/docker/compose/smallbank-local-installed.yaml
@@ -55,9 +55,9 @@ services:
     image: sawtooth-rest-api:latest
     container_name: sawtooth-rest-api-default
     expose:
-      - 8080
+      - 8008
     ports:
-      - "8080:8080"
+      - "8008:8008"
     depends_on:
       - validator
-    entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8080
+    entrypoint: sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8008

--- a/docker/compose/smallbank-local-mounted.yaml
+++ b/docker/compose/smallbank-local-mounted.yaml
@@ -66,12 +66,12 @@ services:
     volumes:
       - ../../:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     ports:
-      - "8080:8080"
+      - "8008:8008"
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080 --opentsdb-url http://influxdb:8086 --opentsdb-db metrics
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008 --opentsdb-url http://influxdb:8086 --opentsdb-db metrics
 
   influxdb:
     image: sawtooth-stats-influxdb:latest

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -101,7 +101,7 @@ RUN apt-get update && apt-get install -y -q \
  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 4004/tcp
-EXPOSE 8080
+EXPOSE 8008
 
 RUN mkdir -p /project/sawtooth-core/ \
  && mkdir -p /var/log/sawtooth \

--- a/docker/sawtooth-int-rest-api
+++ b/docker/sawtooth-int-rest-api
@@ -47,6 +47,6 @@ RUN apt-get install -y -q --allow-unauthenticated \
     python3-sawtooth-rest-api
 
 EXPOSE 4004/tcp
-EXPOSE 8080
+EXPOSE 8008
 
 CMD ["sawtooth-rest-api"]

--- a/docker/sawtooth-validator-mounted
+++ b/docker/sawtooth-validator-mounted
@@ -85,7 +85,7 @@ RUN apt-get update && apt-get install -y -q \
  && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 4004/tcp
-EXPOSE 8080
+EXPOSE 8008
 
 RUN mkdir -p /project/sawtooth-core/ \
  && mkdir -p /var/log/sawtooth \

--- a/docker/telegraf.conf
+++ b/docker/telegraf.conf
@@ -1281,7 +1281,7 @@
 #   ## Remember to change host address to fit your environment.
 #   # [inputs.jolokia.proxy]
 #   #   host = "127.0.0.1"
-#   #   port = "8080"
+#   #   port = "8008"
 #
 #   ## Optional http timeouts
 #   ##
@@ -1304,7 +1304,7 @@
 #   [[inputs.jolokia.servers]]
 #     name = "as-server-01"
 #     host = "127.0.0.1"
-#     port = "8080"
+#     port = "8008"
 #     # username = "myuser"
 #     # password = "mypassword"
 #
@@ -1814,7 +1814,7 @@
 # # Read raindrops stats (raindrops - real-time stats for preforking Rack servers)
 # [[inputs.raindrops]]
 #   ## An array of raindrops middleware URI to gather stats.
-#   urls = ["http://localhost:8080/_raindrops"]
+#   urls = ["http://localhost:8008/_raindrops"]
 
 
 # # Read metrics from one or many redis servers

--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -57,7 +57,7 @@ be found `here <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/launch-market
     to add an inbound rule allowing TCP traffic on port 4004.
 
   * If you'd like to access the REST API remotely, you'll need to add an
-    inbound rule allowing TCP traffic on port 8080.
+    inbound rule allowing TCP traffic on port 8008.
 
   Please see Amazon's `Security Groups
   <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html#AddRemoveRules>`_
@@ -296,7 +296,7 @@ Enter the following command from a terminal window:
 
 .. code-block:: console
 
-  $ curl http://localhost:8080/blocks
+  $ curl http://localhost:8008/blocks
 
 
 Configuring the List of Transaction Families

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -221,7 +221,7 @@ container, run this ``curl`` command as root:
 
 .. code-block:: console
 
-  root@75b380886502:/# curl http://rest-api:8080/blocks
+  root@75b380886502:/# curl http://rest-api:8008/blocks
 
 
 To check connectivity from the host computer, open a new terminal window on your
@@ -229,7 +229,7 @@ host system and use this curl command:
 
 .. code-block:: console
 
-  $ curl http://localhost:8080/blocks
+  $ curl http://localhost:8008/blocks
 
 
 If the validator is running and reachable, the output for each command
@@ -253,7 +253,7 @@ should be similar to this example:
       }
     ],
     "head": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
-    "link": "http://rest-api:8080/blocks?head=119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+    "link": "http://rest-api:8008/blocks?head=119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
     "paging": {
       "start_index": 0,
       "total_count": 1
@@ -281,7 +281,7 @@ Run the following commands from the client container:
 .. code-block:: console
 
   $ intkey create_batch --count 10 --key-count 5
-  $ intkey load -f batches.intkey -U http://rest-api:8080
+  $ intkey load -f batches.intkey -U http://rest-api:8008
 
 The terminal window in which you ran the ``docker-compose`` command will begin
 logging output as the validator and IntegerKey transaction processor handle the
@@ -314,7 +314,7 @@ as generated above with this command:
 
 .. code-block:: console
 
-  $ sawtooth batch submit -f batches.intkey --url http://rest-api:8080
+  $ sawtooth batch submit -f batches.intkey --url http://rest-api:8008
 
 
 Viewing the Block Chain
@@ -335,7 +335,7 @@ Enter the command ``sawtooth block list`` to view the blocks stored by the state
 
 .. code-block:: console
 
-  $ sawtooth block list --url http://rest-api:8080
+  $ sawtooth block list --url http://rest-api:8008
 
 The output of the command will be similar to this:
 
@@ -355,7 +355,7 @@ of a block you want to get more info about, then paste it in place of
 
 .. code-block:: console
 
-  $ sawtooth block show --url http://rest-api:8080 {BLOCK_ID}
+  $ sawtooth block show --url http://rest-api:8008 {BLOCK_ID}
 
 The output of this command includes all data stored under that block, and can be
 quite long. It should look something like this:
@@ -409,7 +409,7 @@ Use the command ``sawtooth state list`` to list the nodes in the Merkle tree:
 
 .. code-block:: console
 
-  $ sawtooth state list --url http://rest-api:8080
+  $ sawtooth state list --url http://rest-api:8008
 
 The output of the command will be similar to this truncated list:
 
@@ -436,7 +436,7 @@ in the following ``sawtooth state show`` command:
 
 .. code-block:: console
 
-  $ sawtooth state show --url http://rest-api:8080 {STATE_ADDRESS}
+  $ sawtooth state show --url http://rest-api:8008 {STATE_ADDRESS}
 
 
 The output of the command will include both the bytes stored at that address
@@ -461,7 +461,7 @@ Enter the following command from the terminal window for the client container:
 
 .. code-block:: console
 
-  $ curl http://rest-api:8080/blocks
+  $ curl http://rest-api:8008/blocks
 
 
 From the Host Operating System
@@ -472,7 +472,7 @@ Enter the following command from the terminal window for your host system:
 
 .. code-block:: console
 
-  $ curl http://localhost:8080/blocks
+  $ curl http://localhost:8008/blocks
 
 
 Connecting to Each Container
@@ -530,7 +530,7 @@ The REST API Container
 ----------------------
 
 * Runs the REST API
-* Available to the client container and host on TCP port 8080
+* Available to the client container and host on TCP port 8008
 * Container name: ``sawtooth-rest-api-default``
 
 Log into this container by running this command from the host computer's
@@ -546,7 +546,7 @@ To see which components are running, run this command from the container:
 
   $ ps --pid 1 fw
     PID TTY      STAT   TIME COMMAND
-    1 ?        Ssl    0:02 /usr/bin/python3 /usr/bin/sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8080
+    1 ?        Ssl    0:02 /usr/bin/python3 /usr/bin/sawtooth-rest-api --connect tcp://validator:4004 --bind rest-api:8008
 
 
 The Settings Transaction Processor Container
@@ -675,10 +675,10 @@ Then run the following command from the validator container:
 .. code-block:: console
 
   $ sawset proposal create \
-    --url http://rest-api:8080 \
+    --url http://rest-api:8008 \
     --key /root/.sawtooth/keys/my_key.priv \
     sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}]'
-  $ sawset settings list --url http://rest-api:8080
+  $ sawset settings list --url http://rest-api:8008
 
 
 A TP_PROCESS_REQUEST message appears in the logging output of the validator,

--- a/docs/source/app_developers_guide/intro_xo_transaction_family.rst
+++ b/docs/source/app_developers_guide/intro_xo_transaction_family.rst
@@ -116,7 +116,7 @@ URL
 ---
 
 The ``xo`` commands all take a ``--url`` argument that defaults to
-``http://127.0.0.1:8080``. This should be set to the URL of the REST
+``http://127.0.0.1:8008``. This should be set to the URL of the REST
 API. The *XO* client will send requests to update and query the
 blockchain to this URL.
 

--- a/docs/source/cli/rest_api.rst
+++ b/docs/source/cli/rest_api.rst
@@ -33,7 +33,7 @@ sawtooth-rest-api
 
 The ``sawtooth-rest-api`` command starts the REST API and connects to
 the validator. Options specify the bind address for the host and port
-(by default, ``http://localhost:8080``) and the TCP address where the
+(by default, ``http://localhost:8008``) and the TCP address where the
 validator is running (the default is ``tcp://localhost:4004``). An
 optional timeout value configures how long the REST API will wait for
 a response for the validator.

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -60,7 +60,7 @@ sawtooth batch list
 ===================
 
 The ``sawtooth batch list`` subcommand queries the specified Sawtooth
-REST API (default: ``http://localhost:8080``) for a list of Batches in
+REST API (default: ``http://localhost:8008``) for a list of Batches in
 the current blockchain. It returns the id of each Batch, the public
 key of each signer, and the number of transactions in each Batch.
 
@@ -85,7 +85,7 @@ information to just the value of a single key, either from the batch
 or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -106,7 +106,7 @@ until processing is complete, with an optional timeout value specified
 in seconds.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_batch_status_usage.out
@@ -124,7 +124,7 @@ contain one or more batches with any number of transactions. The
 processing is complete, with an optional timeout specified in seconds.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -146,7 +146,7 @@ sawtooth block list
 ===================
 
 The ``sawtooth block list`` subcommand queries the Sawtooth REST API
-(default: ``http://localhost:8080``) for a list of all blocks in the
+(default: ``http://localhost:8008``) for a list of all blocks in the
 current chain. It returns the id and number of each block, the public
 key of each signer, and the number of transactions and batches in
 each.
@@ -171,7 +171,7 @@ information to just the value of a single key, either from the block,
 or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 
@@ -341,7 +341,7 @@ and YAML) are available and can be piped into a file for further
 processing.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_state_list_usage.out
@@ -359,7 +359,7 @@ the logic of the transaction family that created it, and must be
 decoded using that same logic.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_state_show_usage.out
@@ -380,7 +380,7 @@ sawtooth transaction list
 =========================
 
 The ``sawtooth transaction list`` subcommand queries the Sawtooth REST
-API (default: ``http://localhost:8080``) for a list of transactions in
+API (default: ``http://localhost:8008``) for a list of transactions in
 the current blockchain. It returns the id of each transaction, its
 family and version, the size of its payload, and the data in the
 payload itself.
@@ -405,7 +405,7 @@ returned information to just the value of a single key, either from
 the transaction or its header.
 
 This subcommand requires the URL of the REST API (default:
-``http://localhost:8080``), and can specify a `username`:`password`
+``http://localhost:8008``), and can specify a `username`:`password`
 combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_transaction_show_usage.out

--- a/docs/source/rest_api/state_delta_websockets.rst
+++ b/docs/source/rest_api/state_delta_websockets.rst
@@ -26,7 +26,7 @@ by using standard means.  In the case of in-browser JavaScript:
 
 .. code-block:: javascript
 
-   let ws = new WebSocket('ws:localhost:8080/subscriptions')
+   let ws = new WebSocket('ws:localhost:8008/subscriptions')
 
 If the REST API is running, it should trigger an event on the web socket's
 `onopen` handler.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -22,11 +22,11 @@ The ``rest_api.toml`` configuration file has the following options:
 - ``bind`` = ["`HOST:PORT`"]
 
   Sets the port and host for the REST API to run on.
-  Default: ``127.0.0.1:8080``. For example:
+  Default: ``127.0.0.1:8008``. For example:
 
   .. code-block:: none
 
-    bind = ["127.0.0.1:8080"]
+    bind = ["127.0.0.1:8008"]
 
 - ``connect`` = "`URL`"
 

--- a/docs/source/sysadmin_guide/rest_auth_proxy.rst
+++ b/docs/source/sysadmin_guide/rest_auth_proxy.rst
@@ -33,7 +33,7 @@ Might instead look like this:
 .. code-block:: json
 
    {
-     "link": "http://localhost:8080/blocks?head=..."
+     "link": "http://localhost:8008/blocks?head=..."
    }
 
 The solution to this problem is sending the destroyed information using HTTP
@@ -65,7 +65,7 @@ are three of these headers that the REST API may look for when building links.
      - An uncommon header implemented specially by the REST API to handle extra
        path information. Only necessary if the proxy endpoints do not map
        directly to the REST API endpoints (i.e.
-       *"hyperledger.org/sawtooth/blocks"* -> *"localhost:8080/blocks"*).
+       *"hyperledger.org/sawtooth/blocks"* -> *"localhost:8008/blocks"*).
      - */sawtooth*
 
 
@@ -102,7 +102,7 @@ response links:
      - An non-standard key header used to handle extra path information. Only
        necessary if the proxy endpoints do not map directly to the REST API
        endpoints (i.e. *"hyperledger.org/sawtooth/blocks"* ->
-       *"localhost:8080/blocks"*).
+       *"localhost:8008/blocks"*).
      - *path="/sawtooth"*
 
 .. note::
@@ -196,8 +196,8 @@ Edit the file to look like this:
        </Location>
    </VirtualHost>
 
-   ProxyPass /sawtooth http://localhost:8080
-   ProxyPassReverse /sawtooth http://localhost:8080
+   ProxyPass /sawtooth http://localhost:8008
+   ProxyPassReverse /sawtooth http://localhost:8008
    RequestHeader set X-Forwarded-Path "/sawtooth"
 
 .. note::
@@ -237,14 +237,14 @@ worked. We'll start by querying the REST API directly:
 
 .. code-block:: console
 
-   $ curl http://localhost:8080/blocks
+   $ curl http://localhost:8008/blocks
 
 The response link should look like this:
 
 .. code-block:: json
 
    {
-     "link": "http://localhost:8080/blocks?head=..."
+     "link": "http://localhost:8008/blocks?head=..."
    }
 
 You should also be able to get back a ``401`` by querying the proxy without

--- a/families/battleship/sawtooth_battleship/battleship_cli.py
+++ b/families/battleship/sawtooth_battleship/battleship_cli.py
@@ -549,7 +549,7 @@ def load_config():
     key_dir = os.path.join(home, ".sawtooth", "keys")
 
     config = configparser.SafeConfigParser()
-    config.set('DEFAULT', 'url', 'http://127.0.0.1:8080')
+    config.set('DEFAULT', 'url', 'http://127.0.0.1:8008')
     config.set('DEFAULT', 'key_dir', key_dir)
     config.set('DEFAULT', 'key_file', '%(key_dir)s/%(username)s.priv')
     config.set('DEFAULT', 'username', real_user)

--- a/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
@@ -54,10 +54,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   basic_auth_proxy:
@@ -67,7 +67,7 @@ services:
     expose:
       - 80
       - 443
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_block_info_injector.yaml
+++ b/integration/sawtooth_integration/docker/test_block_info_injector.yaml
@@ -84,10 +84,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-block-info-injector:
@@ -95,7 +95,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_config_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_config_smoke.yaml
@@ -52,10 +52,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-config-smoke:
@@ -63,7 +63,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
+++ b/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
@@ -62,10 +62,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-events-and-receipts:
@@ -73,7 +73,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_intkey_cli.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_cli.yaml
@@ -65,10 +65,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-intkey-cli:
@@ -76,7 +76,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_go.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_go.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-intkey-smoke-go:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_java.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_java.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-intkey-smoke-java:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_javascript.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_javascript.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-intkey-smoke-javascript:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
@@ -65,10 +65,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-intkey-smoke-python:
@@ -76,7 +76,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_permission.yaml
+++ b/integration/sawtooth_integration/docker/test_permission.yaml
@@ -52,10 +52,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 40000
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:40000 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:40000 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-permission:
@@ -63,7 +63,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_poet_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_poet_liveness.yaml
@@ -27,7 +27,7 @@ services:
         -s /project/sawtooth-core/integration/sawtooth_integration/tests
         test_poet_liveness
     expose:
-      - 8080
+      - 8008
     stop_signal: SIGKILL
     environment:
       PYTHONPATH: "/project/sawtooth-core/sdk/python:\
@@ -40,10 +40,10 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     command: "bash -c \"\
-      while true; do curl -s http://rest-api-0:8080/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
-      intkey workload --rate 2 --display-frequency 15 --urls http://rest-api-0:8080,http://rest-api-1:8080,http://rest-api-2:8080,http://rest-api-3:8080,http://rest-api-4:8080 \
+      while true; do curl -s http://rest-api-0:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
+      intkey workload --rate 2 --display-frequency 15 --urls http://rest-api-0:8008,http://rest-api-1:8008,http://rest-api-2:8008,http://rest-api-3:8008,http://rest-api-4:8008 \
       \""
     stop_signal: SIGKILL
     environment:
@@ -168,8 +168,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api --connect tcp://validator-0:4004 --bind rest-api-0:8080
+      - 8008
+    command: sawtooth-rest-api --connect tcp://validator-0:4004 --bind rest-api-0:8008
     stop_signal: SIGKILL
 
   rest-api-1:
@@ -178,8 +178,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api --connect tcp://validator-1:4004 --bind rest-api-1:8080
+      - 8008
+    command: sawtooth-rest-api --connect tcp://validator-1:4004 --bind rest-api-1:8008
     stop_signal: SIGKILL
 
   rest-api-2:
@@ -188,8 +188,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api --connect tcp://validator-2:4004 --bind rest-api-2:8080
+      - 8008
+    command: sawtooth-rest-api --connect tcp://validator-2:4004 --bind rest-api-2:8008
     stop_signal: SIGKILL
 
   rest-api-3:
@@ -198,8 +198,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api --connect tcp://validator-3:4004 --bind rest-api-3:8080
+      - 8008
+    command: sawtooth-rest-api --connect tcp://validator-3:4004 --bind rest-api-3:8008
     stop_signal: SIGKILL
 
   rest-api-4:
@@ -208,8 +208,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api --connect tcp://validator-4:4004 --bind rest-api-4:8080
+      - 8008
+    command: sawtooth-rest-api --connect tcp://validator-4:4004 --bind rest-api-4:8008
     stop_signal: SIGKILL
 
   intkey-tp-0:

--- a/integration/sawtooth_integration/docker/test_poet_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_poet_smoke.yaml
@@ -104,8 +104,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api -v --connect tcp://validator-0:4004 --bind rest-api-0:8080
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-0:4004 --bind rest-api-0:8008
     stop_signal: SIGKILL
 
   rest-api-1:
@@ -114,8 +114,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api -v --connect tcp://validator-1:4004 --bind rest-api-1:8080
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-1:4004 --bind rest-api-1:8008
     stop_signal: SIGKILL
 
   rest-api-2:
@@ -124,8 +124,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
-    command: sawtooth-rest-api -v --connect tcp://validator-2:4004 --bind rest-api-2:8080
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-2:4004 --bind rest-api-2:8008
     stop_signal: SIGKILL
 
   intkey-tp-0:
@@ -220,7 +220,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - rest-api-0
       - rest-api-1

--- a/integration/sawtooth_integration/docker/test_track_and_trade.yaml
+++ b/integration/sawtooth_integration/docker/test_track_and_trade.yaml
@@ -29,7 +29,7 @@ services:
   rethinkdb:
     image: rethinkdb
     expose:
-      - 8080
+      - 8008
       - 28015
 
   tnt-server:
@@ -37,7 +37,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
       - 3000
     depends_on:
       - rethinkdb
@@ -87,8 +87,8 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8081
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8081
+      - 8009
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8009
     stop_signal: SIGKILL
 
   test-track-and-trade:
@@ -96,8 +96,8 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
-      - 8081
+      - 8008
+      - 8009
     depends_on:
       - tnt-server
     command: "bash -c \" \

--- a/integration/sawtooth_integration/docker/test_transactor_permissioning.yaml
+++ b/integration/sawtooth_integration/docker/test_transactor_permissioning.yaml
@@ -94,10 +94,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -vv --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -vv --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-transactor-permissioning:
@@ -105,7 +105,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_two_families.yaml
+++ b/integration/sawtooth_integration/docker/test_two_families.yaml
@@ -75,10 +75,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-two-families:
@@ -86,7 +86,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
+++ b/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
@@ -44,10 +44,10 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     command: "bash -c \"\
-      while true; do curl -s http://rest-api:8080/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
-      intkey workload --rate 1 --display-frequency 15 --urls http://rest-api:8080
+      while true; do curl -s http://rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
+      intkey workload --rate 1 --display-frequency 15 --urls http://rest-api:8008
       \""
     stop_signal: SIGKILL
     environment:
@@ -80,10 +80,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-web-socket-subscription:
@@ -91,13 +91,13 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api
     working_dir: /project/sawtooth-core/integration/sawtooth_integration/tests
     command: "bash -c \"\
-      while true; do curl -s http://rest-api:8080/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
+      while true; do curl -s http://rest-api:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
       phantomjs test_web_socket_subscription.js
       \""
     stop_signal: SIGKILL

--- a/integration/sawtooth_integration/docker/test_workload.yaml
+++ b/integration/sawtooth_integration/docker/test_workload.yaml
@@ -65,10 +65,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-workload:
@@ -76,7 +76,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_xo_smoke_all.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_all.yaml
@@ -86,10 +86,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
       - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-xo-smoke-all:
@@ -97,7 +97,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_go.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-xo-smoke-go:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_xo_smoke_java.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_java.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-xo-smoke-java:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_javascript.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-xo-smoke-javascript:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
@@ -64,10 +64,10 @@ services:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
-      - 8080
+      - 8008
     depends_on:
      - validator
-    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8080
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
     stop_signal: SIGKILL
 
   test-xo-smoke-python:
@@ -75,7 +75,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
-      - 8080
+      - 8008
     depends_on:
       - validator
       - rest-api

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -102,7 +102,7 @@ def start_node(num,
                                 validator_cmd_func,
                                 poet_kwargs)
 
-    wait_for_rest_apis(['127.0.0.1:{}'.format(8080 + num)], tries=20)
+    wait_for_rest_apis(['127.0.0.1:{}'.format(8008 + num)], tries=20)
 
     return [rest_api] + processors + [validator]
 
@@ -307,7 +307,7 @@ def start_processors(num, processor_func):
 def rest_api_cmd(num):
     return 'sawtooth-rest-api --connect {s} --bind 127.0.0.1:{p}'.format(
         s=connection_address(num),
-        p=(8080 + num)
+        p=(8008 + num)
     )
 
 def start_rest_api(num):
@@ -323,7 +323,7 @@ def connection_address(num):
     return 'tcp://127.0.0.1:{}'.format(4004 + num)
 
 def http_address(num):
-    return 'http://127.0.0.1:{}'.format(8080 + num)
+    return 'http://127.0.0.1:{}'.format(8008 + num)
 
 def bind_component(num):
     return 'tcp://127.0.0.1:{}'.format(4004 + num)

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -32,7 +32,7 @@ class TestBasicAuth(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        wait_until_status('http://rest-api:8080/blocks', status_code=200)
+        wait_until_status('http://rest-api:8008/blocks', status_code=200)
         wait_until_status('http://basic_auth_proxy/sawtooth', status_code=401)
 
     def test_http_basic_auth(self):
@@ -53,7 +53,7 @@ class TestBasicAuth(unittest.TestCase):
         reflects the url of the proxy.
 
         The proxy should redirect from the passed url's domain to
-        `http://rest-api:8080`, and be configured with a Basic Auth
+        `http://rest-api:8008`, and be configured with a Basic Auth
         username:password combination of 'sawtooth:sawtooth'.
 
         In order to get back the correct link, the proxy must both forward the

--- a/integration/sawtooth_integration/tests/test_block_info_injector.py
+++ b/integration/sawtooth_integration/tests/test_block_info_injector.py
@@ -63,7 +63,7 @@ def post_batch(batch):
 
 
 def query_rest_api(suffix='', data=None, headers={}):
-    url = 'http://rest-api:8080' + suffix
+    url = 'http://rest-api:8008' + suffix
     return submit_request(urllib.request.Request(url, data, headers))
 
 

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -38,7 +38,7 @@ class TestConfigSmoke(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        wait_for_rest_apis(['rest-api:8080'])
+        wait_for_rest_apis(['rest-api:8008'])
 
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
@@ -86,16 +86,16 @@ class TestConfigSmoke(unittest.TestCase):
         # Submit transaction, then list it using subprocess
         cmds = [
             ['sawset', 'proposal', 'create', '-k', self._wif_file,
-             '--url', 'http://rest-api:8080', 'x=1', 'y=1'],
+             '--url', 'http://rest-api:8008', 'x=1', 'y=1'],
             ['sawtooth', 'settings', 'list', '--url',
-             'http://rest-api:8080']
+             'http://rest-api:8008']
         ]
 
         for cmd in cmds:
             self._run(cmd)
 
         command = 'sawtooth'
-        args = ['settings', 'list', '--url', 'http://rest-api:8080']
+        args = ['settings', 'list', '--url', 'http://rest-api:8008']
         settings = self._read_from_stdout(command, args).split('\n')
 
         _expected_output = [

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -295,7 +295,7 @@ class BatchSubmitter:
 
     def _query_rest_api(self, suffix='', data=None, headers={},
                         expected_code=200):
-        url = 'http://rest-api:8080' + suffix
+        url = 'http://rest-api:8008' + suffix
         return self._submit_request(urllib.request.Request(url, data, headers),
                                     expected_code=expected_code)
 

--- a/integration/sawtooth_integration/tests/test_intkey_cli.py
+++ b/integration/sawtooth_integration/tests/test_intkey_cli.py
@@ -27,7 +27,7 @@ from sawtooth_integration.tests.integration_tools import RestClient
 LOGGER = logging.getLogger(__name__)
 
 
-URL = 'http://rest-api:8080'
+URL = 'http://rest-api:8008'
 WAIT = 300
 
 

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -39,7 +39,7 @@ class TestIntkeySmoke(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        wait_for_rest_apis(['rest-api:8080'])
+        wait_for_rest_apis(['rest-api:8008'])
 
     def test_intkey_smoke(self):
         '''
@@ -143,7 +143,7 @@ def _get_state():
 
 
 def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
-    url = 'http://rest-api:8080' + suffix
+    url = 'http://rest-api:8008' + suffix
     return _submit_request(urllib.request.Request(url, data, headers),
                            expected_code=expected_code)
 

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -79,7 +79,7 @@ class TestNetworkPermissioning(unittest.TestCase):
         """
 
 
-        walter = Admin("http://127.0.0.1:8080")
+        walter = Admin("http://127.0.0.1:{}".format(8008 + 0))
 
         sawtooth_home0 = mkdtemp()
         self.sawtooth_home[0] = sawtooth_home0
@@ -88,36 +88,35 @@ class TestNetworkPermissioning(unittest.TestCase):
         self.sawtooth_home[1] = sawtooth_home1
 
         with SetSawtoothHome(sawtooth_home0):
-            write_validator_config(sawtooth_home0,
-                                   roles={"network": "trust"},
-                                   endpoint="tcp://127.0.0.1:8800",
-                                   bind=["network:tcp://127.0.0.1:{}".format(8800),
-                                         "component:tcp://127.0.0.1:{}".format(4004)],
-                                   seeds=["tcp://127.0.0.1:8801"],
-                                   peering="dynamic",
-                                   scheduler='parallel')
+            write_validator_config(
+                sawtooth_home0,
+                roles={"network": "trust"},
+                endpoint="tcp://127.0.0.1:{}".format(8800 + 0),
+                bind=["network:tcp://127.0.0.1:{}".format(8800 + 0),
+                      "component:tcp://127.0.0.1:{}".format(4004 + 0)],
+                seeds=["tcp://127.0.0.1:{}".format(8800 + 1)],
+                peering="dynamic",
+                scheduler='parallel')
             validator_non_genesis_init(sawtooth_home1)
             validator_genesis_init(sawtooth_home0, sawtooth_home1,
                                    identity_pub_key=walter.pub_key,
                                    role="network")
             self.processes.extend(start_validator(0, sawtooth_home0))
-            self.clients.append(Client("http://127.0.0.1:8080"))
+            self.clients.append(Client(NodeController.http_address(0)))
 
         with SetSawtoothHome(sawtooth_home1):
-            write_validator_config(sawtooth_home1,
-                                   roles={"network": "trust"},
-                                   endpoint="tcp://127.0.0.1:8801",
-                                   bind=["network:tcp://127.0.0.1:{}".format(
-                                       8801),
-                                         "component:tcp://127.0.0.1:{}".format(
-                                             4005)],
-                                   peering="dynamic",
-                                   seeds=["tcp://127.0.0.1:8800"],
-                                   scheduler='parallel')
+            write_validator_config(
+                sawtooth_home1,
+                roles={"network": "trust"},
+                endpoint="tcp://127.0.0.1:{}".format(8800 + 1),
+                bind=["network:tcp://127.0.0.1:{}".format(8800 + 1),
+                      "component:tcp://127.0.0.1:{}".format(4004 + 1)],
+                peering="dynamic",
+                seeds=["tcp://127.0.0.1:{}".format(8800 + 0)],
+                scheduler='parallel')
 
             self.processes.extend(start_validator(1, sawtooth_home1))
-
-            self.clients.append(Client("http://127.0.0.1:8081"))
+            self.clients.append(Client(NodeController.http_address(1)))
 
         with open(os.path.join(self.sawtooth_home[1], 'keys', 'validator.pub'), 'r') as infile:
             non_genesis_key = infile.read().strip('\n')
@@ -187,7 +186,7 @@ class TestNetworkPermissioning(unittest.TestCase):
 
         """
 
-        walter = Admin("http://127.0.0.1:8082")
+        walter = Admin("http://127.0.0.1:{}".format(8008 + 2))
 
         processes = []
 
@@ -198,38 +197,35 @@ class TestNetworkPermissioning(unittest.TestCase):
         self.sawtooth_home[1] = sawtooth_home1
 
         with SetSawtoothHome(sawtooth_home0):
-            write_validator_config(sawtooth_home0,
-                                   roles={"network": "challenge"},
-                                   endpoint="tcp://127.0.0.1:8802",
-                                   bind=["network:tcp://127.0.0.1:{}".format(
-                                       8802),
-                                         "component:tcp://127.0.0.1:{}".format(
-                                             4006)],
-                                   seeds=["tcp://127.0.0.1:8803"],
-                                   peering="dynamic",
-                                   scheduler='parallel')
+            write_validator_config(
+                sawtooth_home0,
+                roles={"network": "challenge"},
+                endpoint="tcp://127.0.0.1:{}".format(8800 + 2),
+                bind=["network:tcp://127.0.0.1:{}".format(8800 + 2),
+                      "component:tcp://127.0.0.1:{}".format(4004 + 2)],
+                seeds=["tcp://127.0.0.1:{}".format(8800 + 3)],
+                peering="dynamic",
+                scheduler='parallel')
             validator_non_genesis_init(sawtooth_home1)
             validator_genesis_init(sawtooth_home0, sawtooth_home1,
                                    identity_pub_key=walter.pub_key,
                                    role="network")
             processes.extend(start_validator(2, sawtooth_home0))
-            self.clients.append(Client("http://127.0.0.1:8082"))
+            self.clients.append(Client(NodeController.http_address(2)))
 
         with SetSawtoothHome(sawtooth_home1):
-            write_validator_config(sawtooth_home1,
-                                   roles={"network": "challenge"},
-                                   endpoint="tcp://127.0.0.1:8803",
-                                   bind=["network:tcp://127.0.0.1:{}".format(
-                                       8803),
-                                       "component:tcp://127.0.0.1:{}".format(
-                                           4007)],
-                                   peering="dynamic",
-                                   seeds=["tcp://127.0.0.1:8802"],
-                                   scheduler='parallel')
+            write_validator_config(
+                sawtooth_home1,
+                roles={"network": "challenge"},
+                endpoint="tcp://127.0.0.1:{}".format(8800 + 3),
+                bind=["network:tcp://127.0.0.1:{}".format(8800 + 3),
+                      "component:tcp://127.0.0.1:{}".format(4004 + 3)],
+                peering="dynamic",
+                seeds=["tcp://127.0.0.1:{}".format(8800 + 2)],
+                scheduler='parallel')
 
             processes.extend(start_validator(3, sawtooth_home1))
-
-            self.clients.append(Client("http://127.0.0.1:8083"))
+            self.clients.append(Client(NodeController.http_address(3)))
 
         with open(os.path.join(self.sawtooth_home[1], 'keys', 'validator.pub'),
                   'r') as infile:

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -23,7 +23,7 @@ import requests
 
 LOGGER = logging.getLogger(__name__)
 
-URL = 'http://rest-api-%d:8080'
+URL = 'http://rest-api-%d:8008'
 
 # The number of nodes in the test (this needs to match the test's compose file)
 NODES = 5

--- a/integration/sawtooth_integration/tests/test_poet_smoke.py
+++ b/integration/sawtooth_integration/tests/test_poet_smoke.py
@@ -32,7 +32,7 @@ WAIT = 120
 
 class TestPoetSmoke(unittest.TestCase):
     def setUp(self):
-        endpoints = ['rest-api-{}:8080'.format(i)
+        endpoints = ['rest-api-{}:8008'.format(i)
                      for i in range(VALIDATOR_COUNT)]
 
         wait_for_rest_apis(endpoints, tries=10)

--- a/integration/sawtooth_integration/tests/test_transactor_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_transactor_permissioning.py
@@ -30,7 +30,7 @@ class TestTransactorPermissioning(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        REST_API = "rest-api:8080"
+        REST_API = "rest-api:8008"
         wait_for_rest_apis([REST_API])
         cls.REST_ENDPOINT = "http://" + REST_API
 

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -42,7 +42,7 @@ class TestTwoFamilies(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        wait_for_rest_apis(['rest-api:8080'])
+        wait_for_rest_apis(['rest-api:8008'])
 
     def test_two_families(self):
         '''
@@ -86,7 +86,7 @@ class TestTwoFamilies(unittest.TestCase):
             _send_intkey_cmd(intkey_cmd)
             _send_xo_cmd('{} --url {} --wait {}'.format(
                 xo_cmd,
-                'http://rest-api:8080',
+                'http://rest-api:8008',
                 WAIT))
 
             if intkey_cmd == self.intkey_verifier.valid_txns:
@@ -176,7 +176,7 @@ def _get_state_prefix(prefix):
     return response['data']
 
 def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
-    url = 'http://rest-api:8080' + suffix
+    url = 'http://rest-api:8008' + suffix
     return _submit_request(urllib.request.Request(url, data, headers),
                            expected_code=expected_code)
 

--- a/integration/sawtooth_integration/tests/test_web_socket_subscription.js
+++ b/integration/sawtooth_integration/tests/test_web_socket_subscription.js
@@ -16,7 +16,7 @@
  */
 
 
-var ws = new WebSocket('ws:rest-api:8080/subscriptions');
+var ws = new WebSocket('ws:rest-api:8008/subscriptions');
 console.log("WebSocket created");
 
 isEventGood = function(event) {

--- a/integration/sawtooth_integration/tests/test_workload.py
+++ b/integration/sawtooth_integration/tests/test_workload.py
@@ -36,7 +36,7 @@ class TestWorkload(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        url = 'rest-api:8080'
+        url = 'rest-api:8008'
         wait_for_rest_apis([url])
         http = 'http://' + url
         cls.client = RestClient(http)

--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -28,7 +28,7 @@ LOGGER.setLevel(logging.DEBUG)
 
 
 WAIT = 300
-REST_API = 'rest-api:8080'
+REST_API = 'rest-api:8008'
 
 
 class TestXoSmoke(unittest.TestCase):

--- a/perf/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth_workload/src/main.rs
@@ -151,7 +151,7 @@ fn run_submit_command(args: &ArgMatches) -> Result<(), Box<Error>> {
     }
 
     let target: String = match args.value_of("target")
-        .unwrap_or("http://localhost:8080")
+        .unwrap_or("http://localhost:8008")
         .parse() {
             Ok(s) => s,
             Err(_) => String::new()

--- a/perf/smallbank_workload/src/main.rs
+++ b/perf/smallbank_workload/src/main.rs
@@ -158,7 +158,7 @@ fn run_submit_command(args: &ArgMatches) -> Result<(), Box<Error>> {
     }
 
     let target: String = match args.value_of("target")
-        .unwrap_or("http://localhost:8080")
+        .unwrap_or("http://localhost:8008")
         .parse() {
             Ok(s) => s,
             Err(_) => String::new()

--- a/rest_api/packaging/rest_api.toml.example
+++ b/rest_api/packaging/rest_api.toml.example
@@ -3,7 +3,7 @@
 #
 
 # The port and host for the api to run on
-#   bind = ["127.0.0.1:8080"]
+#   bind = ["127.0.0.1:8008"]
 
 # The url to connect to a running Validator
 #   connect = "tcp://localhost:4004"

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 def load_default_rest_api_config():
     return RestApiConfig(
-        bind=["127.0.0.1:8080"],
+        bind=["127.0.0.1:8008"],
         connect="tcp://localhost:4004",
         timeout=300)
 

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -16,13 +16,13 @@ class TestRestApiConfig(unittest.TestCase):
     def test_rest_api_defaults_sawtooth_home(self):
         """Tests the default REST API configuration.
 
-            - bind = ["127.0.0.1:8080"]
+            - bind = ["127.0.0.1:8008"]
             - connect = "tcp://localhost:4004"
             - timeout = 300
 
         """
         config = load_default_rest_api_config()
-        self.assertEqual(config.bind , ["127.0.0.1:8080"])
+        self.assertEqual(config.bind , ["127.0.0.1:8008"])
         self.assertEqual(config.connect, "tcp://localhost:4004")
         self.assertEqual(config.timeout, 300)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
@@ -42,7 +42,7 @@ from sawtooth_intkey.client_cli.exceptions import IntkeyClientException
 DISTRIBUTION_NAME = 'sawtooth-intkey'
 
 
-DEFAULT_URL = 'http://127.0.0.1:8080'
+DEFAULT_URL = 'http://127.0.0.1:8008'
 
 
 def create_console_handler(verbose_level):

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
@@ -227,7 +227,7 @@ def add_workload_parser(subparsers, parent_parser):
     parser.add_argument('-u', '--urls',
                         help='comma separated urls of the REST API to connect '
                         'to.',
-                        default="http://127.0.0.1:8080")
+                        default="http://127.0.0.1:8008")
     parser.add_argument('--auth-user',
                         type=str,
                         help='username for authentication '

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
@@ -114,7 +114,7 @@ def add_load_parser(subparsers, parent_parser):
         '-U', '--url',
         type=str,
         help='url for the REST API',
-        default='http://localhost:8080')
+        default='http://localhost:8008')
 
     parser.add_argument(
         '--auth-user',

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -162,7 +162,7 @@ def add_workload_parser(subparsers, parent_parser):
     parser.add_argument('-u', '--urls',
                         help='comma separated urls of the REST API to connect '
                         'to.',
-                        default="http://127.0.0.1:8080")
+                        default="http://127.0.0.1:8008")
     parser.add_argument('--auth-user',
                         type=str,
                         help='username for authentication '

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -32,7 +32,7 @@ from sawtooth_xo.xo_exceptions import XoException
 DISTRIBUTION_NAME = 'sawtooth-xo'
 
 
-DEFAULT_URL = 'http://127.0.0.1:8080'
+DEFAULT_URL = 'http://127.0.0.1:8008'
 
 
 def create_console_handler(verbose_level):

--- a/tools/Vagrantfile
+++ b/tools/Vagrantfile
@@ -105,7 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.vm.network "forwarded_port", guest: 4004, host: 4004, host_ip: "127.0.0.1"
 
       # rest api
-      config.vm.network "forwarded_port", guest: 8080, host: 18080, host_ip: "127.0.0.1"
+      config.vm.network "forwarded_port", guest: 8008, host: 18008, host_ip: "127.0.0.1"
   end
   config.vm.provision :shell, path: "bootstrap.sh"
 

--- a/tools/guest-files/rethinkdb.instance1.conf
+++ b/tools/guest-files/rethinkdb.instance1.conf
@@ -71,8 +71,8 @@ bind=all
 ### Web options
 
 ## Port for the http admin console
-## Default: 8080 + port-offset
-http-port=18080
+## Default: 8008 + port-offset
+http-port=18008
 
 ## Disable web administration console
 # no-http-admin

--- a/utility/ias_client/tests/unit/test_ias_client.py
+++ b/utility/ias_client/tests/unit/test_ias_client.py
@@ -21,7 +21,7 @@ import requests
 from sawtooth_ias_client.ias_client import IasClient
 import mock_ias_server
 
-URL = "http://127.0.0.1:8080"
+URL = "http://127.0.0.1:8008"
 
 
 class TestIasClient(unittest.TestCase):


### PR DESCRIPTION
8080 is a common port for HTTP services, and is likely to cause collisions. 8008 is similarly derived from the default HTTP port (80), is much less likely to collide, and happens to be twice the default
validator port.