### PR TITLE
Store challenge auth payload in cache

### DIFF
--- a/docs/source/architecture/validator_network.rst
+++ b/docs/source/architecture/validator_network.rst
@@ -353,9 +353,6 @@ Challenge
       // public key of node
       string public_key = 1;
 
-      // payload bytes that was signed to make the signature
-      bytes payload = 2;
-
       // signature derived from signing the challenge payload
       string signature = 3;
 

--- a/protos/authorization.proto
+++ b/protos/authorization.proto
@@ -90,9 +90,6 @@ message AuthorizationChallengeSubmit {
   // public key of node
   string public_key = 1;
 
-  // payload bytes that was signed to make the signature
-  bytes payload = 2;
-
   // signature derived from signing the challenge payload
   string signature = 3;
 

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -891,7 +891,6 @@ class Interconnect(object):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key=self._public_key,
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 
@@ -913,7 +912,6 @@ class Interconnect(object):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key=self._public_key,
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -102,10 +102,11 @@ def add(
             gossip=gossip),
         thread_pool)
 
+    challenge_request_handler = AuthorizationChallengeRequestHandler(
+        network=interconnect)
     dispatcher.add_handler(
         validator_pb2.Message.AUTHORIZATION_CHALLENGE_REQUEST,
-        AuthorizationChallengeRequestHandler(
-            network=interconnect),
+        challenge_request_handler,
         thread_pool)
 
     dispatcher.add_handler(
@@ -113,7 +114,8 @@ def add(
         AuthorizationChallengeSubmitHandler(
             network=interconnect,
             permission_verifier=permission_verifier,
-            gossip=gossip),
+            gossip=gossip,
+            cache=challenge_request_handler.get_challenge_payload_cache()),
         thread_pool)
 
     # -- Gossip -- #

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -316,7 +316,6 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key=public_key,
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 
@@ -352,7 +351,6 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key=public_key,
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 
@@ -365,7 +363,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         permission_verifer = MockPermissionVerifier()
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(
-            network, permission_verifer, gossip)
+            network, permission_verifer, gossip, {"connection_id": payload})
         handler_status = handler.handle(
             "connection_id",
             auth_challenge_submit.SerializeToString())
@@ -388,7 +386,6 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key="other",
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 
@@ -401,7 +398,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         permission_verifer = MockPermissionVerifier()
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(
-            network, permission_verifer, gossip)
+            network, permission_verifer, gossip, {"connection_id": payload})
         handler_status = handler.handle(
             "connection_id",
             auth_challenge_submit.SerializeToString())
@@ -424,7 +421,6 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         auth_challenge_submit = AuthorizationChallengeSubmit(
             public_key=public_key,
-            payload=payload,
             signature=signature,
             roles=[RoleType.Value("NETWORK")])
 
@@ -437,7 +433,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         permission_verifer = MockPermissionVerifier(allow=False)
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(
-            network, permission_verifer, gossip)
+            network, permission_verifer, gossip, {"connection_id": payload})
         handler_status = handler.handle(
             "connection_id",
             auth_challenge_submit.SerializeToString())


### PR DESCRIPTION
Before the payload was included in the response from the authorizing
connection and was trusted without any verification. Instead, the
payload should be stored by the validator and only the signature
returned by the authorizing connection.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>