### PR TITLE
Update the paging and sort controls in the Rest API

### DIFF
--- a/protos/client_list_control.proto
+++ b/protos/client_list_control.proto
@@ -21,40 +21,31 @@ option go_package = "client_list_control_pb2";
 
 // Paging controls to be sent with List requests.
 // Attributes:
-//     start_id: The id of a resource to start the page with
-//     end_id: The id of a resource to end the page with
-//     min_index: A resource index relative to the query, the newest being 0
-//     count: The number of results per page, defaults to and maxes out at 1000
+//     start: The id of a resource to start the page with
+//     limit: The number of results per page, defaults to 100 and maxes out at 1000
 message ClientPagingControls {
-    oneof location_marker {
-        string start_id = 1;
-        string end_id = 2;
-        int32 start_index = 3;
-    }
-    int32 count = 4;
+    string start = 1;
+    int32 limit = 2;
 }
 
 // Information about the pagination used, sent back with List responses.
 // Attributes:
-//     next_id: The id of the first resource in the next page
-//     previous_id: The id of the last resource in the previous page
-//     start_index: The index of the first resource in this page
-//     total_resources: The total resources available from the requested query
+//     next: The id of the first resource in the next page
+//     start: The id of the first resource in the returned page
+//     limit: The number of results per page, defaults to 100 and maxes out at 1000
 message ClientPagingResponse {
-    string next_id = 1;
-    string previous_id = 2;
-    int32 start_index = 3;
-    int32 total_resources = 4;
+    string next = 1;
+    string start = 2;
+    int32 limit = 3;
+
 }
 
 // Sorting controls to be sent with List requests. More than one can be sent.
 // If so, the first is used, and additional controls are tie-breakers.
 // Attributes:
-//     keys: Nested set of keys to sort by (i.e. ['header', 'signer_public_key'])
+//     keys: Nested set of keys to sort by (i.e. ['default, block_num'])
 //     reverse: Whether or not to reverse the sort (i.e. descending order)
-//     compare_length: Sorts by value length, rather than the property itself
 message ClientSortControls {
     repeated string keys = 1;
     bool reverse = 2;
-    bool compare_length = 3;
 }

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -48,10 +48,9 @@ paths:
         Fetches a paginated list of batches from the validator.
       parameters:
         - $ref: "#/parameters/head"
-        - $ref: "#/parameters/count"
-        - $ref: "#/parameters/min"
-        - $ref: "#/parameters/max"
-        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/start"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/reverse"
       responses:
         200:
           description: Successfully retrieved batches
@@ -190,10 +189,9 @@ paths:
           in: query
           type: string
           description: A partial address to filter leaves by
-        - $ref: "#/parameters/count"
-        - $ref: "#/parameters/min"
-        - $ref: "#/parameters/max"
-        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/start"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/reverse"
       responses:
         200:
           description: Successfully retrieved state data
@@ -252,10 +250,9 @@ paths:
         Fetches a paginated list of blocks from the validator.
       parameters:
         - $ref: "#/parameters/head"
-        - $ref: "#/parameters/count"
-        - $ref: "#/parameters/min"
-        - $ref: "#/parameters/max"
-        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/start"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/reverse"
       responses:
         200:
           description: Successfully retrieved blocks
@@ -311,10 +308,9 @@ paths:
         Fetches a paginated list of transactions from the validator.
       parameters:
         - $ref: "#/parameters/head"
-        - $ref: "#/parameters/count"
-        - $ref: "#/parameters/min"
-        - $ref: "#/parameters/max"
-        - $ref: "#/parameters/sort"
+        - $ref: "#/parameters/start"
+        - $ref: "#/parameters/limit"
+        - $ref: "#/parameters/reverse"
       responses:
         200:
           description: Successfully retrieved transactions
@@ -508,33 +504,22 @@ parameters:
     in: query
     type: integer
     description: A time in seconds to wait for commit
-  count:
-    name: count
+  limit:
+    name: limit
     in: query
     type: integer
     default: 1000
     description: Number of items to return
-  min:
-    name: min
+  start:
+    name: start
     in: query
     type: string
-    description: Id or index to start paging (inclusive)
-  max:
-    name: max
+    description: Id to start paging (inclusive)
+  reverse:
+    name: reverse
     in: query
     type: string
-    description: Id or index to end paging (inclusive)
-  sort:
-    name: sort
-    in: query
-    type: string
-    description: |
-      Comma-separated keys to sort a list by:
-        - can reference header keys explicitly or implicitly
-        - dot-notation indicates nested keys
-        - starting a key with a minus-sign indicates descending order
-        - ending a key with `.length` sorts by the length
-        - example: `sort=header.signer_public_key,-transaction_ids.length`
+    description: If the list should be reversed
 
 definitions:
   Head:
@@ -545,18 +530,18 @@ definitions:
     example: https://api.sawtooth.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd
   Paging:
     properties:
-      start_index:
-        type: integer
-        example: 1000
-      total_count:
+      start:
+        type: string
+        example: "65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd"
+      limit:
         type: integer
         example: 54321
-      previous:
+      next_position:
         type: string
-        example: https://api.sawtooth.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd&min=0&count=1000
+        example: "65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd"
       next:
         type: string
-        example: https://api.sawtooth.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd&min=2000&count=1000
+        example: https://api.sawtooth.com/state?head=65cd3a3ce088b265b626f704b7f3db97b6f12e848dccb35d7806f3d0324c71b709ed360d602b8b658b94695374717e3bdb4b76f77886953777d5d008558247dd&start=2000&limit=1000
 
   Error:
     properties:

--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -276,7 +276,7 @@ class StateDeltaSubscriberHandler:
         resp = await self._connection.send(
             Message.CLIENT_BLOCK_LIST_REQUEST,
             client_block_pb2.ClientBlockListRequest(
-                paging=client_list_control_pb2.ClientPagingControls(count=1)
+                paging=client_list_control_pb2.ClientPagingControls(limit=1)
             ).SerializeToString())
 
         block_list_resp = client_block_pb2.ClientBlockListResponse()

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -239,20 +239,12 @@ class BaseApiTest(AioHTTPTestCase):
     def assert_has_valid_paging(self, js_response, pb_paging,
                                 next_link=None, previous_link=None):
         """Asserts a response has a paging dict with the expected values.
-        The expected values for start_index and total_count are in pb_paging.
         """
         self.assertIn('paging', js_response)
         js_paging = js_response['paging']
 
-        self.assertIn('total_count', js_paging)
-        self.assertEqual(js_paging['total_count'], pb_paging.total_resources)
-
-        # if total resources is zero, no start index should be sent
-        if not pb_paging.total_resources:
-            self.assertNotIn('start_index', js_paging)
-        else:
-            self.assertIn('start_index', js_paging)
-            self.assertEqual(js_paging['start_index'], pb_paging.start_index)
+        if pb_paging.next:
+            self.assertIn('next_position', js_paging)
 
         if next_link is not None:
             self.assertIn('next', js_paging)
@@ -260,11 +252,6 @@ class BaseApiTest(AioHTTPTestCase):
         else:
             self.assertNotIn('next', js_paging)
 
-        if previous_link is not None:
-            self.assertIn('previous', js_paging)
-            self.assert_valid_url(js_paging['previous'], previous_link)
-        else:
-            self.assertNotIn('previous', js_paging)
 
     def assert_has_valid_error(self, response, expected_code):
         """Asserts a response has only an error dict with an expected code
@@ -388,34 +375,33 @@ class Mocks(object):
     """A static class with methods that return lists of mock Protobuf objects.
     """
     @staticmethod
-    def make_paging_controls(count=None, start_id=None, end_id=None, start_index=None):
+    def make_paging_controls(limit=None, start=None):
         """Returns a ClientPagingControls Protobuf
         """
         return ClientPagingControls(
-            count=count,
-            start_id=start_id,
-            end_id=end_id,
-            start_index=start_index)
+            limit=limit,
+            start=start
+            )
 
     @staticmethod
-    def make_paging_response(start, total, next_id=None, previous_id=None):
+    def make_paging_response(next_id=None, start=None, limit=None):
         """Returns a ClientPagingResponse Protobuf
         """
         return ClientPagingResponse(
-            start_index=start,
-            total_resources=total,
-            next_id=next_id,
-            previous_id=previous_id)
+            next=next_id,
+            start=start,
+            limit=limit
+            )
 
     @staticmethod
-    def make_sort_controls(*keys, reverse=False, compare_length=False):
+    def make_sort_controls(keys, reverse=False):
         """Returns a ClientSortControls Protobuf in a list. Use concatenation to
         combine multiple sort controls.
         """
         return [ClientSortControls(
-            keys=keys,
-            reverse=reverse,
-            compare_length=compare_length)]
+            keys=[keys],
+            reverse=reverse
+            )]
 
     @staticmethod
     def make_entries(**leaf_data):

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -24,6 +24,8 @@ ID_B = 'b' * 128
 ID_C = 'c' * 128
 ID_D = 'd' * 128
 
+DEFAULT_LIMIT = 100
+
 
 class BatchListTests(BaseApiTest):
 
@@ -42,7 +44,7 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with a start of ID_C and limit of 100
             - three batches with ids of ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
@@ -51,12 +53,12 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/batches?head={}'.format(ID_C)
+            - a link property that ends in '/batches?start={}&limit=100&head={}'.format(ID_C, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
         self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
@@ -65,7 +67,7 @@ class BatchListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/batches?head={}'.format(ID_C))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
@@ -108,7 +110,7 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_B
-            - a paging response with a start of 0, and 2 total resources
+            - a paging response with a start ID_B and limit 100
             - two batches with ids of 1' and ID_A
 
         It should send a Protobuf request with:
@@ -118,12 +120,13 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/batches?head={}'.format(ID_B)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=100'.format(ID_B, ID_B))
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids ID_B and ID_A
         """
-        paging = Mocks.make_paging_response(0, 2)
+        paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_B, ID_A)
         self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
 
@@ -132,7 +135,7 @@ class BatchListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/batches?head={}'.format(ID_B))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_B, ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_B, ID_A)
@@ -159,7 +162,7 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 2 total resources
+            - a paging response with start of ID_C and limit 100
             - two batches with ids of ID_A and ID_C
 
         It should send a Protobuf request with:
@@ -169,12 +172,13 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C, the latest
-            - a link property that ends in '/batches?head={}&id={},{}'.format(ID_C, ID_A, ID_C)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids ID_A and ID_C
         """
-        paging = Mocks.make_paging_response(0, 2)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_A, ID_C)
         self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
@@ -183,7 +187,7 @@ class BatchListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(batch_ids=[ID_A, ID_C], paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/batches?head={}&id={},{}'.format(ID_C, ID_A, ID_C))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_A, ID_C)
@@ -199,11 +203,12 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C, the latest
-            - a link property that ends in '/batches?head={}&id={},{}'.format(ID_C, ID_B, ID_D)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
-        paging = Mocks.make_paging_response(None, 0)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id=ID_C,
@@ -211,7 +216,8 @@ class BatchListTests(BaseApiTest):
         response = await self.get_assert_200('/batches?id={},{}'.format(ID_B, ID_D))
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/batches?head={}&id={},{}'.format(ID_C, ID_B, ID_D))
+        self.assert_has_valid_link(response,
+            '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -221,7 +227,7 @@ class BatchListTests(BaseApiTest):
 
         It should send a Protobuf request with:
             - a head_id property of ID_B
-            - a paging response with a start of 0, and 1 total resource
+            - a paging reponse with a start of ID_B and limit of 100
             - a batch_ids property of [ID_A]
 
         It will receive a Protobuf response with:
@@ -232,12 +238,13 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/batches?head={}&id={}'.format(ID_B, ID_A)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - and that dict is a full batch with an id of ID_A
         """
-        paging = Mocks.make_paging_response(0, 1)
+        paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_A)
         self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
 
@@ -249,56 +256,57 @@ class BatchListTests(BaseApiTest):
             paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/batches?head={}&id={}'.format(ID_B, ID_A))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_batches_well_formed(response['data'], ID_A)
 
     @unittest_run_loop
     async def test_batch_list_paginated(self):
-        """Verifies GET /batches paginated by min id works properly.
+        """Verifies GET /batches paginated by start works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 1, and 4 total resources
+            - a paging response with a start of ID_D, next of ID_C and limit of 1
             - one batch with the id ID_C
 
         It should send a Protobuf request with:
-            - paging controls with a count of 1, and a start_index of 1
+            - paging controls with a start of 1
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/batches?head={}&min=1&count=1'.format(ID_D)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=1'.format(ID_D, ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
             - and that dict is a full batch with the id ID_C
         """
-        paging = Mocks.make_paging_response(1, 4)
+        paging = Mocks.make_paging_response(ID_C, ID_D, 1)
         batches = Mocks.make_batches(ID_C)
         self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?min=1&count=1')
-        controls = Mocks.make_paging_controls(1, start_index=1)
+        response = await self.get_assert_200('/batches?start=1&limit=1')
+        controls = Mocks.make_paging_controls(1, start="1")
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&min=1&count=1'.format(ID_D))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=1'.format(ID_D, ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&min=2&count=1'.format(ID_D),
-                                     '/batches?head={}&min=0&count=1'.format(ID_D))
+                                     '/batches?head={}&start={}&limit=1'.format(ID_D, ID_C))
         self.assert_has_valid_data_list(response, 1)
         self.assert_batches_well_formed(response['data'], ID_C)
 
     @unittest_run_loop
-    async def test_batch_list_with_zero_count(self):
-        """Verifies a GET /batches with a count of zero breaks properly.
+    async def test_batch_list_with_zero_limit(self):
+        """Verifies a GET /batches with a limit of zero breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 53
         """
-        response = await self.get_assert_status('/batches?min=2&count=0', 400)
+        response = await self.get_assert_status('/batches?start=2&limit=0', 400)
 
         self.assert_has_valid_error(response, 53)
 
@@ -314,42 +322,43 @@ class BatchListTests(BaseApiTest):
             - an error property with a code of 54
         """
         self.connection.preset_response(self.status.INVALID_PAGING)
-        response = await self.get_assert_status('/batches?min=-1', 400)
+        response = await self.get_assert_status('/batches?start=-1', 400)
 
         self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
-    async def test_batch_list_paginated_with_just_count(self):
-        """Verifies GET /batches paginated just by count works properly.
+    async def test_batch_list_paginated_with_just_limit(self):
+        """Verifies GET /batches paginated just by limit works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
+            - a paging response with a start ID_D, next ID_B, and limit pf 2
             - two batches with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
-            - paging controls with a count of 2
+            - paging controls with a limit of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/batches?head={}&count=2'.format(ID_D)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=2'.format(ID_D, ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids ID_D and ID_C
         """
-        paging = Mocks.make_paging_response(0, 4)
+        paging = Mocks.make_paging_response(ID_B, ID_D, 2)
         batches = Mocks.make_batches(ID_D, ID_C)
         self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?count=2')
+        response = await self.get_assert_200('/batches?limit=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&count=2'.format(ID_D))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=2'.format(ID_D, ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&min=2&count=2'.format(ID_D))
+                                     '/batches?head={}&start={}&limit=2'.format(ID_D, ID_B))
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_D, ID_C)
 
@@ -359,242 +368,70 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 2, and 4 total resources
+            - a paging response with start of ID_B and limit of 100
             - two batches with the ids ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a start_index of 2
+            - paging controls with a start of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/batches?head={}&min=2'.format(ID_D)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=100'.format(ID_D, ID_B)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids ID_D and ID_C
         """
-        paging = Mocks.make_paging_response(2, 4)
+        paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_B, ID_A)
         self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?min=2')
-        controls = Mocks.make_paging_controls(None, start_index=2)
+        response = await self.get_assert_200('/batches?start={}'.format(ID_B))
+        controls = Mocks.make_paging_controls(None, start=ID_B)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&min=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/batches?head={}&min=0&count=2'.format(ID_D))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_D, ID_B))
+        self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
-    async def test_batch_list_paginated_by_min_id(self):
-        """Verifies GET /batches paginated by a min id works properly.
+    async def test_batch_list_paginated_by_start_id(self):
+        """Verifies GET /batches paginated by a start id works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * total_resources of 4
-                * a previous_id of ID_D
+            - an empty paging response
             - three batches with the ids ID_C, ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a count of 5, and a start_id of ID_C
+            - paging controls with a limit of 5, and a start of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/batches?head={}&min={}&count=5'.format(ID_D, ID_C)
+            - a link property that ends in '/batches?head={}&start={}&limit=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
+        paging = Mocks.make_paging_response("", ID_C, 5)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
         self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?min={}&count=5'.format(ID_C))
-        controls = Mocks.make_paging_controls(5, start_id=ID_C)
+        response = await self.get_assert_200('/batches?start={}&limit=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&min={}&count=5'.format(ID_D, ID_C))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/batches?head={}&max={}&count=5'.format(ID_D, ID_D))
+        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=5'.format(ID_D, ID_C))
+        self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
-    @unittest_run_loop
-    async def test_batch_list_paginated_by_max_id(self):
-        """Verifies GET /batches paginated by a max id works properly.
 
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * a total_resources of 4
-                * a previous_id of ID_D
-                * a next_id of ID_A
-            - two batches with the ids ID_C and ID_B
-
-        It should send a Protobuf request with:
-            - paging controls with a count of 2, and an end_id of ID_B
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/batches?head={}&max={}&count=2'.format(ID_D, ID_B)
-            - paging that matches the response, with next and previous links
-            - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids ID_C and ID_B
-        """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
-        batches = Mocks.make_batches(ID_C, ID_B)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
-
-        response = await self.get_assert_200('/batches?max={}&count=2'.format(ID_B))
-        controls = Mocks.make_paging_controls(2, end_id=ID_B)
-        self.connection.assert_valid_request_sent(paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&max={}&count=2'.format(ID_D, ID_B))
-        self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&min={}&count=2'.format(ID_D, ID_A),
-                                     '/batches?head={}&max={}&count=2'.format(ID_D, ID_D))
-        self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], ID_C, ID_B)
-
-    @unittest_run_loop
-    async def test_batch_list_paginated_by_max_index(self):
-        """Verifies GET /batches paginated by a max index works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
-            - three batches with the ids ID_D, ID_C and ID_B
-
-        It should send a Protobuf request with:
-            - paging controls with a count of 3, and an start_index of 0
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/batches?head={}&min=3&count=7'.format(ID_D)
-            - paging that matches the response, with a next link
-            - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids ID_D, ID_C, and ID_B
-        """
-        paging = Mocks.make_paging_response(0, 4)
-        batches = Mocks.make_batches(ID_D, ID_C, ID_B)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
-
-        response = await self.get_assert_200('/batches?max=2&count=7')
-        controls = Mocks.make_paging_controls(3, start_index=0)
-        self.connection.assert_valid_request_sent(paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&max=2&count=7'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&min=3&count=7'.format(ID_D))
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], ID_D, ID_C, ID_B)
-
-    @unittest_run_loop
-    async def test_batch_list_sorted(self):
-        """Verifies GET /batches can send proper sort controls.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three batches with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'header_signature'
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/batches?head={}&sort=header_signature'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
-
-        response = await self.get_assert_200('/batches?sort=header_signature')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header_signature')
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&sort=header_signature'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
-
-    @unittest_run_loop
-    async def test_batch_list_with_bad_sort(self):
-        """Verifies a GET /batches with a bad sort breaks properly.
-
-        It will receive a Protobuf response with:
-            - a status of INVALID_PAGING
-
-        It should send back a JSON response with:
-            - a response status of 400
-            - an error property with a code of 57
-        """
-        self.connection.preset_response(self.status.INVALID_SORT)
-        response = await self.get_assert_status('/batches?sort=bad', 400)
-
-        self.assert_has_valid_error(response, 57)
-
-    @unittest_run_loop
-    async def test_batch_list_sorted_with_nested_keys(self):
-        """Verifies GET /batches can send proper sort controls with nested keys.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three batches with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with keys of 'header' and 'signer_public_key'
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link ending in '/batches?head={}&sort=header.signer_public_key'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
-
-        response = await self.get_assert_200(
-            '/batches?sort=header.signer_public_key')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header', 'signer_public_key')
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&sort=header.signer_public_key'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_sorted_in_reverse(self):
@@ -602,7 +439,7 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with start of ID_C and limit of 100
             - three batches with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
@@ -612,108 +449,26 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a status of 200
             - a head property of ID_C
-            - a link property ending in '/batches?head={}&sort=-header_signature'.format(ID_C)
+            - a link property ending in
+                '/batches?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
         self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?sort=-header_signature')
+        response = await self.get_assert_200('/batches?reverse')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls(
-            'header_signature', reverse=True)
+        sorting = Mocks.make_sort_controls('default', reverse=True)
         self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head={}&sort=-header_signature'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
-
-    @unittest_run_loop
-    async def test_batch_list_sorted_by_length(self):
-        """Verifies a GET /batches can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three batches with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'transactions' sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/batches?head={}&sort=transactions.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
-
-        response = await self.get_assert_200('/batches?sort=transactions.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('transactions', compare_length=True)
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&sort=transactions.length'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
-
-    @unittest_run_loop
-    async def test_batch_list_sorted_by_many_keys(self):
-        """Verifies a GET /batches can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three batches with ids ID_C, ID_B, and ID_A
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - multiple sort controls with:
-                * a key of 'header_signature' that is reversed
-                * a key of 'transactions' that is sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - link with '/batches?head={}&sort=-header_signature,transactions.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids ID_C, ID_B, and ID_A
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
-
-        response = await self.get_assert_200(
-            '/batches?sort=-header_signature,transactions.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
-                   Mocks.make_sort_controls('transactions', compare_length=True))
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&sort=-header_signature,transactions.length'.format(ID_C))
+            '/batches?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -28,6 +28,8 @@ ID_B = 'b' * 128
 ID_C = 'c' * 128
 ID_D = 'd' * 128
 
+DEFAULT_LIMIT = 100
+
 
 class StateListTests(BaseApiTest):
 
@@ -46,7 +48,7 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a state root of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with start of "a" and a limit of 100
             - three entries with addresses/data of:
                 * 'a': b'3'
                 * 'b': b'5'
@@ -58,12 +60,13 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/state?head={}&min=0&count=3'.format(ID_C)
+            - a link property that ends in
+                /state?head={}&start=a&limit=100'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 leaf dicts
             - three entries that match those in Protobuf response
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", "a", DEFAULT_LIMIT)
         entries = Mocks.make_entries(a=b'3', b=b'5', c=b'7')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -80,7 +83,7 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}'.format(ID_C))
+        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -131,7 +134,7 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_B
-            - a paging response with a start of 0, and 2 total resources
+            - a paging response with start of a and limit of 100
             - two entries with addresses/data of:
                 * 'a': b'2'
                 * 'b': b'4'
@@ -143,12 +146,13 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/state?head={}&min=0&count=2'.format(ID_B)
+            - a link property that ends in
+                '/state?head={}&start=a&limit=100'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 2 leaf dicts
             - three entries that match those in Protobuf response
         """
-        paging = Mocks.make_paging_response(0, 2)
+        paging = Mocks.make_paging_response("", "a", DEFAULT_LIMIT)
         entries = Mocks.make_entries(a=b'2', b=b'4')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -165,7 +169,7 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/state?head={}'.format(ID_B))
+        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
@@ -195,7 +199,7 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 1 total resource
+            - an empty paging response
             - one leaf with addresses/data of: 'c': b'7'
 
         It should send a Protobuf request with:
@@ -206,12 +210,12 @@ class StateListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C
             - a link property that ends in
-            '/state?head={}&min=0&count=1&address=c'.format(ID_C)
+                '/state?head={}&start=c&limit=100&address=c'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 1 leaf dict
             - one leaf that matches the Protobuf response
         """
-        paging = Mocks.make_paging_response(0, 1)
+        paging = Mocks.make_paging_response("", "c", DEFAULT_LIMIT)
         entries = Mocks.make_entries(c=b'7')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -228,7 +232,7 @@ class StateListTests(BaseApiTest):
             state_root='beef', address='c', paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&address=c'.format(ID_C))
+        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&address=c'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
@@ -244,11 +248,11 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/state?head={}&address=bad'.format(ID_C)
+            - a link property that ends in '/state?head={}&start=c&limit=100address=bad'.format(ID_C)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
-        paging = Mocks.make_paging_response(None, 0)
+        paging = Mocks.make_paging_response("", "c", DEFAULT_LIMIT)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
             state_root='beef',
@@ -262,7 +266,7 @@ class StateListTests(BaseApiTest):
         response = await self.get_assert_200('/state?address=bad')
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&address=bad'.format(ID_C))
+        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&address=bad'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -272,7 +276,7 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_B
-            - a paging response with a start of 0, and 1 total resource
+            - a paging response with a start of a and a limit of 100
             - one leaf with addresses/data of: 'a': b'2'
 
         It should send a Protobuf request with:
@@ -284,12 +288,12 @@ class StateListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_B
             - a link property that ends in
-            '/state?head={}&min=0&count=1&address=a'.format(ID_B)
+                '/state?head={}&start=a&limit=100&address=a'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 1 leaf dict
             - one leaf that matches the Protobuf response
         """
-        paging = Mocks.make_paging_response(0, 1)
+        paging = Mocks.make_paging_response("", "a", DEFAULT_LIMIT)
         entries = Mocks.make_entries(a=b'2')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -307,32 +311,33 @@ class StateListTests(BaseApiTest):
             paging=Mocks.make_paging_controls())
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/state?head={}&address=a'.format(ID_B))
+        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100&address=a'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
 
     @unittest_run_loop
     async def test_state_list_paginated(self):
-        """Verifies GET /state paginated by min id works properly.
+        """Verifies GET /state paginated by works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 1, and 4 total resources
+            - a paging response with a start of 2
             - one leaf of {'c': b'3'}
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 1, and a start_index of 1
+            - a paging controls with a limit of 1, and a start of 1
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/state?head={}&min=1&count=1'.format(ID_D)
+            - a link property that ends in
+                '/state?head={}&start=c&limit=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
             - and that dict is a leaf that matches the one received
         """
-        paging = Mocks.make_paging_response(1, 4)
+        paging = Mocks.make_paging_response("b", "c", 1)
         entries = Mocks.make_entries(c=b'3')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -343,28 +348,28 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?min=1&count=1')
-        controls = Mocks.make_paging_controls(1, start_index=1)
+        response = await self.get_assert_200('/state?start=c&limit=1')
+        controls = Mocks.make_paging_controls(1, start="c")
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&min=1&count=1'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=c&limit=1'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&min=2&count=1'.format(ID_D),
-                                     '/state?head={}&min=0&count=1'.format(ID_D))
+                                     '/state?head={}&start=b&limit=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
 
     @unittest_run_loop
-    async def test_state_list_with_zero_count(self):
-        """Verifies a GET /state with a count of zero breaks properly.
+    async def test_state_list_with_zero_limit(self):
+        """Verifies a GET /state with a limit of zero breaks properly.
 
         It should send back a JSON response with:
             - a response status of 400
             - an error property with a code of 53
         """
-        response = await self.get_assert_status('/state?min=2&count=0', 400)
+        response = await self.get_assert_status('/state?start=2&limit=0', 400)
 
         self.assert_has_valid_error(response, 53)
 
@@ -383,31 +388,32 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block())
-        response = await self.get_assert_status('/state?min=-1', 400)
+        response = await self.get_assert_status('/state?start=-1', 400)
 
         self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
-    async def test_state_list_paginated_with_just_count(self):
-        """Verifies GET /state paginated just by count works properly.
+    async def test_state_list_paginated_with_just_limit(self):
+        """Verifies GET /state paginated just by limit works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
+            - a paging response with a start of d and limit of 2
             - two entries of {ID_D: b'4'}, and {'c': b'3'}
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2
+            - a paging controls with a limit of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/state?head={}&min=0&count=2'.format(ID_D)
+            - a link property that ends in
+                '/state?head={}&start=d&limit=2'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
         """
-        paging = Mocks.make_paging_response(0, 4)
+        paging = Mocks.make_paging_response("b", "d", 2)
         entries = Mocks.make_entries(d=b'4', c=b'3')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -418,15 +424,15 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?count=2')
+        response = await self.get_assert_200('/state?limit=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&count=2'.format(ID_D))
+        self.assert_has_valid_link(response, '/state?head={}&start=d&limit=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&min=2&count=2'.format(ID_D))
+                                     '/state?head={}&start=b&limit=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
@@ -436,21 +442,22 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 2, and 4 total resources
+            - a paging response start of "b" and limit of 100
             - two entries of {'b': b'2'} and {'a': b'1'}
 
         It should send a Protobuf request with:
-            - a paging controls with a start_index of 2
+            - a paging controls with a start of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/state?head={}&min=2&count=2'.format(ID_D)
+            - a link property that ends in
+                '/state?head={}&start=b&limit=100'.format(ID_D))
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
         """
-        paging = Mocks.make_paging_response(2, 4)
+        paging = Mocks.make_paging_response("", "b", DEFAULT_LIMIT)
         entries = Mocks.make_entries(b=b'2', a=b'1')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -461,28 +468,24 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?min=2')
-        controls = Mocks.make_paging_controls(None, start_index=2)
+        response = await self.get_assert_200('/state?start=2')
+        controls = Mocks.make_paging_controls(None, start="2")
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&min=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/state?head={}&min=0&count=2'.format(ID_D))
+        self.assert_has_valid_link(response, '/state?head={}&start=b&limit=100'.format(ID_D))
+        self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
     @unittest_run_loop
-    async def test_state_list_paginated_by_min_id(self):
-        """Verifies GET /state paginated by a min id works properly.
+    async def test_state_list_paginated_by_start_id(self):
+        """Verifies GET /state paginated by a start id works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * total_resources of 4
-                * a previous_id of ID_D
+            - a paging response with a start of c and limit of 5
             - three entries of {'c': b'3'}, {'b': b'2'}, and {'a': b'1'}
 
         It should send a Protobuf request with:
@@ -491,12 +494,12 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/state?head={}&min={}&count=5'.format(ID_D, ID_C)
+            - a link property that ends in '/state?head={}&start=c&limit=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are entries that match those received
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
+        paging = Mocks.make_paging_response("", "c", 5)
         entries = Mocks.make_entries(c=b'3', b=b'2', a=b'1')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -507,176 +510,17 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?min={}&count=5'.format(ID_C))
-        controls = Mocks.make_paging_controls(5, start_id=ID_C)
+        response = await self.get_assert_200('/state?start=c&limit=5')
+        controls = Mocks.make_paging_controls(5, "c")
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&min={}&count=5'.format(ID_D, ID_C))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/state?head={}&max={}&count=5'.format(ID_D, ID_D))
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_entries_match(entries, response['data'])
-
-    @unittest_run_loop
-    async def test_state_list_paginated_by_max_id(self):
-        """Verifies GET /state paginated by a max id works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * a total_resources of 4
-                * a previous_id of ID_D
-                * a next_id of ID_A
-            - two entries of {'c': b'3'} and {'b': b'3'}
-
-        It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an end_id of ID_B
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/state?head={}&max={}&count=2'.format(ID_D, ID_B)
-            - paging that matches the response, with next and previous links
-            - a data property that is a list of 2 dicts
-            - and those dicts are entries that match those received
-        """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
-        entries = Mocks.make_entries(c=b'3', b=b'2')
-        self.connection.preset_response(state_root='beef', paging=paging,
-                                        entries=entries)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block(
-                header_signature=ID_D,
-                header=block_pb2.BlockHeader(
-                    state_root_hash='beef').SerializeToString()))
-
-        response = await self.get_assert_200('/state?max={}&count=2'.format(ID_B))
-        controls = Mocks.make_paging_controls(2, end_id=ID_B)
-        self.connection.assert_valid_request_sent(
-            state_root='beef', paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&max={}&count=2'.format(ID_D, ID_B))
-        self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&min={}&count=2'.format(ID_D, ID_A),
-                                     '/state?head={}&max={}&count=2'.format(ID_D, ID_D))
-        self.assert_has_valid_data_list(response, 2)
-        self.assert_entries_match(entries, response['data'])
-
-    @unittest_run_loop
-    async def test_state_list_paginated_by_max_index(self):
-        """Verifies GET /state paginated by a max index works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
-            - three entries with the ids {ID_D: b'4'}, {'c': b'3'} and {'b': b'2'}
-
-        It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an start_index of 0
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/state?head={}&min=3&count=7'.format(ID_D)
-            - paging that matches the response, with a next link
-            - a data property that is a list of 2 dicts
-            - and those dicts are entries that match those received
-        """
-        paging = Mocks.make_paging_response(0, 4)
-        entries = Mocks.make_entries(d=b'4', c=b'3', b=b'2')
-        self.connection.preset_response(state_root='beef', paging=paging,
-                                        entries=entries)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block(
-                header_signature=ID_D,
-                header=block_pb2.BlockHeader(
-                    state_root_hash='beef').SerializeToString()))
-
-        response = await self.get_assert_200('/state?max=2&count=7')
-        controls = Mocks.make_paging_controls(3, start_index=0)
-        self.connection.assert_valid_request_sent(
-            state_root='beef', paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&max=2&count=7'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&min=3&count=7'.format(ID_D))
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_entries_match(entries, response['data'])
-
-    @unittest_run_loop
-    async def test_state_list_sorted(self):
-        """Verifies GET /state can send proper sort controls.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three entries with addresses/data of:
-                * 'a': b'3'
-                * 'b': b'5'
-                * 'c': b'7'
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'address'
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/state?head={}&sort=address'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - three entries that match those in Protobuf response
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        entries = Mocks.make_entries(a=b'3', b=b'5', c=b'7')
-        self.connection.preset_response(state_root='beef', paging=paging,
-                                        entries=entries)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block(
-                header_signature=ID_C,
-                header=block_pb2.BlockHeader(
-                    state_root_hash='beef').SerializeToString()))
-
-        response = await self.get_assert_200('/state?sort=address')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('address')
-        self.connection.assert_valid_request_sent(
-            state_root='beef',
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&sort=address'.format(ID_C))
+        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=5'.format(ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
 
-    @unittest_run_loop
-    async def test_batch_list_with_bad_sort(self):
-        """Verifies a GET /state with a bad sort breaks properly.
-
-        It will receive a Protobuf response with:
-            - a status of INVALID_PAGING
-
-        It should send back a JSON response with:
-            - a response status of 400
-            - an error property with a code of 57
-        """
-        self.connection.preset_response(self.status.INVALID_SORT)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block())
-        response = await self.get_assert_status('/state?sort=bad', 400)
-
-        self.assert_has_valid_error(response, 57)
 
     @unittest_run_loop
     async def test_state_list_sorted_in_reverse(self):
@@ -684,7 +528,7 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with a start of c and  limit of 100
             - three entries with addresses/data of:
                 * 'c': b'7'
                 * 'b': b'5'
@@ -697,12 +541,13 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a status of 200
             - a head property of ID_C
-            - a link property ending in '/state?head={}&sort=-address'.format(ID_C)
+            - a link property ending in
+                '/state?head={}&start=c&limit=100&reverse'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - three entries that match those in Protobuf response
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", "c", DEFAULT_LIMIT)
         entries = Mocks.make_entries(c=b'7', b=b'5', a=b'3')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
@@ -713,119 +558,16 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?sort=-address')
+        response = await self.get_assert_200('/state?reverse')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('address', reverse=True)
+        sorting = Mocks.make_sort_controls('default', reverse=True)
         self.connection.assert_valid_request_sent(
             state_root='beef',
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&sort=-address'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_entries_match(entries, response['data'])
-
-    @unittest_run_loop
-    async def test_state_list_sorted_by_length(self):
-        """Verifies a GET /state can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three entries with addresses/data of:
-                * 'c': b'7'
-                * 'b': b'45'
-                * 'a': b'123'
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'value' sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/state?head={}&sort=value.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - three entries that match those in Protobuf response
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        entries = Mocks.make_entries(c=b'7', b=b'45', a=b'123')
-        self.connection.preset_response(state_root='beef', paging=paging,
-                                        entries=entries)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block(
-                header_signature=ID_C,
-                header=block_pb2.BlockHeader(
-                    state_root_hash='beef').SerializeToString()))
-
-        response = await self.get_assert_200('/state?sort=value.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('value', compare_length=True)
-        self.connection.assert_valid_request_sent(
-            state_root='beef',
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&sort=value.length'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_entries_match(entries, response['data'])
-
-    @unittest_run_loop
-    async def test_state_list_sorted_by_many_keys(self):
-        """Verifies a GET /state can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three entries with addresses/data of:
-                * 'c': b'7'
-                * 'b': b'5'
-                * 'a': b'3'
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - multiple sort controls with:
-                * a key of 'address' that is reversed
-                * a key of 'value' that is sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - link with '/state?head={}&sort=-address,value.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - three entries that match those in Protobuf response
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        entries = Mocks.make_entries(c=b'7', b=b'5', a=b'3')
-        self.connection.preset_response(state_root='beef', paging=paging,
-                                        entries=entries)
-        self.connection.preset_response(
-            proto=client_block_pb2.ClientBlockGetResponse,
-            block=block_pb2.Block(
-                header_signature=ID_C,
-                header=block_pb2.BlockHeader(
-                    state_root_hash='beef').SerializeToString()))
-
-        response = await self.get_assert_200(
-            '/state?sort=-address,value.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = (Mocks.make_sort_controls('address', reverse=True) +
-                   Mocks.make_sort_controls('value', compare_length=True))
-        self.connection.assert_valid_request_sent(
-            state_root='beef',
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/state?head={}&sort=-address,value.length'.format(ID_C))
+        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&reverse'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -24,6 +24,8 @@ ID_B = 'b' * 128
 ID_C = 'c' * 128
 ID_D = 'd' * 128
 
+DEFAULT_LIMIT = 100
+
 
 class TransactionListTests(BaseApiTest):
 
@@ -43,7 +45,7 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with a start of ID_C and limit of 100
             - three transactions with ids of ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
@@ -52,12 +54,13 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/transactions?head={}'.format(ID_C)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100'.format(ID_C, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
             head_id=ID_C,
             paging=paging,
@@ -68,7 +71,9 @@ class TransactionListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/transactions?head={}'.format(ID_C))
+        self.assert_has_valid_link(
+            response,
+            '/transactions?head={}&start={}&limit=100'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
@@ -111,7 +116,7 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_B
-            - a paging response with a start of 0, and 2 total resources
+            - a paging response with a start of ID_B and limit of 100
             - two transactions with ids of 1' and ID_A
 
         It should send a Protobuf request with:
@@ -121,12 +126,13 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/transactions?head={}'.format(ID_B)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100'.format(ID_B, ID_B))
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - those dicts are full transactions with ids ID_B and ID_A
         """
-        paging = Mocks.make_paging_response(0, 2)
+        paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         self.connection.preset_response(
             head_id=ID_B,
             paging=paging,
@@ -135,9 +141,10 @@ class TransactionListTests(BaseApiTest):
         response = await self.get_assert_200('/transactions?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
-
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/transactions?head={}'.format(ID_B))
+        self.assert_has_valid_link(
+            response,
+            '/transactions?head={}&start={}&limit=100'.format(ID_B, ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_B, ID_A)
@@ -164,7 +171,7 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 2 total resources
+            - a paging response with a start of ID_C and limit of 100
             - two transactions with ids of ID_A and ID_C
 
         It should send a Protobuf request with:
@@ -174,12 +181,13 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C, the latest
-            - a link property that ends in '/transactions?head={}&id={},{}'.format(ID_C, ID_A, ID_C)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - those dicts are full transactions with ids ID_A and ID_C
         """
-        paging = Mocks.make_paging_response(0, 2)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         transactions = Mocks.make_txns(ID_A, ID_C)
         self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
@@ -188,7 +196,8 @@ class TransactionListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(transaction_ids=[ID_A, ID_C], paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/transactions?head={}&id={},{}'.format(ID_C, ID_A, ID_C))
+        self.assert_has_valid_link(
+            response, '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_A, ID_C)
@@ -204,11 +213,12 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C, the latest
-            - a link property that ends in '/transactions?head={}&id={},{}'.format(ID_C, ID_B, ID_D)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
-        paging = Mocks.make_paging_response(None, 0)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
             head_id=ID_C,
@@ -216,7 +226,9 @@ class TransactionListTests(BaseApiTest):
         response = await self.get_assert_200('/transactions?id={},{}'.format(ID_B, ID_D))
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/transactions?head={}&id={},{}'.format(ID_C, ID_B, ID_D))
+        self.assert_has_valid_link(
+            response,
+            '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -226,7 +238,7 @@ class TransactionListTests(BaseApiTest):
 
         It should send a Protobuf request with:
             - a head_id property of ID_B
-            - a paging response with a start of 0, and 1 total resource
+            - a paging response with a start of ID_B and limit of 100
             - a transaction_ids property of [ID_A]
 
         It will receive a Protobuf response with:
@@ -237,12 +249,13 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/transactions?head={}&id={}'.format(ID_B, ID_A)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - that dict is a full transaction with an id of ID_A
         """
-        paging = Mocks.make_paging_response(0, 1)
+        paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         self.connection.preset_response(
             head_id=ID_B,
             paging=paging,
@@ -256,48 +269,11 @@ class TransactionListTests(BaseApiTest):
             paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/transactions?head={}&id={}'.format(ID_B, ID_A))
+        self.assert_has_valid_link(
+            response, '/transactions?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_txns_well_formed(response['data'], ID_A)
-
-    @unittest_run_loop
-    async def test_txn_list_paginated(self):
-        """Verifies GET /transactions paginated by min id works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with a start of 1, and 4 total resources
-            - one transaction with the id ID_C
-
-        It should send a Protobuf request with:
-            - paging controls with a count of 1, and a start_index of 1
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&min=1&count=1'.format(ID_D)
-            - paging that matches the response, with next and previous links
-            - a data property that is a list of 1 dict
-            - that dict is a full transaction with the id ID_C
-        """
-        paging = Mocks.make_paging_response(1, 4)
-        self.connection.preset_response(
-            head_id=ID_D,
-            paging=paging,
-            transactions=Mocks.make_txns(ID_C))
-
-        response = await self.get_assert_200('/transactions?min=1&count=1')
-        controls = Mocks.make_paging_controls(1, start_index=1)
-        self.connection.assert_valid_request_sent(paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&min=1&count=1'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head={}&min=2&count=1'.format(ID_D),
-                                     '/transactions?head={}&min=0&count=1'.format(ID_D))
-        self.assert_has_valid_data_list(response, 1)
-        self.assert_txns_well_formed(response['data'], ID_C)
 
     @unittest_run_loop
     async def test_txn_list_with_zero_count(self):
@@ -307,7 +283,7 @@ class TransactionListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 53
         """
-        response = await self.get_assert_status('/transactions?count=0', 400)
+        response = await self.get_assert_status('/transactions?limit=0', 400)
 
         self.assert_has_valid_error(response, 53)
 
@@ -328,39 +304,42 @@ class TransactionListTests(BaseApiTest):
         self.assert_has_valid_error(response, 54)
 
     @unittest_run_loop
-    async def test_txn_list_paginated_with_just_count(self):
-        """Verifies GET /transactions paginated just by count works properly.
+    async def test_txn_list_paginated_with_just_limit(self):
+        """Verifies GET /transactions paginated just by limit works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
+            - a paging response with a start of ID_D, next of ID_B and limit of 2
             - two transactions with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
-            - paging controls with a count of 2
+            - paging controls with a limit of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&count=2'.format(ID_D)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=2'.format(ID_D, ID_D))
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - those dicts are full transactions with ids ID_D and ID_C
         """
-        paging = Mocks.make_paging_response(0, 4)
+        paging = Mocks.make_paging_response(ID_B, ID_D, 2)
         self.connection.preset_response(
             head_id=ID_D,
             paging=paging,
             transactions=Mocks.make_txns(ID_D, ID_C))
 
-        response = await self.get_assert_200('/transactions?count=2')
+        response = await self.get_assert_200('/transactions?limit=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&count=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head={}&min=2&count=2'.format(ID_D))
+        self.assert_has_valid_link(response,
+            '/transactions?head={}&start={}&limit=2'.format(ID_D, ID_D))
+        self.assert_has_valid_paging(
+            response, paging,
+            '/transactions?head={}&start={}&limit=2'.format(ID_D, ID_B))
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_D, ID_C)
 
@@ -370,47 +349,45 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of 2, and 4 total resources
+            - a paging response with a start of ID_D and a limit of 100
             - two transactions with the ids ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a start_index of 2
+            - paging controls with a start of 2
 
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&min=2'.format(ID_D)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=100'.format(ID_D, ID_D))
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - those dicts are full transactions with ids ID_D and ID_C
         """
-        paging = Mocks.make_paging_response(2, 4)
+        paging = Mocks.make_paging_response("", ID_D, DEFAULT_LIMIT)
         self.connection.preset_response(
             head_id=ID_D,
             paging=paging,
             transactions=Mocks.make_txns(ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?min=2')
-        controls = Mocks.make_paging_controls(None, start_index=2)
+        response = await self.get_assert_200('/transactions?start=2')
+        controls = Mocks.make_paging_controls(None, start="2")
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&min=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/transactions?head={}&min=0&count=2'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/transactions?head={}&start={}&limit=100'.format(ID_D, ID_D))
+        self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
-    async def test_txn_list_paginated_by_min_id(self):
-        """Verifies GET /transactions paginated by a min id works properly.
+    async def test_txn_list_paginated_by_start_id(self):
+        """Verifies GET /transactions paginated by a start id works properly.
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * total_resources of 4
-                * a previous_id of ID_D
+            - a paging response with start of ID_C and limit of 5
             - three transactions with the ids ID_C, ID_B and ID_A
 
         It should send a Protobuf request with:
@@ -419,201 +396,28 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&min={}&count=5'.format(ID_D, ID_C)
+            - a link property that ends in
+                '/transactions?head={}&start={}&limit=5'.format(ID_D, ID_C))
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
+        paging = Mocks.make_paging_response("", ID_C, 5)
         self.connection.preset_response(
             head_id=ID_D,
             paging=paging,
             transactions=Mocks.make_txns(ID_C, ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?min={}&count=5'.format(ID_C))
-        controls = Mocks.make_paging_controls(5, start_id=ID_C)
+        response = await self.get_assert_200('/transactions?start={}&limit=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&min={}&count=5'.format(ID_D, ID_C))
-        self.assert_has_valid_paging(response, paging,
-                                     previous_link='/transactions?head={}&max={}&count=5'.format(ID_D, ID_D))
+        self.assert_has_valid_link(response, '/transactions?head={}&start={}&limit=5'.format(ID_D, ID_C))
+        self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
-    @unittest_run_loop
-    async def test_txn_list_paginated_by_max_id(self):
-        """Verifies GET /transactions paginated by a max id works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with:
-                * a start_index of 1
-                * a total_resources of 4
-                * a previous_id of ID_D
-                * a next_id of ID_A
-            - two transactions with the ids ID_C and ID_B
-
-        It should send a Protobuf request with:
-            - paging controls with a count of 2, and an end_id of ID_B
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&max={}&count=2'.format(ID_D, ID_B)
-            - paging that matches the response, with next and previous links
-            - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids ID_C and ID_B
-        """
-        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
-        self.connection.preset_response(
-            head_id=ID_D,
-            paging=paging,
-            transactions=Mocks.make_txns(ID_C, ID_B))
-
-        response = await self.get_assert_200('/transactions?max={}&count=2'.format(ID_B))
-        controls = Mocks.make_paging_controls(2, end_id=ID_B)
-        self.connection.assert_valid_request_sent(paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&max={}&count=2'.format(ID_D, ID_B))
-        self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head={}&min={}&count=2'.format(ID_D, ID_A),
-                                     '/transactions?head={}&max={}&count=2'.format(ID_D, ID_D))
-        self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], ID_C, ID_B)
-
-    @unittest_run_loop
-    async def test_txn_list_paginated_by_max_index(self):
-        """Verifies GET /transactions paginated by a max index works properly.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_D
-            - a paging response with a start of 0, and 4 total resources
-            - three transactions with the ids ID_D, ID_C and ID_B
-
-        It should send a Protobuf request with:
-            - paging controls with a count of 3, and an start_index of 0
-
-        It should send back a JSON response with:
-            - a response status of 200
-            - a head property of ID_D
-            - a link property that ends in '/transactions?head={}&min=3&count=7'.format(ID_D)
-            - paging that matches the response, with a next link
-            - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids ID_D, ID_C, and ID_B
-        """
-        paging = Mocks.make_paging_response(0, 4)
-        self.connection.preset_response(
-            head_id=ID_D,
-            paging=paging,
-            transactions=Mocks.make_txns(ID_D, ID_C, ID_B))
-
-        response = await self.get_assert_200('/transactions?max=2&count=7')
-        controls = Mocks.make_paging_controls(3, start_index=0)
-        self.connection.assert_valid_request_sent(paging=controls)
-
-        self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&max=2&count=7'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head={}&min=3&count=7'.format(ID_D))
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], ID_D, ID_C, ID_B)
-
-    @unittest_run_loop
-    async def test_txn_list_sorted(self):
-        """Verifies GET /transactions can send proper sort controls.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'header_signature'
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/transactions?head={}&sort=header_signature'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
-
-        response = await self.get_assert_200('/transactions?sort=header_signature')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header_signature')
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&sort=header_signature'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
-
-    @unittest_run_loop
-    async def test_batch_list_with_bad_sort(self):
-        """Verifies a GET /transactions with a bad sort breaks properly.
-
-        It will receive a Protobuf response with:
-            - a status of INVALID_PAGING
-
-        It should send back a JSON response with:
-            - a response status of 400
-            - an error property with a code of 57
-        """
-        self.connection.preset_response(self.status.INVALID_SORT)
-        response = await self.get_assert_status('/transactions?sort=bad', 400)
-
-        self.assert_has_valid_error(response, 57)
-
-    @unittest_run_loop
-    async def test_txn_list_sorted_with_nested_keys(self):
-        """Verifies GET /transactions can send proper sort controls with nested keys.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with keys of 'header' and 'signer_public_key'
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link ending in '/transactions?head={}&sort=header.signer_public_key'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
-
-        response = await self.get_assert_200(
-            '/transactions?sort=header.signer_public_key')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('header', 'signer_public_key')
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&sort=header.signer_public_key'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_txn_list_sorted_in_reverse(self):
@@ -621,7 +425,7 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
+            - a paging response with start of ID_C and limit of 100
             - three transactions with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
@@ -631,108 +435,25 @@ class TransactionListTests(BaseApiTest):
         It should send back a JSON response with:
             - a status of 200
             - a head property of ID_C
-            - a link property ending in '/transactions?head={}&sort=-header_signature'.format(ID_C)
+            - a link property ending in
+                '/transactions?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(0, 3)
+        paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         transactions = Mocks.make_txns(ID_C, ID_B, ID_A)
         self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
-
-        response = await self.get_assert_200('/transactions?sort=-header_signature')
+        response = await self.get_assert_200('/transactions?reverse')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls(
-            'header_signature', reverse=True)
+        sorting = Mocks.make_sort_controls("default", reverse=True)
         self.connection.assert_valid_request_sent(
             paging=page_controls,
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head={}&sort=-header_signature'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
-
-    @unittest_run_loop
-    async def test_txn_list_sorted_by_length(self):
-        """Verifies a GET /transactions can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids ID_A, ID_B, and ID_C
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - sort controls with a key of 'payload' sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - a link property ending in '/transactions?head={}&sort=payload.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
-
-        response = await self.get_assert_200('/transactions?sort=payload.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls('payload', compare_length=True)
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&sort=payload.length'.format(ID_C))
-        self.assert_has_valid_paging(response, paging)
-        self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
-
-    @unittest_run_loop
-    async def test_txn_list_sorted_by_many_keys(self):
-        """Verifies a GET /transactions can send proper sort parameters.
-
-        It will receive a Protobuf response with:
-            - a head id of ID_C
-            - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids ID_C, ID_B, and ID_A
-
-        It should send a Protobuf request with:
-            - empty paging controls
-            - multiple sort controls with:
-                * a key of 'header_signature' that is reversed
-                * a key of 'payload' that is sorted by length
-
-        It should send back a JSON response with:
-            - a status of 200
-            - a head property of ID_C
-            - link with '/transactions?head={}&sort=-header_signature,payload.length'.format(ID_C)
-            - a paging property that matches the paging response
-            - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids ID_C, ID_B, and ID_A
-        """
-        paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
-
-        response = await self.get_assert_200(
-            '/transactions?sort=-header_signature,payload.length')
-        page_controls = Mocks.make_paging_controls()
-        sorting = (Mocks.make_sort_controls('header_signature', reverse=True) +
-                   Mocks.make_sort_controls('payload', compare_length=True))
-        self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
-
-        self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&sort=-header_signature,payload.length'.format(ID_C))
+            '/transactions?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)

--- a/validator/tests/test_client_request_handlers/base_case.py
+++ b/validator/tests/test_client_request_handlers/base_case.py
@@ -40,19 +40,16 @@ class ClientHandlerTestCase(unittest.TestCase):
         """Parses out paging kwargs and adds them into a ClientPagingControls object,
         before sending it all on to `make_request`
         """
-        paging_keys = ['start_id', 'end_id', 'start_index', 'count']
+        paging_keys = ['start', 'limit']
         paging_args = {k: kwargs.pop(k) for k in paging_keys if k in kwargs}
         paging_request = client_list_control_pb2.ClientPagingControls(**paging_args)
         return self.make_request(paging=paging_request, **kwargs)
 
-    def make_sort_controls(self, *keys, reverse=False, compare_length=False):
+    def make_sort_controls(self, *keys, reverse=False):
         """Creates a ClientSortControls object and returns it in a list. Use
         concatenation to combine multiple ClientSortControls.
         """
-        return [client_list_control_pb2.ClientSortControls(
-            keys=keys,
-            reverse=reverse,
-            compare_length=compare_length)]
+        return [client_list_control_pb2.ClientSortControls(keys=keys, reverse=reverse)]
 
     def _serialize(self, **kwargs):
         request = self._request_proto(**kwargs)
@@ -86,13 +83,11 @@ class ClientHandlerTestCase(unittest.TestCase):
         for item in items:
             self.assertIsInstance(item, cls)
 
-    def assert_valid_paging(self, response, next_id='', previous_id='',
-                            start_index=0, total=3):
+    def assert_valid_paging(self, response, start, limit, next_id=''):
         """Checks that a response's ClientPagingResponse is set properly.
         Defaults to expecting a single page with all mock resources.
         """
         self.assertIsInstance(response.paging, client_list_control_pb2.ClientPagingResponse)
-        self.assertEqual(response.paging.next_id, next_id)
-        self.assertEqual(response.paging.previous_id, previous_id)
-        self.assertEqual(response.paging.start_index, start_index)
-        self.assertEqual(response.paging.total_resources, total)
+        self.assertEqual(response.paging.start, start)
+        self.assertEqual(response.paging.limit, limit)
+        self.assertEqual(response.paging.next, next_id)

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -48,7 +48,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2' (the latest)
-            - the default paging response, showing all 3 resources returned
+            - a paging response with a start of A_2 and 100
             - a list of batches with 3 items
             - the items are instances of Batch
             - the first item has a header_signature of 'aaa...2'
@@ -57,7 +57,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
+        self.assert_valid_paging(response, A_2, 100)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_2, response.batches[0].header_signature)
@@ -101,7 +101,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...1'
-            - a paging response showing all 2 resources returned
+            - a paging response with start of A_1 and limit 100
             - a list of batches with 2 items
             - the items are instances of Batch
             - the first item has a header_signature of 'aaa...1'
@@ -110,7 +110,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, total=2)
+        self.assert_valid_paging(response, A_1, 100)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_1, response.batches[0].header_signature)
@@ -140,7 +140,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 2 resources returned
+            - a paging response with start of A_0 and limit 100
             - a list of batches with 2 items
             - the items are instances of Batch
             - the first item has a header_signature of 'aaa...0'
@@ -150,7 +150,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, total=2)
+        self.assert_valid_paging(response, A_0, 100)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_0, response.batches[0].header_signature)
@@ -187,7 +187,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 1 resources returned
+            - a paging response with start of A_1 and limit 100
             - a list of batches with 1 items
             - that item is an instances of Batch
             - that item has a header_signature of 'aaa...1'
@@ -196,7 +196,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, total=1)
+        self.assert_valid_paging(response, A_1, 100)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_1, response.batches[0].header_signature)
@@ -211,7 +211,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...1'
-            - a paging response showing all 1 resources returned
+            - a paging response with start of A_0 and limit 100
             - a list of batches with 1 item
             - that item is an instance of Batch
             - that item has a header_signature of 'aaa...0'
@@ -220,7 +220,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, total=1)
+        self.assert_valid_paging(response, A_0, 100)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_0, response.batches[0].header_signature)
@@ -244,7 +244,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assertFalse(response.batches)
 
     def test_batch_list_paginated(self):
-        """Verifies requests for batch lists work when paginated just by count.
+        """Verifies requests for batch lists work when paginated just by limit.
 
         Queries the default mock block store:
             {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...1' ...}] ...}
@@ -254,26 +254,22 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response with:
-                * a next_id of 'aaa...0'
-                * the default empty previous_id
-                * the default start_index of 0
-                * the default total resource count of 3
+            - a paging response with start of A_2, limit 2, and next b-0
             - a list of batches with 2 items
             - those items are instances of Batch
             - the first item has a header_signature of 'aaa...2'
         """
-        response = self.make_paged_request(count=2)
+        response = self.make_paged_request(limit=2)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, next_id=A_0)
+        self.assert_valid_paging(response, A_2, 2, next_id=A_0)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_2, response.batches[0].header_signature)
 
     def test_batch_list_paginated_by_start_id (self):
-        """Verifies batch list requests work paginated by count and start_id.
+        """Verifies batch list requests work paginated by limit and start_id.
 
         Queries the default mock block store:
             {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
@@ -283,77 +279,19 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response with:
-                * a next_id of 'aaa...0'
-                * a previous_id of 'aaa...2'
-                * a start_index of 1
-                * the default total resource count of 3
+            - a paging response with start of A_1 and limit 1, next A_2
             - a list of batches with 1 item
             - that item is an instance of Batch
             - that item has a header_signature of 'aaa...1'
         """
-        response = self.make_paged_request(count=1, start_id=A_1)
+        response = self.make_paged_request(limit=1, start=A_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, A_0, A_2, 1)
+        self.assert_valid_paging(response, A_1, 1, A_0)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_1, response.batches[0].header_signature)
-
-    def test_batch_list_paginated_by_end_id (self):
-        """Verifies batch list requests work paginated by count and end_id.
-
-        Queries the default mock block store:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response with:
-                * the default empty next_id
-                * a previous_id of 'aaa...2'
-                * a start_index of 1
-                * the default total resource count of 3
-            - a list of batches with 2 items
-            - those items are instances of Batch
-            - the first item has a header_signature of 'aaa...1'
-        """
-        response = self.make_paged_request(count=2, end_id=A_0)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, previous_id=A_2, start_index=1)
-        self.assertEqual(2, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_1, response.batches[0].header_signature)
-
-    def test_batch_list_paginated_by_index (self):
-        """Verifies batch list requests work paginated by count and min_index.
-
-        Queries the default mock block store:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response with a next_id of 'aaa...1'
-            - a list of batches with 1 item
-            - that item is an instance of Batch
-            - that item has a header_signature of 'aaa...2'
-        """
-        response = self.make_paged_request(count=1, start_index=0)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, next_id=A_1)
-        self.assertEqual(1, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_2, response.batches[0].header_signature)
 
     def test_batch_list_with_bad_pagination(self):
         """Verifies batch requests break when paging specifies missing batches.
@@ -367,7 +305,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - a status of INVALID_PAGING
             - that head_id, paging, and batches are missing
         """
-        response = self.make_paged_request(count=3, start_id='bad')
+        response = self.make_paged_request(limit=3, start='bad')
 
         self.assertEqual(self.status.INVALID_PAGING, response.status)
         self.assertFalse(response.head_id)
@@ -384,130 +322,22 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...1'
-            - a paging response with:
-                * an empty next_id
-                * a previous_id of 'aaa...1'
-                * a start_index of 1
-                * a total resource count of 2
+            - a paging response with start of A_0 and limit 1
             - a list of batches with 1 item
             - that item is an instance of Batch
             - that has a header_signature of 'aaa...0'
         """
-        response = self.make_paged_request(count=1, start_index=1, head_id=B_1)
+        response = self.make_paged_request(limit=1, start=A_0, head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, '', A_1, 1, 2)
+        self.assert_valid_paging(response, A_0, 1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_0, response.batches[0].header_signature)
 
-    def test_batch_list_sorted_by_key(self):
-        """Verifies batch list requests work sorted by header_signature.
-
-        Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of batches with 3 items
-            - the items are instances of Batch
-            - the first item has a header_signature of 'aaa...0'
-            - the last item has a header_signature of 'aaa...2'
-        """
-        controls = self.make_sort_controls('header_signature')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_0, response.batches[0].header_signature)
-        self.assertEqual(A_2, response.batches[2].header_signature)
-
-    def test_batch_list_sorted_by_bad_key(self):
-        """Verifies batch list requests break properly sorted by a bad key.
-
-        Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of INVALID_SORT
-            - that head_id, paging, and batches are missing
-        """
-        controls = self.make_sort_controls('bad')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.INVALID_SORT, response.status)
-        self.assertFalse(response.head_id)
-        self.assertFalse(response.paging.SerializeToString())
-        self.assertFalse(response.batches)
-
-    def test_batch_list_sorted_by_nested_key(self):
-        """Verifies batch list requests work sorted by header.signer_public_key.
-
-        Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of batches with 3 items
-            - the items are instances of Batch
-            - the first item has a header_signature of 'aaa...0'
-            - the last item has a header_signature of 'aaa...2'
-        """
-        controls = self.make_sort_controls('header', 'signer_public_key')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_0, response.batches[0].header_signature)
-        self.assertEqual(A_2, response.batches[2].header_signature)
-
-    def test_batch_list_sorted_by_implied_header(self):
-        """Verifies batch list requests work sorted by an implicit header key.
-
-        Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of batches with 3 items
-            - the items are instances of Batch
-            - the first item has a header_signature of 'aaa...0'
-            - the last item has a header_signature of 'aaa...2'
-        """
-        controls = self.make_sort_controls('signer_public_key')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_0, response.batches[0].header_signature)
-        self.assertEqual(A_2, response.batches[2].header_signature)
-
     def test_batch_list_sorted_in_reverse(self):
-        """Verifies batch list requests work sorted by a key in reverse.
+        """Verifies batch list requests work sorted in reverse.
 
         Queries the default mock block store with three blocks:
             {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
@@ -517,22 +347,22 @@ class TestBatchListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
+             a paging response with start of A_0 and limit 100
             - a list of batches with 3 items
             - the items are instances of Batch
             - the first item has a header_signature of 'aaa...2'
             - the last item has a header_signature of 'aaa...0'
         """
-        controls = self.make_sort_controls('header_signature', reverse=True)
+        controls = self.make_sort_controls('default', reverse=True)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
+        self.assert_valid_paging(response, A_0, 100)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual(A_2, response.batches[0].header_signature)
-        self.assertEqual(A_0, response.batches[2].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[2].header_signature)
 
 
 class TestBatchGetRequests(ClientHandlerTestCase):

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -59,7 +59,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - the default paging response, showing all 3 resources returned
+            - a paging response with start of C_2 and limit 100
             - a list of transactions with 3 items
             - those items are instances of Transaction
             - the first item has a header_signature of 'ccc...2'
@@ -68,7 +68,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
+        self.assert_valid_paging(response, C_2, 100)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_2, response.transactions[0].header_signature)
@@ -123,7 +123,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...1'
-            - a paging response showing all 2 resources returned
+            - a paging response with start of C_1 and limit 100
             - a list of transactions with 2 items
             - those items are instances of Transaction
             - the first item has a header_signature of 'ccc...1'
@@ -132,7 +132,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, total=2)
+        self.assert_valid_paging(response, C_1, 100)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_1, response.transactions[0].header_signature)
@@ -173,7 +173,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 2 resources returned
+            - a paging response with start of C_0 and limit 100
             - a list of transactions with 2 items
             - the items are instances of Transaction
             - the first item has a header_signature of 'ccc...0'
@@ -183,7 +183,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, total=2)
+        self.assert_valid_paging(response, C_0, 100)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_0, response.transactions[0].header_signature)
@@ -242,7 +242,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 1 resources returned
+        - a paging response with start of C_1 and limit 100
             - a list of transactions with 1 items
             - that item is an instances of Transaction
             - that item has a header_signature of 'ccc...1'
@@ -251,7 +251,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, total=1)
+        self.assert_valid_paging(response, C_1, 100)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_1, response.transactions[0].header_signature)
@@ -277,7 +277,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...1'
-            - a paging response showing all 1 resources returned
+            - a paging response with a start of C_0 and limit 100
             - a list of transactions with 1 item
             - that item is an instance of Transaction
             - that item has a header_signature of 'ccc...0'
@@ -286,7 +286,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, total=1)
+        self.assert_valid_paging(response, C_0, 100)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_0, response.transactions[0].header_signature)
@@ -321,7 +321,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assertFalse(response.transactions)
 
     def test_txn_list_paginated(self):
-        """Verifies requests for txn lists work when paginated just by count.
+        """Verifies requests for txn lists work when paginated just by limit.
 
         Queries the default mock block store:
             {
@@ -343,25 +343,24 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of OK
             - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 'ccc...0'
-                * the default empty previous_id
-                * the default start_index of 0
-                * the default total resource count of 3
+                * a next_id of C_0
+                * the default start of C_2
+                * limit of 2
             - a list of transactions with 2 items
             - those items are instances of Transaction
             - the first item has a header_signature of 'ccc...2'
         """
-        response = self.make_paged_request(count=2)
+        response = self.make_paged_request(limit=2)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, next_id=C_0)
+        self.assert_valid_paging(response, C_2, 2, next_id=C_0)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_2, response.transactions[0].header_signature)
 
     def test_txn_list_paginated_by_start_id (self):
-        """Verifies txn list requests work paginated by count and start_id.
+        """Verifies txn list requests work paginated by limit and start_id.
 
         Queries the default mock block store:
             {
@@ -383,65 +382,24 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of OK
             - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 'ccc...0'
-                * a previous_id of 'ccc...2'
-                * a start_index of 1
-                * the default total resource count of 3
+                * a next_id of C_0
+                * a start of C_1
+                * limit of 1
             - a list of transactions with 1 item
             - that item is an instance of Transaction
             - that item has a header_signature of 'ccc...1'
         """
-        response = self.make_paged_request(count=1, start_id=C_1)
+        response = self.make_paged_request(limit=1, start=C_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, C_0, C_2, 1)
+        self.assert_valid_paging(response, C_1, 1, C_0)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_1, response.transactions[0].header_signature)
 
-    def test_txn_list_paginated_by_end_id (self):
-        """Verifies txn list requests work paginated by count and end_id.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response with:
-                * the default empty next_id
-                * a previous_id of 'ccc...2'
-                * a start_index of 1
-                * the default total resource count of 3
-            - a list of transactions with 2 items
-            - those items are instances of Transaction
-            - the first item has a header_signature of 'ccc...1'
-        """
-        response = self.make_paged_request(count=2, end_id=C_0)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, previous_id=C_2, start_index=1)
-        self.assertEqual(2, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_1, response.transactions[0].header_signature)
-
     def test_txn_list_paginated_by_index (self):
-        """Verifies txn list requests work paginated by count and min_index.
+        """Verifies txn list requests work paginated by limit and min_index.
 
         Queries the default mock block store:
             {
@@ -462,16 +420,16 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response with a next_id of 'ccc...1'
+            - a paging response with a next of C_1, start of C_2 and limit of 1
             - a list of transactions with 1 item
             - that item is an instance of Transaction
             - that item has a header_signature of 'ccc...2'
         """
-        response = self.make_paged_request(count=1, start_index=0)
+        response = self.make_paged_request(limit=1, start=C_2)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, next_id=C_1)
+        self.assert_valid_paging(response, C_2, 1, C_1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_2, response.transactions[0].header_signature)
@@ -499,7 +457,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of INVALID_PAGING
             - that head_id, paging, and transactions are missing
         """
-        response = self.make_paged_request(count=3, start_id='bad')
+        response = self.make_paged_request(limit=3, start='bad')
 
         self.assertEqual(self.status.INVALID_PAGING, response.status)
         self.assertFalse(response.head_id)
@@ -517,210 +475,20 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of OK
             - a head_id of 'bbb...1'
             - a paging response with:
-                * an empty next_id
-                * a previous_id of 'ccc...1'
-                * a start_index of 1
-                * a total resource count of 2
+                * a start of C_0
+                * limit of 1
             - a list of transactions with 1 item
             - that item is an instance of Transaction
             - that has a header_signature of 'ccc...0'
         """
-        response = self.make_paged_request(count=1, start_index=1, head_id=B_1)
+        response = self.make_paged_request(limit=1, start=C_0, head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_1, response.head_id)
-        self.assert_valid_paging(response, '', C_1, 1, 2)
+        self.assert_valid_paging(response, C_0, 1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_0, response.transactions[0].header_signature)
-
-    def test_txn_list_sorted_by_key(self):
-        """Verifies txn list requests work sorted by header_signature.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of transactions with 3 items
-            - the items are instances of Transaction
-            - the first item has a header_signature of 'ccc...0'
-            - the last item has a header_signature of 'ccc...2'
-        """
-        controls = self.make_sort_controls('header_signature')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_0, response.transactions[0].header_signature)
-        self.assertEqual(C_2, response.transactions[2].header_signature)
-
-    def test_txn_list_sorted_by_bad_key(self):
-        """Verifies txn list requests break properly sorted by a bad key.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of INVALID_SORT
-            - that head_id, paging, and transactions are missing
-        """
-        controls = self.make_sort_controls('bad')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.INVALID_SORT, response.status)
-        self.assertFalse(response.head_id)
-        self.assertFalse(response.paging.SerializeToString())
-        self.assertFalse(response.transactions)
-
-    def test_txn_list_sorted_by_nested_key(self):
-        """Verifies txn list requests work sorted by header.signer_public_key.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of transactions with 3 items
-            - the items are instances of Transaction
-            - the first item has a header_signature of 'ccc...0'
-            - the last item has a header_signature of 'ccc...2'
-        """
-        controls = self.make_sort_controls('header', 'signer_public_key')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_0, response.transactions[0].header_signature)
-        self.assertEqual(C_2, response.transactions[2].header_signature)
-
-    def test_txn_list_sorted_by_implied_header(self):
-        """Verifies txn list requests work sorted by an implicit header key.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of transactions with 3 items
-            - the items are instances of Transaction
-            - the first item has a header_signature of 'ccc...0'
-            - the last item has a header_signature of 'ccc...2'
-        """
-        controls = self.make_sort_controls('signer_public_key')
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_0, response.transactions[0].header_signature)
-        self.assertEqual(C_2, response.transactions[2].header_signature)
-
-    def test_txn_list_sorted_by_many_keys(self):
-        """Verifies txn list requests work sorted by two keys.
-
-        Queries the default mock block store:
-            {
-                header_signature: 'bbb...2',
-                batches: [{
-                    header_signature: 'aaa...2',
-                    transactions: [{
-                        header_signature: 'ccc...2',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'bbb...1', ...},
-            {header_signature: 'bbb...0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
-            - a list of transactions with 3 items
-            - the items are instances of Transaction
-            - the first item has a header_signature of 'ccc...0'
-            - the last item has a header_signature of 'ccc...2'
-        """
-        controls = (self.make_sort_controls('family_name') +
-                    self.make_sort_controls('signer_public_key'))
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
-        self.assertEqual(3, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_0, response.transactions[0].header_signature)
-        self.assertEqual(C_2, response.transactions[2].header_signature)
 
     def test_txn_list_sorted_in_reverse(self):
         """Verifies txn list requests work sorted by a key in reverse.
@@ -744,22 +512,22 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - a head_id of 'bbb...2', the latest
-            - a paging response showing all 3 resources returned
+            - a paging response start of C_0 and limit of 100
             - a list of transactions with 3 items
             - the items are instances of Transaction
             - the first item has a header_signature of 'ccc...0'
             - the last item has a header_signature of 'ccc...2'
         """
-        controls = self.make_sort_controls('header_signature', reverse=True)
+        controls = self.make_sort_controls('default', reverse=True)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response)
+        self.assert_valid_paging(response, C_0, 100)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual(C_2, response.transactions[0].header_signature)
-        self.assertEqual(C_0, response.transactions[2].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[2].header_signature)
 
 
 class TestTransactionGetRequests(ClientHandlerTestCase):


### PR DESCRIPTION
Update paging to only have use start which should be an start id and
limit which is the number to be returned. The response will only
contain next.

Sort endpoint is changed to /reverse, compare_lengths have been
removed. When reversing, it is done by the order they are returned
from the blockstore and the key used is "default"

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>