### PR TITLE
Fix REST API hanging bug, validate ids

### DIFF
--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -150,6 +150,10 @@ Error Codes and Descriptions
      - Invalid Sort Query
      - The validator rejected the sort request submitted. Most likely one of
        the keys specified was not found in the resources sorted.
+   * - 60
+     - Invalid Resource Id
+     - A submitted block, batch, or transaction id was invalid. All such
+       resources are identified by 128 character hex-strings.
    * - 62
      - Invalid State Address
      - The state address submitted was invalid. Returned when attempting to

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -44,7 +44,7 @@ class _ApiError(HTTPError):
     title = None
     message = None
 
-    def __init__(self):
+    def __init__(self, additional_info=''):
         assert self.api_code is not None, 'Invalid ApiError, api_code not set'
         assert self.status_code is not None, 'Invalid ApiError, status not set'
         assert self.title is not None, 'Invalid ApiError, title not set'
@@ -53,7 +53,7 @@ class _ApiError(HTTPError):
         error = {
             'code': self.api_code,
             'title': self.title,
-            'message': self.message}
+            'message': self.message + additional_info}
 
         super().__init__(
             content_type='application/json',
@@ -199,6 +199,14 @@ class SortInvalid(_ApiError):
     title = 'Invalid Sort Query'
     message = ("The sort request failed as written. Some of the keys "
                "specified were not valid.")
+
+
+class InvalidResourceId(_ApiError):
+    api_code = 60
+    status_code = 400
+    title = 'Invalid Resource Id'
+    message = ('Blockchain items are identified by 128 character hex-strings. '
+               'A submitted block, batch, or transaction id was invalid: ')
 
 
 class InvalidStateAddress(_ApiError):

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -19,6 +19,12 @@ from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_batch_pb2
 
 
+ID_A = 'a' * 128
+ID_B = 'b' * 128
+ID_C = 'c' * 128
+ID_D = 'd' * 128
+
+
 class BatchListTests(BaseApiTest):
 
     async def get_application(self):
@@ -35,34 +41,34 @@ class BatchListTests(BaseApiTest):
         """Verifies a GET /batches without parameters works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids of '2', '1', and '0'
+            - three batches with ids of ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/batches?head=2'
+            - a head property of ID_C
+            - a link property that ends in '/batches?head={}'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '2', '1', and '0'
+            - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches')
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/batches?head=2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/batches?head={}'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '2', '1', '0')
+        self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_batch_list_with_validator_error(self):
@@ -101,35 +107,35 @@ class BatchListTests(BaseApiTest):
         """Verifies a GET /batches with a head parameter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a paging response with a start of 0, and 2 total resources
-            - two batches with ids of 1' and '0'
+            - two batches with ids of 1' and ID_A
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/batches?head=1'
+            - a head property of ID_B
+            - a link property that ends in '/batches?head={}'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids '1' and '0'
+            - and those dicts are full batches with ids ID_B and ID_A
         """
         paging = Mocks.make_paging_response(0, 2)
-        batches = Mocks.make_batches('1', '0')
-        self.connection.preset_response(head_id='1', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?head=1')
+        response = await self.get_assert_200('/batches?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/batches?head=1')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/batches?head={}'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], '1', '0')
+        self.assert_batches_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_head(self):
@@ -143,7 +149,7 @@ class BatchListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/batches?head=bad', 404)
+        response = await self.get_assert_status('/batches?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -152,35 +158,35 @@ class BatchListTests(BaseApiTest):
         """Verifies GET /batches with an id filter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 2 total resources
-            - two batches with ids of '0' and '2'
+            - two batches with ids of ID_A and ID_C
 
         It should send a Protobuf request with:
-            - a batch_ids property of ['0', '2']
+            - a batch_ids property of [ID_A, ID_C]
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/batches?head=2&id=0,2'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/batches?head={}&id={},{}'.format(ID_C, ID_A, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids '0' and '2'
+            - and those dicts are full batches with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response(0, 2)
-        batches = Mocks.make_batches('0', '2')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_A, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?id=0,2')
+        response = await self.get_assert_200('/batches?id={},{}'.format(ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(batch_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(batch_ids=[ID_A, ID_C], paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/batches?head=2&id=0,2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/batches?head={}&id={},{}'.format(ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], '0', '2')
+        self.assert_batches_well_formed(response['data'], ID_A, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_ids(self):
@@ -188,24 +194,24 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
-            - a head id of '2'
+            - a head id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/batches?head=2&id=bad,notgood'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/batches?head={}&id={},{}'.format(ID_C, ID_B, ID_D)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
-            head_id='2',
+            head_id=ID_C,
             paging=paging)
-        response = await self.get_assert_200('/batches?id=bad,notgood')
+        response = await self.get_assert_200('/batches?id={},{}'.format(ID_B, ID_D))
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/batches?head=2&id=bad,notgood')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/batches?head={}&id={},{}'.format(ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -214,75 +220,75 @@ class BatchListTests(BaseApiTest):
         """Verifies GET /batches with head and id parameters work properly.
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - a paging response with a start of 0, and 1 total resource
-            - a batch_ids property of ['0']
+            - a batch_ids property of [ID_A]
 
         It will receive a Protobuf response with:
-            - a head id of '1'
-            - one batch with an id of '0'
+            - a head id of ID_B
+            - one batch with an id of ID_A
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/batches?head=1&id=0'
+            - a head property of ID_B
+            - a link property that ends in '/batches?head={}&id={}'.format(ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
-            - and that dict is a full batch with an id of '0'
+            - and that dict is a full batch with an id of ID_A
         """
         paging = Mocks.make_paging_response(0, 1)
-        batches = Mocks.make_batches('0')
-        self.connection.preset_response(head_id='1', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_A)
+        self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?id=0&head=1')
+        response = await self.get_assert_200('/batches?id={}&head={}'.format(ID_A, ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(
-            head_id='1',
-            batch_ids=['0'],
+            head_id=ID_B,
+            batch_ids=[ID_A],
             paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/batches?head=1&id=0')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/batches?head={}&id={}'.format(ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
-        self.assert_batches_well_formed(response['data'], '0')
+        self.assert_batches_well_formed(response['data'], ID_A)
 
     @unittest_run_loop
     async def test_batch_list_paginated(self):
         """Verifies GET /batches paginated by min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 1, and 4 total resources
-            - one batch with the id 'c'
+            - one batch with the id ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 1, and a start_index of 1
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=1&count=1'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&min=1&count=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
-            - and that dict is a full batch with the id 'c'
+            - and that dict is a full batch with the id ID_C
         """
         paging = Mocks.make_paging_response(1, 4)
-        batches = Mocks.make_batches('c')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_C)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&min=1&count=1')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&min=1&count=1'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head=d&min=2&count=1',
-                                     '/batches?head=d&min=0&count=1')
+                                     '/batches?head={}&min=2&count=1'.format(ID_D),
+                                     '/batches?head={}&min=0&count=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
-        self.assert_batches_well_formed(response['data'], 'c')
+        self.assert_batches_well_formed(response['data'], ID_C)
 
     @unittest_run_loop
     async def test_batch_list_with_zero_count(self):
@@ -317,192 +323,192 @@ class BatchListTests(BaseApiTest):
         """Verifies GET /batches paginated just by count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - two batches with the ids 'd' and 'c'
+            - two batches with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&count=2'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids 'd' and 'c'
+            - and those dicts are full batches with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response(0, 4)
-        batches = Mocks.make_batches('d', 'c')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_D, ID_C)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?count=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&count=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head=d&min=2&count=2')
+                                     '/batches?head={}&min=2&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], 'd', 'c')
+        self.assert_batches_well_formed(response['data'], ID_D, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_paginated_without_count(self):
         """Verifies GET /batches paginated without count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 2, and 4 total resources
-            - two batches with the ids 'b' and 'a'
+            - two batches with the ids ID_B and ID_A
 
         It should send a Protobuf request with:
             - paging controls with a start_index of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=2'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&min=2'.format(ID_D)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids 'd' and 'c'
+            - and those dicts are full batches with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response(2, 4)
-        batches = Mocks.make_batches('b', 'a')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&min=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&min=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/batches?head=d&min=0&count=2')
+                                     previous_link='/batches?head={}&min=0&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], 'b', 'a')
+        self.assert_batches_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_batch_list_paginated_by_min_id(self):
         """Verifies GET /batches paginated by a min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * total_resources of 4
-                * a previous_id of 'd'
-            - three batches with the ids 'c', 'b' and 'a'
+                * a previous_id of ID_D
+            - three batches with the ids ID_C, ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a count of 5, and a start_id of 'c'
+            - paging controls with a count of 5, and a start_id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=c&count=5'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&min={}&count=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids 'c', 'b', and 'a'
+            - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d')
-        batches = Mocks.make_batches('c', 'b', 'a')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
+        batches = Mocks.make_batches(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?min=c&count=5')
-        controls = Mocks.make_paging_controls(5, start_id='c')
+        response = await self.get_assert_200('/batches?min={}&count=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start_id=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&min=c&count=5')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&min={}&count=5'.format(ID_D, ID_C))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/batches?head=d&max=d&count=5')
+                                     previous_link='/batches?head={}&max={}&count=5'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], 'c', 'b', 'a')
+        self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_batch_list_paginated_by_max_id(self):
         """Verifies GET /batches paginated by a max id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * a total_resources of 4
-                * a previous_id of 'd'
-                * a next_id of 'a'
-            - two batches with the ids 'c' and 'b'
+                * a previous_id of ID_D
+                * a next_id of ID_A
+            - two batches with the ids ID_C and ID_B
 
         It should send a Protobuf request with:
-            - paging controls with a count of 2, and an end_id of 'b'
+            - paging controls with a count of 2, and an end_id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&max=b&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&max={}&count=2'.format(ID_D, ID_B)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids 'c' and 'b'
+            - and those dicts are full batches with ids ID_C and ID_B
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
-        batches = Mocks.make_batches('c', 'b')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
+        batches = Mocks.make_batches(ID_C, ID_B)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?max=b&count=2')
-        controls = Mocks.make_paging_controls(2, end_id='b')
+        response = await self.get_assert_200('/batches?max={}&count=2'.format(ID_B))
+        controls = Mocks.make_paging_controls(2, end_id=ID_B)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&max=b&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&max={}&count=2'.format(ID_D, ID_B))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head=d&min=a&count=2',
-                                     '/batches?head=d&max=d&count=2')
+                                     '/batches?head={}&min={}&count=2'.format(ID_D, ID_A),
+                                     '/batches?head={}&max={}&count=2'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_batches_well_formed(response['data'], 'c', 'b')
+        self.assert_batches_well_formed(response['data'], ID_C, ID_B)
 
     @unittest_run_loop
     async def test_batch_list_paginated_by_max_index(self):
         """Verifies GET /batches paginated by a max index works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - three batches with the ids 'd', 'c' and 'b'
+            - three batches with the ids ID_D, ID_C and ID_B
 
         It should send a Protobuf request with:
             - paging controls with a count of 3, and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/batches?head=d&min=3&count=7'
+            - a head property of ID_D
+            - a link property that ends in '/batches?head={}&min=3&count=7'.format(ID_D)
             - paging that matches the response, with a next link
             - a data property that is a list of 2 dicts
-            - and those dicts are full batches with ids 'd', 'c', and 'b'
+            - and those dicts are full batches with ids ID_D, ID_C, and ID_B
         """
         paging = Mocks.make_paging_response(0, 4)
-        batches = Mocks.make_batches('d', 'c', 'b')
-        self.connection.preset_response(head_id='d', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_D, ID_C, ID_B)
+        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/batches?head=d&max=2&count=7')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/batches?head={}&max=2&count=7'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/batches?head=d&min=3&count=7')
+                                     '/batches?head={}&min=3&count=7'.format(ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], 'd', 'c', 'b')
+        self.assert_batches_well_formed(response['data'], ID_D, ID_C, ID_B)
 
     @unittest_run_loop
     async def test_batch_list_sorted(self):
         """Verifies GET /batches can send proper sort controls.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids '0', '1', and '2'
+            - three batches with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -510,15 +516,15 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/batches?head=2&sort=header_signature'
+            - a head property of ID_C
+            - a link property ending in '/batches?head={}&sort=header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '0', '1', and '2'
+            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -527,12 +533,12 @@ class BatchListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=header_signature')
+            '/batches?head={}&sort=header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '0', '1', '2')
+        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_sort(self):
@@ -555,9 +561,9 @@ class BatchListTests(BaseApiTest):
         """Verifies GET /batches can send proper sort controls with nested keys.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids '0', '1', and '2'
+            - three batches with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -565,15 +571,15 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link ending in '/batches?head=2&sort=header.signer_public_key'
+            - a head property of ID_C
+            - a link ending in '/batches?head={}&sort=header.signer_public_key'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '0', '1', and '2'
+            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200(
             '/batches?sort=header.signer_public_key')
@@ -583,21 +589,21 @@ class BatchListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=header.signer_public_key')
+            '/batches?head={}&sort=header.signer_public_key'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '0', '1', '2')
+        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_sorted_in_reverse(self):
         """Verifies a GET /batches can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids '2', '1', and '0'
+            - three batches with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -605,15 +611,15 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/batches?head=2&sort=-header_signature'
+            - a head property of ID_C
+            - a link property ending in '/batches?head={}&sort=-header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '2', '1', and '0'
+            - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -623,21 +629,21 @@ class BatchListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=-header_signature')
+            '/batches?head={}&sort=-header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '2', '1', '0')
+        self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_batch_list_sorted_by_length(self):
         """Verifies a GET /batches can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids '0', '1', and '2'
+            - three batches with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -645,15 +651,15 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/batches?head=2&sort=transactions.length'
+            - a head property of ID_C
+            - a link property ending in '/batches?head={}&sort=transactions.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '0', '1', and '2'
+            - and those dicts are full batches with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?sort=transactions.length')
         page_controls = Mocks.make_paging_controls()
@@ -662,21 +668,21 @@ class BatchListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=transactions.length')
+            '/batches?head={}&sort=transactions.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '0', '1', '2')
+        self.assert_batches_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_sorted_by_many_keys(self):
         """Verifies a GET /batches can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three batches with ids '2', '1', and '0'
+            - three batches with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -686,15 +692,15 @@ class BatchListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - link with '/batches?head=2&sort=-header_signature,transactions.length'
+            - a head property of ID_C
+            - link with '/batches?head={}&sort=-header_signature,transactions.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full batches with ids '2', '1', and '0'
+            - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        batches = Mocks.make_batches('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, batches=batches)
+        batches = Mocks.make_batches(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200(
             '/batches?sort=-header_signature,transactions.length')
@@ -705,12 +711,12 @@ class BatchListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/batches?head=2&sort=-header_signature,transactions.length')
+            '/batches?head={}&sort=-header_signature,transactions.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_batches_well_formed(response['data'], '2', '1', '0')
+        self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
 class BatchGetTests(BaseApiTest):
@@ -729,26 +735,26 @@ class BatchGetTests(BaseApiTest):
         """Verifies a GET /batches/{batch_id} works properly.
 
         It should send a Protobuf request with:
-            - a batch_id property of '1'
+            - a batch_id property of ID_B
 
         It will receive a Protobuf response with:
-            - a batch with an id of '1'
+            - a batch with an id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
             - no head property
-            - a link property that ends in '/batches/1'
-            - a data property that is a full batch with an id of '1'
+            - a link property that ends in '/batches/{}'.format(ID_B)
+            - a data property that is a full batch with an id of ID_B
         """
-        self.connection.preset_response(batch=Mocks.make_batches('1')[0])
+        self.connection.preset_response(batch=Mocks.make_batches(ID_B)[0])
 
-        response = await self.get_assert_200('/batches/1')
-        self.connection.assert_valid_request_sent(batch_id='1')
+        response = await self.get_assert_200('/batches/{}'.format(ID_B))
+        self.connection.assert_valid_request_sent(batch_id=ID_B)
 
         self.assertNotIn('head', response)
-        self.assert_has_valid_link(response, '/batches/1')
+        self.assert_has_valid_link(response, '/batches/{}'.format(ID_B))
         self.assertIn('data', response)
-        self.assert_batches_well_formed(response['data'], '1')
+        self.assert_batches_well_formed(response['data'], ID_B)
 
     @unittest_run_loop
     async def test_batch_get_with_validator_error(self):
@@ -762,7 +768,7 @@ class BatchGetTests(BaseApiTest):
             - an error property with a code of 10
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
-        response = await self.get_assert_status('/batches/1', 500)
+        response = await self.get_assert_status('/batches/{}'.format(ID_B), 500)
 
         self.assert_has_valid_error(response, 10)
 
@@ -778,6 +784,6 @@ class BatchGetTests(BaseApiTest):
             - an error property with a code of 71
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
-        response = await self.get_assert_status('/batches/bad', 404)
+        response = await self.get_assert_status('/batches/{}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 71)

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -19,6 +19,12 @@ from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_block_pb2
 
 
+ID_A = 'a' * 128
+ID_B = 'b' * 128
+ID_C = 'c' * 128
+ID_D = 'd' * 128
+
+
 class BlockListTests(BaseApiTest):
 
     async def get_application(self):
@@ -35,34 +41,34 @@ class BlockListTests(BaseApiTest):
         """Verifies a GET /blocks without parameters works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '2', '1', and '0'
+            - three blocks with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property that ends in '/blocks?head=2'
+            - a head property of ID_C
+            - a link property that ends in '/blocks?head={}'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '2', '1', and '0'
+            - and those dicts are full blocks with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks')
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/blocks?head=2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/blocks?head={}'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '2', '1', '0')
+        self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_block_list_with_validator_error(self):
@@ -101,35 +107,35 @@ class BlockListTests(BaseApiTest):
         """Verifies a GET /blocks with a head parameter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 2 total resources
-            - three blocks with ids '1' and '0'
+            - three blocks with ids ID_B and ID_A
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - empty paging controls
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '1'
-            - a link property that ends in '/blocks?head=1'
+            - a head property of ID_B
+            - a link property that ends in '/blocks?head={}'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids '1' and '0'
+            - and those dicts are full blocks with ids ID_B and ID_A
         """
         paging = Mocks.make_paging_response(0, 2)
-        blocks = Mocks.make_blocks('1', '0')
-        self.connection.preset_response(head_id='1', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_B, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?head=1')
+        response = await self.get_assert_200('/blocks?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/blocks?head=1')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/blocks?head={}'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_blocks_well_formed(response['data'], '1', '0')
+        self.assert_blocks_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_block_list_with_bad_head(self):
@@ -143,7 +149,7 @@ class BlockListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/blocks?head=bad', 404)
+        response = await self.get_assert_status('/blocks?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -152,35 +158,35 @@ class BlockListTests(BaseApiTest):
         """Verifies GET /blocks with an id filter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 2 total resources
-            - two blocks with ids '0' and '2'
+            - two blocks with ids ID_A and ID_C
 
         It should send a Protobuf request with:
-            - a block_ids property of ['0', '2']
+            - a block_ids property of [ID_A, ID_C]
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/blocks?head=2&id=0,2'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/blocks?head={}&id={},{}'.format(ID_C, ID_A, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids '0' and '2'
+            - and those dicts are full blocks with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response(0, 2)
-        blocks = Mocks.make_blocks('0', '2')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_A, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?id=0,2')
+        response = await self.get_assert_200('/blocks?id={},{}'.format(ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(block_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(block_ids=[ID_A, ID_C], paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/blocks?head=2&id=0,2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/blocks?head={}&id={},{}'.format(ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_blocks_well_formed(response['data'], '0', '2')
+        self.assert_blocks_well_formed(response['data'], ID_A, ID_C)
 
     @unittest_run_loop
     async def test_block_list_with_bad_ids(self):
@@ -188,24 +194,24 @@ class BlockListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
-            - a head property of '2'
+            - a head property of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/blocks?head=2&id=bad,notgood'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/blocks?head={}&id={},{}'.format(ID_C, ID_B, ID_D)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
-            head_id='2',
+            head_id=ID_C,
             paging=paging)
-        response = await self.get_assert_200('/blocks?id=bad,notgood')
+        response = await self.get_assert_200('/blocks?id={},{}'.format(ID_B, ID_D))
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/blocks?head=2&id=bad,notgood')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/blocks?head={}&id={},{}'.format(ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -214,76 +220,76 @@ class BlockListTests(BaseApiTest):
         """Verifies GET /blocks with head and id parameters work properly.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a paging response with a start of 0, and 1 total resource
-            - one block with an id of '0'
+            - one block with an id of ID_A
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
-            - a block_ids property of ['0']
+            - a head_id property of ID_B
+            - a block_ids property of [ID_A]
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/blocks?head=1&id=0'
+            - a head property of ID_B
+            - a link property that ends in '/blocks?head={}&id={}'.format(ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
-            - and that dict is a full block with an id of '0'
+            - and that dict is a full block with an id of ID_A
         """
         paging = Mocks.make_paging_response(0, 1)
-        blocks = Mocks.make_blocks('0')
-        self.connection.preset_response(head_id='1', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_A)
+        self.connection.preset_response(head_id=ID_B, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?id=0&head=1')
+        response = await self.get_assert_200('/blocks?id={}&head={}'.format(ID_A, ID_B))
         self.connection.assert_valid_request_sent(
-            head_id='1',
-            block_ids=['0'],
+            head_id=ID_B,
+            block_ids=[ID_A],
             paging=Mocks.make_paging_controls())
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/blocks?head=1&id=0')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/blocks?head={}&id={}'.format(ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
-        self.assert_blocks_well_formed(response['data'], '0')
+        self.assert_blocks_well_formed(response['data'], ID_A)
 
     @unittest_run_loop
     async def test_block_list_paginated(self):
         """Verifies GET /blocks paginated by min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 1, and 4 total resources
-            - one block with the id 'c'
+            - one block with the id ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 1, and a start_index of 1
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&min=1&count=1'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}&min=1&count=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
-            - and that dict is a full block with the id 'c'
+            - and that dict is a full block with the id ID_C
         """
         # Block list only returns a next id
         paging = Mocks.make_paging_response(None, 4, next_id='0x0002')
-        blocks = Mocks.make_blocks('c')
-        self.connection.preset_response(head_id='d', paging=paging,
+        blocks = Mocks.make_blocks(ID_C)
+        self.connection.preset_response(head_id=ID_D, paging=paging,
                                         blocks=blocks)
 
         response = await self.get_assert_200('/blocks?min=0x0003&count=1')
         controls = Mocks.make_paging_controls(1, start_id='0x0003')
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
+        self.assert_has_valid_head(response, ID_D)
         self.assert_has_valid_link(response,
-                                   '/blocks?head=d&min=0x0003&count=1')
+                                   '/blocks?head={}&min=0x0003&count=1'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head=d&min=0x0002&count=1')
+                                     '/blocks?head={}&min=0x0002&count=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
-        self.assert_blocks_well_formed(response['data'], 'c')
+        self.assert_blocks_well_formed(response['data'], ID_C)
 
     @unittest_run_loop
     async def test_block_list_with_zero_count(self):
@@ -318,194 +324,194 @@ class BlockListTests(BaseApiTest):
         """Verifies GET /blocks paginated just by count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - two blocks with the ids 'd' and 'c'
+            - two blocks with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids 'd' and 'c'
+            - and those dicts are full blocks with ids ID_D and ID_C
         """
         # Block list only returns a next id
         paging = Mocks.make_paging_response(None, 4, next_id='0x0002')
-        blocks = Mocks.make_blocks('d', 'c')
-        self.connection.preset_response(head_id='d', paging=paging,
+        blocks = Mocks.make_blocks(ID_D, ID_C)
+        self.connection.preset_response(head_id=ID_D, paging=paging,
                                         blocks=blocks)
 
         response = await self.get_assert_200('/blocks?count=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/blocks?head=d&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/blocks?head={}&count=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head=d&min=0x0002&count=2')
+                                     '/blocks?head={}&min=0x0002&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_blocks_well_formed(response['data'], 'd', 'c')
+        self.assert_blocks_well_formed(response['data'], ID_D, ID_C)
 
     @unittest_run_loop
     async def test_block_list_paginated_without_count(self):
         """Verifies GET /blocks paginated without count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 2, and 4 total resources
-            - two blocks with the ids 'b' and 'a'
+            - two blocks with the ids ID_B and ID_A
 
         It should send a Protobuf request with:
             - paging controls with a start_index of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&min=2&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}&min=2&count=2'.format(ID_D)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids 'd' and 'c'
+            - and those dicts are full blocks with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response(2, 4)
-        blocks = Mocks.make_blocks('b', 'a')
-        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/blocks?head=d&min=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/blocks?head={}&min=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/blocks?head=d&min=0&count=2')
+                                     previous_link='/blocks?head={}&min=0&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_blocks_well_formed(response['data'], 'b', 'a')
+        self.assert_blocks_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_block_list_paginated_by_min_id(self):
         """Verifies GET /blocks paginated by a min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * total_resources of 4
-                * a previous_id of 'd'
-            - three blocks with the ids 'c', 'b' and 'a'
+                * a previous_id of ID_D
+            - three blocks with the ids ID_C, ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a count of 5, and a start_id of 'c'
+            - paging controls with a count of 5, and a start_id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&min=c&count=5'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}&min={}&count=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids 'c', 'b', and 'a'
+            - and those dicts are full blocks with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d')
-        blocks = Mocks.make_blocks('c', 'b', 'a')
-        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
+        blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?min=c&count=5')
-        controls = Mocks.make_paging_controls(5, start_id='c')
+        response = await self.get_assert_200('/blocks?min={}&count=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start_id=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/blocks?head=d&min=c&count=5')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/blocks?head={}&min={}&count=5'.format(ID_D, ID_C))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/blocks?head=d&max=d&count=5')
+                                     previous_link='/blocks?head={}&max={}&count=5'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], 'c', 'b', 'a')
+        self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_block_list_paginated_by_max_id(self):
         """Verifies GET /blocks paginated by a max id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * a total_resources of 4
-                * a previous_id of 'd'
-                * a next_id of 'a'
-            - two blocks with the ids 'c' and 'b'
+                * a previous_id of ID_D
+                * a next_id of ID_A
+            - two blocks with the ids ID_C and ID_B
 
         It should send a Protobuf request with:
-            - paging controls with a count of 2, and an end_id of 'b'
+            - paging controls with a count of 2, and an end_id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&max=b&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}&max={}&count=2'.format(ID_D, ID_B)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids 'c' and 'b'
+            - and those dicts are full blocks with ids ID_C and ID_B
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
-        blocks = Mocks.make_blocks('c', 'b')
-        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
+        blocks = Mocks.make_blocks(ID_C, ID_B)
+        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?max=b&count=2')
-        controls = Mocks.make_paging_controls(2, end_id='b')
+        response = await self.get_assert_200('/blocks?max={}&count=2'.format(ID_B))
+        controls = Mocks.make_paging_controls(2, end_id=ID_B)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/blocks?head=d&max=b&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/blocks?head={}&max={}&count=2'.format(ID_D, ID_B))
         self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head=d&min=a&count=2',
-                                     '/blocks?head=d&max=d&count=2')
+                                     '/blocks?head={}&min={}&count=2'.format(ID_D, ID_A),
+                                     '/blocks?head={}&max={}&count=2'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_blocks_well_formed(response['data'], 'c', 'b')
+        self.assert_blocks_well_formed(response['data'], ID_C, ID_B)
 
     @unittest_run_loop
     async def test_block_list_paginated_by_max_index(self):
         """Verifies GET /blocks paginated by a max index works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - three blocks with the ids 'd', 'c' and 'b'
+            - three blocks with the ids ID_D, ID_C and ID_B
 
         It should send a Protobuf request with:
             - paging controls with a count of 3, and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/blocks?head=d&min=3&count=7'
+            - a head property of ID_D
+            - a link property that ends in '/blocks?head={}&min=3&count=7'.format(ID_D)
             - paging that matches the response, with a next link
             - a data property that is a list of 2 dicts
-            - and those dicts are full blocks with ids 'd', 'c', and 'b'
+            - and those dicts are full blocks with ids ID_D, ID_C, and ID_B
         """
         paging = Mocks.make_paging_response(0, 4)
-        blocks = Mocks.make_blocks('d', 'c', 'b')
-        self.connection.preset_response(head_id='d', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_D, ID_C, ID_B)
+        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/blocks?head=d&max=2&count=7')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/blocks?head={}&max=2&count=7'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head=d&min=3&count=7')
+                                     '/blocks?head={}&min=3&count=7'.format(ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], 'd', 'c', 'b')
+        self.assert_blocks_well_formed(response['data'], ID_D, ID_C, ID_B)
 
     @unittest_run_loop
     async def test_block_list_sorted(self):
         """Verifies GET /blocks can send proper sort controls.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '0', '1', and '2'
+            - three blocks with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -513,15 +519,15 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/blocks?head=2&sort=header_signature'
+            - a head property of ID_C
+            - a link property ending in '/blocks?head={}&sort=header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '0', '1', and '2'
+            - and those dicts are full blocks with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -530,12 +536,12 @@ class BlockListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=header_signature')
+            '/blocks?head={}&sort=header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+        self.assert_blocks_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_sort(self):
@@ -558,9 +564,9 @@ class BlockListTests(BaseApiTest):
         """Verifies GET /blocks can send proper sort controls with nested keys.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '0', '1', and '2'
+            - three blocks with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -568,15 +574,15 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link ending in '/blocks?head=2&sort=header.signer_public_key'
+            - a head property of ID_C
+            - a link ending in '/blocks?head={}&sort=header.signer_public_key'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '0', '1', and '2'
+            - and those dicts are full blocks with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200(
             '/blocks?sort=header.signer_public_key')
@@ -586,21 +592,21 @@ class BlockListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=header.signer_public_key')
+            '/blocks?head={}&sort=header.signer_public_key'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+        self.assert_blocks_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_block_list_sorted_in_reverse(self):
         """Verifies a GET /blocks can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '2', '1', and '0'
+            - three blocks with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -608,15 +614,15 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/blocks?head=2&sort=-header_signature'
+            - a head property of ID_C
+            - a link property ending in '/blocks?head={}&sort=-header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '2', '1', and '0'
+            - and those dicts are full blocks with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -626,21 +632,21 @@ class BlockListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=-header_signature')
+            '/blocks?head={}&sort=-header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '2', '1', '0')
+        self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_block_list_sorted_by_length(self):
         """Verifies a GET /blocks can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '0', '1', and '2'
+            - three blocks with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -648,15 +654,15 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/blocks?head=2&sort=batches.length'
+            - a head property of ID_C
+            - a link property ending in '/blocks?head={}&sort=batches.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '0', '1', and '2'
+            - and those dicts are full blocks with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?sort=batches.length')
         page_controls = Mocks.make_paging_controls()
@@ -665,21 +671,21 @@ class BlockListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=batches.length')
+            '/blocks?head={}&sort=batches.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '0', '1', '2')
+        self.assert_blocks_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_block_list_sorted_by_many_keys(self):
         """Verifies a GET /blocks can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three blocks with ids '2', '1', and '0'
+            - three blocks with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -689,15 +695,15 @@ class BlockListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - link with '/blocks?head=2&sort=-header_signature,batches.length'
+            - a head property of ID_C
+            - link with '/blocks?head={}&sort=-header_signature,batches.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full blocks with ids '2', '1', and '0'
+            - and those dicts are full blocks with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        blocks = Mocks.make_blocks('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, blocks=blocks)
+        blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200(
             '/blocks?sort=-header_signature,batches.length')
@@ -708,12 +714,12 @@ class BlockListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/blocks?head=2&sort=-header_signature,batches.length')
+            '/blocks?head={}&sort=-header_signature,batches.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_blocks_well_formed(response['data'], '2', '1', '0')
+        self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
 class BlockGetTests(BaseApiTest):
@@ -732,26 +738,26 @@ class BlockGetTests(BaseApiTest):
         """Verifies a GET /blocks/{block_id} works properly.
 
         It should send a Protobuf request with:
-            - a block_id property of '1'
+            - a block_id property of ID_B
 
         It will receive a Protobuf response with:
-            - a block with an id of '1'
+            - a block with an id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
             - no head property
-            - a link property that ends in '/blocks/1'
-            - a data property that is a full block with an id of '0'
+            - a link property that ends in '/blocks/{}'.format(ID_B)
+            - a data property that is a full block with an id of ID_A
         """
-        self.connection.preset_response(block=Mocks.make_blocks('1')[0])
+        self.connection.preset_response(block=Mocks.make_blocks(ID_B)[0])
 
-        response = await self.get_assert_200('/blocks/1')
-        self.connection.assert_valid_request_sent(block_id='1')
+        response = await self.get_assert_200('/blocks/{}'.format(ID_B))
+        self.connection.assert_valid_request_sent(block_id=ID_B)
 
         self.assertNotIn('head', response)
-        self.assert_has_valid_link(response, '/blocks/1')
+        self.assert_has_valid_link(response, '/blocks/{}'.format(ID_B))
         self.assertIn('data', response)
-        self.assert_blocks_well_formed(response['data'], '1')
+        self.assert_blocks_well_formed(response['data'], ID_B)
 
     @unittest_run_loop
     async def test_block_get_with_validator_error(self):
@@ -765,7 +771,7 @@ class BlockGetTests(BaseApiTest):
             - an error property with a code of 10
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
-        response = await self.get_assert_status('/blocks/1', 500)
+        response = await self.get_assert_status('/blocks/{}'.format(ID_B), 500)
 
         self.assert_has_valid_error(response, 10)
 
@@ -781,6 +787,6 @@ class BlockGetTests(BaseApiTest):
             - an error property with a code of 70
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
-        response = await self.get_assert_status('/blocks/bad', 404)
+        response = await self.get_assert_status('/blocks/{}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 70)

--- a/rest_api/tests/unit/test_receipt_requests.py
+++ b/rest_api/tests/unit/test_receipt_requests.py
@@ -21,6 +21,12 @@ from sawtooth_rest_api.protobuf import client_receipt_pb2
 from sawtooth_rest_api.protobuf.transaction_receipt_pb2 import TransactionReceipt
 
 
+ID_A = 'a' * 128
+ID_B = 'b' * 128
+ID_C = 'c' * 128
+ID_D = 'd' * 128
+
+
 class ReceiptGetRequestTests(BaseApiTest):
 
     async def get_application(self):
@@ -47,22 +53,22 @@ class ReceiptGetRequestTests(BaseApiTest):
             - a transaction receipt with matching id
 
         It should send a Protobuf request with:
-            - a transaction_ids property of ['1']
+            - a transaction_ids property of [ID_B]
 
         It should send back a JSON response with:
             - a response status of 200
-            - a link property that ends in '/receipts?id=1'
+            - a link property that ends in '/receipts?id={}'.format(ID_B)
             - a data property matching the receipts received
         """
-        receipts = [TransactionReceipt(transaction_id='1')]
+        receipts = [TransactionReceipt(transaction_id=ID_B)]
         self.connection.preset_response(
             receipts=receipts,
             status=self.status.OK)
 
-        response = await self.get_assert_200('/receipts?id=1')
-        self.connection.assert_valid_request_sent(transaction_ids=['1'])
+        response = await self.get_assert_200('/receipts?id={}'.format(ID_B))
+        self.connection.assert_valid_request_sent(transaction_ids=[ID_B])
 
-        self.assert_has_valid_link(response, '/receipts?id=1')
+        self.assert_has_valid_link(response, '/receipts?id={}'.format(ID_B))
         self.assert_receipts_match(receipts, response['data'])
 
     @unittest_run_loop
@@ -77,7 +83,7 @@ class ReceiptGetRequestTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 404
-            - a link property that ends in '/receipts?id=bad'
+            - a link property that ends in '/receipts?id={}'.format(ID_D)
             - a data property matching the receipts statuses received
         """
         receipts = []
@@ -85,8 +91,8 @@ class ReceiptGetRequestTests(BaseApiTest):
             receipts=receipts,
             status=self.status.NO_RESOURCE)
 
-        response = await self.get_assert_status('/receipts?id=missing', 404)
-        self.connection.assert_valid_request_sent(transaction_ids=['missing'])
+        response = await self.get_assert_status('/receipts?id={}'.format(ID_D), 404)
+        self.connection.assert_valid_request_sent(transaction_ids=[ID_D])
 
         self.assert_has_valid_error(response, 80)
 
@@ -95,34 +101,34 @@ class ReceiptGetRequestTests(BaseApiTest):
         """Verifies a GET /receipts with many ids works properly.
 
         It will receive a Protobuf response with receipts with ids:
-            - '1'
-            - '2'
-            - '3'
+            - ID_B
+            - ID_C
+            - ID_D
 
         It should send a Protobuf request with:
-            - a transaction_ids property of ['1', '2', '3']
+            - a transaction_ids property of [ID_B, ID_C, ID_D]
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/receipts?id=1,2,3'
+            - link property ending in '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D)
             - a data property matching the batch statuses received
         """
         receipts = [
             TransactionReceipt(transaction_id=t_id)
-            for t_id in ('1', '2', '3')
+            for t_id in (ID_B, ID_C, ID_D)
         ]
         self.connection.preset_response(
             status=self.status.OK,
             receipts=receipts)
 
         response = await self.get_assert_200(
-            '/receipts?id=1,2,3')
+            '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D))
         self.connection.assert_valid_request_sent(
-            transaction_ids=['1', '2', '3'])
+            transaction_ids=[ID_B, ID_C, ID_D])
 
         self.assert_has_valid_link(
             response,
-            '/receipts?id=1,2,3')
+            '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D))
         self.assert_receipts_match(receipts, response['data'])
 
     @unittest_run_loop
@@ -130,21 +136,21 @@ class ReceiptGetRequestTests(BaseApiTest):
         """Verifies a POST to /receipts with many ids works properly.
 
         It will receive a Protobuf response with receipts with ids:
-            - '1'
-            - '2'
-            - '3'
+            - ID_B
+            - ID_C
+            - ID_D
 
         It should send a Protobuf request with:
-            - a transaction_ids property of ['1', '2', '3']
+            - a transaction_ids property of [ID_B, ID_C, ID_D]
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/receipts?id=1,2,3'
+            - link property ending in '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D)
             - a data property matching the batch statuses received
         """
         receipts = [
             TransactionReceipt(transaction_id=t_id)
-            for t_id in ('1', '2', '3')
+            for t_id in (ID_B, ID_C, ID_D)
         ]
         self.connection.preset_response(
             status=self.status.OK,
@@ -152,10 +158,10 @@ class ReceiptGetRequestTests(BaseApiTest):
 
         request = await self.client.post(
             '/receipts',
-            data=json.dumps(['1', '2', '3']).encode(),
+            data=json.dumps([ID_B, ID_C, ID_D]).encode(),
             headers={'content-type': 'application/json'})
         self.connection.assert_valid_request_sent(
-            transaction_ids=['1', '2', '3'])
+            transaction_ids=[ID_B, ID_C, ID_D])
         self.assertEqual(200, request.status)
 
         response = await request.json()

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -23,6 +23,12 @@ from sawtooth_rest_api.protobuf import client_block_pb2
 from sawtooth_rest_api.protobuf import block_pb2
 
 
+ID_A = 'a' * 128
+ID_B = 'b' * 128
+ID_C = 'c' * 128
+ID_D = 'd' * 128
+
+
 class StateListTests(BaseApiTest):
 
     async def get_application(self):
@@ -39,7 +45,7 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state without parameters works properly.
 
         It will receive a Protobuf response with:
-            - a state root of '2'
+            - a state root of ID_C
             - a paging response with a start of 0, and 3 total resources
             - three entries with addresses/data of:
                 * 'a': b'3'
@@ -51,8 +57,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/state?head=2&min=0&count=3'
+            - a head property of ID_C
+            - a link property that ends in '/state?head={}&min=0&count=3'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 leaf dicts
             - three entries that match those in Protobuf response
@@ -64,7 +70,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -73,8 +79,8 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -124,20 +130,20 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state works properly with head specified.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a paging response with a start of 0, and 2 total resources
             - two entries with addresses/data of:
                 * 'a': b'2'
                 * 'b': b'4'
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/state?head=1&min=0&count=2'
+            - a head property of ID_B
+            - a link property that ends in '/state?head={}&min=0&count=2'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 2 leaf dicts
             - three entries that match those in Protobuf response
@@ -149,17 +155,17 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='1',
+                header_signature=ID_B,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?head=1')
+        response = await self.get_assert_200('/state?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/state?head=1')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/state?head={}'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
@@ -179,7 +185,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block())
-        response = await self.get_assert_status('/state?head=bad', 404)
+        response = await self.get_assert_status('/state?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -188,7 +194,7 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state works properly filtered by address.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 1 total resource
             - one leaf with addresses/data of: 'c': b'7'
 
@@ -198,9 +204,9 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
+            - a head property of ID_C
             - a link property that ends in
-            '/state?head=2&min=0&count=1&address=c'
+            '/state?head={}&min=0&count=1&address=c'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 1 leaf dict
             - one leaf that matches the Protobuf response
@@ -212,7 +218,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -221,8 +227,8 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', address='c', paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2&address=c')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}&address=c'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
@@ -233,12 +239,12 @@ class StateListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
-            - a head id of '2'
+            - a head id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/state?head=2&address=bad'
+            - a head property of ID_C
+            - a link property that ends in '/state?head={}&address=bad'.format(ID_C)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
@@ -250,13 +256,13 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
         response = await self.get_assert_200('/state?address=bad')
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2&address=bad')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}&address=bad'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -265,20 +271,20 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state works with a head and filtered by address.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a paging response with a start of 0, and 1 total resource
             - one leaf with addresses/data of: 'a': b'2'
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - an address property of 'a'
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
+            - a head property of ID_B
             - a link property that ends in
-            '/state?head=1&min=0&count=1&address=a'
+            '/state?head={}&min=0&count=1&address=a'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 1 leaf dict
             - one leaf that matches the Protobuf response
@@ -290,18 +296,18 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='1',
+                header_signature=ID_B,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?address=a&head=1')
+        response = await self.get_assert_200('/state?address=a&head={}'.format(ID_B))
         self.connection.assert_valid_request_sent(
             state_root='beef',
             address='a',
             paging=Mocks.make_paging_controls())
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/state?head=1&address=a')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/state?head={}&address=a'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
@@ -311,7 +317,7 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated by min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 1, and 4 total resources
             - one leaf of {'c': b'3'}
 
@@ -320,8 +326,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&min=1&count=1'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&min=1&count=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
             - and that dict is a leaf that matches the one received
@@ -333,7 +339,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -342,11 +348,11 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&min=1&count=1')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&min=1&count=1'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head=d&min=2&count=1',
-                                     '/state?head=d&min=0&count=1')
+                                     '/state?head={}&min=2&count=1'.format(ID_D),
+                                     '/state?head={}&min=0&count=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
 
@@ -386,17 +392,17 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated just by count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - two entries of {'d': b'4'}, and {'c': b'3'}
+            - two entries of {ID_D: b'4'}, and {'c': b'3'}
 
         It should send a Protobuf request with:
             - a paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&min=0&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&min=0&count=2'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
@@ -408,7 +414,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -417,10 +423,10 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&count=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head=d&min=2&count=2')
+                                     '/state?head={}&min=2&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
@@ -429,7 +435,7 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated without count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 2, and 4 total resources
             - two entries of {'b': b'2'} and {'a': b'1'}
 
@@ -438,8 +444,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&min=2&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&min=2&count=2'.format(ID_D)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
@@ -451,7 +457,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -460,10 +466,10 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&min=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&min=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/state?head=d&min=0&count=2')
+                                     previous_link='/state?head={}&min=0&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
@@ -472,44 +478,44 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated by a min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * total_resources of 4
-                * a previous_id of 'd'
+                * a previous_id of ID_D
             - three entries of {'c': b'3'}, {'b': b'2'}, and {'a': b'1'}
 
         It should send a Protobuf request with:
-            - a paging controls with a start_id of 'c'
+            - a paging controls with a start_id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&min=c&count=5'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&min={}&count=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are entries that match those received
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d')
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
         entries = Mocks.make_entries(c=b'3', b=b'2', a=b'1')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?min=c&count=5')
-        controls = Mocks.make_paging_controls(5, start_id='c')
+        response = await self.get_assert_200('/state?min={}&count=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start_id=ID_C)
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&min=c&count=5')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&min={}&count=5'.format(ID_D, ID_C))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/state?head=d&max=d&count=5')
+                                     previous_link='/state?head={}&max={}&count=5'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
 
@@ -518,46 +524,46 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated by a max id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * a total_resources of 4
-                * a previous_id of 'd'
-                * a next_id of 'a'
+                * a previous_id of ID_D
+                * a next_id of ID_A
             - two entries of {'c': b'3'} and {'b': b'3'}
 
         It should send a Protobuf request with:
-            - a paging controls with a count of 2 and an end_id of 'b'
+            - a paging controls with a count of 2 and an end_id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&max=b&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&max={}&count=2'.format(ID_D, ID_B)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
         entries = Mocks.make_entries(c=b'3', b=b'2')
         self.connection.preset_response(state_root='beef', paging=paging,
                                         entries=entries)
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?max=b&count=2')
-        controls = Mocks.make_paging_controls(2, end_id='b')
+        response = await self.get_assert_200('/state?max={}&count=2'.format(ID_B))
+        controls = Mocks.make_paging_controls(2, end_id=ID_B)
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&max=b&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&max={}&count=2'.format(ID_D, ID_B))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head=d&min=a&count=2',
-                                     '/state?head=d&max=d&count=2')
+                                     '/state?head={}&min={}&count=2'.format(ID_D, ID_A),
+                                     '/state?head={}&max={}&count=2'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
@@ -566,17 +572,17 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state paginated by a max index works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - three entries with the ids {'d': b'4'}, {'c': b'3'} and {'b': b'2'}
+            - three entries with the ids {ID_D: b'4'}, {'c': b'3'} and {'b': b'2'}
 
         It should send a Protobuf request with:
             - a paging controls with a count of 2 and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/state?head=d&min=3&count=7'
+            - a head property of ID_D
+            - a link property that ends in '/state?head={}&min=3&count=7'.format(ID_D)
             - paging that matches the response, with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are entries that match those received
@@ -588,7 +594,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='d',
+                header_signature=ID_D,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -597,10 +603,10 @@ class StateListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/state?head=d&max=2&count=7')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/state?head={}&max=2&count=7'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/state?head=d&min=3&count=7')
+                                     '/state?head={}&min=3&count=7'.format(ID_D))
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
 
@@ -609,7 +615,7 @@ class StateListTests(BaseApiTest):
         """Verifies GET /state can send proper sort controls.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
             - three entries with addresses/data of:
                 * 'a': b'3'
@@ -622,8 +628,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/state?head=2&sort=address'
+            - a head property of ID_C
+            - a link property ending in '/state?head={}&sort=address'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - three entries that match those in Protobuf response
@@ -635,7 +641,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -647,8 +653,8 @@ class StateListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2&sort=address')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}&sort=address'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -677,7 +683,7 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
             - three entries with addresses/data of:
                 * 'c': b'7'
@@ -690,8 +696,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/state?head=2&sort=-address'
+            - a head property of ID_C
+            - a link property ending in '/state?head={}&sort=-address'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - three entries that match those in Protobuf response
@@ -703,7 +709,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -715,8 +721,8 @@ class StateListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2&sort=-address')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}&sort=-address'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -726,7 +732,7 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
             - three entries with addresses/data of:
                 * 'c': b'7'
@@ -739,8 +745,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/state?head=2&sort=value.length'
+            - a head property of ID_C
+            - a link property ending in '/state?head={}&sort=value.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - three entries that match those in Protobuf response
@@ -752,7 +758,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -764,8 +770,8 @@ class StateListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state?head=2&sort=value.length')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state?head={}&sort=value.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -775,7 +781,7 @@ class StateListTests(BaseApiTest):
         """Verifies a GET /state can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
             - three entries with addresses/data of:
                 * 'c': b'7'
@@ -790,8 +796,8 @@ class StateListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - link with '/state?head=2&sort=-address,value.length'
+            - a head property of ID_C
+            - link with '/state?head={}&sort=-address,value.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - three entries that match those in Protobuf response
@@ -803,7 +809,7 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -817,9 +823,9 @@ class StateListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/state?head=2&sort=-address,value.length')
+            '/state?head={}&sort=-address,value.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -841,7 +847,7 @@ class StateGetTests(BaseApiTest):
         """Verifies a GET /state/{address} without parameters works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a leaf with addresses/data of: 'a': b'3'
 
         It should send a Protobuf request with:
@@ -849,15 +855,15 @@ class StateGetTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/state/b?head=2'
+            - a head property of ID_C
+            - a link property that ends in '/state/b?head={}'.format(ID_C)
             - a data property that b64decodes to b'3'
         """
         self.connection.preset_response(state_root='beef', value=b'3')
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='2',
+                header_signature=ID_C,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
@@ -865,8 +871,8 @@ class StateGetTests(BaseApiTest):
         self.connection.assert_valid_request_sent(
             state_root='beef', address='a')
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/state/a?head=2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/state/a?head={}'.format(ID_C))
         self.assertIn('data', response)
 
         data = response['data']
@@ -935,33 +941,33 @@ class StateGetTests(BaseApiTest):
         """Verifies a GET /state/{address} works properly with head parameter.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a leaf with addresses/data of: 'b': b'4'
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - an address property of 'b'
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/state/b?head=2'
+            - a head property of ID_C
+            - a link property that ends in '/state/b?head={}'.format(ID_C)
             - a data property that b64decodes to b'4'
         """
         self.connection.preset_response(state_root='beef', value=b'4')
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block(
-                header_signature='1',
+                header_signature=ID_B,
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state/b?head=1')
+        response = await self.get_assert_200('/state/b?head={}'.format(ID_B))
         self.connection.assert_valid_request_sent(
             state_root='beef', address='b')
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/state/b?head=1')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/state/b?head={}'.format(ID_B))
         self.assertIn('data', response)
 
         data = response['data']
@@ -983,6 +989,6 @@ class StateGetTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block())
-        response = await self.get_assert_status('/state/b?head=bad', 404)
+        response = await self.get_assert_status('/state/b?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -19,6 +19,12 @@ from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_transaction_pb2
 
 
+ID_A = 'a' * 128
+ID_B = 'b' * 128
+ID_C = 'c' * 128
+ID_D = 'd' * 128
+
+
 class TransactionListTests(BaseApiTest):
 
     async def get_application(self):
@@ -36,36 +42,36 @@ class TransactionListTests(BaseApiTest):
         """Verifies a GET /transactions without parameters works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids of '2', '1', and '0'
+            - three transactions with ids of ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2'
-            - a link property that ends in '/transactions?head=2'
+            - a head property of ID_C
+            - a link property that ends in '/transactions?head={}'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - those dicts are full transactions with ids '2', '1', and '0'
+            - those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
         self.connection.preset_response(
-            head_id='2',
+            head_id=ID_C,
             paging=paging,
-            transactions=Mocks.make_txns('2', '1', '0'))
+            transactions=Mocks.make_txns(ID_C, ID_B, ID_A))
 
         response = await self.get_assert_200('/transactions')
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/transactions?head=2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/transactions?head={}'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+        self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_txn_list_with_validator_error(self):
@@ -104,37 +110,37 @@ class TransactionListTests(BaseApiTest):
         """Verifies a GET /transactions with a head parameter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '1'
+            - a head id of ID_B
             - a paging response with a start of 0, and 2 total resources
-            - two transactions with ids of 1' and '0'
+            - two transactions with ids of 1' and ID_A
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/transactions?head=1'
+            - a head property of ID_B
+            - a link property that ends in '/transactions?head={}'.format(ID_B)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids '1' and '0'
+            - those dicts are full transactions with ids ID_B and ID_A
         """
         paging = Mocks.make_paging_response(0, 2)
         self.connection.preset_response(
-            head_id='1',
+            head_id=ID_B,
             paging=paging,
-            transactions=Mocks.make_txns('1', '0'))
+            transactions=Mocks.make_txns(ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?head=1')
+        response = await self.get_assert_200('/transactions?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id='1', paging=controls)
+        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/transactions?head=1')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/transactions?head={}'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], '1', '0')
+        self.assert_txns_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_txn_list_with_bad_head(self):
@@ -148,7 +154,7 @@ class TransactionListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/transactions?head=bad', 404)
+        response = await self.get_assert_status('/transactions?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -157,35 +163,35 @@ class TransactionListTests(BaseApiTest):
         """Verifies GET /transactions with an id filter works properly.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 2 total resources
-            - two transactions with ids of '0' and '2'
+            - two transactions with ids of ID_A and ID_C
 
         It should send a Protobuf request with:
-            - a transaction_ids property of ['0', '2']
+            - a transaction_ids property of [ID_A, ID_C]
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/transactions?head=2&id=0,2'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/transactions?head={}&id={},{}'.format(ID_C, ID_A, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids '0' and '2'
+            - those dicts are full transactions with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response(0, 2)
-        transactions = Mocks.make_txns('0', '2')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_A, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
-        response = await self.get_assert_200('/transactions?id=0,2')
+        response = await self.get_assert_200('/transactions?id={},{}'.format(ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(transaction_ids=['0', '2'], paging=controls)
+        self.connection.assert_valid_request_sent(transaction_ids=[ID_A, ID_C], paging=controls)
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/transactions?head=2&id=0,2')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/transactions?head={}&id={},{}'.format(ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], '0', '2')
+        self.assert_txns_well_formed(response['data'], ID_A, ID_C)
 
     @unittest_run_loop
     async def test_txn_list_with_bad_ids(self):
@@ -193,24 +199,24 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE
-            - a head id of '2'
+            - a head id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '2', the latest
-            - a link property that ends in '/transactions?head=2&id=bad,notgood'
+            - a head property of ID_C, the latest
+            - a link property that ends in '/transactions?head={}&id={},{}'.format(ID_C, ID_B, ID_D)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response(None, 0)
         self.connection.preset_response(
             self.status.NO_RESOURCE,
-            head_id='2',
+            head_id=ID_C,
             paging=paging)
-        response = await self.get_assert_200('/transactions?id=bad,notgood')
+        response = await self.get_assert_200('/transactions?id={},{}'.format(ID_B, ID_D))
 
-        self.assert_has_valid_head(response, '2')
-        self.assert_has_valid_link(response, '/transactions?head=2&id=bad,notgood')
+        self.assert_has_valid_head(response, ID_C)
+        self.assert_has_valid_link(response, '/transactions?head={}&id={},{}'.format(ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -219,79 +225,79 @@ class TransactionListTests(BaseApiTest):
         """Verifies GET /transactions with head and id parameters work properly.
 
         It should send a Protobuf request with:
-            - a head_id property of '1'
+            - a head_id property of ID_B
             - a paging response with a start of 0, and 1 total resource
-            - a transaction_ids property of ['0']
+            - a transaction_ids property of [ID_A]
 
         It will receive a Protobuf response with:
-            - a head id of '1'
-            - one transaction with an id of '0'
+            - a head id of ID_B
+            - one transaction with an id of ID_A
             - empty paging controls
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of '1'
-            - a link property that ends in '/transactions?head=1&id=0'
+            - a head property of ID_B
+            - a link property that ends in '/transactions?head={}&id={}'.format(ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
-            - that dict is a full transaction with an id of '0'
+            - that dict is a full transaction with an id of ID_A
         """
         paging = Mocks.make_paging_response(0, 1)
         self.connection.preset_response(
-            head_id='1',
+            head_id=ID_B,
             paging=paging,
-            transactions=Mocks.make_txns('0'))
+            transactions=Mocks.make_txns(ID_A))
 
-        response = await self.get_assert_200('/transactions?id=0&head=1')
+        response = await self.get_assert_200('/transactions?id={}&head={}'.format(ID_A, ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(
-            head_id='1',
-            transaction_ids=['0'],
+            head_id=ID_B,
+            transaction_ids=[ID_A],
             paging=controls)
 
-        self.assert_has_valid_head(response, '1')
-        self.assert_has_valid_link(response, '/transactions?head=1&id=0')
+        self.assert_has_valid_head(response, ID_B)
+        self.assert_has_valid_link(response, '/transactions?head={}&id={}'.format(ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
-        self.assert_txns_well_formed(response['data'], '0')
+        self.assert_txns_well_formed(response['data'], ID_A)
 
     @unittest_run_loop
     async def test_txn_list_paginated(self):
         """Verifies GET /transactions paginated by min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 1, and 4 total resources
-            - one transaction with the id 'c'
+            - one transaction with the id ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 1, and a start_index of 1
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&min=1&count=1'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&min=1&count=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
-            - that dict is a full transaction with the id 'c'
+            - that dict is a full transaction with the id ID_C
         """
         paging = Mocks.make_paging_response(1, 4)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('c'))
+            transactions=Mocks.make_txns(ID_C))
 
         response = await self.get_assert_200('/transactions?min=1&count=1')
         controls = Mocks.make_paging_controls(1, start_index=1)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&min=1&count=1')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&min=1&count=1'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head=d&min=2&count=1',
-                                     '/transactions?head=d&min=0&count=1')
+                                     '/transactions?head={}&min=2&count=1'.format(ID_D),
+                                     '/transactions?head={}&min=0&count=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
-        self.assert_txns_well_formed(response['data'], 'c')
+        self.assert_txns_well_formed(response['data'], ID_C)
 
     @unittest_run_loop
     async def test_txn_list_with_zero_count(self):
@@ -326,202 +332,202 @@ class TransactionListTests(BaseApiTest):
         """Verifies GET /transactions paginated just by count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - two transactions with the ids 'd' and 'c'
+            - two transactions with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
             - paging controls with a count of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&count=2'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids 'd' and 'c'
+            - those dicts are full transactions with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response(0, 4)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('d', 'c'))
+            transactions=Mocks.make_txns(ID_D, ID_C))
 
         response = await self.get_assert_200('/transactions?count=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&count=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head=d&min=2&count=2')
+                                     '/transactions?head={}&min=2&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], 'd', 'c')
+        self.assert_txns_well_formed(response['data'], ID_D, ID_C)
 
     @unittest_run_loop
     async def test_txn_list_paginated_without_count(self):
         """Verifies GET /transactions paginated without count works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 2, and 4 total resources
-            - two transactions with the ids 'b' and 'a'
+            - two transactions with the ids ID_B and ID_A
 
         It should send a Protobuf request with:
             - paging controls with a start_index of 2
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&min=2'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&min=2'.format(ID_D)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids 'd' and 'c'
+            - those dicts are full transactions with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response(2, 4)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('b', 'a'))
+            transactions=Mocks.make_txns(ID_B, ID_A))
 
         response = await self.get_assert_200('/transactions?min=2')
         controls = Mocks.make_paging_controls(None, start_index=2)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&min=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&min=2'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/transactions?head=d&min=0&count=2')
+                                     previous_link='/transactions?head={}&min=0&count=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], 'b', 'a')
+        self.assert_txns_well_formed(response['data'], ID_B, ID_A)
 
     @unittest_run_loop
     async def test_txn_list_paginated_by_min_id(self):
         """Verifies GET /transactions paginated by a min id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * total_resources of 4
-                * a previous_id of 'd'
-            - three transactions with the ids 'c', 'b' and 'a'
+                * a previous_id of ID_D
+            - three transactions with the ids ID_C, ID_B and ID_A
 
         It should send a Protobuf request with:
-            - paging controls with a count of 5, and a start_id of 'c'
+            - paging controls with a count of 5, and a start_id of ID_C
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&min=c&count=5'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&min={}&count=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
-            - those dicts are full transactions with ids 'c', 'b', and 'a'
+            - those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d')
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('c', 'b', 'a'))
+            transactions=Mocks.make_txns(ID_C, ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?min=c&count=5')
-        controls = Mocks.make_paging_controls(5, start_id='c')
+        response = await self.get_assert_200('/transactions?min={}&count=5'.format(ID_C))
+        controls = Mocks.make_paging_controls(5, start_id=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&min=c&count=5')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&min={}&count=5'.format(ID_D, ID_C))
         self.assert_has_valid_paging(response, paging,
-                                     previous_link='/transactions?head=d&max=d&count=5')
+                                     previous_link='/transactions?head={}&max={}&count=5'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], 'c', 'b', 'a')
+        self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_txn_list_paginated_by_max_id(self):
         """Verifies GET /transactions paginated by a max id works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with:
                 * a start_index of 1
                 * a total_resources of 4
-                * a previous_id of 'd'
-                * a next_id of 'a'
-            - two transactions with the ids 'c' and 'b'
+                * a previous_id of ID_D
+                * a next_id of ID_A
+            - two transactions with the ids ID_C and ID_B
 
         It should send a Protobuf request with:
-            - paging controls with a count of 2, and an end_id of 'b'
+            - paging controls with a count of 2, and an end_id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&max=b&count=2'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&max={}&count=2'.format(ID_D, ID_B)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids 'c' and 'b'
+            - those dicts are full transactions with ids ID_C and ID_B
         """
-        paging = Mocks.make_paging_response(1, 4, previous_id='d', next_id='a')
+        paging = Mocks.make_paging_response(1, 4, previous_id=ID_D, next_id=ID_A)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('c', 'b'))
+            transactions=Mocks.make_txns(ID_C, ID_B))
 
-        response = await self.get_assert_200('/transactions?max=b&count=2')
-        controls = Mocks.make_paging_controls(2, end_id='b')
+        response = await self.get_assert_200('/transactions?max={}&count=2'.format(ID_B))
+        controls = Mocks.make_paging_controls(2, end_id=ID_B)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&max=b&count=2')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&max={}&count=2'.format(ID_D, ID_B))
         self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head=d&min=a&count=2',
-                                     '/transactions?head=d&max=d&count=2')
+                                     '/transactions?head={}&min={}&count=2'.format(ID_D, ID_A),
+                                     '/transactions?head={}&max={}&count=2'.format(ID_D, ID_D))
         self.assert_has_valid_data_list(response, 2)
-        self.assert_txns_well_formed(response['data'], 'c', 'b')
+        self.assert_txns_well_formed(response['data'], ID_C, ID_B)
 
     @unittest_run_loop
     async def test_txn_list_paginated_by_max_index(self):
         """Verifies GET /transactions paginated by a max index works properly.
 
         It will receive a Protobuf response with:
-            - a head id of 'd'
+            - a head id of ID_D
             - a paging response with a start of 0, and 4 total resources
-            - three transactions with the ids 'd', 'c' and 'b'
+            - three transactions with the ids ID_D, ID_C and ID_B
 
         It should send a Protobuf request with:
             - paging controls with a count of 3, and an start_index of 0
 
         It should send back a JSON response with:
             - a response status of 200
-            - a head property of 'd'
-            - a link property that ends in '/transactions?head=d&min=3&count=7'
+            - a head property of ID_D
+            - a link property that ends in '/transactions?head={}&min=3&count=7'.format(ID_D)
             - paging that matches the response, with a next link
             - a data property that is a list of 2 dicts
-            - those dicts are full transactions with ids 'd', 'c', and 'b'
+            - those dicts are full transactions with ids ID_D, ID_C, and ID_B
         """
         paging = Mocks.make_paging_response(0, 4)
         self.connection.preset_response(
-            head_id='d',
+            head_id=ID_D,
             paging=paging,
-            transactions=Mocks.make_txns('d', 'c', 'b'))
+            transactions=Mocks.make_txns(ID_D, ID_C, ID_B))
 
         response = await self.get_assert_200('/transactions?max=2&count=7')
         controls = Mocks.make_paging_controls(3, start_index=0)
         self.connection.assert_valid_request_sent(paging=controls)
 
-        self.assert_has_valid_head(response, 'd')
-        self.assert_has_valid_link(response, '/transactions?head=d&max=2&count=7')
+        self.assert_has_valid_head(response, ID_D)
+        self.assert_has_valid_link(response, '/transactions?head={}&max=2&count=7'.format(ID_D))
         self.assert_has_valid_paging(response, paging,
-                                     '/transactions?head=d&min=3&count=7')
+                                     '/transactions?head={}&min=3&count=7'.format(ID_D))
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], 'd', 'c', 'b')
+        self.assert_txns_well_formed(response['data'], ID_D, ID_C, ID_B)
 
     @unittest_run_loop
     async def test_txn_list_sorted(self):
         """Verifies GET /transactions can send proper sort controls.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids '0', '1', and '2'
+            - three transactions with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -529,15 +535,15 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/transactions?head=2&sort=header_signature'
+            - a head property of ID_C
+            - a link property ending in '/transactions?head={}&sort=header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids '0', '1', and '2'
+            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -546,12 +552,12 @@ class TransactionListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=header_signature')
+            '/transactions?head={}&sort=header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_batch_list_with_bad_sort(self):
@@ -574,9 +580,9 @@ class TransactionListTests(BaseApiTest):
         """Verifies GET /transactions can send proper sort controls with nested keys.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids '0', '1', and '2'
+            - three transactions with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -584,15 +590,15 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link ending in '/transactions?head=2&sort=header.signer_public_key'
+            - a head property of ID_C
+            - a link ending in '/transactions?head={}&sort=header.signer_public_key'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids '0', '1', and '2'
+            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
         response = await self.get_assert_200(
             '/transactions?sort=header.signer_public_key')
@@ -602,21 +608,21 @@ class TransactionListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=header.signer_public_key')
+            '/transactions?head={}&sort=header.signer_public_key'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_txn_list_sorted_in_reverse(self):
         """Verifies a GET /transactions can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids '2', '1', and '0'
+            - three transactions with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -624,15 +630,15 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/transactions?head=2&sort=-header_signature'
+            - a head property of ID_C
+            - a link property ending in '/transactions?head={}&sort=-header_signature'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids '2', '1', and '0'
+            - and those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=-header_signature')
         page_controls = Mocks.make_paging_controls()
@@ -642,21 +648,21 @@ class TransactionListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=-header_signature')
+            '/transactions?head={}&sort=-header_signature'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+        self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
     @unittest_run_loop
     async def test_txn_list_sorted_by_length(self):
         """Verifies a GET /transactions can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids '0', '1', and '2'
+            - three transactions with ids ID_A, ID_B, and ID_C
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -664,15 +670,15 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - a link property ending in '/transactions?head=2&sort=payload.length'
+            - a head property of ID_C
+            - a link property ending in '/transactions?head={}&sort=payload.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids '0', '1', and '2'
+            - and those dicts are full transactions with ids ID_A, ID_B, and ID_C
         """
         paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns('0', '1', '2')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_A, ID_B, ID_C)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
         response = await self.get_assert_200('/transactions?sort=payload.length')
         page_controls = Mocks.make_paging_controls()
@@ -681,21 +687,21 @@ class TransactionListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=payload.length')
+            '/transactions?head={}&sort=payload.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '0', '1', '2')
+        self.assert_txns_well_formed(response['data'], ID_A, ID_B, ID_C)
 
     @unittest_run_loop
     async def test_txn_list_sorted_by_many_keys(self):
         """Verifies a GET /transactions can send proper sort parameters.
 
         It will receive a Protobuf response with:
-            - a head id of '2'
+            - a head id of ID_C
             - a paging response with a start of 0, and 3 total resources
-            - three transactions with ids '2', '1', and '0'
+            - three transactions with ids ID_C, ID_B, and ID_A
 
         It should send a Protobuf request with:
             - empty paging controls
@@ -705,15 +711,15 @@ class TransactionListTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a status of 200
-            - a head property of '2'
-            - link with '/transactions?head=2&sort=-header_signature,payload.length'
+            - a head property of ID_C
+            - link with '/transactions?head={}&sort=-header_signature,payload.length'.format(ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids '2', '1', and '0'
+            - and those dicts are full transactions with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response(0, 3)
-        transactions = Mocks.make_txns('2', '1', '0')
-        self.connection.preset_response(head_id='2', paging=paging, transactions=transactions)
+        transactions = Mocks.make_txns(ID_C, ID_B, ID_A)
+        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
 
         response = await self.get_assert_200(
             '/transactions?sort=-header_signature,payload.length')
@@ -724,12 +730,12 @@ class TransactionListTests(BaseApiTest):
             paging=page_controls,
             sorting=sorting)
 
-        self.assert_has_valid_head(response, '2')
+        self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(response,
-            '/transactions?head=2&sort=-header_signature,payload.length')
+            '/transactions?head={}&sort=-header_signature,payload.length'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
-        self.assert_txns_well_formed(response['data'], '2', '1', '0')
+        self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
 class TransactionGetTests(BaseApiTest):
@@ -751,26 +757,26 @@ class TransactionGetTests(BaseApiTest):
         """Verifies a GET /transactions/{transaction_id} works properly.
 
         It should send a Protobuf request with:
-            - a transaction_id property of '1'
+            - a transaction_id property of ID_B
 
         It will receive a Protobuf response with:
-            - a transaction with an id of '1'
+            - a transaction with an id of ID_B
 
         It should send back a JSON response with:
             - a response status of 200
             - no head property
-            - a link property that ends in '/transactions/1'
-            - a data property that is a full batch with an id of '1'
+            - a link property that ends in '/transactions/{}'.format(ID_B)
+            - a data property that is a full batch with an id of ID_B
         """
-        self.connection.preset_response(transaction=Mocks.make_txns('1')[0])
+        self.connection.preset_response(transaction=Mocks.make_txns(ID_B)[0])
 
-        response = await self.get_assert_200('/transactions/1')
-        self.connection.assert_valid_request_sent(transaction_id='1')
+        response = await self.get_assert_200('/transactions/{}'.format(ID_B))
+        self.connection.assert_valid_request_sent(transaction_id=ID_B)
 
         self.assertNotIn('head', response)
-        self.assert_has_valid_link(response, '/transactions/1')
+        self.assert_has_valid_link(response, '/transactions/{}'.format(ID_B))
         self.assertIn('data', response)
-        self.assert_txns_well_formed(response['data'], '1')
+        self.assert_txns_well_formed(response['data'], ID_B)
 
     @unittest_run_loop
     async def test_txn_get_with_validator_error(self):
@@ -784,7 +790,7 @@ class TransactionGetTests(BaseApiTest):
             - an error property with a code of 10
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
-        response = await self.get_assert_status('/transactions/1', 500)
+        response = await self.get_assert_status('/transactions/{}'.format(ID_B), 500)
 
         self.assert_has_valid_error(response, 10)
 
@@ -800,6 +806,6 @@ class TransactionGetTests(BaseApiTest):
             - an error property with a code of 72
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
-        response = await self.get_assert_status('/transactions/bad', 404)
+        response = await self.get_assert_status('/transactions/{}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 72)

--- a/validator/sawtooth_validator/database/indexed_database.py
+++ b/validator/sawtooth_validator/database/indexed_database.py
@@ -135,7 +135,10 @@ class IndexedDatabase(database.Database):
                 read_key = key.encode()
                 # If we're looking at an index, check the index first
                 if index_cursor:
-                    read_key = index_cursor.get(read_key)
+                    try:
+                        read_key = index_cursor.get(read_key)
+                    except lmdb.BadValsizeError:
+                        raise KeyError("Invalid key: %s" % read_key)
                     if not read_key:
                         continue
 

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import re
 # pylint: disable=no-name-in-module
 from collections.abc import MutableMapping
 
@@ -20,6 +21,9 @@ from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.state.merkle import INIT_ROOT_KEY
+
+
+ID_REGEX = re.compile('[0-9a-f]{128}')
 
 
 class BlockStore(MutableMapping):
@@ -44,6 +48,8 @@ class BlockStore(MutableMapping):
         del self._block_store[key]
 
     def __contains__(self, x):
+        if ID_REGEX.fullmatch(x) is None:
+            return False
         return x in self._block_store
 
     def __iter__(self):
@@ -252,7 +258,11 @@ class BlockStore(MutableMapping):
         Returns
             list of block wrappers found for the given block ids
         """
-        return [block for _, block in self._block_store.get_multi(block_ids)]
+        return [block for _, block in self._get_blocks_by_valid_ids(block_ids)]
+
+    def _get_blocks_by_valid_ids(self, rsc_ids, index=None):
+        valid_ids = [i for i in rsc_ids if ID_REGEX.fullmatch(i) is not None]
+        return self._block_store.get_multi(valid_ids, index=index)
 
     def get_block_by_transaction_id(self, txn_id):
         """Returns the block that contains the given transaction id.
@@ -301,7 +311,7 @@ class BlockStore(MutableMapping):
         Returns:
             True if it is contained in a committed block, False otherwise
         """
-        return self._block_store.contains_key(txn_id, index='transaction')
+        return self._has_resource_by_valid_id(txn_id, index='transaction')
 
     def get_block_by_batch_id(self, batch_id):
         """Returns the block that contains the given batch id.
@@ -333,7 +343,7 @@ class BlockStore(MutableMapping):
         Raises:
             ValueError if no block containing the batch is found
         """
-        return self._block_store.get_multi(batch_ids, index='batch')
+        return self._get_blocks_by_valid_ids(batch_ids, index='batch')
 
     def has_batch(self, batch_id):
         """Returns True if the batch is contained in a block in the
@@ -345,7 +355,12 @@ class BlockStore(MutableMapping):
         Returns:
             True if it is contained in a committed block, False otherwise
         """
-        return self._block_store.contains_key(batch_id, index='batch')
+        return self._has_resource_by_valid_id(batch_id, index='batch')
+
+    def _has_resource_by_valid_id(self, resource_id, index=None):
+        if ID_REGEX.fullmatch(resource_id) is None:
+            return False
+        return self._block_store.contains_key(resource_id, index=index)
 
     def get_batch_by_transaction(self, transaction_id):
         """
@@ -391,7 +406,7 @@ class BlockStore(MutableMapping):
         Returns:
             A list of the batches found by the given batch ids
         """
-        blocks = self._block_store.get_multi(batch_ids, index='batch')
+        blocks = self._get_blocks_by_valid_ids(batch_ids, index='batch')
 
         return [BlockStore._get_batch_from_block(block, batch_id)
                 for batch_id, block in blocks]
@@ -422,8 +437,8 @@ class BlockStore(MutableMapping):
         return BlockStore._get_txn_from_block(block, transaction_id)
 
     def get_transactions(self, transaction_ids):
-        blocks = self._block_store.get_multi(
-            transaction_ids, index='transaction')
+        blocks = self._get_blocks_by_valid_ids(transaction_ids,
+                                               index='transaction')
 
         return [BlockStore._get_txn_from_block(block, txn_id)
                 for txn_id, block in blocks]

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -34,7 +34,7 @@ def _increment_key(key, offset=1):
         return chr(ord(key) + offset)
 
 def _make_mock_transaction(base_id='id', payload='payload'):
-    txn_id = 't-' + base_id
+    txn_id = 'c' * (128 - len(base_id)) + base_id
     header = TransactionHeader(
         batcher_public_key='public_key-' + base_id,
         family_name='family',
@@ -48,7 +48,7 @@ def _make_mock_transaction(base_id='id', payload='payload'):
         payload=payload.encode())
 
 def make_mock_batch(base_id='id'):
-    batch_id = 'b-' + base_id
+    batch_id = 'a' * (128 - len(base_id)) + base_id
     txn = _make_mock_transaction(base_id)
 
     header = BatchHeader(
@@ -64,9 +64,9 @@ def make_mock_batch(base_id='id'):
 class MockBlockStore(BlockStore):
     """
     Creates a block store with a preseeded chain of blocks.
-    With defaults, creates three blocks with ids ranging from 'b' * 127 + '0' to 'b' * 127 + '2',
-    and a single batch, and single transaction in each, with ids prefixed by
-    'b-' or 't-'. Using the optional root parameter for add_block, it is
+    With defaults, creates three blocks with ids ranging from 'bbb...0' to 'bbb...2',
+    with a single batch, and single transaction in each, with ids prefixed by
+    'aaa...'' or 'ccc...'. Using the optional root parameter for add_block, it is
     possible to save meaningful state_root_hashes to a block.
     """
     def __init__(self, size=3, start='0'):
@@ -143,17 +143,17 @@ def make_store_and_tracker(size=3):
         * tracker - a batch tracker attached to the store, with one pending batch
 
     With defaults, the three block ids in the store will be:
-        * 'b' * 127 + '0', 'b' * 127 + '1', B-2'
+        * 'bbb...0', 'bbb...1', 'bbb...2'
     The three batch ids in the store will be:
-        * 'b-0', 'b-1', b-2'
+        * 'aaa...0', 'aaa...1', 'aaa...2'
     The pending batch in the tracker will be:
-        * 'b-3'
+        * 'aaa...3'
     """
     store = MockBlockStore(size=size)
     tracker = BatchTracker(store)
-    tracker.notify_batch_pending(make_mock_batch('pending'))
-    tracker.notify_batch_pending(make_mock_batch('invalid'))
-    tracker.notify_txn_invalid('t-invalid', 'error message', b'error data')
+    tracker.notify_batch_pending(make_mock_batch('d'))
+    tracker.notify_batch_pending(make_mock_batch('f'))
+    tracker.notify_txn_invalid('c' * 127 + 'f', 'error message', b'error data')
 
     return store, tracker
 

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -20,6 +20,14 @@ from test_client_request_handlers.base_case import ClientHandlerTestCase
 from test_client_request_handlers.mocks import MockBlockStore
 
 
+B_0 = 'b' * 127 + '0'
+B_1 = 'b' * 127 + '1'
+B_2 = 'b' * 127 + '2'
+A_0 = 'a' * 127 + '0'
+A_1 = 'a' * 127 + '1'
+A_2 = 'a' * 127 + '2'
+
+
 class TestBatchListRequests(ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
@@ -33,26 +41,26 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for batch lists without parameters work properly.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2' (the latest)
+            - a head_id of 'bbb...2' (the latest)
             - the default paging response, showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...2'
         """
         response = self.make_request()
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-2', response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[0].header_signature)
 
     def test_batch_list_bad_request(self):
         """Verifies requests for lists of batches break with bad protobufs.
@@ -61,7 +69,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that head_id, paging, and batches are missing
         """
-        response = self.make_bad_request(head_id='b' * 127 + '1')
+        response = self.make_bad_request(head_id=B_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
@@ -87,25 +95,25 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of batches work properly with a head id.
 
         Queries the default mock block store with '1' as the head:
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 2 resources returned
             - a list of batches with 2 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-1'
+            - the first item has a header_signature of 'aaa...1'
         """
-        response = self.make_request(head_id='b' * 127 + '1')
+        response = self.make_request(head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-1', response.batches[0].header_signature)
+        self.assertEqual(A_1, response.batches[0].header_signature)
 
     def test_batch_list_with_bad_head(self):
         """Verifies requests for lists of batches break with a bad head.
@@ -125,46 +133,46 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of batches work filtered by batch ids.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 2 resources returned
             - a list of batches with 2 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-0'
-            - the second item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...0'
+            - the second item has a header_signature of 'aaa...2'
         """
-        response = self.make_request(batch_ids=['b-0', 'b-2'])
+        response = self.make_request(batch_ids=[A_0, A_2])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
-        self.assertEqual('b-2', response.batches[1].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[1].header_signature)
 
     def test_batch_list_by_bad_ids(self):
         """Verifies batch list requests break when ids are not found.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - that paging and batches are missing
         """
         response = self.make_request(batch_ids=['bad', 'also-bad'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
@@ -172,66 +180,66 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 1 resources returned
             - a list of batches with 1 items
             - that item is an instances of Batch
-            - that item has a header_signature of 'b-1'
+            - that item has a header_signature of 'aaa...1'
         """
-        response = self.make_request(batch_ids=['bad', 'b-1'])
+        response = self.make_request(batch_ids=['bad', A_1])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-1', response.batches[0].header_signature)
+        self.assertEqual(A_1, response.batches[0].header_signature)
 
     def test_batch_list_by_head_and_ids(self):
         """Verifies batch list requests work with both head and batch ids.
 
         Queries the default mock block store with '1' as the head:
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 1 resources returned
             - a list of batches with 1 item
             - that item is an instance of Batch
-            - that item has a header_signature of 'b-0'
+            - that item has a header_signature of 'aaa...0'
         """
-        response = self.make_request(head_id='b' * 127 + '1', batch_ids=['b-0'])
+        response = self.make_request(head_id=B_1, batch_ids=[A_0])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
 
     def test_batch_list_head_ids_mismatch(self):
         """Verifies batch list requests break when ids not found with head.
 
         Queries the default mock block store with '0' as the head:
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '0'
+            - a head_id of 'bbb...0'
             - that paging and batches are missing
         """
-        response = self.make_request(head_id='b' * 127 + '0', batch_ids=['b-1', 'b-2'])
+        response = self.make_request(head_id=B_0, batch_ids=[A_1, A_2])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '0', response.head_id)
+        self.assertEqual(B_0, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
@@ -239,121 +247,121 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for batch lists work when paginated just by count.
 
         Queries the default mock block store:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 'b-0'
+                * a next_id of 'aaa...0'
                 * the default empty previous_id
                 * the default start_index of 0
                 * the default total resource count of 3
             - a list of batches with 2 items
             - those items are instances of Batch
-            - the first item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...2'
         """
         response = self.make_paged_request(count=2)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, next_id='b-0')
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, next_id=A_0)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-2', response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[0].header_signature)
 
     def test_batch_list_paginated_by_start_id (self):
         """Verifies batch list requests work paginated by count and start_id.
 
         Queries the default mock block store:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 'b-0'
-                * a previous_id of 'b-2'
+                * a next_id of 'aaa...0'
+                * a previous_id of 'aaa...2'
                 * a start_index of 1
                 * the default total resource count of 3
             - a list of batches with 1 item
             - that item is an instance of Batch
-            - that item has a header_signature of 'b-1'
+            - that item has a header_signature of 'aaa...1'
         """
-        response = self.make_paged_request(count=1, start_id='b-1')
+        response = self.make_paged_request(count=1, start_id=A_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, 'b-0', 'b-2', 1)
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, A_0, A_2, 1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-1', response.batches[0].header_signature)
+        self.assertEqual(A_1, response.batches[0].header_signature)
 
     def test_batch_list_paginated_by_end_id (self):
         """Verifies batch list requests work paginated by count and end_id.
 
         Queries the default mock block store:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
                 * the default empty next_id
-                * a previous_id of 'b-2'
+                * a previous_id of 'aaa...2'
                 * a start_index of 1
                 * the default total resource count of 3
             - a list of batches with 2 items
             - those items are instances of Batch
-            - the first item has a header_signature of 'b-1'
+            - the first item has a header_signature of 'aaa...1'
         """
-        response = self.make_paged_request(count=2, end_id='b-0')
+        response = self.make_paged_request(count=2, end_id=A_0)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, previous_id='b-2', start_index=1)
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, previous_id=A_2, start_index=1)
         self.assertEqual(2, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-1', response.batches[0].header_signature)
+        self.assertEqual(A_1, response.batches[0].header_signature)
 
     def test_batch_list_paginated_by_index (self):
         """Verifies batch list requests work paginated by count and min_index.
 
         Queries the default mock block store:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
-            - a paging response with a next_id of 'b-1'
+            - a head_id of 'bbb...2', the latest
+            - a paging response with a next_id of 'aaa...1'
             - a list of batches with 1 item
             - that item is an instance of Batch
-            - that item has a header_signature of 'b-2'
+            - that item has a header_signature of 'aaa...2'
         """
         response = self.make_paged_request(count=1, start_index=0)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, next_id='b-1')
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, next_id=A_1)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-2', response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[0].header_signature)
 
     def test_batch_list_with_bad_pagination(self):
         """Verifies batch requests break when paging specifies missing batches.
 
         Queries the default mock block store:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of INVALID_PAGING
@@ -369,66 +377,66 @@ class TestBatchListRequests(ClientHandlerTestCase):
     def test_batch_list_paginated_with_head (self):
         """Verifies batch list requests work with both paging and a head id.
 
-        Queries the default mock block store with 'b' * 127 + '1' as the head:
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+        Queries the default mock block store with 'bbb...1' as the head:
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response with:
                 * an empty next_id
-                * a previous_id of 'b-1'
+                * a previous_id of 'aaa...1'
                 * a start_index of 1
                 * a total resource count of 2
             - a list of batches with 1 item
             - that item is an instance of Batch
-            - that has a header_signature of 'b-0'
+            - that has a header_signature of 'aaa...0'
         """
-        response = self.make_paged_request(count=1, start_index=1, head_id='b' * 127 + '1')
+        response = self.make_paged_request(count=1, start_index=1, head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
-        self.assert_valid_paging(response, '', 'b-1', 1, 2)
+        self.assertEqual(B_1, response.head_id)
+        self.assert_valid_paging(response, '', A_1, 1, 2)
         self.assertEqual(1, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
 
     def test_batch_list_sorted_by_key(self):
         """Verifies batch list requests work sorted by header_signature.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-0'
-            - the last item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...0'
+            - the last item has a header_signature of 'aaa...2'
         """
         controls = self.make_sort_controls('header_signature')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
-        self.assertEqual('b-2', response.batches[2].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[2].header_signature)
 
     def test_batch_list_sorted_by_bad_key(self):
         """Verifies batch list requests break properly sorted by a bad key.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of INVALID_SORT
@@ -446,117 +454,85 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests work sorted by header.signer_public_key.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-0'
-            - the last item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...0'
+            - the last item has a header_signature of 'aaa...2'
         """
         controls = self.make_sort_controls('header', 'signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
-        self.assertEqual('b-2', response.batches[2].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[2].header_signature)
 
     def test_batch_list_sorted_by_implied_header(self):
         """Verifies batch list requests work sorted by an implicit header key.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-0'
-            - the last item has a header_signature of 'b-2'
+            - the first item has a header_signature of 'aaa...0'
+            - the last item has a header_signature of 'aaa...2'
         """
         controls = self.make_sort_controls('signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-0', response.batches[0].header_signature)
-        self.assertEqual('b-2', response.batches[2].header_signature)
+        self.assertEqual(A_0, response.batches[0].header_signature)
+        self.assertEqual(A_2, response.batches[2].header_signature)
 
     def test_batch_list_sorted_in_reverse(self):
         """Verifies batch list requests work sorted by a key in reverse.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
+            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
+            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
+            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of batches with 3 items
             - the items are instances of Batch
-            - the first item has a header_signature of 'b-2'
-            - the last item has a header_signature of 'b-0'
+            - the first item has a header_signature of 'aaa...2'
+            - the last item has a header_signature of 'aaa...0'
         """
         controls = self.make_sort_controls('header_signature', reverse=True)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.batches))
         self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-2', response.batches[0].header_signature)
-        self.assertEqual('b-0', response.batches[2].header_signature)
-
-    def test_batch_list_sorted_by_length(self):
-        """Verifies batch list requests work sorted by a property's length.
-
-        Queries the default mock block store with two added blocks:
-            {header_signature: 'b' * 127 + 'long', batches: [{header_signature: 'b-long' ...}] ...}
-            {header_signature: 'b' * 127 + 'longest', batches: [{header_signature: 'b-longest' ...}] ...}
-            {header_signature: 'b' * 127 + '2', batches: [{header_signature: 'b-2' ...}] ...}
-            {header_signature: 'b' * 127 + '1', batches: [{header_signature: 'b-1' ...}] ...}
-            {header_signature: 'b' * 127 + '0', batches: [{header_signature: 'b-0' ...}] ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'b' * 127 + 'long', the latest
-            - a paging response showing all 5 resources returned
-            - a list of batches with 5 items
-            - the items are instances of Batch
-            - the second to last item has a header_signature of 'b' * 127 + 'long'
-            - the last item has a header_signature of 'b' * 127 + 'longest'
-        """
-        self.add_blocks('longest', 'long')
-        controls = self.make_sort_controls(
-            'header_signature', compare_length=True)
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 124 + 'long', response.head_id)
-        self.assert_valid_paging(response, total=5)
-        self.assertEqual(5, len(response.batches))
-        self.assert_all_instances(response.batches, Batch)
-        self.assertEqual('b-long', response.batches[3].header_signature)
-        self.assertEqual('b-longest', response.batches[4].header_signature)
+        self.assertEqual(A_2, response.batches[0].header_signature)
+        self.assertEqual(A_0, response.batches[2].header_signature)
 
 
 class TestBatchGetRequests(ClientHandlerTestCase):
@@ -570,17 +546,17 @@ class TestBatchGetRequests(ClientHandlerTestCase):
     def test_batch_get_request(self):
         """Verifies requests for a specific batch by id work properly.
 
-        Queries the default three block mock store for a batch id of 'b-1'.
+        Queries the default three block mock store for a batch id of 'aaa...1'.
         Expects to find:
             - a status of OK
             - a batch property which is an instances of Batch
-            - the batch has a header_signature of 'b-1'
+            - the batch has a header_signature of 'aaa...1'
         """
-        response = self.make_request(batch_id='b-1')
+        response = self.make_request(batch_id=A_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.batch, Batch)
-        self.assertEqual('b-1', response.batch.header_signature)
+        self.assertEqual(A_1, response.batch.header_signature)
 
     def test_batch_get_bad_request(self):
         """Verifies requests for a specific batch break with a bad protobuf.
@@ -589,7 +565,7 @@ class TestBatchGetRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that the Batch returned, when serialized, is actually empty
         """
-        response = self.make_bad_request(batch_id='b-1')
+        response = self.make_bad_request(batch_id=A_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.batch.SerializeToString())
@@ -613,7 +589,7 @@ class TestBatchGetRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that the Batch returned, when serialized, is actually empty
         """
-        response = self.make_request(batch_id='b' * 127 + '1')
+        response = self.make_request(batch_id=B_1)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.batch.SerializeToString())

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -21,6 +21,12 @@ from test_client_request_handlers.base_case import ClientHandlerTestCase
 from test_client_request_handlers.mocks import MockBlockStore
 
 
+B_0 = 'b' * 127 + '0'
+B_1 = 'b' * 127 + '1'
+B_2 = 'b' * 127 + '2'
+A_1 = 'a' * 127 + '1'
+C_1 = 'c' * 127 + '1'
+
 class TestBlockListRequests(ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
@@ -34,26 +40,26 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies requests for block lists without parameters work properly.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...}
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2' (the latest)
+            - a head_id of 'bbb...2' (the latest)
             - the default paging response, showing all 3 resources returned
             - a list of blocks with 3 items
             - the items are instances of Block
-            - The first item has a header_signature of 'b' * 127 + '2'
+            - The first item has a header_signature of 'bbb...2'
         """
         response = self.make_request()
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '2', response.blocks[0].header_signature)
+        self.assertEqual(B_2, response.blocks[0].header_signature)
 
     def test_block_list_bad_request(self):
         """Verifies requests for lists of blocks break with bad protobufs.
@@ -62,7 +68,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that blocks, head_id, and paging are missing
         """
-        response = self.make_bad_request(head_id='b' * 127 + '1')
+        response = self.make_bad_request(head_id=B_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
@@ -88,25 +94,25 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of blocks work properly with a head id.
 
         Queries the default mock block store with '1' as the head:
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...}
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 2 resources returned
             - a list of blocks with 2 items
             - the items are instances of Block
-            - The first item has a header_signature of 'b' * 127 + '1'
+            - The first item has a header_signature of 'bbb...1'
         """
-        response = self.make_request(head_id='b' * 127 + '1')
+        response = self.make_request(head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '1', response.blocks[0].header_signature)
+        self.assertEqual(B_1, response.blocks[0].header_signature)
 
     def test_block_list_with_bad_head(self):
         """Verifies requests for lists of blocks break with a bad head.
@@ -126,46 +132,46 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of blocks work filtered by block ids.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 2 resources returned
             - a list of blocks with 2 items
             - the items are instances of Block
-            - the first item has a header_signature of 'b' * 127 + '0'
-            - the second item has a header_signature of 'b' * 127 + '2'
+            - the first item has a header_signature of 'bbb...0'
+            - the second item has a header_signature of 'bbb...2'
         """
-        response = self.make_request(block_ids=['b' * 127 + '0', 'b' * 127 + '2'])
+        response = self.make_request(block_ids=[B_0, B_2])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '0', response.blocks[0].header_signature)
-        self.assertEqual('b' * 127 + '2', response.blocks[1].header_signature)
+        self.assertEqual(B_0, response.blocks[0].header_signature)
+        self.assertEqual(B_2, response.blocks[1].header_signature)
 
     def test_block_list_by_bad_ids(self):
         """Verifies block list requests break when ids are not found.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - that blocks and paging are missing
         """
         response = self.make_request(block_ids=['bad', 'also-bad'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.blocks)
 
@@ -173,65 +179,65 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies block list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 1 resources returned
             - a list of blocks with 1 items
             - that item is an instances of Block
-            - that item has a header_signature of 'b' * 127 + '1'
+            - that item has a header_signature of 'bbb...1'
         """
-        response = self.make_request(block_ids=['bad', 'b' * 127 + '1'])
+        response = self.make_request(block_ids=['bad', B_1])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '1', response.blocks[0].header_signature)
+        self.assertEqual(B_1, response.blocks[0].header_signature)
 
     def test_block_list_by_head_and_ids(self):
         """Verifies block list requests work with both head and block ids.
 
         Queries the default mock block store with '1' as the head:
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 1 resources returned
             - a list of blocks with 1 item
             - that item is an instance of Block
-            - that item has a header_signature of 'b' * 127 + '0'
+            - that item has a header_signature of 'bbb...0'
         """
-        response = self.make_request(head_id='b' * 127 + '1', block_ids=['b' * 127 + '0'])
+        response = self.make_request(head_id=B_1, block_ids=[B_0])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '0', response.blocks[0].header_signature)
+        self.assertEqual(B_0, response.blocks[0].header_signature)
 
     def test_block_list_head_ids_mismatch(self):
         """Verifies block list requests break when ids not found with head.
 
         Queries the default mock block store with '0' as the head:
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '0'
+            - a head_id of 'bbb...0'
             - that paging and blocks are missing
         """
-        response = self.make_request(head_id='b' * 127 + '0', block_ids=['b' * 127 + '1', 'b' * 127 + '2'])
+        response = self.make_request(head_id=B_0, block_ids=[B_1, B_2])
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '0', response.head_id)
+        self.assertEqual(B_0, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.blocks)
 
@@ -239,25 +245,25 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies requests for block lists work when paginated just by count.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: B_2 ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
-            - a paging response with a next_id of 'b' * 127 + '0'
+            - a head_id of 'bbb...2', the latest
+            - a paging response with a next_id of 'bbb...0'
             - a list of blocks with 2 items
             - those items are instances of Block
-            - the first item has a header_signature of 'b' * 127 + '2'
+            - the first item has a header_signature of 'bbb...2'
         """
         response = self.make_paged_request(count=2)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assertEqual(2, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '2', response.blocks[0].header_signature)
+        self.assertEqual(B_2, response.blocks[0].header_signature)
         self.assert_valid_paging(response,
                                  next_id=BlockStore.block_num_to_hex(0))
 
@@ -265,40 +271,40 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies block list requests work paginated by count and start_id.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 'b' * 127 + '0'
-                * a previous_id of 'b' * 127 + '2'
+                * a next_id of 'bbb...0'
+                * a previous_id of 'bbb...2'
                 * a start_index of 1
                 * the default total resource count of 3
             - a list of blocks with 1 item
             - that item is an instance of Block
-            - that item has a header_signature of 'b' * 127 + '1'
+            - that item has a header_signature of 'bbb...1'
         """
         response = self.make_paged_request(
             count=1, start_id=BlockStore.block_num_to_hex(1))
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response,
                                  next_id=BlockStore.block_num_to_hex(0))
         self.assertEqual(1, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '1', response.blocks[0].header_signature)
+        self.assertEqual(B_1, response.blocks[0].header_signature)
 
     def test_block_list_with_bad_pagination(self):
         """Verifies block requests break when paging specifies missing blocks.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of INVALID_PAGING
@@ -315,9 +321,9 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies block list requests break properly sorted by a bad key.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of INVALID_SORT
@@ -335,29 +341,29 @@ class TestBlockListRequests(ClientHandlerTestCase):
         """Verifies block list requests work sorted by a key in reverse.
 
         Queries the default mock block store with three blocks:
-            {header: {block_num: 2 ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {block_num: 1 ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {block_num: 0 ...}, header_signature: 'b' * 127 + '0' ...},
+            {header: {block_num: 2 ...}, header_signature: 'bbb...2' ...},
+            {header: {block_num: 1 ...}, header_signature: 'bbb...1' ...},
+            {header: {block_num: 0 ...}, header_signature: 'bbb...0' ...},
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of blocks with 3 items
             - the items are instances of Block
-            - the first item has a header_signature of 'b' * 127 + '2'
-            - the last item has a header_signature of 'b' * 127 + '0'
+            - the first item has a header_signature of 'bbb...2'
+            - the last item has a header_signature of 'bbb...0'
         """
         controls = self.make_sort_controls('block_num', reverse=True)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
-        self.assertEqual('b' * 127 + '0', response.blocks[0].header_signature)
-        self.assertEqual('b' * 127 + '2', response.blocks[2].header_signature)
+        self.assertEqual(B_0, response.blocks[0].header_signature)
+        self.assertEqual(B_2, response.blocks[2].header_signature)
 
 
 class TestBlockGetByIdRequests(ClientHandlerTestCase):
@@ -371,17 +377,17 @@ class TestBlockGetByIdRequests(ClientHandlerTestCase):
     def test_block_get_request(self):
         """Verifies requests for a specific block by id work properly.
 
-        Queries the default three block mock store for an id of 'b' * 127 + '1'.
+        Queries the default three block mock store for an id of 'bbb...1'.
         Expects to find:
             - a status of OK
             - the block property which is an instances of Block
-            - The block has a header_signature of 'b' * 127 + '1'
+            - The block has a header_signature of 'bbb...1'
         """
-        response = self.make_request(block_id='b' * 127 + '1')
+        response = self.make_request(block_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.block, Block)
-        self.assertEqual('b' * 127 + '1', response.block.header_signature)
+        self.assertEqual(B_1, response.block.header_signature)
 
     def test_block_get_bad_request(self):
         """Verifies requests for a specific block break with a bad protobuf.
@@ -390,7 +396,7 @@ class TestBlockGetByIdRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_bad_request(block_id='b' * 127 + '1')
+        response = self.make_bad_request(block_id=B_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.block.SerializeToString())
@@ -414,7 +420,7 @@ class TestBlockGetByIdRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_request(block_id='b-1')
+        response = self.make_request(block_id=A_1)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())
@@ -434,13 +440,13 @@ class TestBlockGetByTransactionRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - the block property which is an instances of Block
-            - The block has a header_signature of 'b' * 127 + '1'
+            - The block has a header_signature of 'bbb...1'
         """
-        response = self.make_request(transaction_id='t-1')
+        response = self.make_request(transaction_id=C_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.block, Block)
-        self.assertEqual('b' * 127 + '1', response.block.header_signature)
+        self.assertEqual(B_1, response.block.header_signature)
 
     def test_block_get_bad_request(self):
         """Verifies requests for a specific block break with a bad protobuf.
@@ -449,7 +455,7 @@ class TestBlockGetByTransactionRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_bad_request(transaction_id='t-1')
+        response = self.make_bad_request(transaction_id=C_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.block.SerializeToString())
@@ -481,13 +487,13 @@ class TestBlockGetByBatchRequests(ClientHandlerTestCase):
         Expects to find:
             - a status of OK
             - the block property which is an instances of Block
-            - The block has a header_signature of 'b' * 127 + '1'
+            - The block has a header_signature of 'bbb...1'
         """
-        response = self.make_request(batch_id='b-1')
+        response = self.make_request(batch_id=A_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.block, Block)
-        self.assertEqual('b' * 127 + '1', response.block.header_signature)
+        self.assertEqual(B_1, response.block.header_signature)
 
     def test_block_get_bad_request(self):
         """Verifies requests for a specific block break with a bad protobuf.
@@ -496,7 +502,7 @@ class TestBlockGetByBatchRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_bad_request(batch_id='b-1')
+        response = self.make_bad_request(batch_id=A_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.block.SerializeToString())

--- a/validator/tests/test_client_request_handlers/test_peer_handler.py
+++ b/validator/tests/test_client_request_handlers/test_peer_handler.py
@@ -35,11 +35,11 @@ class TestPeerRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2' (the latest)
+            - a head_id of 'bbb...2' (the latest)
             - the default paging response, showing all 3 resources returned
             - a list of blocks with 3 items
             - the items are instances of Block
-            - The first item has a header_signature of 'b' * 127 + '2'
+            - The first item has a header_signature of 'bbb...2'
         """
         response = self.make_request()
 

--- a/validator/tests/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_state_handlers.py
@@ -179,7 +179,7 @@ class TestStateListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of OK
-            - the state_root from block 'b' * 127 + '1'
+            - the state_root from block 'bbb...1'
             - a paging response showing all 1 resources returned
             - a list of entries with 1 item
             - that the list contains instances of ClientStateListResponse.Entry
@@ -206,7 +206,7 @@ class TestStateListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of NO_RESOURCE
-            - the state_root from block 'b' * 127 + '1'
+            - the state_root from block 'bbb...1'
             - that paging and entries are missing
         """
         response = self.make_request(address='c', state_root=self.roots[1])
@@ -348,7 +348,7 @@ class TestStateListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of OK
-            - the state_root of block 'b' * 127 + '1'
+            - the state_root of block 'bbb...1'
             - a paging response with:
                 * an empty next_id
                 * a previous_id of 'a'

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -25,6 +25,11 @@ from test_client_request_handlers.mocks import make_mock_batch
 from test_client_request_handlers.mocks import make_store_and_tracker
 
 
+A_0 = 'a' * 127 + '0'
+A_1 = 'a' * 127 + '1'
+A_2 = 'a' * 127 + '2'
+
+
 class TestBatchSubmitFinisher(ClientHandlerTestCase):
     def setUp(self):
         store, tracker = make_store_and_tracker()
@@ -73,18 +78,18 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies requests for status of a batch in the block store work.
 
         Queries the default mock block store with three blocks/batches:
-            {header: {batch_ids: ['b-2'] ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {batch_ids: ['b-1'] ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {batch_ids: ['b-0'] ...}, header_signature: 'b' * 127 + '0' ...}
+            {header: {batch_ids: ['aaa...2'] ...}, header_signature: 'bbb...2' ...},
+            {header: {batch_ids: ['aaa...1'] ...}, header_signature: 'bbb...1' ...},
+            {header: {batch_ids: ['aaa...0'] ...}, header_signature: 'bbb...0' ...}
 
         Expects to find:
             - a response status of OK
             - a status of COMMITTED at key '0' in batch_statuses
         """
-        response = self.make_request(batch_ids=['b-0'])
+        response = self.make_request(batch_ids=[A_0])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses[0].batch_id, 'b-0')
+        self.assertEqual(response.batch_statuses[0].batch_id, A_0)
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.COMMITTED)
 
@@ -94,7 +99,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         Expects to find:
             - a response status of INTERNAL_ERROR
         """
-        response = self.make_bad_request(batch_ids=['b-0'])
+        response = self.make_bad_request(batch_ids=[A_0])
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
 
@@ -114,26 +119,26 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies batch status requests marked INVALID by the tracker work.
 
         Queries the default mock batch tracker with invalid batch ids of:
-            - 'b-invalid'
+            - 'aaa...f'
 
         Expects to find:
             - a response status of OK
-            - a status of INVALID at key 'b-invalid' in batch_statuses
+            - a status of INVALID at key 'aaa...f' in batch_statuses
             - an invalid_transaction with
-                * an 'id' of 't-invalid'
+                * an 'id' of 'ccc...f'
                 * a message of 'error message'
                 * extended_data of b'error data'
         """
-        response = self.make_request(batch_ids=['b-invalid'])
+        response = self.make_request(batch_ids=['a' * 127 + 'f'])
 
         self.assertEqual(self.status.OK, response.status)
         status = response.batch_statuses[0]
-        self.assertEqual(status.batch_id, 'b-invalid')
+        self.assertEqual(status.batch_id, 'a' * 127 + 'f')
         self.assertEqual(status.status, ClientBatchStatus.INVALID)
         self.assertEqual(1, len(status.invalid_transactions))
 
         invalid_txn = status.invalid_transactions[0]
-        self.assertEqual(invalid_txn.transaction_id, 't-invalid')
+        self.assertEqual(invalid_txn.transaction_id, 'c' * 127 + 'f')
         self.assertEqual(invalid_txn.message, 'error message')
         self.assertEqual(invalid_txn.extended_data, b'error data')
 
@@ -141,16 +146,16 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies batch status requests marked PENDING by the tracker work.
 
         Queries the default mock batch tracker with pending batch ids of:
-            - 'b-pending'
+            - 'aaa...d'
 
         Expects to find:
             - a response status of OK
-            - a status of PENDING at key 'b-pending' in batch_statuses
+            - a status of PENDING at key 'aaa...d' in batch_statuses
         """
-        response = self.make_request(batch_ids=['b-pending'])
+        response = self.make_request(batch_ids=['a' * 127 + 'd'])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses[0].batch_id, 'b-pending')
+        self.assertEqual(response.batch_statuses[0].batch_id, 'a' * 127 + 'd')
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.PENDING)
 
@@ -172,22 +177,22 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies requests for status of many batches work properly.
 
         Queries the default mock block store with three blocks/batches:
-            {header: {batch_ids: ['b-2'] ...}, header_signature: 'b' * 127 + '2' ...},
-            {header: {batch_ids: ['b-1'] ...}, header_signature: 'b' * 127 + '1' ...},
-            {header: {batch_ids: ['b-0'] ...}, header_signature: 'b' * 127 + '0' ...}
+            {header: {batch_ids: ['aaa...2'] ...}, header_signature: 'bbb...2' ...},
+            {header: {batch_ids: ['aaa...1'] ...}, header_signature: 'bbb...1' ...},
+            {header: {batch_ids: ['aaa...0'] ...}, header_signature: 'bbb...0' ...}
 
         ...and the default mock batch tracker with pending batch ids of:
-            - 'b-pending'
+            - 'aaa...d'
 
         Expects to find:
             - a response status of OK
-            - a status of COMMITTED at key 'b-1' in batch_statuses
-            - a status of COMMITTED at key 'b-2' in batch_statuses
-            - a status of PENDING at key 'b-pending' in batch_statuses
-            - a status of UNKNOWN at key 'b-y' in batch_statuses
+            - a status of COMMITTED at key 'aaa...1' in batch_statuses
+            - a status of COMMITTED at key 'aaa...2' in batch_statuses
+            - a status of PENDING at key 'aaa...d' in batch_statuses
+            - a status of UNKNOWN at key 'fff...f' in batch_statuses
         """
         response = self.make_request(
-            batch_ids=['b-1', 'b-2', 'b-pending', 'y'])
+            batch_ids=[A_1, A_2, 'a' * 127 + 'd', 'f' * 128])
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(response.batch_statuses[0].status,
@@ -203,25 +208,25 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies requests for status that wait for commit work properly.
 
         Queries the default mock block store which will have no block with
-        the id 'b-new' until added by a separate thread.
+        the id 'aaa...e' until added by a separate thread.
 
         Expects to find:
             - less than 8 seconds to have passed (i.e. did not wait for
             timeout)
             - a response status of OK
-            - a status of COMMITTED at key 'b-new' in batch_statuses
+            - a status of COMMITTED at key 'aaa...e' in batch_statuses
         """
-        self._tracker.notify_batch_pending(make_mock_batch('new'))
+        self._tracker.notify_batch_pending(make_mock_batch('e'))
         start_time = time()
 
         def delayed_add():
             sleep(1)
-            self._store.add_block('new')
+            self._store.add_block('e')
             self._tracker.chain_update(None, [])
         Thread(target=delayed_add).start()
 
         response = self.make_request(
-            batch_ids=['b-new'],
+            batch_ids=['a' * 127 + 'e'],
             wait=True,
             timeout=10)
 
@@ -238,11 +243,11 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
             - less than 8 seconds to have passed (i.e. did not wait for
             timeout)
             - a response status of OK
-            - a status of COMMITTED at key 'b-0' in batch_statuses
+            - a status of COMMITTED at key 'aaa...0' in batch_statuses
         """
         start_time = time()
         response = self.make_request(
-            batch_ids=['b-0'],
+            batch_ids=[A_0],
             wait=True,
             timeout=10)
 

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -20,6 +20,14 @@ from test_client_request_handlers.base_case import ClientHandlerTestCase
 from test_client_request_handlers.mocks import MockBlockStore
 
 
+B_0 = 'b' * 127 + '0'
+B_1 = 'b' * 127 + '1'
+B_2 = 'b' * 127 + '2'
+C_0 = 'c' * 127 + '0'
+C_1 = 'c' * 127 + '1'
+C_2 = 'c' * 127 + '2'
+
+
 class TestTransactionListRequests(ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
@@ -34,36 +42,36 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Queries the default mock block store with three blocks:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - the default paging response, showing all 3 resources returned
             - a list of transactions with 3 items
             - those items are instances of Transaction
-            - the first item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...2'
         """
         response = self.make_request()
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-2', response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[0].header_signature)
 
     def test_txn_list_bad_request(self):
         """Verifies requests for txn lists break with bad protobufs.
@@ -72,7 +80,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that head_id, paging, and transactions are missing
         """
-        response = self.make_bad_request(head_id='b' * 127 + '1')
+        response = self.make_bad_request(head_id=B_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.head_id)
@@ -97,37 +105,37 @@ class TestTransactionListRequests(ClientHandlerTestCase):
     def test_txn_list_with_head(self):
         """Verifies requests for txn lists work properly with a head id.
 
-        Queries the default mock block store with 'b' * 127 + '1' as the head:
+        Queries the default mock block store with 'bbb...1' as the head:
             {
-                header_signature: 'b' * 127 + '1',
+                header_signature: 'bbb...1',
                 batches: [{
-                    header_signature: 'b-1',
+                    header_signature: 'aaa...1',
                     transactions: [{
-                        header_signature: 't-1',
+                        header_signature: 'ccc...1',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 2 resources returned
             - a list of transactions with 2 items
             - those items are instances of Transaction
-            - the first item has a header_signature of 't-1'
+            - the first item has a header_signature of 'ccc...1'
         """
-        response = self.make_request(head_id='b' * 127 + '1')
+        response = self.make_request(head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-1', response.transactions[0].header_signature)
+        self.assertEqual(C_1, response.transactions[0].header_signature)
 
     def test_txn_list_with_bad_head(self):
         """Verifies requests for txn lists break with a bad head.
@@ -148,67 +156,67 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Queries the default mock block store with three blocks:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 2 resources returned
             - a list of transactions with 2 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the second item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the second item has a header_signature of 'ccc...2'
         """
-        response = self.make_request(transaction_ids=['t-0', 't-2'])
+        response = self.make_request(transaction_ids=[C_0, C_2])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=2)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
-        self.assertEqual('t-2', response.transactions[1].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[1].header_signature)
 
     def test_txn_list_by_bad_ids(self):
         """Verifies txn list requests break properly when ids are not found.
 
         Queries the default mock block store with three blocks:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - that paging and transactions are missing
         """
         response = self.make_request(transaction_ids=['bad', 'notgood'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.transactions)
 
@@ -217,82 +225,82 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Queries the default mock block store with three blocks:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 1 resources returned
             - a list of transactions with 1 items
             - that item is an instances of Transaction
-            - that item has a header_signature of 't-1'
+            - that item has a header_signature of 'ccc...1'
         """
-        response = self.make_request(transaction_ids=['bad', 't-1'])
+        response = self.make_request(transaction_ids=['bad', C_1])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-1', response.transactions[0].header_signature)
+        self.assertEqual(C_1, response.transactions[0].header_signature)
 
     def test_txn_list_by_head_and_ids(self):
         """Verifies txn list requests work with both head and txn ids.
 
-        Queries the default mock block store with 'b' * 127 + '1' as the head:
+        Queries the default mock block store with 'bbb...1' as the head:
             {
-                header_signature: 'b' * 127 + '1',
+                header_signature: 'bbb...1',
                 batches: [{
-                    header_signature: 'b-1',
+                    header_signature: 'aaa...1',
                     transactions: [{
-                        header_signature: 't-1',
+                        header_signature: 'ccc...1',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response showing all 1 resources returned
             - a list of transactions with 1 item
             - that item is an instance of Transaction
-            - that item has a header_signature of 't-0'
+            - that item has a header_signature of 'ccc...0'
         """
-        response = self.make_request(head_id='b' * 127 + '1', transaction_ids=['t-0'])
+        response = self.make_request(head_id=B_1, transaction_ids=[C_0])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
+        self.assertEqual(B_1, response.head_id)
         self.assert_valid_paging(response, total=1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
 
     def test_txn_list_head_ids_mismatch(self):
         """Verifies txn list requests break when ids not found with head.
 
-        Queries the default mock block store with 'b' * 127 + '0' as the head:
+        Queries the default mock block store with 'bbb...0' as the head:
             {
-                header_signature: 'b' * 127 + '0',
+                header_signature: 'bbb...0',
                 batches: [{
-                    header_signature: 'b-0',
+                    header_signature: 'aaa...0',
                     transactions: [{
-                        header_signature: 't-0',
+                        header_signature: 'ccc...0',
                         ...
                     }],
                     ...
@@ -302,13 +310,13 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a status of NO_RESOURCE
-            - a head_id of 'b' * 127 + '0'
+            - a head_id of 'bbb...0'
             - that paging and transactions are missing
         """
-        response = self.make_request(head_id='b' * 127 + '0', transaction_ids=['t-1', 't-2'])
+        response = self.make_request(head_id=B_0, transaction_ids=['ccc...1', 'ccc...2'])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
-        self.assertEqual('b' * 127 + '0', response.head_id)
+        self.assertEqual(B_0, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.transactions)
 
@@ -317,175 +325,175 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 't-0'
+                * a next_id of 'ccc...0'
                 * the default empty previous_id
                 * the default start_index of 0
                 * the default total resource count of 3
             - a list of transactions with 2 items
             - those items are instances of Transaction
-            - the first item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...2'
         """
         response = self.make_paged_request(count=2)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, next_id='t-0')
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, next_id=C_0)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-2', response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[0].header_signature)
 
     def test_txn_list_paginated_by_start_id (self):
         """Verifies txn list requests work paginated by count and start_id.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
-                * a next_id of 't-0'
-                * a previous_id of 't-2'
+                * a next_id of 'ccc...0'
+                * a previous_id of 'ccc...2'
                 * a start_index of 1
                 * the default total resource count of 3
             - a list of transactions with 1 item
             - that item is an instance of Transaction
-            - that item has a header_signature of 't-1'
+            - that item has a header_signature of 'ccc...1'
         """
-        response = self.make_paged_request(count=1, start_id='t-1')
+        response = self.make_paged_request(count=1, start_id=C_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, 't-0', 't-2', 1)
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, C_0, C_2, 1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-1', response.transactions[0].header_signature)
+        self.assertEqual(C_1, response.transactions[0].header_signature)
 
     def test_txn_list_paginated_by_end_id (self):
         """Verifies txn list requests work paginated by count and end_id.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response with:
                 * the default empty next_id
-                * a previous_id of 't-2'
+                * a previous_id of 'ccc...2'
                 * a start_index of 1
                 * the default total resource count of 3
             - a list of transactions with 2 items
             - those items are instances of Transaction
-            - the first item has a header_signature of 't-1'
+            - the first item has a header_signature of 'ccc...1'
         """
-        response = self.make_paged_request(count=2, end_id='t-0')
+        response = self.make_paged_request(count=2, end_id=C_0)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, previous_id='t-2', start_index=1)
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, previous_id=C_2, start_index=1)
         self.assertEqual(2, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-1', response.transactions[0].header_signature)
+        self.assertEqual(C_1, response.transactions[0].header_signature)
 
     def test_txn_list_paginated_by_index (self):
         """Verifies txn list requests work paginated by count and min_index.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
-            - a paging response with a next_id of 't-1'
+            - a head_id of 'bbb...2', the latest
+            - a paging response with a next_id of 'ccc...1'
             - a list of transactions with 1 item
             - that item is an instance of Transaction
-            - that item has a header_signature of 't-2'
+            - that item has a header_signature of 'ccc...2'
         """
         response = self.make_paged_request(count=1, start_index=0)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
-        self.assert_valid_paging(response, next_id='t-1')
+        self.assertEqual(B_2, response.head_id)
+        self.assert_valid_paging(response, next_id=C_1)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-2', response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[0].header_signature)
 
     def test_txn_list_with_bad_pagination(self):
         """Verifies txn requests break when paging specifies missing txns.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of INVALID_PAGING
@@ -501,88 +509,88 @@ class TestTransactionListRequests(ClientHandlerTestCase):
     def test_txn_list_paginated_with_head (self):
         """Verifies txn list requests work with both paging and a head id.
 
-        Queries the default mock block store with 'b' * 127 + '1' as the head:
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+        Queries the default mock block store with 'bbb...1' as the head:
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '1'
+            - a head_id of 'bbb...1'
             - a paging response with:
                 * an empty next_id
-                * a previous_id of 't-1'
+                * a previous_id of 'ccc...1'
                 * a start_index of 1
                 * a total resource count of 2
             - a list of transactions with 1 item
             - that item is an instance of Transaction
-            - that has a header_signature of 't-0'
+            - that has a header_signature of 'ccc...0'
         """
-        response = self.make_paged_request(count=1, start_index=1, head_id='b' * 127 + '1')
+        response = self.make_paged_request(count=1, start_index=1, head_id=B_1)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '1', response.head_id)
-        self.assert_valid_paging(response, '', 't-1', 1, 2)
+        self.assertEqual(B_1, response.head_id)
+        self.assert_valid_paging(response, '', C_1, 1, 2)
         self.assertEqual(1, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
 
     def test_txn_list_sorted_by_key(self):
         """Verifies txn list requests work sorted by header_signature.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of transactions with 3 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the last item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the last item has a header_signature of 'ccc...2'
         """
         controls = self.make_sort_controls('header_signature')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
-        self.assertEqual('t-2', response.transactions[2].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[2].header_signature)
 
     def test_txn_list_sorted_by_bad_key(self):
         """Verifies txn list requests break properly sorted by a bad key.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of INVALID_SORT
@@ -601,200 +609,157 @@ class TestTransactionListRequests(ClientHandlerTestCase):
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of transactions with 3 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the last item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the last item has a header_signature of 'ccc...2'
         """
         controls = self.make_sort_controls('header', 'signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
-        self.assertEqual('t-2', response.transactions[2].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[2].header_signature)
 
     def test_txn_list_sorted_by_implied_header(self):
         """Verifies txn list requests work sorted by an implicit header key.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of transactions with 3 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the last item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the last item has a header_signature of 'ccc...2'
         """
         controls = self.make_sort_controls('signer_public_key')
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
-        self.assertEqual('t-2', response.transactions[2].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[2].header_signature)
 
     def test_txn_list_sorted_by_many_keys(self):
         """Verifies txn list requests work sorted by two keys.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of transactions with 3 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the last item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the last item has a header_signature of 'ccc...2'
         """
         controls = (self.make_sort_controls('family_name') +
                     self.make_sort_controls('signer_public_key'))
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-0', response.transactions[0].header_signature)
-        self.assertEqual('t-2', response.transactions[2].header_signature)
+        self.assertEqual(C_0, response.transactions[0].header_signature)
+        self.assertEqual(C_2, response.transactions[2].header_signature)
 
     def test_txn_list_sorted_in_reverse(self):
         """Verifies txn list requests work sorted by a key in reverse.
 
         Queries the default mock block store:
             {
-                header_signature: 'b' * 127 + '2',
+                header_signature: 'bbb...2',
                 batches: [{
-                    header_signature: 'b-2',
+                    header_signature: 'aaa...2',
                     transactions: [{
-                        header_signature: 't-2',
+                        header_signature: 'ccc...2',
                         ...
                     }],
                     ...
                 }],
                 ...
             },
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
+            {header_signature: 'bbb...1', ...},
+            {header_signature: 'bbb...0', ...}
 
         Expects to find:
             - a status of OK
-            - a head_id of 'b' * 127 + '2', the latest
+            - a head_id of 'bbb...2', the latest
             - a paging response showing all 3 resources returned
             - a list of transactions with 3 items
             - the items are instances of Transaction
-            - the first item has a header_signature of 't-0'
-            - the last item has a header_signature of 't-2'
+            - the first item has a header_signature of 'ccc...0'
+            - the last item has a header_signature of 'ccc...2'
         """
         controls = self.make_sort_controls('header_signature', reverse=True)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 127 + '2', response.head_id)
+        self.assertEqual(B_2, response.head_id)
         self.assert_valid_paging(response)
         self.assertEqual(3, len(response.transactions))
         self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-2', response.transactions[0].header_signature)
-        self.assertEqual('t-0', response.transactions[2].header_signature)
-
-    def test_txn_list_sorted_by_length(self):
-        """Verifies txn list requests work sorted by a property's length.
-
-        Queries the default mock block store with two added blocks:
-            {
-                header_signature: 'b' * 127 + 'long',
-                batches: [{
-                    header_signature: 'b-long',
-                    transactions: [{
-                        header_signature: 't-long',
-                        ...
-                    }],
-                    ...
-                }],
-                ...
-            },
-            {header_signature: 'b' * 127 + 'longest', ...},
-            {header_signature: 'b' * 127 + '2', ...},
-            {header_signature: 'b' * 127 + '1', ...},
-            {header_signature: 'b' * 127 + '0', ...}
-
-        Expects to find:
-            - a status of OK
-            - a head_id of 'b' * 127 + 'long', the latest
-            - a paging response showing all 5 resources returned
-            - a list of transactions with 5 items
-            - the items are instances of Transaction
-            - the second to last item has a header_signature of 't-long'
-            - the last item has a header_signature of 't-longest'
-        """
-        self.add_blocks('longest', 'long')
-        controls = self.make_sort_controls(
-            'header_signature', compare_length=True)
-        response = self.make_request(sorting=controls)
-
-        self.assertEqual(self.status.OK, response.status)
-        self.assertEqual('b' * 124 + 'long', response.head_id)
-        self.assert_valid_paging(response, total=5)
-        self.assertEqual(5, len(response.transactions))
-        self.assert_all_instances(response.transactions, Transaction)
-        self.assertEqual('t-long', response.transactions[3].header_signature)
-        self.assertEqual('t-longest', response.transactions[4].header_signature)
+        self.assertEqual(C_2, response.transactions[0].header_signature)
+        self.assertEqual(C_0, response.transactions[2].header_signature)
 
 
 class TestTransactionGetRequests(ClientHandlerTestCase):
@@ -808,18 +773,18 @@ class TestTransactionGetRequests(ClientHandlerTestCase):
     def test_txn_get_request(self):
         """Verifies requests for a specific txn by id work properly.
 
-        Queries the default three block mock store for a txn id of 't-1'
+        Queries the default three block mock store for a txn id of 'ccc...1'
 
         Expects to find:
             - a status of OK
             - a transaction property which is an instances of Transaction
-            - the transaction has a header_signature of 't-1'
+            - the transaction has a header_signature of 'ccc...1'
         """
-        response = self.make_request(transaction_id='t-1')
+        response = self.make_request(transaction_id=C_1)
 
         self.assertEqual(self.status.OK, response.status)
         self.assertIsInstance(response.transaction, Transaction)
-        self.assertEqual('t-1', response.transaction.header_signature)
+        self.assertEqual(C_1, response.transaction.header_signature)
 
     def test_txn_get_bad_request(self):
         """Verifies requests for a specific txn break with a bad protobuf.
@@ -828,7 +793,7 @@ class TestTransactionGetRequests(ClientHandlerTestCase):
             - a status of INTERNAL_ERROR
             - that the Transaction returned, when serialized, is actually empty
         """
-        response = self.make_bad_request(transaction_id='t-1')
+        response = self.make_bad_request(transaction_id=C_1)
 
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.transaction.SerializeToString())
@@ -852,7 +817,7 @@ class TestTransactionGetRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that the Transaction returned, when serialized, is actually empty
         """
-        response = self.make_request(transaction_id='b' * 127 + '1')
+        response = self.make_request(transaction_id=B_1)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.transaction.SerializeToString())


### PR DESCRIPTION
This PR fixes the bug, where the validator could be caused to raise an error if sent an empty string as a batch id.

It also adds a validation to all input ids, checking to make sure they are 128 character hex strings.