### PR TITLE
Get version fixes

### DIFF
--- a/bin/get_version
+++ b/bin/get_version
@@ -42,12 +42,12 @@ def auto_version(default, strict):
         msg = "VERSION file and (bumped?) git describe versions differ: " \
               "{} != {}".format(default, parts[0])
         if strict:
-            print >> sys.stderr, "ERROR: " + msg
+            print("ERROR: " + msg, file=sys.stderr)
             sys.exit(1)
         else:
-            print >> sys.stderr, "WARNING: " + msg
-            print >> sys.stderr, "WARNING: using setup.py version {}".format(
-                default)
+            print("WARNING: " + msg, file=sys.stderr)
+            print("WARNING: using setup.py version {}".format(
+                  default), file=sys.stderr)
             parts[0] = default
 
     if len(parts) > 1:

--- a/bin/get_version
+++ b/bin/get_version
@@ -19,12 +19,13 @@ import os
 import subprocess
 import sys
 
-top_dir=os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+top_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
-version_file=top_dir + "/VERSION"
+version_file = top_dir + "/VERSION"
 
-with open(version_file, 'r')  as f:
+with open(version_file, 'r') as f:
     version_data = f.read().strip()
+
 
 def bump_version(version):
     (major, minor, patch) = version.split('.')
@@ -70,5 +71,6 @@ def version(default):
     else:
         version = default + ".dev1"
     return version
+
 
 print(version(version_data))

--- a/bin/get_version
+++ b/bin/get_version
@@ -29,7 +29,12 @@ with open(version_file, 'r') as f:
 
 def bump_version(version):
     (major, minor, patch) = version.split('.')
-    patch = str(int(patch) + 1)
+    if 'rc' in patch:
+        parts = patch.split('rc')
+        parts[1] = str(int(parts[1]) + 1)
+        patch = "rc".join(parts)
+    else:
+        patch = str(int(patch) + 1)
     return ".".join([major, minor, patch])
 
 


### PR DESCRIPTION
This adds support for tags like 'v1.0.0rc1' and fixes some PEP8/python2/3 issues.