### PR TITLE
Edit CLI usage for consistency, spelling, grammar, etc.

### DIFF
--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -90,4 +90,5 @@ save_usage xo create
 save_usage xo list
 save_usage xo show
 save_usage xo take
+save_usage xo delete
 save_usage xo-tp-python

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -43,13 +43,14 @@ def add_genesis_parser(subparsers, parent_parser):
     parser.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to ouput the GenesisData')
+        help='choose the output file for GenesisData')
 
     parser.add_argument(
         'input_file',
         nargs='*',
         type=str,
-        help='input files of batches to add to the resulting GenesisData')
+        help='file or files containing batches to add to the resulting '
+        'GenesisData')
 
 
 def do_genesis(args, data_dir=None):

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -57,7 +57,7 @@ def add_keygen_parser(subparsers, parent_parser):
     parser.add_argument(
         '-q',
         '--quiet',
-        help="print no output",
+        help="do not display output",
         action='store_true')
 
 

--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -37,11 +37,11 @@ def add_batch_parser(subparsers, parent_parser):
     """
     parser = subparsers.add_parser(
         'batch',
-        help='Display information about batches and submit new batches',
+        help='Displays information about batches and submit new batches',
         description='Provides subcommands to display Batch information and '
         'submit Batches to the validator via the REST API.')
 
-    grand_parsers = parser.add_subparsers(title='grandchildcommands',
+    grand_parsers = parser.add_subparsers(title='subcommands',
                                           dest='subcommand')
     grand_parsers.required = True
     add_batch_list_parser(grand_parsers, parent_parser)
@@ -73,7 +73,7 @@ def add_batch_show_parser(subparsers, parent_parser):
     show_parser.add_argument(
         'batch_id',
         type=str,
-        help='the id (i.e. header_signature) of the batch')
+        help='id (header_signature) of the batch')
 
 
 def add_batch_status_parser(subparsers, parent_parser):
@@ -87,19 +87,19 @@ def add_batch_status_parser(subparsers, parent_parser):
         nargs='?',
         const=maxsize,
         type=int,
-        help='a time in seconds to wait for commit')
+        help='set time, in seconds, to wait for commit')
 
     status_parser.add_argument(
         'batch_ids',
         type=str,
-        help='a comma-separated list of batch ids')
+        help='single batch id or comma-separated list of batch ids')
 
     status_parser.add_argument(
         '-F', '--format',
         action='store',
         default='yaml',
         choices=['yaml', 'json'],
-        help='the format to use for printing the output (defaults to yaml)')
+        help='choose the output format (default: yaml)')
 
 
 def add_batch_submit_parser(subparsers, parent_parser):
@@ -116,18 +116,19 @@ def add_batch_submit_parser(subparsers, parent_parser):
         nargs='?',
         const=maxsize,
         type=int,
-        help='wait for batches to commit, set an integer to specify a timeout')
+        help='set time, in seconds, to wait for batches to commit')
 
     submit_parser.add_argument(
         '-f', '--filename',
         type=str,
-        help='location of input file',
+        help='specify location of input file',
         default='batches.intkey')
 
     submit_parser.add_argument(
         '--batch-size-limit',
         type=int,
-        help='batches are split for processing if they exceed this size',
+        help='set maximum batch size; batches are split for processing '
+        'if they exceed this size',
         default=100
     )
 

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -33,10 +33,10 @@ def add_block_parser(subparsers, parent_parser):
         'block',
         description='Provides subcommands to display information about the '
         'blocks in the current blockchain.',
-        help='Display information on blocks in the current blockchain')
+        help='Displays information on blocks in the current blockchain')
 
     grand_parsers = parser.add_subparsers(
-        title='grandchildcommands',
+        title='subcommands',
         dest='subcommand')
 
     grand_parsers.required = True
@@ -66,7 +66,7 @@ def add_block_parser(subparsers, parent_parser):
     show_parser.add_argument(
         'block_id',
         type=str,
-        help='the id (i.e. header_signature) of the block')
+        help='id (header_signature) of the block')
 
 
 def do_block(args):

--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -61,7 +61,7 @@ def add_identity_parser(subparsers, parent_parser):
     # identity
     parser = subparsers.add_parser(
         'identity',
-        help='Work with optional roles, policies, and permissions',
+        help='Works with optional roles, policies, and permissions',
         description='Provides subcommands to work with roles and policies.')
 
     identity_parsers = parser.add_subparsers(
@@ -75,7 +75,7 @@ def add_identity_parser(subparsers, parent_parser):
         'policy',
         help='Provides subcommands to display existing policies and create '
         'new policies',
-        description='This subcommand is used to list the current policies '
+        description='Provides subcommands to list the current policies '
         'stored in state and to create new policies.')
 
     policy_parsers = policy_parser.add_subparsers(
@@ -87,7 +87,7 @@ def add_identity_parser(subparsers, parent_parser):
     # policy create
     create_parser = policy_parsers.add_parser(
         'create',
-        help='creates batches of sawtooth-identity transactions for setting a '
+        help='Creates batches of sawtooth-identity transactions for setting a '
         'policy',
         description='Creates a policy that can be set to a role or changes a '
         'policy without resetting the role.')
@@ -95,64 +95,64 @@ def add_identity_parser(subparsers, parent_parser):
     create_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='the signing key for the resulting batches')
+        help='specify the signing key for the resulting batches')
 
     create_target_group = create_parser.add_mutually_exclusive_group()
 
     create_target_group.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to output the resulting batches')
+        help='specify the output filename for the resulting batches')
 
     create_target_group.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     create_parser.add_argument(
         '--wait',
         type=int,
         default=15,
-        help="time to wait for the policy to commit when "
-             "submitting to the rest api.")
+        help="set time, in seconds, to wait for the policy to commit when "
+             "submitting to the REST API.")
 
     create_parser.add_argument(
         'name',
         type=str,
-        help='The name of the new policy')
+        help='name of the new policy')
 
     create_parser.add_argument(
         'rule',
         type=str,
         nargs="+",
-        help='Each rule should be in the following format "PERMIT_KEY <key>"'
-        ' or "DENY_KEY <key>". Multiple "rule" arguments can be added.')
+        help='rule with the format "PERMIT_KEY <key>" or "DENY_KEY <key> '
+        '(multiple "rule" arguments can be specified)')
 
     # policy list
     list_parser = policy_parsers.add_parser(
         'list',
-        help='list the current policies',
-        description='Lists the policies that are currently set in state')
+        help='Lists the current policies',
+        description='Lists the policies that are currently set in state.')
 
     list_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     list_parser.add_argument(
         '--format',
         default='default',
         choices=['default', 'csv', 'json', 'yaml'],
-        help='the format of the output')
+        help='choose the output format')
 
     # role
     role_parser = identity_parsers.add_parser(
         'role',
         help='Provides subcommands to display existing roles and create '
         'new roles',
-        description='This subcommand is used to list the current roles '
+        description='Provides subcommands to list the current roles '
         'stored in state and to create new roles.')
 
     role_parsers = role_parser.add_subparsers(
@@ -164,28 +164,28 @@ def add_identity_parser(subparsers, parent_parser):
     # role create
     create_parser = role_parsers.add_parser(
         'create',
-        help='creates a new role that can be used to enforce permissions',
+        help='Creates a new role that can be used to enforce permissions',
         description='Creates a new role that can be used to enforce '
         'permissions.')
 
     create_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='the signing key for the resulting batches')
+        help='specify the signing key for the resulting batches')
 
     create_parser.add_argument(
         '--wait',
         type=int,
         default=15,
-        help='time to wait for a role to commit when submitting to '
-             'the rest api.')
+        help='set time, in seconds, to wait for a role to commit '
+        'when submitting to  the REST API.')
 
     create_target_group = create_parser.add_mutually_exclusive_group()
 
     create_target_group.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to output the resulting batches')
+        help='specify the output filename for the resulting batches')
 
     create_target_group.add_argument(
         '--url',
@@ -196,30 +196,30 @@ def add_identity_parser(subparsers, parent_parser):
     create_parser.add_argument(
         'name',
         type=str,
-        help='The name of the role')
+        help='name of the role')
 
     create_parser.add_argument(
         'policy',
         type=str,
-        help='the name of the policy the role will be restricted to.')
+        help='identify policy that role will be restricted to')
 
     # role list
     list_parser = role_parsers.add_parser(
         'list',
-        help='list the current keys and values of roles',
+        help='Lists the current keys and values of roles',
         description='Displays the roles that are currently set in state.')
 
     list_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     list_parser.add_argument(
         '--format',
         default='default',
         choices=['default', 'csv', 'json', 'yaml'],
-        help='the format of the output')
+        help='choose the output format')
 
 
 def do_identity(args):

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -26,7 +26,7 @@ import sawtooth_signing as signing
 def add_keygen_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'keygen',
-        help='Create user signing keys',
+        help='Creates user signing keys',
         description='Generates keys with which the user can sign '
         'transactions and batches.',
         epilog='The private and public key files are stored in '
@@ -36,12 +36,12 @@ def add_keygen_parser(subparsers, parent_parser):
 
     parser.add_argument(
         'key_name',
-        help='name of the key to create',
+        help='specify the name of the key to create',
         nargs='?')
 
     parser.add_argument(
         '--key-dir',
-        help="directory to write key files")
+        help="specify the directory for the key files")
 
     parser.add_argument(
         '--force',
@@ -51,7 +51,7 @@ def add_keygen_parser(subparsers, parent_parser):
     parser.add_argument(
         '-q',
         '--quiet',
-        help="print no output",
+        help="do not display output",
         action='store_true')
 
 

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -97,7 +97,7 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parent_parser
 
@@ -107,7 +107,7 @@ def create_parser(prog_name):
 
     parser = argparse.ArgumentParser(
         description='Provides subcommands to configure, manage, '
-        'and use Sawtooth components',
+        'and use Sawtooth components.',
         parents=[parent_parser],)
 
     subparsers = parser.add_subparsers(title='subcommands', dest='command')

--- a/cli/sawtooth_cli/parent_parsers.py
+++ b/cli/sawtooth_cli/parent_parsers.py
@@ -28,12 +28,13 @@ def base_http_parser():
     base_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of the validator's REST API")
+        help="identify the URL of the validator's REST API "
+        "(default: http://localhost:8008)")
     base_parser.add_argument(
         '-u', '--user',
         type=str,
         metavar='USERNAME[:PASSWORD]',
-        help='user login info to authorize request')
+        help='specify the user to authorize request')
 
     return base_parser
 
@@ -52,7 +53,7 @@ def base_list_parser():
         action='store',
         default='default',
         choices=['csv', 'json', 'yaml', 'default'],
-        help='the format to use when printing the output')
+        help='choose the output format')
 
     return base_parser
 
@@ -69,12 +70,12 @@ def base_show_parser():
     base_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='specify to show a single property from the block or header')
+        help='show a single property from the block or header')
     base_parser.add_argument(
         '-F', '--format',
         action='store',
         default='yaml',
         choices=['yaml', 'json'],
-        help='the format to use for printing the output (defaults to yaml)')
+        help='choose the output format (default: yaml)')
 
     return base_parser

--- a/cli/sawtooth_cli/sawadm.py
+++ b/cli/sawtooth_cli/sawadm.py
@@ -139,6 +139,6 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parent_parser

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -62,13 +62,10 @@ def add_config_parser(subparsers, parent_parser):
     """
     parser = subparsers.add_parser(
         'config',
-        help='Change genesis block settings and create, view, and '
+        help='Changes genesis block settings and create, view, and '
         'vote on settings proposals',
-        description='Sawtooth supports storing settings on-chain. The '
-                    'subcommands provided here can be used to view the '
-                    'current proposals, create proposals and vote on existing '
-                    'proposals, and produce setting values that will be set '
-                    'in the genesis block.'
+        description='Provides subcommands to change genesis block settings '
+                    'and to view, create, and vote on existing proposals.'
     )
 
     config_parsers = parser.add_subparsers(title="subcommands",
@@ -455,7 +452,7 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parent_parser
 
@@ -464,11 +461,8 @@ def create_parser(prog_name):
     parent_parser = create_parent_parser(prog_name)
 
     parser = argparse.ArgumentParser(
-        description='Sawtooth supports storing settings on-chain. The '
-        'subcommands provided here can be used to view the '
-        'current proposals, create proposals and vote on existing '
-        'proposals, and produce setting values that will be set '
-        'in the genesis block.',
+        description='Provides subcommands to change genesis block settings '
+        'and to view, create, and vote on settings proposals.',
         parents=[parent_parser])
 
     subparsers = parser.add_subparsers(title='subcommands', dest='subcommand')
@@ -479,7 +473,7 @@ def create_parser(prog_name):
     # transactions for on-chain settings
     genesis_parser = subparsers.add_parser(
         'genesis',
-        help='Create a genesis batch file of settings transactions',
+        help='Creates a genesis batch file of settings transactions',
         description='Creates a Batch of settings proposals that can be '
                     'consumed by "sawadm genesis" and used '
                     'during genesis block construction.'
@@ -487,25 +481,25 @@ def create_parser(prog_name):
     genesis_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='the signing key for the resulting batches '
+        help='specify signing key for resulting batches '
              'and initial authorized key')
 
     genesis_parser.add_argument(
         '-o', '--output',
         type=str,
         default='config-genesis.batch',
-        help='the name of the file to output the resulting batches')
+        help='specify the output file for the resulting batches')
 
     genesis_parser.add_argument(
         '-T', '--approval-threshold',
         type=int,
-        help='the required number of votes to enable a setting change')
+        help='set the number of votes required to enable a setting change')
 
     genesis_parser.add_argument(
         '-A', '--authorized-key',
         type=str,
         action='append',
-        help='a public key for an user authorized to submit '
+        help='specify a public key for the user authorized to submit '
              'config transactions')
 
     # The following parser is for the `proposal` subcommand group. These
@@ -515,20 +509,18 @@ def create_parser(prog_name):
 
     proposal_parser = subparsers.add_parser(
         'proposal',
-        help='View, create or vote on settings change proposals',
-        description='sawtooth-settings supports a simple voting mechanism for '
-                    'applying changes to on-change settings.  These commands '
-                    'provide tools to view, create or vote on proposed '
-                    'settings')
+        help='Views, creates, or votes on settings change proposals',
+        description='Provides subcommands to view, create, or vote on '
+                    'proposed settings')
     proposal_parsers = proposal_parser.add_subparsers(
-        title='proposals',
+        title='subcommands',
         dest='proposal_cmd')
     proposal_parsers.required = True
 
     prop_parser = proposal_parsers.add_parser(
         'create',
-        help='creates proposals for setting changes',
-        description='Create proposals for settings changes.  The change '
+        help='Creates proposals for setting changes',
+        description='Create proposals for settings changes. The change '
                     'may be applied immediately or after a series of votes, '
                     'depending on the vote threshold setting.'
     )
@@ -536,85 +528,85 @@ def create_parser(prog_name):
     prop_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='the signing key for the resulting batches')
+        help='specify a signing key for the resulting batches')
 
     prop_target_group = prop_parser.add_mutually_exclusive_group()
     prop_target_group.add_argument(
         '-o', '--output',
         type=str,
-        help='the name of the file to ouput the resulting batches')
+        help='specify the output file for the resulting batches')
 
     prop_target_group.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     prop_parser.add_argument(
         'setting',
         type=str,
         nargs='+',
-        help='configuration setting, as a key/value pair: <key>=<value>')
+        help='configuration setting as key/value pair with the '
+        'format <key>=<value>')
 
     proposal_list_parser = proposal_parsers.add_parser(
         'list',
-        help='lists the currently proposed, but not active, settings',
-        description='Lists the currently proposed, but not active, settings. '
-                    'This list of proposals can be used to find proposals to '
+        help='Lists the currently proposed (not active) settings',
+        description='Lists the currently proposed (not active) settings. '
+                    'Use this list of proposals to find proposals to '
                     'vote on.')
 
     proposal_list_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     proposal_list_parser.add_argument(
         '--public-key',
         type=str,
         default='',
-        help='filters proposals from a particular public key.')
+        help='filter proposals from a particular public key')
 
     proposal_list_parser.add_argument(
         '--filter',
         type=str,
         default='',
-        help='filters keys that begin with this value')
+        help='filter keys that begin with this value')
 
     proposal_list_parser.add_argument(
         '--format',
         default='default',
         choices=['default', 'csv', 'json', 'yaml'],
-        help='the format of the output')
+        help='choose the output format')
 
     vote_parser = proposal_parsers.add_parser(
         'vote',
-        help='votes for specific setting change proposals',
-        description='Votes for a specific settings change proposal. The '
-                    'proposal id can be found using "sawset proposal '
-                    'list".')
+        help='Votes for specific setting change proposals',
+        description='Votes for a specific settings change proposal. Use '
+                    '"sawset proposal list" to find the proposal id.')
 
     vote_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     vote_parser.add_argument(
         '-k', '--key',
         type=str,
-        help='the signing key for the resulting transaction batch')
+        help='specify a signing key for the resulting transaction batch')
 
     vote_parser.add_argument(
         'proposal_id',
         type=str,
-        help='the proposal to vote on')
+        help='identify the proposal to vote on')
 
     vote_parser.add_argument(
         'vote_value',
         type=str,
         choices=['accept', 'reject'],
-        help='the value of the vote')
+        help='specify the value of the vote')
 
     return parser
 

--- a/cli/sawtooth_cli/settings.py
+++ b/cli/sawtooth_cli/settings.py
@@ -45,7 +45,7 @@ def add_settings_parser(subparsers, parent_parser):
 
     settings_parser = subparsers.add_parser(
         'settings',
-        help='List and show on-chain settings',
+        help='Displays on-chain settings',
         description='Displays the values of currently active on-chain '
                     'settings.')
 
@@ -56,16 +56,16 @@ def add_settings_parser(subparsers, parent_parser):
 
     list_parser = settings_parsers.add_parser(
         'list',
-        help='list the current keys and values of on-chain settings',
+        help='Lists the current keys and values of on-chain settings',
         description='List the current keys and values of on-chain '
-                    'settings.  The content can be exported to various '
+                    'settings. The content can be exported to various '
                     'formats for external consumption.'
     )
 
     list_parser.add_argument(
         '--url',
         type=str,
-        help="the URL of a validator's REST API",
+        help="identify the URL of a validator's REST API",
         default='http://localhost:8008')
 
     list_parser.add_argument(
@@ -78,7 +78,7 @@ def add_settings_parser(subparsers, parent_parser):
         '--format',
         default='default',
         choices=['default', 'csv', 'json', 'yaml'],
-        help='the format of the output')
+        help='choose the output format')
 
 
 def do_settings(args):

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -31,12 +31,12 @@ def add_state_parser(subparsers, parent_parser):
     """
     parser = subparsers.add_parser(
         'state',
-        help='Display information on the entries in state',
+        help='Displays information on the entries in state',
         description='Provides subcommands to display information about the '
         'state entries in the current blockchain state.')
 
     grand_parsers = parser.add_subparsers(
-        title='grandchildcommands',
+        title='subcommands',
         dest='subcommand')
 
     grand_parsers.required = True
@@ -52,13 +52,13 @@ def add_state_parser(subparsers, parent_parser):
         type=str,
         nargs='?',
         default=None,
-        help='the address of a subtree to filter list by')
+        help='address of a subtree to filter the list by')
 
     list_parser.add_argument(
         '--head',
         action='store',
         default=None,
-        help='the id of the block to set as the chain head')
+        help='specify the id of the block to set as the chain head')
 
     show_parser = grand_parsers.add_parser(
         'show',
@@ -70,13 +70,13 @@ def add_state_parser(subparsers, parent_parser):
     show_parser.add_argument(
         'address',
         type=str,
-        help='the address of the leaf')
+        help='address of the leaf')
 
     show_parser.add_argument(
         '--head',
         action='store',
         default=None,
-        help='the id of the block to set as the chain head')
+        help='specify the id of the block to set as the chain head')
 
 
 def do_state(args):

--- a/cli/sawtooth_cli/transaction.py
+++ b/cli/sawtooth_cli/transaction.py
@@ -32,12 +32,12 @@ def add_transaction_parser(subparsers, parent_parser):
     """
     parser = subparsers.add_parser(
         'transaction',
-        help='Show information on transactions in the current chain',
+        help='Shows information on transactions in the current chain',
         description='Provides subcommands to display information about '
         'the transactions in the current blockchain.')
 
     grand_parsers = parser.add_subparsers(
-        title='grandchildcommands',
+        title='subcommands',
         dest='subcommand')
 
     grand_parsers.required = True
@@ -57,7 +57,7 @@ def add_transaction_parser(subparsers, parent_parser):
     show_parser.add_argument(
         'transaction_id',
         type=str,
-        help='the id (i.e. header_signature) of the transaction')
+        help='id (header_signature) of the transaction')
 
 
 def do_transaction(args):

--- a/consensus/poet/cli/sawtooth_poet_cli/enclave.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/enclave.py
@@ -33,7 +33,7 @@ def add_enclave_parser(subparsers, parent_parser):
         default='simulator',
         choices=['simulator', 'sgx'],
         type=str,
-        help='the enclave module to query')
+        help='identify the enclave module to query')
     parser.add_argument(
         'characteristic',
         choices=['measurement', 'basename'],

--- a/consensus/poet/cli/sawtooth_poet_cli/main.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/main.py
@@ -81,7 +81,7 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parent_parser
 
@@ -91,12 +91,11 @@ def create_parser(prog_name):
         prog_name)
 
     parser = argparse.ArgumentParser(
-        description='Provides subcommands to generate PoET information '
-        'for configuring a node.',
+        description='Provides subcommands for creating PoET registration.',
         parents=[parent_parser],
         formatter_class=argparse.RawDescriptionHelpFormatter)
 
-    subparsers = parser.add_subparsers(title='subcommand', dest='command')
+    subparsers = parser.add_subparsers(title='subcommands', dest='command')
     subparsers.required = True
 
     add_registration_parser(subparsers, parent_parser)

--- a/consensus/poet/cli/sawtooth_poet_cli/registration.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/registration.py
@@ -44,7 +44,7 @@ def add_registration_parser(subparsers, parent_parser):
     """Add argument parser arguments for the `poet registration`
     subcommand
     """
-    description = 'Provides subcommands for creating PoET registration'
+    description = 'Provides a subcommand for creating PoET registration'
 
     parser = subparsers.add_parser(
         'registration',
@@ -80,19 +80,20 @@ def add_create_parser(subparsers, parent_parser):
     parser.add_argument(
         '-k', '--key',
         type=str,
-        help='name of file containing transaction signing key')
+        help='identify file containing transaction signing key')
 
     parser.add_argument(
         '-o', '--output',
         default='poet-genesis.batch',
         type=str,
-        help='the name of the file to output the resulting batches')
+        help='change default output file name for resulting batches')
 
     parser.add_argument(
         '-b', '--block',
         default=NULL_BLOCK_IDENTIFIER,
         type=str,
-        help='the most recent block identifier to use as a sign-up nonce')
+        help='specify the most recent block identifier to use as '
+        'a sign-up nonce')
 
 
 def do_registration(args):

--- a/docs/source/cli/xo.rst
+++ b/docs/source/cli/xo.rst
@@ -76,3 +76,12 @@ already taken.
 .. literalinclude:: output/xo_take_usage.out
    :language: console
    :linenos:
+
+xo delete
+=========
+
+The ``xo delete`` subcommand deletes an existing xo game.
+
+.. literalinclude:: output/xo_delete_usage.out
+   :language: console
+   :linenos:

--- a/families/block_info/sawtooth_block_info/processor/main.py
+++ b/families/block_info/sawtooth_block_info/processor/main.py
@@ -94,13 +94,13 @@ def create_parser(prog_name):
     parser.add_argument(
         '-C', '--connect',
         default='tcp://localhost:4004',
-        help='Endpoint for the validator connection')
+        help='specify the endpoint for the validator connection')
 
     parser.add_argument(
         '-v', '--verbose',
         action='count',
         default=0,
-        help='Increase output sent to stderr')
+        help='enable more verbose output to stderr')
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version

--- a/families/identity/sawtooth_identity/processor/main.py
+++ b/families/identity/sawtooth_identity/processor/main.py
@@ -88,7 +88,7 @@ def setup_loggers(verbose_level, processor):
 
 def create_parser(prog_name):
     parser = argparse.ArgumentParser(
-        description='Starts a sawtooth-identity transaction processor.',
+        description='Starts an Identity transaction processor.',
         epilog='This process is required to apply any changes to on-chain '
         'permissions used by the Sawtooth platform.',
         prog=prog_name,
@@ -96,13 +96,13 @@ def create_parser(prog_name):
 
     parser.add_argument(
         '-C', '--connect',
-        help='Endpoint for the validator connection')
+        help='specify the endpoint for the validator connection')
 
     parser.add_argument(
         '-v', '--verbose',
         action='count',
         default=0,
-        help='Increase output sent to stderr')
+        help='enable more verbose output to stderr')
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
@@ -114,7 +114,7 @@ def create_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parser
 

--- a/families/settings/sawtooth_settings/processor/main.py
+++ b/families/settings/sawtooth_settings/processor/main.py
@@ -97,14 +97,14 @@ def create_parser(prog_name):
 
     parser.add_argument(
         '-C', '--connect',
-        help='Endpoint for the validator connection, defaults to '
-             'tcp://localhost:4004 ')
+        help='specify the endpoint for the validator connection (default: '
+             'tcp://localhost:4004) ')
 
     parser.add_argument(
         '-v', '--verbose',
         action='count',
         default=0,
-        help='Increase output sent to stderr')
+        help='enable more verbose output to stderr')
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
@@ -116,7 +116,7 @@ def create_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parser
 

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -54,22 +54,23 @@ def parse_args(args):
         'specified validator.')
 
     parser.add_argument('-B', '--bind',
-                        help='The host and port for the api to run on.',
+                        help='identify host and port for API to run on \
+                        default: http://localhost:8080)',
                         action='append')
     parser.add_argument('-C', '--connect',
-                        help='The url to connect to a running Validator')
+                        help='specify URL to connect to a running validator')
     parser.add_argument('-t', '--timeout',
-                        help='Seconds to wait for a validator response')
+                        help='set time (in seconds) to wait for validator \
+                        response')
     parser.add_argument('-v', '--verbose',
                         action='count',
                         default=0,
-                        help='Increase level of output sent to stderr')
+                        help='enable more verbose output to stderr')
     parser.add_argument('--opentsdb-url',
-                        help='The host and port for Open TSDB database \
+                        help='specify host and port for Open TSDB database \
                         used for metrics')
     parser.add_argument('--opentsdb-db',
-                        help='The name of the database used for storing \
-                        metrics')
+                        help='specify name of database for storing metrics')
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
@@ -81,7 +82,7 @@ def parse_args(args):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parser.parse_args(args)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_cli.py
@@ -95,7 +95,7 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parent_parser
 
@@ -125,7 +125,7 @@ def create_parser(prog_name):
 
 
 def add_set_parser(subparsers, parent_parser):
-    message = 'Sends an intkey transaction to set <name> to <value>'
+    message = 'Sends an intkey transaction to set <name> to <value>.'
 
     parser = subparsers.add_parser(
         'set',
@@ -136,29 +136,29 @@ def add_set_parser(subparsers, parent_parser):
     parser.add_argument(
         'name',
         type=str,
-        help='the name of the key to set')
+        help='name of key to set')
 
     parser.add_argument(
         'value',
         type=int,
-        help='the amount to set')
+        help='amount to set')
 
     parser.add_argument(
         '--url',
         type=str,
-        help='the url of the REST API')
+        help='specify URL of REST API')
 
     parser.add_argument(
         '--keyfile',
         type=str,
-        help="the file containing the user's private key")
+        help="identify file containing user's private key")
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='seconds to wait for the transaction to commit')
+        help='set time, in seconds, to wait for transaction to commit')
 
 
 def do_set(args):
@@ -169,7 +169,7 @@ def do_set(args):
 
 
 def add_inc_parser(subparsers, parent_parser):
-    message = 'Sends an intkey transaction to increment <name> by <value>'
+    message = 'Sends an intkey transaction to increment <name> by <value>.'
 
     parser = subparsers.add_parser(
         'inc',
@@ -180,29 +180,29 @@ def add_inc_parser(subparsers, parent_parser):
     parser.add_argument(
         'name',
         type=str,
-        help='the name of the key to increment')
+        help='identify name of key to increment')
 
     parser.add_argument(
         'value',
         type=int,
-        help='the amount to increment')
+        help='specify amount to increment')
 
     parser.add_argument(
         '--url',
         type=str,
-        help='the url of the REST API')
+        help='specify URL of REST API')
 
     parser.add_argument(
         '--keyfile',
         type=str,
-        help="the file containing the user's private key")
+        help="identify file containing user's private key")
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='seconds to wait for the transaction to commit')
+        help='set time, in seconds, to wait for transaction to commit')
 
 
 def do_inc(args):
@@ -213,7 +213,7 @@ def do_inc(args):
 
 
 def add_dec_parser(subparsers, parent_parser):
-    message = 'Sends an intkey transaction to decrement <name> by <value>'
+    message = 'Sends an intkey transaction to decrement <name> by <value>.'
 
     parser = subparsers.add_parser(
         'dec',
@@ -224,29 +224,29 @@ def add_dec_parser(subparsers, parent_parser):
     parser.add_argument(
         'name',
         type=str,
-        help='the name of the key to decrement')
+        help='identify name of key to decrement')
 
     parser.add_argument(
         'value',
         type=int,
-        help='the amount to decrement')
+        help='amount to decrement')
 
     parser.add_argument(
         '--url',
         type=str,
-        help='the url of the REST API')
+        help='specify URL of REST API')
 
     parser.add_argument(
         '--keyfile',
         type=str,
-        help="the file containing the user's private key")
+        help="identify file containing user's private key")
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='seconds to wait for the transaction to commit')
+        help='set time, in seconds, to wait for transaction to commit')
 
 
 def do_dec(args):
@@ -257,23 +257,23 @@ def do_dec(args):
 
 
 def add_show_parser(subparsers, parent_parser):
-    message = 'Shows the value of the key <name>'
+    message = 'Shows the value of the key <name>.'
 
     parser = subparsers.add_parser(
         'show',
         parents=[parent_parser],
         description=message,
-        help='Displays some intkey value')
+        help='Displays the specified intkey value')
 
     parser.add_argument(
         'name',
         type=str,
-        help='the name of the key to show')
+        help='name of key to show')
 
     parser.add_argument(
         '--url',
         type=str,
-        help='the url of the REST API')
+        help='specify URL of REST API')
 
 
 def do_show(args):
@@ -284,7 +284,7 @@ def do_show(args):
 
 
 def add_list_parser(subparsers, parent_parser):
-    message = 'Shows the values of all keys in intkey state'
+    message = 'Shows the values of all keys in intkey state.'
 
     parser = subparsers.add_parser(
         'list',
@@ -295,7 +295,7 @@ def add_list_parser(subparsers, parent_parser):
     parser.add_argument(
         '--url',
         type=str,
-        help='the url of the REST API')
+        help='specify URL of REST API')
 
 
 def do_list(args):

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -74,7 +74,7 @@ def add_create_parser(subparsers, parent_parser):
         help='Creates a new xo game',
         description='Sends a transaction to start an xo game with the '
         'identifier <name>. This transaction will fail if the specified '
-	'game already exists.',
+        'game already exists.',
         parents=[parent_parser])
 
     parser.add_argument(
@@ -100,12 +100,14 @@ def add_create_parser(subparsers, parent_parser):
     parser.add_argument(
         '--auth-user',
         type=str,
-        help='specify username for authentication if REST API is using Basic Auth')
+        help='specify username for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--auth-password',
         type=str,
-        help='specify password for authentication if REST API is using Basic Auth')
+        help='specify password for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--disable-client-validation',
@@ -147,19 +149,22 @@ def add_list_parser(subparsers, parent_parser):
     parser.add_argument(
         '--auth-user',
         type=str,
-        help='specify username for authentication if REST API is using Basic Auth')
+        help='specify username for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--auth-password',
         type=str,
-        help='specify password for authentication if REST API is using Basic Auth')
+        help='specify password for authentication if REST API '
+        'is using Basic Auth')
+
 
 def add_show_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'show',
         help='Displays information about an xo game',
-        description='Displays the xo game <name>, showing the players, the '
-        'game state, and the board',
+        description='Displays the xo game <name>, showing the players, '
+        'the game state, and the board',
         parents=[parent_parser])
 
     parser.add_argument(
@@ -185,20 +190,23 @@ def add_show_parser(subparsers, parent_parser):
     parser.add_argument(
         '--auth-user',
         type=str,
-        help='specify username for authentication if REST API is using Basic Auth')
+        help='specify username for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--auth-password',
         type=str,
-        help='specify password for authentication if REST API is using Basic Auth')
+        help='specify password for authentication if REST API '
+        'is using Basic Auth')
+
 
 def add_take_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'take',
         help='Takes a space in an xo game',
         description='Sends a transaction to take a square in the xo game '
-	'with the identifier <name>. This transaction will fail if the '
-	'specified game does not exist.',
+        'with the identifier <name>. This transaction will fail if the '
+        'specified game does not exist.',
         parents=[parent_parser])
 
     parser.add_argument(
@@ -210,7 +218,7 @@ def add_take_parser(subparsers, parent_parser):
         'space',
         type=int,
         help='number of the square to take (1-9); the upper-left space is '
-	     '1, and the lower-right space is 9')
+        '1, and the lower-right space is 9')
 
     parser.add_argument(
         '--url',
@@ -230,36 +238,31 @@ def add_take_parser(subparsers, parent_parser):
     parser.add_argument(
         '--auth-user',
         type=str,
-        help='specify username for authentication if REST API is using Basic Auth')
+        help='specify username for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--auth-password',
         type=str,
-        help='specify password for authentication if REST API is using Basic Auth')
+        help='specify password for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='set time, in seconds, to wait for take transaction to commit')
+        help='set time, in seconds, to wait for take transaction '
+        'to commit')
+
 
 def add_delete_parser(subparsers, parent_parser):
     parser = subparsers.add_parser('delete', parents=[parent_parser])
 
-# def add_delete_parser(subparsers, parent_parser):
-#     parser = subparsers.add_parser(
-#         'delete',
-#          help='Deletes an xo game',
-#          description='Sends a transaction to delete an xo game with the '
-#          'identifier <name>. This transaction will fail if the specified '
-#          ' game does not exist.',
-#          parents=[parent_parser])
-
     parser.add_argument(
         'name',
         type=str,
-        help='specify the name of the game to be deleted')
+        help='name of the game to be deleted')
 
     parser.add_argument(
         '--url',
@@ -279,19 +282,21 @@ def add_delete_parser(subparsers, parent_parser):
     parser.add_argument(
         '--auth-user',
         type=str,
-        help='specify username for authentication if REST API is using Basic Auth')
+        help='specify username for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--auth-password',
         type=str,
-        help='specify password for authentication if REST API is using Basic Auth')
+        help='specify password for authentication if REST API '
+        'is using Basic Auth')
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='set time, in seconds, to wait for take transaction to commit')
+        help='set time, in seconds, to wait for delete transaction to commit')
 
 
 def create_parent_parser(prog_name):
@@ -312,31 +317,6 @@ def create_parent_parser(prog_name):
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
         help='display version information')
-
-#   parent_parser.add_argument(
-#       '--url',
-#       type=str,
-#       help='specify URL of REST API')
-
-#   parent_parser.add_argument(
-#       '--username',
-#       type=str,
-#       help="identify name of user's private key file")
-
-#   parent_parser.add_argument(
-#       '--key-dir',
-#       type=str,
-#       help="identify directory of user's private key file")
-
-#   parent_parser.add_argument(
-#       '--auth-user',
-#       type=str,
-#       help='specify username for authentication if REST API is using Basic Auth')
-
-#   parent_parser.add_argument(
-#       '--auth-password',
-#       type=str,
-#       help='specify password for authentication if REST API is using Basic Auth')
 
     return parent_parser
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_cli.py
@@ -71,16 +71,41 @@ def setup_loggers(verbose_level):
 def add_create_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'create',
-        help='creates a new xo game',
+        help='Creates a new xo game',
         description='Sends a transaction to start an xo game with the '
-        'identifier <name>. This transaction will fail if a game already '
-        'exists with the name <name>.',
+        'identifier <name>. This transaction will fail if the specified '
+	'game already exists.',
         parents=[parent_parser])
 
     parser.add_argument(
         'name',
         type=str,
-        help='an identifier for the new game')
+        help='unique identifier for the new game')
+
+    parser.add_argument(
+        '--url',
+        type=str,
+        help='specify URL of REST API')
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help="identify name of user's private key file")
+
+    parser.add_argument(
+        '--key-dir',
+        type=str,
+        help="identify directory of user's private key file")
+
+    parser.add_argument(
+        '--auth-user',
+        type=str,
+        help='specify username for authentication if REST API is using Basic Auth')
+
+    parser.add_argument(
+        '--auth-password',
+        type=str,
+        help='specify password for authentication if REST API is using Basic Auth')
 
     parser.add_argument(
         '--disable-client-validation',
@@ -93,22 +118,46 @@ def add_create_parser(subparsers, parent_parser):
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='wait for game to commit, set an integer to specify a timeout')
+        help='set time, in seconds, to wait for game to commit')
 
 
 def add_list_parser(subparsers, parent_parser):
-    subparsers.add_parser(
+    parser = subparsers.add_parser(
         'list',
-        help='displays information for all xo games',
+        help='Displays information for all xo games',
         description='Displays information for all xo games in state, showing '
         'the players, the game state, and the board for each game.',
         parents=[parent_parser])
 
+    parser.add_argument(
+        '--url',
+        type=str,
+        help='specify URL of REST API')
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help="identify name of user's private key file")
+
+    parser.add_argument(
+        '--key-dir',
+        type=str,
+        help="identify directory of user's private key file")
+
+    parser.add_argument(
+        '--auth-user',
+        type=str,
+        help='specify username for authentication if REST API is using Basic Auth')
+
+    parser.add_argument(
+        '--auth-password',
+        type=str,
+        help='specify password for authentication if REST API is using Basic Auth')
 
 def add_show_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'show',
-        help='displays information about an xo game',
+        help='Displays information about an xo game',
         description='Displays the xo game <name>, showing the players, the '
         'game state, and the board',
         parents=[parent_parser])
@@ -116,50 +165,133 @@ def add_show_parser(subparsers, parent_parser):
     parser.add_argument(
         'name',
         type=str,
-        help='the identifier for the game')
+        help='identifier for the game')
 
+    parser.add_argument(
+        '--url',
+        type=str,
+        help='specify URL of REST API')
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help="identify name of user's private key file")
+
+    parser.add_argument(
+        '--key-dir',
+        type=str,
+        help="identify directory of user's private key file")
+
+    parser.add_argument(
+        '--auth-user',
+        type=str,
+        help='specify username for authentication if REST API is using Basic Auth')
+
+    parser.add_argument(
+        '--auth-password',
+        type=str,
+        help='specify password for authentication if REST API is using Basic Auth')
 
 def add_take_parser(subparsers, parent_parser):
     parser = subparsers.add_parser(
         'take',
-        help='takes a space in an xo game',
-        description='Sends a transaction to start an xo game with the '
-        'identifier <name>. This transaction will fail if a game already '
-        'exists with the name <name>.',
+        help='Takes a space in an xo game',
+        description='Sends a transaction to take a square in the xo game '
+	'with the identifier <name>. This transaction will fail if the '
+	'specified game does not exist.',
         parents=[parent_parser])
 
     parser.add_argument(
         'name',
         type=str,
-        help='the identifier for the game')
+        help='identifier for the game')
 
     parser.add_argument(
         'space',
         type=int,
-        help='the square number to take')
+        help='number of the square to take (1-9); the upper-left space is '
+	     '1, and the lower-right space is 9')
+
+    parser.add_argument(
+        '--url',
+        type=str,
+        help='specify URL of REST API')
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help="identify name of user's private key file")
+
+    parser.add_argument(
+        '--key-dir',
+        type=str,
+        help="identify directory of user's private key file")
+
+    parser.add_argument(
+        '--auth-user',
+        type=str,
+        help='specify username for authentication if REST API is using Basic Auth')
+
+    parser.add_argument(
+        '--auth-password',
+        type=str,
+        help='specify password for authentication if REST API is using Basic Auth')
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='wait for take to commit, set an integer to specify a timeout')
-
+        help='set time, in seconds, to wait for take transaction to commit')
 
 def add_delete_parser(subparsers, parent_parser):
     parser = subparsers.add_parser('delete', parents=[parent_parser])
 
+# def add_delete_parser(subparsers, parent_parser):
+#     parser = subparsers.add_parser(
+#         'delete',
+#          help='Deletes an xo game',
+#          description='Sends a transaction to delete an xo game with the '
+#          'identifier <name>. This transaction will fail if the specified '
+#          ' game does not exist.',
+#          parents=[parent_parser])
+
     parser.add_argument(
         'name',
         type=str,
-        help='the identifier for the game to be deleted')
+        help='specify the name of the game to be deleted')
+
+    parser.add_argument(
+        '--url',
+        type=str,
+        help='specify URL of REST API')
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help="identify name of user's private key file")
+
+    parser.add_argument(
+        '--key-dir',
+        type=str,
+        help="identify directory of user's private key file")
+
+    parser.add_argument(
+        '--auth-user',
+        type=str,
+        help='specify username for authentication if REST API is using Basic Auth')
+
+    parser.add_argument(
+        '--auth-password',
+        type=str,
+        help='specify password for authentication if REST API is using Basic Auth')
 
     parser.add_argument(
         '--wait',
         nargs='?',
         const=sys.maxsize,
         type=int,
-        help='wait for take to commit, set an integer to specify a timeout')
+        help='set time, in seconds, to wait for take transaction to commit')
 
 
 def create_parent_parser(prog_name):
@@ -179,32 +311,32 @@ def create_parent_parser(prog_name):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
-    parent_parser.add_argument(
-        '--url',
-        type=str,
-        help='the url of the REST API')
+#   parent_parser.add_argument(
+#       '--url',
+#       type=str,
+#       help='specify URL of REST API')
 
-    parent_parser.add_argument(
-        '--username',
-        type=str,
-        help="the name of the user's private key file")
+#   parent_parser.add_argument(
+#       '--username',
+#       type=str,
+#       help="identify name of user's private key file")
 
-    parent_parser.add_argument(
-        '--key-dir',
-        type=str,
-        help="the directory of the user's private key file")
+#   parent_parser.add_argument(
+#       '--key-dir',
+#       type=str,
+#       help="identify directory of user's private key file")
 
-    parent_parser.add_argument(
-        '--auth-user',
-        type=str,
-        help='username for authentication if REST API is using Basic Auth')
+#   parent_parser.add_argument(
+#       '--auth-user',
+#       type=str,
+#       help='specify username for authentication if REST API is using Basic Auth')
 
-    parent_parser.add_argument(
-        '--auth-password',
-        type=str,
-        help='password for authentication if REST API is using Basic Auth')
+#   parent_parser.add_argument(
+#       '--auth-password',
+#       type=str,
+#       help='specify password for authentication if REST API is using Basic Auth')
 
     return parent_parser
 

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -49,64 +49,57 @@ def parse_args(args):
         formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('--config-dir',
-                        help='Configuration directory',
+                        help='specify the configuration directory',
                         type=str)
     parser.add_argument('-B', '--bind',
-                        help='Set the endpoint url for the network and the '
-                             'validator component service endpoints. Multiple '
-                             '--bind arguments should be provided in the '
-                             'format network:endpoint and component:endpoint.',
+                        help='set the URL for the network or validator '
+                        'component service endpoints with the format '
+                        'network:<endpoint> or component:<endpoint>. '
+                        'Use two --bind options to specify both '
+                        'endpoints.',
                         action='append',
                         type=str)
     parser.add_argument('-P', '--peering',
-                        help='The type of peering approach the validator '
-                             'should take. Choices are \'static\' which '
-                             'only attempts to peer with candidates '
-                             'provided with the --peers option, and '
-                             '\'dynamic\' which will do topology buildouts. '
-                             'If \'dynamic\' is provided, any static peers '
-                             'will be processed first, prior to the topology '
-                             'buildout starting',
+                        help='determine peering type for the validator: '
+                        '\'static\' (must use --peers to list peers) or '
+                        '\'dynamic\' (processes any static peers first, '
+                        'then starts topology buildout).',
                         choices=['static', 'dynamic'],
                         type=str)
     parser.add_argument('-E', '--endpoint',
-                        help='Advertised network endpoint URL',
+                        help='specifies the advertised network endpoint URL',
                         type=str)
     parser.add_argument('-s', '--seeds',
-                        help='uri(s) to connect to in order to initially '
-                             'connect to the validator network, in the '
-                             'format tcp://hostname:port. Multiple --seeds '
-                             'arguments can be provided, and a single '
-                             '--seeds argument will accept a comma separated '
-                             'list of tcp://hostname:port,tcp://hostname:port '
-                             'parameters',
+                        help='provide URI(s) for the initial connection to '
+                        'the validator network, in the format '
+                        'tcp://<hostname>:<port>. Specify multiple URIs '
+                        'in a comma-separated list. Repeating the --seeds '
+                             'option is also accepted.',
                         action='append',
                         type=str)
     parser.add_argument('-p', '--peers',
-                        help='A list of peers to attempt to connect to '
-                             'in the format tcp://hostname:port. Multiple '
-                             '--peers arguments can be provided, and a single '
-                             '--peers argument will accept a comma separated '
-                             'list of tcp://hostname:port,tcp://hostname:port '
-                             'parameters',
+                        help='list static peers to attempt to connect to '
+                        'in the format tcp://<hostname>:<port>. Specify '
+                        'multiple peers in a comma-separated list. '
+                        'Repeating the --peers option is also accepted.',
                         action='append',
                         type=str)
     parser.add_argument('-v', '--verbose',
                         action='count',
                         default=0,
-                        help='Increase output sent to stderr')
+                        help='enable more verbose output to stderr')
     parser.add_argument('--scheduler',
                         choices=['serial', 'parallel'],
-                        help='The type of scheduler to be used.')
+                        help='set scheduler type: serial or parallel')
     parser.add_argument('--network-auth',
                         choices=['trust', 'challenge'],
-                        help='The type of authorization required to join the '
+                        help='identify type of authorization required to join '
                              'validator network.')
     parser.add_argument('--opentsdb-url',
-                        help='The host and port for Open TSDB database \
+                        help='specify host and port for Open TSDB database \
                         used for metrics')
     parser.add_argument('--opentsdb-db',
-                        help='The name of the database used for storing \
+                        help='specify name of database used for storing \
                         metrics')
 
     try:
@@ -119,7 +112,7 @@ def parse_args(args):
         action='version',
         version=(DISTRIBUTION_NAME + ' (Hyperledger Sawtooth) version {}')
         .format(version),
-        help='print version information')
+        help='display version information')
 
     return parser.parse_args(args)
 


### PR DESCRIPTION
Made usage text consistent by starting option descriptions with an imperative verb, "positional arguments" with a noun, and subcommand descriptions with an initial-capped verb in 3rd person singular.

Note: For the xo parent command, deleted the subcommand-only options (moved them into the subcommands).

Also added the missing "xo delete" subcommand to CLI reference doc.