### PR TITLE
Add links to API docs

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -106,7 +106,7 @@ RUN apt-get update && apt-get install -y -q \
     sphinx_rtd_theme
 
 ENV GOPATH=/go:/project/sawtooth-core/sdk/go \
-    PYTHONPATH=/project/sawtooth-core/sdk/python
+    PYTHONPATH=/project/sawtooth-core/sdk/python:/project/sawtooth-core/signing
 
 WORKDIR /project/sawtooth-core/docs
 CMD make html latexpdf

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -62,22 +62,35 @@ templates:
 cli:
 	$(SAWTOOTH)/bin/generate_cli_output
 
+PYTHONSDKDIR := $(HTMLDIR)/python_sdk
 python:
     # pydoc doesn't allow specifying an output directory, so make the
     # files first and then move them.
-	mkdir -p $(HTMLDIR)/python_sdk/processor
+	mkdir -p $(PYTHONSDKDIR)/processor
+	pydoc3 -w sawtooth_sdk.processor
 	pydoc3 -w sawtooth_sdk.processor.core
 	pydoc3 -w sawtooth_sdk.processor.context
 	pydoc3 -w sawtooth_sdk.processor.handler
-	mv sawtooth_sdk.processor*.html $(HTMLDIR)/python_sdk/processor
+	pydoc3 -w sawtooth_sdk.processor.exceptions
+	mv sawtooth_sdk.processor*.html $(PYTHONSDKDIR)/processor
 
+	mkdir -p $(PYTHONSDKDIR)/signing
+	pydoc3 -w sawtooth_signing
+	pydoc3 -w sawtooth_signing.core
+	pydoc3 -w sawtooth_signing.secp256k1
+	mv sawtooth_signing*.html $(PYTHONSDKDIR)/signing
+
+GOSDKDIR := $(HTMLDIR)/go_sdk
 go:
-	mkdir -p $(HTMLDIR)/go_sdk/
-	godoc -html sawtooth_sdk/processor > $(HTMLDIR)/go_sdk/processor.html
+	mkdir -p $(GOSDKDIR)
+	godoc -html sawtooth_sdk/processor > $(GOSDKDIR)/processor.html
+	godoc -html sawtooth_sdk/signing > $(GOSDKDIR)/signing.html
 
+JAVASCRIPTSDKDIR := $(HTMLDIR)/javascript_sdk
 javascript:
-	mkdir -p $(HTMLDIR)/javascript_sdk/
-	jsdoc $(SAWTOOTH)/sdk/javascript/processor/ -d $(HTMLDIR)/javascript_sdk/processor/
+	mkdir -p $(JAVASCRIPTSDKDIR)/
+	jsdoc $(SAWTOOTH)/sdk/javascript/processor/ -d $(JAVASCRIPTSDKDIR)/processor/
+	jsdoc $(SAWTOOTH)/sdk/javascript/signing -d $(JAVASCRIPTSDKDIR)/signing/
 
 html: templates cli python go javascript
 	@mkdir -p source/_static

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -10,6 +10,7 @@ Table of Contents
    core_developers_guide.rst
    sysadmin_guide.rst
    rest_api.rst
+   sdks.rst
    cli.rst
    transaction_family_specifications.rst
    examples.rst

--- a/docs/source/sdks.rst
+++ b/docs/source/sdks.rst
@@ -1,0 +1,24 @@
+=================
+Sawtooth SDK APIs
+=================
+
+- Python
+
+  - `Transaction Processor
+    <python_sdk/processor/sawtooth_sdk.processor.html#http://>`__
+  - `Signing
+    <python_sdk/signing/sawtooth_signing.html#http://>`__
+
+- Go
+
+  - `Transaction Processor
+    <go_sdk/processor.html#http://>`__
+  - `Signing
+    <go_sdk/signing.html#http://>`__
+
+- Javascript
+
+  - `Transaction Processor
+    <javascript_sdk/processor/index.html#http://>`__
+  - `Signing
+    <javascript_sdk/signing/index.html#http://>`__

--- a/sdk/python/sawtooth_sdk/processor/__init__.py
+++ b/sdk/python/sawtooth_sdk/processor/__init__.py
@@ -13,6 +13,17 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+'''The processor module defines:
+
+1. A TransactionHandler interface to be
+used to create new transaction families.
+
+2. A high-level, general purpose TransactionProcessor to which any
+number of handlers can be added.
+
+3. A Context class used to abstract getting and setting addresses in
+global validator state.
+'''
 
 __all__ = [
     'core',


### PR DESCRIPTION
This PR adds a file that links to the published nightly docs. This will work for now, but a better way should be figured out.