### PR TITLE
Refactor validator id checks to just client input

### DIFF
--- a/protos/client_batch.proto
+++ b/protos/client_batch.proto
@@ -54,6 +54,7 @@ message ClientBatchListResponse {
         NO_RESOURCE = 5;
         INVALID_PAGING = 6;
         INVALID_SORT = 7;
+        INVALID_ID = 8;
     }
     Status status = 1;
     repeated Batch batches = 2;
@@ -78,6 +79,7 @@ message ClientBatchGetResponse {
         OK = 1;
         INTERNAL_ERROR = 2;
         NO_RESOURCE = 5;
+        INVALID_ID = 8;
     }
     Status status = 1;
     Batch batch = 2;

--- a/protos/client_batch_submit.proto
+++ b/protos/client_batch_submit.proto
@@ -94,6 +94,7 @@ message ClientBatchStatusResponse {
         OK = 1;
         INTERNAL_ERROR = 2;
         NO_RESOURCE = 5;
+        INVALID_ID = 8;
     }
     Status status = 1;
     repeated ClientBatchStatus batch_statuses = 2;

--- a/protos/client_block.proto
+++ b/protos/client_block.proto
@@ -55,6 +55,7 @@ message ClientBlockListResponse {
         NO_RESOURCE = 5;
         INVALID_PAGING = 6;
         INVALID_SORT = 7;
+        INVALID_ID = 8;
     }
     Status status = 1;
     repeated Block blocks = 2;
@@ -101,6 +102,7 @@ message ClientBlockGetResponse {
         OK = 1;
         INTERNAL_ERROR = 2;
         NO_RESOURCE = 5;
+        INVALID_ID = 8;
     }
     Status status = 1;
     Block block = 2;

--- a/protos/client_receipt.proto
+++ b/protos/client_receipt.proto
@@ -39,6 +39,7 @@ message ClientReceiptGetResponse {
         OK = 1;
         INTERNAL_ERROR = 2;
         NO_RESOURCE = 5;
+        INVALID_ID = 8;
     }
     Status status = 1;
     repeated TransactionReceipt receipts = 2;

--- a/protos/client_transaction.proto
+++ b/protos/client_transaction.proto
@@ -54,6 +54,7 @@ message ClientTransactionListResponse {
         NO_RESOURCE = 5;
         INVALID_PAGING = 6;
         INVALID_SORT = 7;
+        INVALID_ID = 8;
     }
     Status status = 1;
     repeated Transaction transactions = 2;
@@ -78,6 +79,7 @@ message ClientTransactionGetResponse {
         OK = 1;
         INTERNAL_ERROR = 2;
         NO_RESOURCE = 5;
+        INVALID_ID = 8;
     }
     Status status = 1;
     Transaction transaction = 2;

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -201,6 +201,19 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_1, response.batches[0].header_signature)
 
+    def test_batch_list_by_invalid_ids(self):
+        """Verifies batch list requests break when invalid ids are sent.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that paging and batches are missing
+        """
+        response = self.make_request(batch_ids=['not', 'valid'])
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.batches)
+
     def test_batch_list_by_head_and_ids(self):
         """Verifies batch list requests work with both head and batch ids.
 
@@ -410,6 +423,18 @@ class TestBatchGetRequests(ClientHandlerTestCase):
         response = self.make_request(batch_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.batch.SerializeToString())
+
+    def test_batch_get_with_invalid_id(self):
+        """Verifies requests for a specific batch break with an invalid id.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the Batch returned, when serialized, is actually empty
+        """
+        response = self.make_request(batch_id='invalid')
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
         self.assertFalse(response.batch.SerializeToString())
 
     def test_batch_get_with_block_id(self):

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -122,7 +122,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - a status of NO_ROOT
             - that head_id, paging, and batches are missing
         """
-        response = self.make_request(head_id='bad')
+        response = self.make_request(head_id='f' * 128)
 
         self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
@@ -156,7 +156,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assertEqual(A_0, response.batches[0].header_signature)
         self.assertEqual(A_2, response.batches[1].header_signature)
 
-    def test_batch_list_by_bad_ids(self):
+    def test_batch_list_by_missing_ids(self):
         """Verifies batch list requests break when ids are not found.
 
         Queries the default mock block store with three blocks:
@@ -169,14 +169,14 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - a head_id of 'bbb...2', the latest
             - that paging and batches are missing
         """
-        response = self.make_request(batch_ids=['bad', 'also-bad'])
+        response = self.make_request(batch_ids=['f' * 128, 'e' * 128])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
-    def test_batch_list_by_good_and_bad_ids(self):
+    def test_batch_list_by_found_and_missing_ids(self):
         """Verifies batch list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
@@ -192,7 +192,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - that item is an instances of Batch
             - that item has a header_signature of 'aaa...1'
         """
-        response = self.make_request(batch_ids=['bad', A_1])
+        response = self.make_request(batch_ids=['f' * 128, A_1])
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
@@ -305,7 +305,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
             - a status of INVALID_PAGING
             - that head_id, paging, and batches are missing
         """
-        response = self.make_paged_request(limit=3, start='bad')
+        response = self.make_paged_request(limit=3, start='f' * 128)
 
         self.assertEqual(self.status.INVALID_PAGING, response.status)
         self.assertFalse(response.head_id)
@@ -400,14 +400,14 @@ class TestBatchGetRequests(ClientHandlerTestCase):
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.batch.SerializeToString())
 
-    def test_batch_get_with_bad_id(self):
-        """Verifies requests for a specific batch break with a bad id.
+    def test_batch_get_with_missing_id(self):
+        """Verifies requests for a specific batch break with an unfound id.
 
         Expects to find:
             - a status of NO_RESOURCE
             - that the Batch returned, when serialized, is actually empty
         """
-        response = self.make_request(batch_id='bad')
+        response = self.make_request(batch_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.batch.SerializeToString())

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -121,7 +121,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - a status of NO_ROOT
             - that blocks, head_id, and paging are missing
         """
-        response = self.make_request(head_id='bad')
+        response = self.make_request(head_id='f' * 128)
 
         self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
@@ -155,7 +155,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assertEqual(B_0, response.blocks[0].header_signature)
         self.assertEqual(B_2, response.blocks[1].header_signature)
 
-    def test_block_list_by_bad_ids(self):
+    def test_block_list_by_missing_ids(self):
         """Verifies block list requests break when ids are not found.
 
         Queries the default mock block store with three blocks:
@@ -168,14 +168,14 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - a head_id of 'bbb...2', the latest
             - that blocks and paging are missing
         """
-        response = self.make_request(block_ids=['bad', 'also-bad'])
+        response = self.make_request(block_ids=['f' * 128, 'e' * 128])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.blocks)
 
-    def test_block_list_by_good_and_bad_ids(self):
+    def test_block_list_by_found_and_missing_ids(self):
         """Verifies block list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
@@ -191,7 +191,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - that item is an instances of Block
             - that item has a header_signature of 'bbb...1'
         """
-        response = self.make_request(block_ids=['bad', B_1])
+        response = self.make_request(block_ids=['f' * 128, B_1])
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
@@ -311,7 +311,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - a status of INVALID_PAGING
             - that head_id, paging, and blocks are missing
         """
-        response = self.make_paged_request(limit=3, start='bad')
+        response = self.make_paged_request(limit=3, start='f' * 128)
 
         self.assertEqual(self.status.INVALID_PAGING, response.status)
         self.assertFalse(response.head_id)
@@ -330,7 +330,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
             - a status of INVALID_SORT
             - that head_id, paging, and blocks are missing
         """
-        controls = self.make_sort_controls('bad')
+        controls = self.make_sort_controls('f' * 128)
         response = self.make_request(sorting=controls)
 
         self.assertEqual(self.status.INVALID_SORT, response.status)
@@ -402,14 +402,14 @@ class TestBlockGetByIdRequests(ClientHandlerTestCase):
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.block.SerializeToString())
 
-    def test_block_get_with_bad_id(self):
-        """Verifies requests for a specific block break with a bad id.
+    def test_block_get_with_missing_id(self):
+        """Verifies requests for a specific block break with an unfound id.
 
         Expects to find:
             - a status of NO_RESOURCE
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_request(block_id='bad')
+        response = self.make_request(block_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())
@@ -468,7 +468,7 @@ class TestBlockGetByTransactionRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_request(transaction_id='bad')
+        response = self.make_request(transaction_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())
@@ -515,7 +515,7 @@ class TestBlockGetByBatchRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that the Block returned, when serialized, is empty
         """
-        response = self.make_request(batch_id='bad')
+        response = self.make_request(batch_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.block.SerializeToString())

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -200,6 +200,19 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.blocks, Block)
         self.assertEqual(B_1, response.blocks[0].header_signature)
 
+    def test_block_list_by_invalid_ids(self):
+        """Verifies block list requests break when invalid ids are sent.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that paging and blocks are missing
+        """
+        response = self.make_request(block_ids=['not', 'valid'])
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.blocks)
+
     def test_block_list_by_head_and_ids(self):
         """Verifies block list requests work with both head and block ids.
 
@@ -412,6 +425,18 @@ class TestBlockGetByIdRequests(ClientHandlerTestCase):
         response = self.make_request(block_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.block.SerializeToString())
+
+    def test_block_get_with_invalid_id(self):
+        """Verifies requests for a specific block break with an invalid id.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the Block returned, when serialized, is actually empty
+        """
+        response = self.make_request(block_id='invalid')
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
         self.assertFalse(response.block.SerializeToString())
 
     def test_block_get_with_batch_id(self):

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -164,12 +164,12 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
 
         Expects to find:
             - a response status of OK
-            - a status of UNKNOWN at key 'z' in batch_statuses
+            - a status of UNKNOWN at key 'fff...' in batch_statuses
         """
-        response = self.make_request(batch_ids=['z'])
+        response = self.make_request(batch_ids=['f' * 128])
 
         self.assertEqual(self.status.OK, response.status)
-        self.assertEqual(response.batch_statuses[0].batch_id, 'z')
+        self.assertEqual(response.batch_statuses[0].batch_id, 'f' * 128)
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.UNKNOWN)
 

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -173,6 +173,18 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         self.assertEqual(response.batch_statuses[0].status,
                          ClientBatchStatus.UNKNOWN)
 
+    def test_batch_statuses_when_invalid(self):
+        """Verifies requests for status of a batch break with invalid ids.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the batch_statuses are missing
+        """
+        response = self.make_request(batch_ids=['not', 'valid'])
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertFalse(response.batch_statuses)
+
     def test_batch_statuses_for_many_batches(self):
         """Verifies requests for status of many batches work properly.
 

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -144,7 +144,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of NO_ROOT
             - that head_id, paging, and transactions are missing
         """
-        response = self.make_request(head_id='bad')
+        response = self.make_request(head_id='f' * 128)
 
         self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.head_id)
@@ -189,7 +189,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assertEqual(C_0, response.transactions[0].header_signature)
         self.assertEqual(C_2, response.transactions[1].header_signature)
 
-    def test_txn_list_by_bad_ids(self):
+    def test_txn_list_by_missing_ids(self):
         """Verifies txn list requests break properly when ids are not found.
 
         Queries the default mock block store with three blocks:
@@ -213,14 +213,14 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a head_id of 'bbb...2', the latest
             - that paging and transactions are missing
         """
-        response = self.make_request(transaction_ids=['bad', 'notgood'])
+        response = self.make_request(transaction_ids=['f' * 128, 'e' * 128])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual(B_2, response.head_id)
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.transactions)
 
-    def test_txn_list_by_good_and_bad_ids(self):
+    def test_txn_list_by_found_and_missing_ids(self):
         """Verifies txn list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
@@ -247,7 +247,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - that item is an instances of Transaction
             - that item has a header_signature of 'ccc...1'
         """
-        response = self.make_request(transaction_ids=['bad', C_1])
+        response = self.make_request(transaction_ids=['f' * 128, C_1])
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
@@ -313,7 +313,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a head_id of 'bbb...0'
             - that paging and transactions are missing
         """
-        response = self.make_request(head_id=B_0, transaction_ids=['ccc...1', 'ccc...2'])
+        response = self.make_request(head_id=B_0, transaction_ids=[C_1, C_2])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual(B_0, response.head_id)
@@ -457,7 +457,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
             - a status of INVALID_PAGING
             - that head_id, paging, and transactions are missing
         """
-        response = self.make_paged_request(limit=3, start='bad')
+        response = self.make_paged_request(limit=3, start='f' * 128)
 
         self.assertEqual(self.status.INVALID_PAGING, response.status)
         self.assertFalse(response.head_id)
@@ -566,14 +566,14 @@ class TestTransactionGetRequests(ClientHandlerTestCase):
         self.assertEqual(self.status.INTERNAL_ERROR, response.status)
         self.assertFalse(response.transaction.SerializeToString())
 
-    def test_txn_get_with_bad_id(self):
-        """Verifies requests for a specific txn break with a bad id.
+    def test_txn_get_with_missing_id(self):
+        """Verifies requests for a specific txn break with an unfound id.
 
         Expects to find:
             - a status of NO_RESOURCE
             - that the Transaction returned, when serialized, is actually empty
         """
-        response = self.make_request(transaction_id='bad')
+        response = self.make_request(transaction_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.transaction.SerializeToString())

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -256,6 +256,19 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_1, response.transactions[0].header_signature)
 
+    def test_txn_list_by_invalid_ids(self):
+        """Verifies txn list requests break when invalid ids are sent.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that paging and transactions are missing
+        """
+        response = self.make_request(transaction_ids=['not', 'valid'])
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
+        self.assertFalse(response.paging.SerializeToString())
+        self.assertFalse(response.transactions)
+
     def test_txn_list_by_head_and_ids(self):
         """Verifies txn list requests work with both head and txn ids.
 
@@ -576,6 +589,18 @@ class TestTransactionGetRequests(ClientHandlerTestCase):
         response = self.make_request(transaction_id='f' * 128)
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
+        self.assertFalse(response.transaction.SerializeToString())
+
+    def test_txn_get_with_invalid_id(self):
+        """Verifies requests for a specific txn break with an invalid id.
+
+        Expects to find:
+            - a status of INVALID_ID
+            - that the Transaction returned, when serialized, is actually empty
+        """
+        response = self.make_request(transaction_id='invalid')
+
+        self.assertEqual(self.status.INVALID_ID, response.status)
         self.assertFalse(response.transaction.SerializeToString())
 
     def test_txn_get_with_block_id(self):


### PR DESCRIPTION
Adding RegEx checks to the block store creates unnecessary performance overhead. These checks have been moved to just validate client input.

A new return status has been added to the client protos to reflect invalid id input.