### PR TITLE
Replace encoder with basic protobuf/signer doc

### DIFF
--- a/docs/source/_templates/partials/submitting_to_validator.rst
+++ b/docs/source/_templates/partials/submitting_to_validator.rst
@@ -20,7 +20,7 @@ prepared the BatchList:
 
     request.post({
         url: 'http://rest.api.domain/batches',
-        body: batchBytes,
+        body: batchListBytes,
         headers: {'Content-Type': 'application/octet-stream'}
     }, (err, response) => {
         if (err) return console.log(err)
@@ -37,7 +37,7 @@ prepared the BatchList:
     try:
         request = urllib.request.Request(
             'http://rest.api.domain/batches',
-            batch_bytes,
+            batch_list_bytes,
             method='POST',
             headers={'Content-Type': 'application/octet-stream'})
         response = urllib.request.urlopen(request)
@@ -58,7 +58,7 @@ sent it from the command-line with *curl*:
     const fs = require('fs')
 
     const fileStream = fs.createWriteStream('intkey.batches')
-    fileStream.write(batchBytes)
+    fileStream.write(batchListBytes)
     fileStream.end()
 
 {% else %}
@@ -66,7 +66,7 @@ sent it from the command-line with *curl*:
 .. code-block:: python
 
     output = open('intkey.batches', 'wb')
-    output.write(batch_bytes)
+    output.write(batch_list_bytes)
 
 {% endif %}
 


### PR DESCRIPTION
Since the Encoders have been removed from the SDK's, replace the usage
in the documentation with the basic protobuf messages.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>