### PR TITLE
Increase connection_timeout from 30 seconds to 120

### DIFF
--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -15,7 +15,8 @@
 
 import hashlib
 import string
-import time
+import os
+import binascii
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
@@ -111,7 +112,7 @@ class MessageFactory(object):
                                    set_nonce=True, batcher_pub_key=None):
 
         if set_nonce:
-            nonce = str(time.time())
+            nonce = binascii.b2a_hex(os.urandom(16))
         else:
             nonce = ""
         txn_pub_key = self._signer.get_public_key().as_hex()

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -68,8 +68,15 @@ class GetPeersResponseHandler(Handler):
 
         self._gossip.add_candidate_peer_endpoints(response.peer_endpoints)
 
+        temp = self._gossip.is_temp(connection_id)
+
         ack = NetworkAcknowledgement()
         ack.status = ack.OK
+        if temp:
+            return HandlerResult(
+                HandlerStatus.RETURN_AND_CLOSE,
+                message_out=ack,
+                message_type=validator_pb2.Message.NETWORK_ACK)
 
         return HandlerResult(
             HandlerStatus.RETURN,

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -215,7 +215,7 @@ class PingHandler(Handler):
         if connection_id in self._last_message:
             if time.time() - self._last_message[connection_id] < \
                     self._allowed_frequency:
-                LOGGER.debug("Too many Pings in %s seconds before"
+                LOGGER.debug("Too many Pings in %s seconds before "
                              "authorization is complete: %s",
                              self._allowed_frequency,
                              connection_id)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -162,7 +162,7 @@ class Validator(object):
             server_private_key=network_private_key,
             heartbeat=True,
             public_endpoint=endpoint,
-            connection_timeout=30,
+            connection_timeout=120,
             max_incoming_connections=100,
             max_future_callback_workers=10,
             authorize=True,


### PR DESCRIPTION
Also improves nonce creation in the message factory and fixes the case where the Network Ack is never received when removing temp connections on PeerResponse.