### PR TITLE
 Use Sphinx for Python API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 /docs/build/
 /docs/source/_autogen/
 /docs/source/cli/output/
+/docs/source/sdks/
 
 /integration/**/__pycache__/
 

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -47,33 +47,21 @@ ENV GOPATH=/go:/project/sawtooth-core/sdk/go:/project/sawtooth-core/sdk/examples
 
 RUN mkdir /go
 
-RUN go get -u github.com/golang/protobuf/proto \
+RUN go get -u \
+    github.com/golang/protobuf/proto \
     github.com/golang/protobuf/protoc-gen-go \
     github.com/pebbe/zmq4 \
     github.com/brianolson/cbor_go \
     github.com/satori/go.uuid \
     github.com/btcsuite/btcd/btcec \
     github.com/btcsuite/btcutil/base58 \
-    gopkg.in/fatih/set.v0 \
-    golang.org/x/crypto/ripemd160 \
     github.com/jessevdk/go-flags \
     github.com/pelletier/go-toml \
+    github.com/golang/mock/gomock \
+    github.com/golang/mock/mockgen \
+    golang.org/x/crypto/ripemd160 \
     golang.org/x/crypto/ssh/terminal \
- && cd /go/src/github.com/golang \
- && git clone https://github.com/golang/mock \
- && cd mock \
- && git checkout v1.0.0 \
- && cd /go/src/github.com/golang/mock/mockgen \
- && go build -o /go/bin/mockgen
-
-# A PR was merged into the github.com/golang/mock repository on 10/10/17 that
-# broke it due to an import issue. Since the "go get" command does not support
-# checking out specific commits/tags/branches, the above hack was used instead
-# to retrieve the dependency and checkout a stable version. The following was
-# created to track the issue: https://github.com/golang/mock/issues/116. Once
-# the issue is resolved, we can revert to using "go get" again with the paths:
-# - github.com/golang/mock/gomock
-# - github.com/golang/mock/mockgen
+    gopkg.in/fatih/set.v0
 
 EXPOSE 4004/tcp
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -62,23 +62,12 @@ templates:
 cli:
 	$(SAWTOOTH)/bin/generate_cli_output
 
-PYTHONSDKDIR := $(HTMLDIR)/python_sdk
+PYTHONSDKDIR := source/sdks/python_sdk
+PYTHONAPIDOC := $(SPHINXAPIDOC) -f -o $(PYTHONSDKDIR)
 python:
-    # pydoc doesn't allow specifying an output directory, so make the
-    # files first and then move them.
-	mkdir -p $(PYTHONSDKDIR)/processor
-	pydoc3 -w sawtooth_sdk.processor
-	pydoc3 -w sawtooth_sdk.processor.core
-	pydoc3 -w sawtooth_sdk.processor.context
-	pydoc3 -w sawtooth_sdk.processor.handler
-	pydoc3 -w sawtooth_sdk.processor.exceptions
-	mv sawtooth_sdk.processor*.html $(PYTHONSDKDIR)/processor
-
-	mkdir -p $(PYTHONSDKDIR)/signing
-	pydoc3 -w sawtooth_signing
-	pydoc3 -w sawtooth_signing.core
-	pydoc3 -w sawtooth_signing.secp256k1
-	mv sawtooth_signing*.html $(PYTHONSDKDIR)/signing
+	mkdir -p $(PYTHONSDKDIR)
+	$(PYTHONAPIDOC) ../sdk/python/sawtooth_sdk/processor
+	$(PYTHONAPIDOC) ../signing/sawtooth_signing
 
 GOSDKDIR := $(HTMLDIR)/go_sdk
 go:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,6 +21,8 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+sys.path.insert(0, os.path.abspath('../../sdk/python/sawtooth_sdk'))
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -91,7 +93,10 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['community/how_to_report_issues.rst']
+exclude_patterns = [
+    'community/how_to_report_issues.rst',
+    'sdks/python_sdk/modules.rst',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/sdks.rst
+++ b/docs/source/sdks.rst
@@ -1,24 +1,28 @@
-=================
-Sawtooth SDK APIs
-=================
+===================
+ Sawtooth SDK APIs
+===================
 
-- Python
 
-  - `Transaction Processor
-    <python_sdk/processor/sawtooth_sdk.processor.html#http://>`__
-  - `Signing
-    <python_sdk/signing/sawtooth_signing.html#http://>`__
+Python
+------
 
-- Go
+.. toctree::
 
-  - `Transaction Processor
-    <go_sdk/processor.html#http://>`__
-  - `Signing
-    <go_sdk/signing.html#http://>`__
+   sdks/python_sdk/processor.rst
+   sdks/python_sdk/sawtooth_signing.rst
 
-- Javascript
+Go
+--
 
-  - `Transaction Processor
-    <javascript_sdk/processor/index.html#http://>`__
-  - `Signing
-    <javascript_sdk/signing/index.html#http://>`__
+- `Transaction Processor
+  <go_sdk/processor.html#http://>`__
+- `Signing
+  <go_sdk/signing.html#http://>`__
+
+Javascript
+----------
+
+- `Transaction Processor
+  <javascript_sdk/processor/index.html#http://>`__
+- `Signing
+  <javascript_sdk/signing/index.html#http://>`__

--- a/signing/sawtooth_signing/core.py
+++ b/signing/sawtooth_signing/core.py
@@ -131,6 +131,7 @@ class Context(metaclass=ABCMeta):
     @abstractmethod
     def new_random_private_key(self):
         """Generates a new random PrivateKey using this context.
+
         Returns:
             (:obj:`PrivateKey`): a random private key
         """


### PR DESCRIPTION
The pydoc API docs were ugly and broken, but it turns out that Sphinx can be used instead.

Unrelated to that, I added a commit to fix a version compatibility hack in `sawtooth-dev-go`.