### PR TITLE
except ParseError: --> except ParseError as e:

### DIFF
--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -560,7 +560,7 @@ def _read_signer(key_filename):
 
     try:
         private_key = Secp256k1PrivateKey.from_hex(signing_key)
-    except ParseError:
+    except ParseError as e:
         try:
             private_key = Secp256k1PrivateKey.from_wif(signing_key)
         except ParseError:

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -286,7 +286,7 @@ def _read_signer(key_filename):
     except ParseError:
         try:
             private_key = Secp256k1PrivateKey.from_wif(signing_key)
-        except ParseError:
+        except ParseError as e:
             raise CliException('Unable to read key in file: {}'.format(str(e)))
 
     context = create_context('secp256k1')

--- a/consensus/poet/cli/sawtooth_poet_cli/registration.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/registration.py
@@ -254,7 +254,7 @@ def _read_signer(key_filename):
     except ParseError:
         try:
             private_key = Secp256k1PrivateKey.from_wif(signing_key)
-        except ParseError:
+        except ParseError as e:
             raise CliException('Unable to read key in file: {}'.format(str(e)))
 
     context = create_context('secp256k1')

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -57,7 +57,7 @@ def load_identity_signer(key_dir, key_name):
     except signing.ParseError:
         try:
             private_key = Secp256k1PrivateKey.from_wif(private_key_str)
-        except signing.ParseError:
+        except signing.ParseError as e:
             raise LocalConfigurationError(
                 "Invalid key in file {}: {}".format(key_path, str(e)))
 


### PR DESCRIPTION
Make the same fix in four different files where we are catching a ParseError and then re-raising it.  In the except statement, we need to capture the exception into the variable in __e__ so that we can re-raise it in the lines immediately following.  Without this change, we would raise a NameError instead of the intended exception.

Discovered via [flake8](http://flake8.pycqa.org) testing of https://github.com/hyperledger/sawtooth-core on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./cli/sawtooth_cli/identity.py:567:76: F821 undefined name 'e'
            raise CliException('Unable to read key in file: {}'.format(str(e)))
                                                                           ^

./cli/sawtooth_cli/sawset.py:290:76: F821 undefined name 'e'
            raise CliException('Unable to read key in file: {}'.format(str(e)))
                                                                           ^

./consensus/poet/cli/sawtooth_poet_cli/registration.py:258:76: F821 undefined name 'e'
            raise CliException('Unable to read key in file: {}'.format(str(e)))
                                                                           ^

./validator/sawtooth_validator/server/keys.py:62:67: F821 undefined name 'e'
                "Invalid key in file {}: {}".format(key_path, str(e)))
                                                                  ^

4     F821 undefined name 'e'
```

Signed-off-by: cclauss <cclauss@bluewin.ch>