### PR TITLE
Bugfix in rest-api state-delta

### DIFF
--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -354,7 +354,7 @@ class StateDeltaSubscriberHandler:
     @staticmethod
     def _make_subscriptions(address_prefixes=None):
         return [
-            events_pb2.EventSubscription(event_type="state_delta"),
+            events_pb2.EventSubscription(event_type="sawtooth/state-delta"),
             events_pb2.EventSubscription(event_type="sawtooth/block-commit"),
         ]
 


### PR DESCRIPTION
Typo in state_delta_subscription handler that prevents the state-delta
to work.

Signed-off-by: Benoit Razet <benoit.razet@pokitdok.com>