### PR TITLE
Add Reference Counting  to BlockCache

### DIFF
--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -89,8 +89,8 @@ valid.
 
 The BlockCache keeps blocks that are currently relevant, tracked by the last
 time the block was accessed. Periodically, the blocks that have not been
-accessed recently are purged from the block cache. The time horizon for purging
-and the frequency of purging are set in the Completer.
+accessed recently are purged from the block cache, but only if none of the
+other blocks in the BlockCache reference those blocks as predecessors.
 
 The Completer
 =============

--- a/validator/sawtooth_validator/journal/block_cache.py
+++ b/validator/sawtooth_validator/journal/block_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Intel Corporation
+# Copyright 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,27 +13,45 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from sawtooth_validator.journal.timed_cache import TimedCache
+from collections.abc import MutableMapping
+from threading import RLock
+import time
+
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 
 
-class BlockCache(TimedCache):
+class BlockCache(MutableMapping):
     """
     A dict like interface to access blocks. Stores BlockState objects.
     """
-    def __init__(self, block_store=None, keep_time=10, purge_frequency=10):
-        super(BlockCache, self).__init__(keep_time, purge_frequency)
-        self._block_store = block_store if block_store is not None else {}
 
-    def __getitem__(self, key):
-        with self._lock:
-            try:
-                return super(BlockCache, self).__getitem__(key)
-            except KeyError:
-                if key in self._block_store:
-                    value = self._block_store[key]
-                    super(BlockCache, self).__setitem__(key, value)
-                    return value
-                raise
+    class CachedValue(object):
+        def __init__(self, value):
+            self.value = value
+            self.timestamp = time.time()  # the time this State was created,
+            # used for house keeping, ie when to flush this from the cache.
+            self.count = 0
+
+        def touch(self):
+            """
+            Mark this entry as accessed.
+            """
+            self.timestamp = time.time()
+
+        def inc_count(self):
+            self.count += 1
+
+        def dec_count(self):
+            self.count -= 1
+
+    def __init__(self, block_store=None, keep_time=30, purge_frequency=30):
+        super(BlockCache, self).__init__()
+        self._lock = RLock()
+        self._cache = {}
+        self._keep_time = keep_time
+        self._purge_frequency = purge_frequency
+        self._next_purge_time = time.time() + purge_frequency
+        self._block_store = block_store if block_store is not None else {}
 
     @property
     def block_store(self):
@@ -42,3 +60,86 @@ class BlockCache(TimedCache):
         type BlockStoreAdapter.
         """
         return self._block_store
+
+    def __getitem__(self, block_id):
+        with self._lock:
+            try:
+                value = self._cache[block_id]
+                value.touch()
+                return value.value
+            except KeyError:
+                if block_id in self._block_store:
+                    block = self._block_store[block_id]
+                    self.__setitem__(block_id, block)
+                    return block
+                raise
+
+    def __setitem__(self, block_id, block):
+        with self._lock:
+            self._cache[block_id] = self.CachedValue(block)
+            if block_id != NULL_BLOCK_IDENTIFIER and \
+                    block.previous_block_id in self._cache:
+                self._cache[block.previous_block_id].inc_count()
+
+            if time.time() > self._next_purge_time:
+                self._purge_expired()
+                self._next_purge_time = time.time() + self._purge_frequency
+
+    def __delitem__(self, block_id):
+        with self._lock:
+            block = self._cache[block_id].value
+            if block.previous_block_id in self._cache:
+                self._cache[block.previous_block_id].dec_count()
+            del self._cache[block_id]
+
+    def __iter__(self):
+        with self._lock:
+            return iter(self._cache)
+
+    def __len__(self):
+        with self._lock:
+            return len(self._cache)
+
+    def __str__(self):
+        with self._lock:
+            out = []
+            for v in self._cache.values():
+                out.append(str(v.value))
+            return ','.join(out)
+
+    @property
+    def cache(self):
+        return self._cache
+
+    @property
+    def keep_time(self):
+        return self._keep_time
+
+    @property
+    def purge_frequency(self):
+        with self._lock:
+            return self._purge_frequency
+
+    def _purge_expired(self):
+        """
+        Remove all expired entries from the cache that do not have a reference
+        count.
+        """
+        time_horizon = time.time() - self._keep_time
+        new_cache = {}
+        dec_count_for = []
+        for (k, v) in self._cache.items():
+            if v.count > 0:
+                new_cache[k] = v
+
+            elif v.timestamp > time_horizon:
+                new_cache[k] = v
+
+            else:
+                block = v.value
+                dec_count_for.append(block.previous_block_id)
+
+        self._cache = new_cache
+        for block_id in dec_count_for:
+            if block_id in self._cache:
+                self._cache[block_id].dec_count()

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -257,7 +257,12 @@ class BlockValidator(object):
         found to not be permitted, the block is invalid.
         """
         if blkw.block_num != 0:
-            state_root = self._get_previous_block_root_state_hash(blkw)
+            try:
+                state_root = self._get_previous_block_root_state_hash(blkw)
+            except KeyError:
+                LOGGER.debug("Block rejected due to missing" +
+                             " predecessor: %s", blkw)
+                return False
             for batch in blkw.batches:
                 if not self._permission_verifier.is_batch_signer_authorized(
                         batch, state_root):
@@ -271,7 +276,12 @@ class BlockValidator(object):
         invalid.
         """
         if blkw.block_num != 0:
-            state_root = self._get_previous_block_root_state_hash(blkw)
+            try:
+                state_root = self._get_previous_block_root_state_hash(blkw)
+            except KeyError:
+                LOGGER.debug("Block rejected due to missing" +
+                             " predecessor: %s", blkw)
+                return False
             return self._validation_rule_enforcer.validate(blkw, state_root)
         return True
 

--- a/validator/sawtooth_validator/journal/timed_cache.py
+++ b/validator/sawtooth_validator/journal/timed_cache.py
@@ -20,7 +20,7 @@ import time
 
 class TimedCache(MutableMapping):
     """
-    A dict like interface to access blocks. Stores BlockState objects.
+    A dict like interface that removes entries after sometime of no access.
 
     Accesses are Thread safe.
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -281,6 +281,7 @@ class Validator(object):
 
         completer.set_on_batch_received(block_publisher.queue_batch)
         completer.set_on_block_received(chain_controller.queue_block)
+        completer.set_chain_has_block(chain_controller.has_block)
 
         # -- Register Message Handler -- #
         network_handlers.add(

--- a/validator/tests/test_block_cache/tests.py
+++ b/validator/tests/test_block_cache/tests.py
@@ -1,0 +1,66 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import unittest
+import time
+
+from sawtooth_validator.journal.block_cache import BlockCache
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
+
+from sawtooth_validator.protobuf.block_pb2 import Block
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BlockCacheTest(unittest.TestCase):
+    def test_block_cache(self):
+        block_store = {}
+        cache = BlockCache(block_store=block_store, keep_time=1,
+                           purge_frequency=1)
+
+        header1 = BlockHeader(previous_block_id="000")
+        block1 = BlockWrapper(Block(header=header1.SerializeToString(),
+                              header_signature="ABC"))
+
+        header2 = BlockHeader(previous_block_id="ABC")
+        block2 = BlockWrapper(Block(header=header2.SerializeToString(),
+                              header_signature="DEF"))
+
+        header3 = BlockHeader(previous_block_id="BCA")
+        block3 = BlockWrapper(Block(header=header3.SerializeToString(),
+                              header_signature="FED"))
+
+        cache[block1.header_signature] = block1
+        cache[block2.header_signature] = block2
+
+        # Check that blocks are in the BlockCache
+        self.assertIn("ABC", cache)
+        self.assertIn("DEF", cache)
+
+        # Wait for purge time to expire
+        time.sleep(1)
+        # Add "FED"
+        cache[block3.header_signature] = block3
+
+        # Check that "ABC" is still in the cache even though the keep time has
+        # expired because it has a referecne count of 1 but "DEF" has been
+        # removed
+        self.assertIn("ABC", cache)
+        self.assertNotIn("DEF", cache)
+        self.assertIn("FED", cache)

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -80,12 +80,19 @@ class TestBlockCache(unittest.TestCase):
         """ Test that misses will load from the block store.
         """
         bs = {}
-        bs["test"] = "value"
-        bs["test2"] = "value"
+        block1 = Block(
+            header=BlockHeader(previous_block_id="000").SerializeToString(),
+            header_signature="test")
+        bs["test"] = BlockWrapper(block1)
+        block2 = Block(
+            header=BlockHeader(previous_block_id="000").SerializeToString(),
+            header_signature="test2")
+        blkw2 = BlockWrapper(block2)
+        bs["test2"] = blkw2
         bc = BlockCache(bs)
 
         self.assertTrue("test" in bc)
-        self.assertTrue(bc["test2"] == "value")
+        self.assertTrue(bc["test2"] == blkw2)
 
         with self.assertRaises(KeyError):
             bc["test-missing"]


### PR DESCRIPTION
If a block has a count above 0, it will not be purged from the catch.

Also, catch KeyErrors in _validate_permissions and _validate_on_chain_rules and update the completer to check if the journal has the predecessor for the block it is verifying.