### PR TITLE
Remove python3-ecdsa dependency from PoET

### DIFF
--- a/ci/sawtooth-build-debs
+++ b/ci/sawtooth-build-debs
@@ -63,7 +63,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     python3-chardet=2.3.0-1 \
     python3-cryptography-vectors=1.7.2-1 \
     python3-cryptography=1.7.2-1 \
-    python3-ecdsa \
     python3-grpcio-tools=1.1.3-1 \
     python3-grpcio=1.1.3-1 \
     python3-lmdb=0.92-1 \

--- a/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.h
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.h
@@ -249,6 +249,12 @@ WaitCertificate* deserialize_wait_certificate(
     const std::string& signature
     );
 
+bool _verify_wait_certificate(
+    const std::string& serializedWaitCertificate,
+    const std::string& waitCertificateSignature,
+    const std::string& poetPublicKey
+    );
+
 class Poet
 {
 public:

--- a/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/wait_certificate.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/poet_enclave_sgx/wait_certificate.cpp
@@ -198,3 +198,22 @@ WaitCertificate* deserialize_wait_certificate(
             serialized_certificate,
             signature);
 } // deserialize_wait_certificate
+
+bool _verify_wait_certificate(
+    const std::string& serializedWaitCertificate,
+    const std::string& waitCertificateSignature,
+    const std::string& poetPublicKey
+    )
+{
+    PyLog(POET_LOG_INFO, "Verify SGX Wait Certificate");
+
+    poet_err_t ret =
+        Poet_VerifyWaitCertificate(
+            serializedWaitCertificate.c_str(),
+            waitCertificateSignature.c_str(),
+            poetPublicKey.c_str() );
+    ThrowPoetError(ret);
+
+    if(ret == POET_SUCCESS) return true;
+    return false;
+}

--- a/consensus/poet/sgx/setup.py
+++ b/consensus/poet/sgx/setup.py
@@ -121,7 +121,6 @@ setup(name='sawtooth-poet-sgx',
       packages=find_packages(),
       install_requires=[
           'toml',
-          'ecdsa',
           'sawtooth-ias-client',
           'sawtooth-poet-common'
           ],


### PR DESCRIPTION
Wait certificates are intended to be verifiable outside of an enclave.
The python portion of PoET took this on to verify the NIST 256p ECDSA
signature created in the enclave using the SGX SDK. It used an ECC library
available for python. Sawtooth security reviewers did not have time
to review that library ahead of Sawtooth's planned 1.0 release and it
was not yet listed in available whitelists. It was deemed more secure
in the near term not to use the python ecdsa library until reviewers
can gain more familiarity with it.

As such this commit reverts wait certificate signature verification to
use the SGX SDK's ECC library call.

This commit does not preclude an observer node verifying wait
certificates using its own ECC lib without SGX.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>