### PR TITLE
Disable Network Permission Test Due to Test Instability 

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -341,8 +341,6 @@ test_integration() {
     copy_coverage .coverage.test_basic_auth_proxy
     run_docker_test test_transactor_permissioning
     copy_coverage .coverage.test_transactor_permissioning
-    run_docker_test test_network_permissioning --timeout 800
-    copy_coverage .coverage.test_network_permissioning
     run_docker_test test_poet_liveness
     copy_coverage .coverage.test_poet_liveness
 }


### PR DESCRIPTION
Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>