### PR TITLE
Revert "Change default scheduler from serial to parallel" and disable network permissioning test

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -341,8 +341,6 @@ test_integration() {
     copy_coverage .coverage.test_basic_auth_proxy
     run_docker_test test_transactor_permissioning
     copy_coverage .coverage.test_transactor_permissioning
-    run_docker_test test_network_permissioning --timeout 800
-    copy_coverage .coverage.test_network_permissioning
     run_docker_test test_poet_liveness
     copy_coverage .coverage.test_poet_liveness
 }

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -33,7 +33,7 @@ def load_default_validator_config():
         bind_component='tcp://127.0.0.1:4004',
         endpoint=None,
         peering='static',
-        scheduler='parallel')
+        scheduler='serial')
 
 
 def load_toml_validator_config(filename):

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -160,7 +160,7 @@ class TestValidatorConfig(unittest.TestCase):
         self.assertEquals(config.bind_component, "tcp://127.0.0.1:4004")
         self.assertEquals(config.endpoint, None)
         self.assertEquals(config.peering, "static")
-        self.assertEquals(config.scheduler, "parallel")
+        self.assertEquals(config.scheduler, "serial")
 
     def test_validator_config_load_from_file(self):
         """Tests loading config settings from a TOML configuration file.


### PR DESCRIPTION
This reverts commit bacfcae1310df319f32e28f3470bd98ebcc9ffe4 and also disables the network permissioning test.

The parallel scheduler change has seemingly introduced some occasional test failures in master. More testing is required.