### PR TITLE
(consensus-prototype) Create BlockValidationScheduler and rewrite ChainCommitState

### DIFF
--- a/validator/sawtooth_validator/concurrent/atomic.py
+++ b/validator/sawtooth_validator/concurrent/atomic.py
@@ -62,6 +62,11 @@ class ConcurrentSet:
         with self.lock:
             self.set.remove(element)
 
+    def remove_all(self, elements):
+        with self.lock:
+            for elem in elements:
+                self.set.remove(elem)
+
     def __contains__(self, element):
         with self.lock:
             return element in self.set
@@ -84,6 +89,16 @@ class ConcurrentMultiMap:
         """
         with self.lock:
             if key in self.dict:
+                self.dict[key].append(item)
+            else:
+                self.dict[key] = [item]
+
+    def append_if_unique(self, key, item, compare_fn):
+        with self.lock:
+            if key in self.dict:
+                for i in self.dict[key]:
+                    if compare_fn(i, item):
+                        return
                 self.dict[key].append(item)
             else:
                 self.dict[key] = [item]

--- a/validator/sawtooth_validator/journal/block_scheduler.py
+++ b/validator/sawtooth_validator/journal/block_scheduler.py
@@ -1,0 +1,177 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+import queue
+
+from sawtooth_validator.concurrent.thread import InstrumentedThread
+from sawtooth_validator.concurrent.atomic import ConcurrentSet
+from sawtooth_validator.concurrent.atomic import ConcurrentMultiMap
+
+from sawtooth_validator.journal.block_wrapper import BlockStatus
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class _BlockValidationSchedulerThread(InstrumentedThread):
+    """This thread's job is to pull blocks off of the queue and to submit them
+    for scheduling."""
+    def __init__(self, block_queue, submit_function, exit_poll_interval=1):
+        super().__init__(name='_BlockValidationSchedulerThread')
+        self._block_queue = block_queue
+        self._submit_function = submit_function
+        self._exit_poll_interval = exit_poll_interval
+        self._exit = False
+
+    def run(self):
+        while True:
+            try:
+                # Set timeout so we can check if the thread has been stopped
+                block = self._block_queue.get(timeout=self._exit_poll_interval)
+                self._submit_function(block)
+
+            except queue.Empty:
+                pass
+
+            if self._exit:
+                return
+
+    def stop(self):
+        self._exit = True
+
+
+class BlockValidationScheduler:
+    """BlockValidationScheduler is responsible for receiving blocks from an
+    incoming queue and determining when they are ready to be validated. A block
+    is ready to be validated when:
+
+        1. All predecessor blocks are known (if this is not true, it is
+           considered an error as it should be guaranteed by the completer)
+        2. All predecesor blocks have been validated
+
+    The BlockValidationScheduler does not do any validation itself.
+    """
+
+    def __init__(self, incoming, outgoing, block_cache):
+        self._incoming = incoming
+        self._outgoing = outgoing
+        self._block_cache = block_cache
+
+        # In process
+        self._blocks_processing = ConcurrentSet()
+
+        # Pending
+        self._blocks_pending = ConcurrentSet()
+        self._block_dependencies = ConcurrentMultiMap()
+
+        self._receive_thread = _BlockValidationSchedulerThread(
+            self._incoming, self.handle_incoming_block)
+
+    def start(self):
+        self._receive_thread.start()
+
+    def stop(self):
+        self._receive_thread.stop()
+
+    def on_block_validated(self, block_id):
+        """Listen for blocks that have been processed and schedule blocks that
+        are now ready for processing.
+        """
+        LOGGER.debug("Removing block from processing %s", block_id)
+        self._blocks_processing.remove(block_id)
+        for block in self.release_pending_blocks(block_id):
+            self.schedule_block(block)
+
+    def handle_incoming_block(self, block):
+        """Handle the block on the incoming queue."""
+        # If we already have the block, just drop it
+        if block.header_signature in self._block_cache:
+            LOGGER.debug("Received duplicate block: %s", block)
+            return
+
+        LOGGER.debug("Received block: %s", block)
+
+        self._block_cache[block.header_signature] = block
+
+        # If this is a genesis block, schedule it immediately
+        if block.previous_block_id == NULL_BLOCK_IDENTIFIER:
+            LOGGER.debug("Scheduling genesis block: %s", block)
+            self.schedule_block(block)
+            return
+
+        # If predecessor is not in block cache, something external is wrong
+        # and all we can do is report an error
+        try:
+            previous = self._block_cache[block.previous_block_id]
+        except KeyError:
+            LOGGER.error("Received block with missing predecessor: %s", block)
+            return
+
+        # If predecessor's status is known, put the block in outgoing
+        if previous.status != BlockStatus.Unknown:
+            LOGGER.debug("Scheduling block: %s", block)
+            self.schedule_block(block)
+            return
+
+        # If predecessor's status is unknown, and in inproc or pending, add to
+        # pending
+        if self.is_pending(previous.header_signature):
+            LOGGER.debug(
+                "Previous block is pending, adding block to pending: %s",
+                block)
+            self.add_to_pending(block)
+            return
+
+        if self.is_processing(previous.header_signature):
+            LOGGER.debug(
+                "Previous block is processing, adding block to pending: %s",
+                block)
+            self.add_to_pending(block)
+            return
+
+        # If predecessor's status is unknown, and not inproc or pending,
+        # something is very wrong.
+        LOGGER.error("Received block before predecessor: %s", block)
+
+    def schedule_block(self, block):
+        self._outgoing.put(block)
+        self._blocks_processing.add(block.header_signature)
+
+    def add_to_pending(self, block):
+        """Add the block to pending so it can be scheduled when its dependencies
+        are done."""
+        self._blocks_pending.add(block.header_signature)
+        self._block_dependencies.append_if_unique(
+            block.previous_block_id,
+            block,
+            lambda a, b: a.header_signature == b.header_signature)
+
+    def is_pending(self, block_id):
+        """Return whether this block is pending validation."""
+        return block_id in self._blocks_pending
+
+    def is_processing(self, block_id):
+        """Return whether this block is being validated."""
+        return block_id in self._blocks_processing
+
+    def release_pending_blocks(self, block_id):
+        """Remove blocks that were pending on the validation of the block with
+        block_id."""
+        ready = self._block_dependencies.pop(block_id, [])
+        block_ids = [block.header_signature for block in ready]
+        self._blocks_pending.remove_all(block_ids)
+        return ready

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -435,7 +435,7 @@ class BlockValidator(object):
 
         except Exception:
             LOGGER.exception(
-                "Unhandled exception BlockPublisher.validate_block()")
+                "Unhandled exception BlockValidator.validate_block()")
             return False
 
     @staticmethod

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -399,7 +399,12 @@ class BlockValidator(object):
                 blkw.status = BlockStatus.Invalid
                 return False
 
-            consensus = self._load_consensus(chain_head)
+            try:
+                prev_block = self._block_cache[blkw.previous_block_id]
+            except KeyError:
+                prev_block = None
+
+            consensus = self._load_consensus(prev_block)
             consensus_block_verifier = consensus.BlockVerifier(
                 block_cache=self._block_cache,
                 state_view_factory=self._state_view_factory,

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -575,6 +575,12 @@ class BlockValidator(object):
             result = BlockValidationResult(block)
             LOGGER.info("Starting block validation of : %s", block)
 
+            # If this is a genesis block, we can skip the rest
+            if block.previous_block_id == NULL_BLOCK_IDENTIFIER:
+                valid = self.validate_block(block)
+                callback(valid, result)
+                return
+
             # Get the current chain_head and store it in the result
             chain_head = self._block_cache.block_store.chain_head
             result.chain_head = chain_head

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -89,11 +89,17 @@ class ForkResolutionResult:
 class BlockValidationResult:
     def __init__(self, block):
         self.block = block
-        self.execution_results = []
-        self.transaction_count = 0
 
     def __bool__(self):
         return self.block.status == BlockStatus.Valid
+
+    @property
+    def execution_results(self):
+        return self.block.execution_results
+
+    @property
+    def transaction_count(self):
+        return self.block.execution_results
 
     def set_valid(self, is_valid):
         if is_valid:
@@ -102,9 +108,9 @@ class BlockValidationResult:
             self.block.status = BlockStatus.Invalid
 
     def merge_batch_results(self, batch_validation_results):
-        self.transaction_count =\
+        self.block.transaction_count += \
             batch_validation_results.transaction_count
-        self.execution_results.extend(
+        self.block.execution_results.extend(
             batch_validation_results.execution_results)
 
 

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -43,6 +43,8 @@ class BlockWrapper(object):
         self.weight = weight  # the block weight calculated by the
         # consensus algorithm.
         self.status = status  # One of the BlockStatus types.
+        self.execution_results = []
+        self.transaction_count = 0
 
     @staticmethod
     def wrap(block, weight=0, status=BlockStatus.Unknown):

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -111,12 +111,19 @@ class ChainController(object):
 
     def _set_chain_head_from_block_store(self):
         try:
-            self._chain_head = self._block_store.chain_head
-            if self._chain_head is not None:
-                LOGGER.info("Chain controller initialized with chain head: %s",
-                            self._chain_head)
-                self._chain_head_gauge.set_value(
-                    self._chain_head.identifier[:8])
+            chain_head = self._block_store.chain_head
+            if chain_head is not None:
+                if chain_head.status == BlockStatus.Valid:
+                    self._chain_head = chain_head
+                    LOGGER.info(
+                        "Chain controller initialized with chain head: %s",
+                        self._chain_head)
+                    self._chain_head_gauge.set_value(
+                        self._chain_head.identifier[:8])
+                else:
+                    LOGGER.warning(
+                        "Tried to set chain head from block store, but chain"
+                        " head isn't valid: %s", chain_head)
         except Exception:
             LOGGER.exception(
                 "Invalid block store. Head of the block chain cannot be"

--- a/validator/sawtooth_validator/journal/chain_commit_state.py
+++ b/validator/sawtooth_validator/journal/chain_commit_state.py
@@ -13,6 +13,174 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
+
+
+class MissingDependency(Exception):
+    def __init__(self, txn_id):
+        super().__init__("Missing dependency: {}".format(txn_id))
+        self.transaction_id = txn_id
+
+
+class DuplicateTransaction(Exception):
+    def __init__(self, txn_id):
+        super().__init__("Duplicate transaction: {}".format(txn_id))
+        self.transaction_id = txn_id
+
+
+class DuplicateBatch(Exception):
+    def __init__(self, batch_id):
+        super().__init__("Duplicate batch: {}".format(batch_id))
+        self.batch_id = batch_id
+
+
+class ChainCommitState:
+    """Checking to see if a batch or transaction in a block has already been
+    committed is somewhat difficult because of the presence of forks. While
+    the block store is the definitive source for all batches and transactions
+    that have been committed on the current chain. Validation of blocks on
+    another fork requires determing what blocks would actually be in the chain
+    if that block were to be committed and only checking the batches and
+    transactions contained within. ChainCommitState abstracts this process.
+    """
+    def __init__(self, head_id, block_cache, block_store):
+        """The constructor should be passed the previous block id of the block
+        being validated."""
+        uncommitted_block_ids = list()
+        uncommitted_batch_ids = set()
+        uncommitted_txn_ids = set()
+
+        # Find the most recent ancestor of this block that is in the block
+        # store. Batches and transactions that are in a block that is in the
+        # block store and that has a greater block number than this block must
+        # be ignored.
+        if head_id != NULL_BLOCK_IDENTIFIER:
+            head = block_cache[head_id]
+            ancestor = head
+            while ancestor.header_signature not in block_store:
+                # For every block not in the block store, we need to track all
+                # its batch ids and transaction ids separately to ensure there
+                # are no duplicates.
+                for batch in ancestor.batches:
+                    uncommitted_batch_ids.add(batch.header_signature)
+
+                    for txn in batch.transactions:
+                        uncommitted_txn_ids.add(txn.header_signature)
+
+                uncommitted_block_ids.append(ancestor.header_signature)
+
+                previous_block_id = ancestor.previous_block_id
+                if previous_block_id == NULL_BLOCK_IDENTIFIER:
+                    break
+
+                ancestor = block_cache[previous_block_id]
+        else:
+            ancestor = None
+
+        self.block_store = block_store
+        self.common_ancestor = ancestor
+        self.uncommitted_block_ids = uncommitted_block_ids
+        self.uncommitted_batch_ids = uncommitted_batch_ids
+        self.uncommitted_txn_ids = uncommitted_txn_ids
+
+    def _block_in_chain(self, block):
+        if self.common_ancestor is not None:
+            return block.block_num <= self.common_ancestor.block_num
+        return False
+
+    @staticmethod
+    def _check_for_duplicates_within(key_fn, items):
+        for i, item_i in enumerate(items):
+            for item_j in items[i+1:]:
+                if key_fn(item_i) == key_fn(item_j):
+                    return key_fn(item_i)
+        return None
+
+    def check_for_duplicate_transactions(self, transactions):
+        """Check that none of the transactions passed in have already been
+        committed in the chain. Also checks that the list of transactions
+        passed contains no duplicates."""
+        # Same as for batches
+        duplicate = self._check_for_duplicates_within(
+            lambda txn: txn.header_signature, transactions)
+        if duplicate is not None:
+            raise DuplicateTransaction(duplicate)
+
+        for txn in transactions:
+            txn_id = txn.header_signature
+            if txn_id in self.uncommitted_txn_ids:
+                raise DuplicateTransaction(txn_id)
+
+            if self.block_store.has_transaction(txn_id):
+                committed_block =\
+                    self.block_store.get_block_by_transaction_id(txn_id)
+
+                if self._block_in_chain(committed_block):
+                    raise DuplicateTransaction(txn_id)
+
+    def check_for_duplicate_batches(self, batches):
+        """Check that none of the batches passed in have already been committed
+        in the chain. Also checks that the list of batches passed contains no
+        duplicates."""
+        # Check for duplicates within the given list
+        duplicate = self._check_for_duplicates_within(
+            lambda batch: batch.header_signature, batches)
+        if duplicate is not None:
+            raise DuplicateBatch(duplicate)
+
+        for batch in batches:
+            batch_id = batch.header_signature
+
+            # Make sure the batch isn't in one of the uncommitted block
+            if batch_id in self.uncommitted_batch_ids:
+                raise DuplicateBatch(batch_id)
+
+            # Check if the batch is in one of the committed blocks
+            if self.block_store.has_batch(batch_id):
+                committed_block =\
+                    self.block_store.get_block_by_batch_id(batch_id)
+
+                # This is only a duplicate batch if the batch is in a block
+                # that would stay committed if this block were committed. This
+                # is equivalent to asking if the number of the block that this
+                # batch is in is less than or equal to the number of the common
+                # ancestor block.
+                if self._block_in_chain(committed_block):
+                    raise DuplicateBatch(batch_id)
+
+    def check_for_transaction_dependencies(self, transactions):
+        """Check that all explicit dependencies in all transactions passed have
+        been satisfied."""
+        dependencies = []
+        txn_ids = []
+        for txn in transactions:
+            txn_ids.append(txn.header_signature)
+            txn_hdr = TransactionHeader()
+            txn_hdr.ParseFromString(txn.header)
+            dependencies.extend(txn_hdr.dependencies)
+
+        for dep in dependencies:
+            # Check for dependency within the given block's batches
+            if dep in txn_ids:
+                continue
+
+            # Check for dependency in the uncommitted blocks
+            if dep in self.uncommitted_txn_ids:
+                continue
+
+            # Check for dependency in the committe blocks
+            if self.block_store.has_transaction(dep):
+                committed_block =\
+                    self.block_store.get_block_by_transaction_id(dep)
+
+                # Make sure the block wouldn't be uncomitted if the given block
+                # were uncommitted
+                if self._block_in_chain(committed_block):
+                    continue
+
+            raise MissingDependency(dep)
+
 
 class _CommitCache(object):
     """Tracks the commit status of a set of identifiers and these identifiers
@@ -45,49 +213,6 @@ class _CommitCache(object):
         elif identifier in self._uncommitted:
             return False
         return self.block_store_check(identifier)
-
-
-class ChainCommitState(object):
-    """Tracks the set of Batches and Transactions that are committed to a
-    hypothetical chain. This is used to to detect duplicate batches, duplicate
-    transactions, and missing transactions dependencies when evaluating a new
-    chain. This is used to to detect duplicate batches, duplicate transactions,
-    and missing transactions dependencies when evaluating a new chain.
-    """
-    def __init__(self, block_store, uncommitted_blocks):
-        self._batch_commit_state = _CommitCache(block_store.has_batch)
-        self._transaction_commit_state = _CommitCache(
-            block_store.has_transaction)
-
-        for block in uncommitted_blocks:
-            self._uncommit_block(block)
-
-    def _uncommit_block(self, block):
-        for batch in block.batches:
-            self._batch_commit_state.uncommit(batch.header_signature)
-
-            for txn in batch.transactions:
-                self._transaction_commit_state.uncommit(txn.header_signature)
-
-    def add_txn(self, txn_id):
-        self._transaction_commit_state.add(txn_id)
-
-    def add_batch(self, batch, add_transactions=True):
-        self._batch_commit_state.add(batch.header_signature)
-        if add_transactions:
-            for txn in batch.transactions:
-                self._transaction_commit_state.add(txn.header_signature)
-
-    def remove_batch(self, batch):
-        self._batch_commit_state.remove(batch.header_signature)
-        for txn in batch.transactions:
-            self._transaction_commit_state.remove(txn.header_signature)
-
-    def has_batch(self, batch_id):
-        return batch_id in self._batch_commit_state
-
-    def has_transaction(self, txn_id):
-        return txn_id in self._transaction_commit_state
 
 
 class TransactionCommitCache(_CommitCache):

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -36,14 +36,14 @@ LOGGER = logging.getLogger(__name__)
 
 class Completer(object):
     """
-    The Completer is responsible for making sure blocks are formally
-    complete before they are delivered to the chain controller. A formally
-    complete block is a block whose predecessor is in the block cache and all
-    the batches are present in the batch list and in the order specified by the
-    block header. If the predecessor or a batch is missing, a request message
-    is sent sent out over the gossip network. It also checks that all batches
-    have their dependencies satisifed, otherwise it will request the batch that
-    has the missing transaction.
+    The Completer is responsible for making sure blocks are formally complete
+    before they are passed on. A formally complete block is a block whose
+    predecessor is in the block cache and all the batches are present in the
+    batch list and in the order specified by the block header. If the
+    predecessor or a batch is missing, a request message is sent sent out over
+    the gossip network. It also checks that all batches have their dependencies
+    satisifed, otherwise it will request the batch that has the missing
+    transaction.
     """
     def __init__(self,
                  block_store,

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -23,11 +23,15 @@ from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.journal.block_cache import BlockCache
 from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_validator import BlockValidator
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
+from sawtooth_validator.journal.chain_commit_state import DuplicateTransaction
+from sawtooth_validator.journal.chain_commit_state import DuplicateBatch
+from sawtooth_validator.journal.chain_commit_state import MissingDependency
 from sawtooth_validator.journal.publisher import BlockPublisher
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.journal.event_extractors \
@@ -41,6 +45,8 @@ from sawtooth_validator.server.events.subscription import EventSubscription
 from sawtooth_validator.server.events.subscription import EventFilterType
 from sawtooth_validator.server.events.subscription import EventFilterFactory
 
+from sawtooth_validator.protobuf.transaction_pb2 import Transaction
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
@@ -1388,131 +1394,359 @@ class TestTimedCache(unittest.TestCase):
 
 
 class TestChainCommitState(unittest.TestCase):
+    """Test for:
+    - No duplicates found for batches
+    - No duplicates found for transactions
+    - Duplicate batch found in current chain
+    - Duplicate batch found in fork
+    - Duplicate transaction found in current chain
+    - Duplicate transaction found in fork
+    - Missing dependencies caught
+    - Dependencies found for transactions in current chain
+    - Dependencies found for transactions in fork
+    """
 
-    def setUp(self):
-        self.commit_state = None
-        self.block_tree_manager = BlockTreeManager()
+    def gen_block(self, id, prev_id, num, batches):
+        return BlockWrapper(
+            Block(
+                header_signature=id,
+                batches=batches,
+                header=BlockHeader(
+                    block_num=num,
+                    previous_block_id=prev_id).SerializeToString()))
 
-    def test_fall_thru(self):
-        """ Test that the requests correctly fall thru to the
-        underlying BlockStore.
+    def gen_batch(self, id, transactions):
+        return Batch(header_signature=id, transactions=transactions)
+
+    def gen_txn(self, id, deps=None):
+        return Transaction(
+            header_signature=id,
+            header=TransactionHeader(dependencies=deps).SerializeToString())
+
+    # Batches
+    def test_no_duplicate_batch_found(self):
+        """Verify that DuplicateBatch is not raised for a completely new
+        batch.
         """
-        blocks = self.generate_chain(1)
-        commit_state = self.create_chain_commit_state(blocks)
-        self.commit_state = commit_state
+        _, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
 
-        self.assert_block_present(blocks[0])
-
-        self.assert_missing()
-
-    def test_uncommitted_blocks(self):
-        """ Test that the ChainCommitState can simulate blocks being
-        uncommited from the BlockStore
-        """
-        blocks = self.generate_chain(2)
-        block, uncommitted_block = blocks
         commit_state = self.create_chain_commit_state(
-            blocks=blocks,
-            uncommitted_blocks=[uncommitted_block],
-            )
-        self.commit_state = commit_state
+            committed_blocks, uncommitted_blocks, 'B6')
 
-        # the first block is still present
-        self.assert_block_present(block)
-        # batch from the uncommited block should not be present
-        self.assert_block_not_present(uncommitted_block)
+        commit_state.check_for_duplicate_batches([self.gen_batch('b10', [])])
 
-        self.assert_missing()
-
-    def test_add_remove_batch(self):
-        """ Test that we can incrementatlly build the commit state and
-        roll it back
+    def test_duplicate_batch_in_both_chains(self):
+        """Verify that DuplicateBatch is raised for a batch in both the current
+        chain and the fork.
         """
-        blocks = self.generate_chain(2)
-        block, uncommitted_block = blocks
+        _, batches, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
         commit_state = self.create_chain_commit_state(
-            blocks=blocks,
-            uncommitted_blocks=[uncommitted_block],
-            )
-        self.commit_state = commit_state
+            committed_blocks, uncommitted_blocks, 'B6')
 
-        # the first block is still present
-        self.assert_block_present(block)
-        # batch from the uncommited block should not be present
-        self.assert_block_not_present(uncommitted_block)
+        with self.assertRaises(DuplicateBatch) as cm:
+            commit_state.check_for_duplicate_batches(
+                [batches[2]])
 
-        batch = uncommitted_block.batches[0]
-        commit_state.add_batch(batch)
+        self.assertEqual(cm.exception.batch_id, 'b2')
 
-        # the batch should appear present
-        self.assert_batch_present(batch)
+    def test_duplicate_batch_in_current_chain(self):
+        """Verify that DuplicateBatch is raised for a batch in the current
+        chain.
+        """
+        _, batches, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
 
-        # check that we can remove the batch again.
-        commit_state.remove_batch(batch)
-        self.assert_batch_not_present(batch)
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
 
-        # Do an incremental add of the batch
-        for txn in batch.transactions:
-            commit_state.add_txn(txn.header_signature)
-            self.assert_txn_present(txn)
-        self.assertFalse(commit_state.has_batch(
-            batch.header_signature))
+        with self.assertRaises(DuplicateBatch) as cm:
+            commit_state.check_for_duplicate_batches(
+                [batches[5]])
 
-        commit_state.add_batch(batch, add_transactions=False)
-        self.assert_batch_present(batch)
+        self.assertEqual(cm.exception.batch_id, 'b5')
 
-        # check that we can remove the batch again.
-        commit_state.remove_batch(batch)
-        self.assert_batch_not_present(batch)
+    def test_duplicate_batch_in_fork(self):
+        """Verify that DuplicateBatch is raised for a batch in the fork.
+        """
+        _, batches, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
 
-    def generate_chain(self, block_count):
-        return self.block_tree_manager.generate_chain(
-            None, [{} for _ in range(block_count)])
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
 
-    def create_chain_commit_state(self, blocks, uncommitted_blocks=None,
-                                  chain_head=None):
+        with self.assertRaises(DuplicateBatch) as cm:
+            commit_state.check_for_duplicate_batches(
+                [batches[8]])
+
+        self.assertEqual(cm.exception.batch_id, 'b8')
+
+    def test_no_duplicate_batch_in_current_chain(self):
+        """Verify that DuplicateBatch is not raised for a batch that is in the
+        current chain but not the fork when head is on the fork.
+        """
+        _, batches, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
+
+        commit_state.check_for_duplicate_batches(
+            [batches[5]])
+
+    def test_no_duplicate_batch_in_fork(self):
+        """Verify that DuplicateBatch is not raised for a batch that is in the
+        fork but not the current chain when head is on the current chain.
+        """
+        _, batches, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_duplicate_batches(
+            [batches[8]])
+
+    # Transactions
+    def test_no_duplicate_txn_found(self):
+        """Verify that DuplicateTransaction is not raised for a completely new
+        transaction.
+        """
+        _, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_duplicate_transactions([self.gen_txn('t10')])
+
+    def test_duplicate_txn_in_both_chains(self):
+        """Verify that DuplicateTransaction is raised for a transaction in both
+        the current chain and the fork.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        with self.assertRaises(DuplicateTransaction) as cm:
+            commit_state.check_for_duplicate_transactions(
+                [transactions[2]])
+
+        self.assertEqual(cm.exception.transaction_id, 't2')
+
+    def test_duplicate_txn_in_current_chain(self):
+        """Verify that DuplicateTransaction is raised for a transaction in the
+        current chain.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        with self.assertRaises(DuplicateTransaction) as cm:
+            commit_state.check_for_duplicate_transactions(
+                [transactions[5]])
+
+        self.assertEqual(cm.exception.transaction_id, 't5')
+
+    def test_duplicate_txn_in_fork(self):
+        """Verify that DuplicateTransaction is raised for a transaction in the
+        fork.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
+
+        with self.assertRaises(DuplicateTransaction) as cm:
+            commit_state.check_for_duplicate_transactions(
+                [transactions[8]])
+
+        self.assertEqual(cm.exception.transaction_id, 't8')
+
+    def test_no_duplicate_txn_in_current_chain(self):
+        """Verify that DuplicateTransaction is not raised for a transaction
+        that is in the current chain but not the fork when head is on the fork.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
+
+        commit_state.check_for_duplicate_transactions(
+            [transactions[5]])
+
+    def test_no_duplicate_txn_in_fork(self):
+        """Verify that DuplicateTransaction is not raised for a transaction
+        that is in the fork but not the current chain when head is on the
+        current chain.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_duplicate_transactions(
+            [transactions[8]])
+
+    # Dependencies
+    def test_present_dependency(self):
+        """Verify that a present dependency is found."""
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_transaction_dependencies([
+            self.gen_txn('t10', deps=[transactions[2].header_signature])
+        ])
+
+    def test_missing_dependency_in_both_chains(self):
+        """Verifies that MissingDependency is raised when a dependency is not
+        committed anywhere.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        with self.assertRaises(MissingDependency) as cm:
+            commit_state.check_for_transaction_dependencies([
+                self.gen_txn('t10', deps=['t11'])
+            ])
+
+        self.assertEqual(cm.exception.transaction_id, 't11')
+
+    def test_present_dependency_in_current_chain(self):
+        """Verify that a dependency present in the current chain is found.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_transaction_dependencies([
+            self.gen_txn('t10', deps=[transactions[5].header_signature])
+        ])
+
+    def test_present_dependency_in_fork(self):
+        """Verify that a dependency present in the fork is found.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
+
+        commit_state.check_for_transaction_dependencies([
+            self.gen_txn('t10', deps=[transactions[8].header_signature])
+        ])
+
+    def test_missing_dependency_in_current_chain(self):
+        """Verify that MissingDependency is raised for a dependency that is
+        committed to the current chain but not the fork when head is on the
+        fork.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B9')
+
+        commit_state.check_for_duplicate_transactions(
+            [transactions[5]])
+
+    def test_missing_dependency_in_fork(self):
+        """Verify that MissingDependency is raised for a dependency that is
+        committed to the fork but not the current chain when head is on the
+        current chain.
+        """
+        transactions, _, committed_blocks, uncommitted_blocks =\
+            self.create_new_chain()
+
+        commit_state = self.create_chain_commit_state(
+            committed_blocks, uncommitted_blocks, 'B6')
+
+        commit_state.check_for_duplicate_transactions(
+            [transactions[8]])
+
+    def create_new_chain(self):
+        """
+        NUM     0  1  2  3  4  5  6
+        CURRENT B0-B1-B2-B3-B4-B5-B6
+                         |
+        FORK             +--B7-B8-B9
+        """
+        txns = [
+            self.gen_txn('t' + format(i, 'x'))
+            for i in range(10)
+        ]
+        batches = [
+            self.gen_batch('b' + format(i, 'x'), [txns[i]])
+            for i in range(10)
+        ]
+        committed_blocks = [
+            self.gen_block(
+                id='B0',
+                prev_id=NULL_BLOCK_IDENTIFIER,
+                num=0,
+                batches=[batches[0]])
+        ]
+        committed_blocks.extend([
+            self.gen_block(
+                id='B' + format(i, 'x'),
+                prev_id='B' + format(i - 1, 'x'),
+                num=i,
+                batches=[batches[i]])
+            for i in range(1, 7)
+        ])
+        uncommitted_blocks = [
+            self.gen_block(
+                id='B7',
+                prev_id='B3',
+                num=4,
+                batches=[batches[0]])
+        ]
+        uncommitted_blocks.extend([
+            self.gen_block(
+                id='B' + format(i, 'x'),
+                prev_id='B' + format(i - 1, 'x'),
+                num=5 + (i - 8),
+                batches=[batches[i]])
+            for i in range(8, 10)
+        ])
+
+        return txns, batches, committed_blocks, uncommitted_blocks
+
+    def create_chain_commit_state(
+        self,
+        committed_blocks,
+        uncommitted_blocks,
+        head_id,
+    ):
         block_store = BlockStore(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
-        block_store.update_chain(blocks)
-        if chain_head is None:
-            chain_head = block_store.chain_head.identifier
-        if uncommitted_blocks is None:
-            uncommitted_blocks = []
-        return ChainCommitState(block_store, uncommitted_blocks)
+        block_store.update_chain(committed_blocks)
 
-    def assert_txn_present(self, txn):
-        self.assertTrue(self.commit_state.has_transaction(
-            txn.header_signature))
+        block_cache = BlockCache(
+            block_store=block_store)
 
-    def assert_batch_present(self, batch):
-        self.assertTrue(self.commit_state.has_batch(
-            batch.header_signature))
-        for txn in batch.transactions:
-            self.assert_txn_present(txn)
+        for block in uncommitted_blocks:
+            block_cache[block.header_signature] = block
 
-    def assert_block_present(self, block):
-        for batch in block.batches:
-            self.assert_batch_present(batch)
+        return ChainCommitState(head_id, block_cache, block_store)
 
-    def assert_txn_not_present(self, txn):
-        self.assertFalse(self.commit_state.has_transaction(
-            txn.header_signature))
-
-    def assert_batch_not_present(self, batch):
-        self.assertFalse(self.commit_state.has_batch(
-            batch.header_signature))
-        for txn in batch.transactions:
-            self.assert_txn_not_present(txn)
-
-    def assert_block_not_present(self, block):
-        for batch in block.batches:
-            self.assert_batch_not_present(batch)
-
-    def assert_missing(self):
-        """check missing keys behave as expected.
-        """
-        self.assertFalse(self.commit_state.has_batch("missing"))
-        self.assertFalse(self.commit_state.has_transaction("missing"))
 
 class TestBlockEventExtractor(unittest.TestCase):
     def test_block_event_extractor(self):

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -17,6 +17,7 @@ import logging
 from threading import RLock
 import unittest
 from unittest.mock import patch
+import queue
 
 from sawtooth_validator.database.dict_database import DictDatabase
 
@@ -823,7 +824,7 @@ class TestBlockValidator(unittest.TestCase):
 
 class TestChainController(unittest.TestCase):
     def setUp(self):
-        self.block_tree_manager = BlockTreeManager()
+        self.block_tree_manager = BlockTreeManager(with_genesis=False)
         self.gossip = MockNetwork()
         self.txn_executor = MockTransactionExecutor()
         self.block_sender = MockBlockSender()
@@ -864,12 +865,19 @@ class TestChainController(unittest.TestCase):
         # Patch the threadpool
         self.executor = SynchronousExecutor()
         self.block_validator._thread_pool = self.executor
+
+        # Set genesis after validating
+        genesis = self.block_tree_manager.generate_genesis_block()
+        self.block_validator.validate_block(genesis)
+        self.block_tree_manager.set_chain_head(genesis)
+        self.chain_ctrl._set_chain_head_from_block_store()
+
         init_root = self.chain_ctrl.chain_head
         self.assert_is_chain_head(init_root)
 
         # create a chain of length 5 extending the root
-        _, head = self.generate_chain(init_root, 5)
-        self.receive_and_process_blocks(head)
+        chain, head = self.generate_chain(init_root, 5)
+        self.receive_and_process_blocks(*chain)
         self.assert_is_chain_head(head)
 
         self.init_head = head
@@ -944,14 +952,11 @@ class TestChainController(unittest.TestCase):
     def test_fork_lengths(self):
         '''Tests competing forks of different lengths
         '''
-        _, head_2 = self.generate_chain(self.init_head, 2)
-        _, head_7 = self.generate_chain(self.init_head, 7)
-        _, head_5 = self.generate_chain(self.init_head, 5)
+        chain_2, head_2 = self.generate_chain(self.init_head, 2)
+        chain_7, head_7 = self.generate_chain(self.init_head, 7)
+        chain_5, head_5 = self.generate_chain(self.init_head, 5)
 
-        self.receive_and_process_blocks(
-            head_2,
-            head_7,
-            head_5)
+        self.receive_and_process_blocks(*(chain_2 + chain_7 + chain_5))
 
         self.assert_is_chain_head(head_7)
 
@@ -959,15 +964,15 @@ class TestChainController(unittest.TestCase):
         '''Tests the chain being advanced between a fork's
         creation and validation
         '''
-        _, fork_5 = self.generate_chain(self.init_head, 5)
-        _, fork_3 = self.generate_chain(self.init_head, 3)
+        fork_5, head_5 = self.generate_chain(self.init_head, 5)
+        fork_3, head_3 = self.generate_chain(self.init_head, 3)
 
-        self.receive_and_process_blocks(fork_3)
-        self.assert_is_chain_head(fork_3)
+        self.receive_and_process_blocks(*fork_3)
+        self.assert_is_chain_head(head_3)
 
         # fork_5 is longer than fork_3, so it should be accepted
-        self.receive_and_process_blocks(fork_5)
-        self.assert_is_chain_head(fork_5)
+        self.receive_and_process_blocks(*fork_5)
+        self.assert_is_chain_head(head_5)
 
     def test_fork_missing_block(self):
         '''Tests a fork with a missing block
@@ -975,20 +980,14 @@ class TestChainController(unittest.TestCase):
         # make new chain
         new_chain, new_head = self.generate_chain(self.init_head, 5)
 
-        self.on_block_received(new_head)
-
         # delete a block from the new chain
-        del self.chain_ctrl._block_cache[new_chain[3].identifier]
+        for block in new_chain[:3] + new_chain[4:]:
+            self.on_block_received(block)
 
-        self.executor.process_all()
+        self.receive_and_process_blocks()
 
         # chain shouldn't advance
-        self.assert_is_chain_head(self.init_head)
-
-        # try again, chain still shouldn't advance
-        self.receive_and_process_blocks(new_head)
-
-        self.assert_is_chain_head(self.init_head)
+        self.assert_is_chain_head(new_chain[2])
 
     def test_fork_bad_block(self):
         '''Tests a fork with a bad block in the middle
@@ -997,13 +996,16 @@ class TestChainController(unittest.TestCase):
         good_chain, good_head = self.generate_chain(self.init_head, 5)
         bad_chain, bad_head = self.generate_chain(self.init_head, 5)
 
-        self.on_block_received(bad_head)
-        self.on_block_received(good_head)
-
         # invalidate block in the middle of bad_chain
         bad_chain[3].status = BlockStatus.Invalid
 
-        self.executor.process_all()
+        for block in bad_chain:
+            self.on_block_received(block)
+
+        for block in good_chain:
+            self.on_block_received(block)
+
+        self.receive_and_process_blocks()
 
         # good_chain should be accepted
         self.assert_is_chain_head(good_head)
@@ -1011,18 +1013,19 @@ class TestChainController(unittest.TestCase):
     def test_advancing_fork(self):
         '''Tests a fork advancing before getting validated
         '''
-        _, fork_head = self.generate_chain(self.init_head, 5)
+        fork, fork_head = self.generate_chain(self.init_head, 5)
 
-        self.on_block_received(fork_head)
+        for block in fork:
+            self.on_block_received(block)
 
         # advance fork before it gets accepted
-        _, ext_head = self.generate_chain(fork_head, 3)
+        ext_fork, ext_head = self.generate_chain(fork_head, 3)
 
-        self.executor.process_all()
+        self.receive_and_process_blocks()
 
         self.assert_is_chain_head(fork_head)
 
-        self.receive_and_process_blocks(ext_head)
+        self.receive_and_process_blocks(*ext_fork)
 
         self.assert_is_chain_head(ext_head)
 
@@ -1036,7 +1039,7 @@ class TestChainController(unittest.TestCase):
         self.assert_is_chain_head(self.init_head)
 
         # queue up the candidate block, but don't process
-        self.on_block_received(candidate)
+        self.block_validator._block_scheduler.handle_incoming_block(candidate)
 
         # create a new block extending the candidate block
         extending_block = self.block_tree_manager.generate_block(
@@ -1046,7 +1049,15 @@ class TestChainController(unittest.TestCase):
 
         # queue and process the extending block,
         # which should be the new head
+        self.block_validator._block_scheduler.handle_incoming_block(
+            extending_block)
         self.receive_and_process_blocks(extending_block)
+
+        self.block_validator._on_scheduled_block_received(
+            candidate, self.block_validator.on_block_validated)
+        self.block_validator._on_scheduled_block_received(
+            extending_block, self.block_validator.on_block_validated)
+
         self.assert_is_chain_head(extending_block)
 
     def test_multiple_extended_forks(self):
@@ -1066,40 +1077,48 @@ class TestChainController(unittest.TestCase):
         '''
 
         # create forks of various lengths
-        _, a_0 = self.generate_chain(self.init_head, 3)
-        _, b_0 = self.generate_chain(self.init_head, 5)
-        _, c_0 = self.generate_chain(self.init_head, 7)
+        a_0_chain, a_0 = self.generate_chain(self.init_head, 3)
+        b_0_chain, b_0 = self.generate_chain(self.init_head, 5)
+        c_0_chain, c_0 = self.generate_chain(self.init_head, 7)
 
-        self.receive_and_process_blocks(a_0, b_0, c_0)
+        self.receive_and_process_blocks(*a_0_chain)
+        self.receive_and_process_blocks(*b_0_chain)
+        self.receive_and_process_blocks(*c_0_chain)
         self.assert_is_chain_head(c_0)
 
         # extend every fork by 2
-        _, a_1 = self.generate_chain(a_0, 2)
-        _, b_1 = self.generate_chain(b_0, 2)
-        _, c_1 = self.generate_chain(c_0, 2)
+        a_1_chain, a_1 = self.generate_chain(a_0, 2)
+        b_1_chain, b_1 = self.generate_chain(b_0, 2)
+        c_1_chain, c_1 = self.generate_chain(c_0, 2)
 
-        self.receive_and_process_blocks(a_1, b_1, c_1)
+        self.receive_and_process_blocks(*a_1_chain)
+        self.receive_and_process_blocks(*b_1_chain)
+        self.receive_and_process_blocks(*c_1_chain)
         self.assert_is_chain_head(c_1)
 
         # extend the forks by different lengths
-        _, a_2 = self.generate_chain(a_1, 1)
-        _, b_2 = self.generate_chain(b_1, 6)
-        _, c_2 = self.generate_chain(c_1, 3)
+        a_2_chain, a_2 = self.generate_chain(a_1, 1)
+        b_2_chain, b_2 = self.generate_chain(b_1, 6)
+        c_2_chain, c_2 = self.generate_chain(c_1, 3)
 
-        self.receive_and_process_blocks(a_2, b_2, c_2)
+        self.receive_and_process_blocks(*a_2_chain)
+        self.receive_and_process_blocks(*b_2_chain)
+        self.receive_and_process_blocks(*c_2_chain)
         self.assert_is_chain_head(b_2)
 
         # extend every fork by 2
-        _, a_3 = self.generate_chain(a_2, 8)
-        _, b_3 = self.generate_chain(b_2, 8)
-        _, c_3 = self.generate_chain(c_2, 8)
+        a_3_chain, a_3 = self.generate_chain(a_2, 8)
+        b_3_chain, b_3 = self.generate_chain(b_2, 8)
+        c_3_chain, c_3 = self.generate_chain(c_2, 8)
 
-        self.receive_and_process_blocks(a_3, b_3, c_3)
+        self.receive_and_process_blocks(*a_3_chain)
+        self.receive_and_process_blocks(*b_3_chain)
+        self.receive_and_process_blocks(*c_3_chain)
         self.assert_is_chain_head(b_3)
 
         # create a new longest chain
-        _, wow = self.generate_chain(self.init_head, 30)
-        self.receive_and_process_blocks(wow)
+        wow_chain, wow = self.generate_chain(self.init_head, 30)
+        self.receive_and_process_blocks(*wow_chain)
         self.assert_is_chain_head(wow)
 
     # next multi threaded
@@ -1111,8 +1130,9 @@ class TestChainController(unittest.TestCase):
     # helpers
 
     def on_block_received(self, block):
-        self.block_validator._on_block_received(
-            block, self.chain_ctrl.on_block_validated)
+        self.block_validator.queue_block(block)
+        self.block_validator._block_scheduler.handle_incoming_block(
+            self.block_validator._incoming_blocks.get_nowait())
 
     def assert_is_chain_head(self, block):
         chain_head_sig = self.chain_ctrl.chain_head.header_signature
@@ -1124,7 +1144,7 @@ class TestChainController(unittest.TestCase):
             'Not chain head')
 
     def generate_chain(self, root_block, num_blocks,
-                                 params={'add_to_cache': True}):
+                       params={'add_to_cache': False, 'add_to_store': False}):
         '''Returns (chain, chain_head).
         Usually only the head is needed,
         but occasionally the chain itself is used.
@@ -1143,7 +1163,14 @@ class TestChainController(unittest.TestCase):
     def receive_and_process_blocks(self, *blocks):
         for block in blocks:
             self.on_block_received(block)
-        self.executor.process_all()
+        while True:
+            try:
+                block = self.block_validator._ready_blocks.get_nowait()
+            except queue.Empty:
+                break
+            self.block_validator.submit_blocks_for_validation(
+                [block], self.block_validator.on_block_validated)
+            self.executor.process_all()
 
 
 class TestChainControllerGenesisPeer(unittest.TestCase):
@@ -1245,7 +1272,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
         self.assertIsNone(self.chain_ctrl.chain_head)
 
     def on_block_received(self, block):
-        self.block_validator._on_block_received(
+        self.block_validator._on_scheduled_block_received(
             block, self.chain_ctrl.on_block_validated)
 
 
@@ -1313,6 +1340,8 @@ class TestJournal(unittest.TestCase):
 
             self.gossip.on_batch_received = block_publisher.queue_batch
             self.gossip.on_block_received = block_validator.queue_block
+
+            block_validator.validate_block(btm.chain_head)
 
             block_publisher.start()
             chain_controller.start()


### PR DESCRIPTION
This PR makes some additional architectural changes required to decouple the block validator from the chain controller.

Next steps are:
1. Move `ForkResolutionResult` from block validator to chain controller, along with required methods.
2. Only validate the given block in `process_block_validation`
3. Improve separation between completer, block scheduler, block validator, and chain controller using queues.