### PR TITLE
Fix old URLs & names (Distributed Ledger & Sawtooth Lake)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
-# Contributing to Distributed Ledger
+# Contributing to Hyperledger Sawtooth
 
-This document covers how to report issues and contribute code.
+This document covers how to report issues and contribute code
+to the Hyperledger Sawtooth project.
 
 ## Topics
 
@@ -9,14 +10,15 @@ This document covers how to report issues and contribute code.
 
 # Reporting Issues
 
-Please refer to the article on [Issue Tracking](http://intelledger.github.io/community/issue_tracking.html) in the Sawtooth Lake documentation.
+Please refer to [Issue Tracking](https://sawtooth.hyperledger.org/docs/core/releases/latest/community/issue_tracking.html)
+in the Sawtooth documentation.
 
 # Contributing Code
 
-Distributed Ledger is Apache 2.0 licensed and accepts contributions via 
-[GitHub](https://github.com/hyperledger/) pull requests.
+Hyperledger Sawtooth is Apache 2.0 licensed and accepts contributions via
+[GitHub](https://github.com/hyperledger/sawtooth-core) pull requests.
 
-Please refer to the article on 
-[Contributing](http://intelledger.github.io/community/contributing.html)
-in the Sawtooth Lake documentation for information on contributing, and the 
-guidelines to use. 
+Please see
+[Contributing](https://sawtooth.hyperledger.org/docs/core/releases/latest/community/contributing.html)
+in the Sawtooth documentation for information on how to contribute and the guidelines for contributions.
+

--- a/docs/source/community/issue_tracking.rst
+++ b/docs/source/community/issue_tracking.rst
@@ -23,7 +23,7 @@ issue within the vagrant development environment.
 Details are key. Please include the following:
 
 * OS version
-* Distributed Ledger version
+* Sawtooth version
 * Environment details (virtual, physical, etc.)
 * Steps to reproduce
 * Actual results


### PR DESCRIPTION
Change old names in the documentation (two *.rst files)
and a README-type Markdown file.

Signed-off-by: Anne Chenette <chenette@bitwise.io>