### PR TITLE
Prevent users from writing to /etc/sawtooth

### DIFF
--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -106,6 +106,14 @@ def do_keygen(args):
                     print('writing file: {}'.format(priv_filename))
             priv_fd.write(private_key.as_hex())
             priv_fd.write('\n')
+            # Get the uid and gid of the key directory
+            keydir_info = os.stat(key_dir)
+            keydir_gid = keydir_info.st_gid
+            keydir_uid = keydir_info.st_uid
+            # Set user and group on keys to the user/group of the key directory
+            os.chown(priv_filename, keydir_uid, keydir_gid)
+            # Set the private key u+rw g+r
+            os.chmod(priv_filename, 0o640)
 
         pub_exists = os.path.exists(pub_filename)
         with open(pub_filename, 'w') as pub_fd:
@@ -116,6 +124,10 @@ def do_keygen(args):
                     print('writing file: {}'.format(pub_filename))
             pub_fd.write(public_key.as_hex())
             pub_fd.write('\n')
+            # Set user and group on keys to the user/group of the key directory
+            os.chown(pub_filename, keydir_uid, keydir_gid)
+            # Set the public key u+rw g+r o+r
+            os.chmod(pub_filename, 0o644)
 
     except IOError as ioe:
         raise CliException('IOError: {}'.format(str(ioe)))

--- a/cli/sawtooth_cli/keygen.py
+++ b/cli/sawtooth_cli/keygen.py
@@ -71,7 +71,7 @@ def do_keygen(args):
             if not args.quiet:
                 print('creating key directory: {}'.format(key_dir))
             try:
-                os.makedirs(key_dir)
+                os.makedirs(key_dir, 0o755)
             except IOError as e:
                 raise CliException('IOError: {}'.format(str(e)))
 
@@ -102,6 +102,8 @@ def do_keygen(args):
                     print('writing file: {}'.format(priv_filename))
             priv_fd.write(private_key.as_hex())
             priv_fd.write('\n')
+            # Set the private key u+rw g+r
+            os.chmod(priv_filename, 0o640)
 
         pub_exists = os.path.exists(pub_filename)
         with open(pub_filename, 'w') as pub_fd:
@@ -112,6 +114,8 @@ def do_keygen(args):
                     print('writing file: {}'.format(pub_filename))
             pub_fd.write(public_key.as_hex())
             pub_fd.write('\n')
+            # Set the public key u+rw g+r o+r
+            os.chmod(pub_filename, 0o644)
 
     except IOError as ioe:
         raise CliException('IOError: {}'.format(str(ioe)))

--- a/validator/packaging/ubuntu/postinst
+++ b/validator/packaging/ubuntu/postinst
@@ -5,7 +5,6 @@ set -e
 directories="
     /var/lib/sawtooth
     /var/log/sawtooth
-    /etc/sawtooth
 "
 
 user="sawtooth"
@@ -22,4 +21,12 @@ fi
 for dir in $directories
 do
     chown -R $user:$group $dir
+    chmod 750 $dir
 done
+
+chown -R root:root /etc/sawtooth
+chmod 755 /etc/sawtooth
+chmod 640 /etc/sawtooth/*.toml*
+chown root:$group /etc/sawtooth/*.toml*
+chown root:$group /etc/sawtooth/keys
+chmod 755 /etc/sawtooth/keys


### PR DESCRIPTION
This prevents sawtooth and other users from being
able to read private keys while allowing the group
to read them.

create ~/.sawtooth in a way that it is not group
writable and further restrict the keys there.

Signed-off-by: Richard Berg <rberg@bitwise.io>