### PR TITLE
Fix bug where not matching a txn family would crash event reporting

### DIFF
--- a/validator/sawtooth_validator/journal/event_extractors.py
+++ b/validator/sawtooth_validator/journal/event_extractors.py
@@ -93,3 +93,6 @@ class ReceiptEventExtractor(EventExtractor):
         for subscription in subscriptions:
             if event in subscription:
                 return [event]
+
+        # Event not in subscriptions
+        return []


### PR DESCRIPTION
Reproducable by subscribing to sawtooth/state-delta events with a RegEx filter and submitting a state change that doesn't match.