### PR TITLE
Remove EventFilterType

### DIFF
--- a/validator/sawtooth_validator/server/events/subscription.py
+++ b/validator/sawtooth_validator/server/events/subscription.py
@@ -138,9 +138,10 @@ class RegexAnyFilter(EventFilter):
         super().__init__(key, match_string)
         try:
             self.regex = re.compile(match_string)
-        except:
+        except Exception as e:
             raise InvalidFilterError(
-                "Invalid regular expression: {}".format(match_string))
+                "Invalid regular expression: {}: {}".format(
+                    match_string, str(e)))
 
     def matches(self, event):
         for attribute in event.attributes:
@@ -173,9 +174,10 @@ class RegexAllFilter(EventFilter):
         super().__init__(key, match_string)
         try:
             self.regex = re.compile(match_string)
-        except:
+        except Exception as e:
             raise InvalidFilterError(
-                "Invalid regular expression: {}".format(match_string))
+                "Invalid regular expression: {}: {}".format(
+                    match_string, str(e)))
 
     def matches(self, event):
         for attribute in event.attributes:

--- a/validator/sawtooth_validator/server/events/subscription.py
+++ b/validator/sawtooth_validator/server/events/subscription.py
@@ -17,6 +17,8 @@ from abc import ABCMeta
 from abc import abstractmethod
 import re
 
+from sawtooth_validator.protobuf import events_pb2
+
 
 class EventSubscription:
     """Represents a subscription to events. An event is part of a subscription
@@ -55,26 +57,17 @@ class InvalidFilterError(Exception):
     pass
 
 
-class EventFilterType:
-    # Not using Enum here because we want compatibility with the protobuf
-    # filter types, which are just integers
-    simple_any = 0
-    simple_all = 1
-    regex_any = 2
-    regex_all = 3
-
-
 class EventFilterFactory:
     def __init__(self):
         self.filter_types = {
-            EventFilterType.simple_any: SimpleAnyFilter,
-            EventFilterType.simple_all: SimpleAllFilter,
-            EventFilterType.regex_any: RegexAnyFilter,
-            EventFilterType.regex_all: RegexAllFilter,
+            events_pb2.EventFilter.SIMPLE_ANY: SimpleAnyFilter,
+            events_pb2.EventFilter.SIMPLE_ALL: SimpleAllFilter,
+            events_pb2.EventFilter.REGEX_ANY: RegexAnyFilter,
+            events_pb2.EventFilter.REGEX_ALL: RegexAllFilter,
         }
 
     def create(self, key, match_string,
-               filter_type=EventFilterType.simple_any):
+               filter_type=events_pb2.EventFilter.SIMPLE_ANY):
         try:
             return self.filter_types[filter_type](key, match_string)
         except KeyError:

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -37,7 +37,6 @@ from sawtooth_validator.server.events.handlers \
 
 from sawtooth_validator.server.events.subscription import EventSubscription
 from sawtooth_validator.server.events.subscription import EventFilterFactory
-from sawtooth_validator.server.events.subscription import EventFilterType
 
 from sawtooth_validator.execution.tp_state_handlers import TpEventAddHandler
 
@@ -132,8 +131,9 @@ class EventSubscriptionTest(unittest.TestCase):
             events_pb2.Event(attributes=[
                 events_pb2.Event.Attribute(
                     key="address", value="000000" + "f" * 64)]),
-            FILTER_FACTORY.create(key="address", match_string="000000.*",
-                filter_type=EventFilterType.regex_any))
+            FILTER_FACTORY.create(
+                key="address", match_string="000000.*",
+                filter_type=events_pb2.EventFilter.REGEX_ANY))
 
         self.assertIn(
             events_pb2.Event(attributes=[
@@ -165,7 +165,12 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
             subscriptions=[events_pb2.EventSubscription(
                 event_type="test_event",
                 filters=[
-                    events_pb2.EventFilter(key="test", match_string="test")],
+                    events_pb2.EventFilter(
+                        key="test",
+                        match_string="test",
+                        filter_type=events_pb2.EventFilter.SIMPLE_ANY
+                    )
+                ],
             )],
             last_known_block_ids=["0" * 128]).SerializeToString()
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -38,7 +38,6 @@ from sawtooth_validator.journal.batch_injector import \
     DefaultBatchInjectorFactory
 
 from sawtooth_validator.server.events.subscription import EventSubscription
-from sawtooth_validator.server.events.subscription import EventFilterType
 from sawtooth_validator.server.events.subscription import EventFilterFactory
 
 from sawtooth_validator.protobuf.batch_pb2 import Batch
@@ -50,6 +49,7 @@ from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChange
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChangeList
 from sawtooth_validator.protobuf.events_pb2 import Event
 from sawtooth_validator.protobuf.events_pb2 import EventList
+from sawtooth_validator.protobuf.events_pb2 import EventFilter
 
 from sawtooth_validator.state.merkle import MerkleDatabase
 
@@ -1559,7 +1559,7 @@ class TestReceiptEventExtractor(unittest.TestCase):
             EventSubscription(
                 event_type="sawtooth/state-delta",
                 filters=[factory.create(
-                    "address", "[ce]", EventFilterType.regex_any)],
+                    "address", "[ce]", EventFilter.REGEX_ANY)],
             )
         ])
         self.assertEqual(events, [Event(


### PR DESCRIPTION
Remove EventFilterType, as this shadows the EventFilter.FilterType enum
defined in the protobuf message. As the protobuf message is the source
of truth for the value of those enums, the shadowed type opens up the
possibility of subtle bugs with mismatched enum values.  Replacing this
type with the message enum corrects the problem