### PR TITLE
Update NULL_BLOCK_IDENTIFIER to be 128 characters long.

### DIFF
--- a/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
+++ b/consensus/poet/core/tests/test_consensus/test_wait_certificate.py
@@ -334,7 +334,7 @@ class TestWaitCertificate(TestCase):
 
         # set the identifier for mock_poet_enclave_wait_certificate
         mock_poet_enclave_wait_certificate.identifier.return_value = \
-            mock_poet_enclave_wait_certificate.previous_certificate_id[:16]
+            mock_poet_enclave_wait_certificate.previous_certificate_id
 
         mock_poet_enclave_module.create_wait_certificate.return_value = \
             mock_poet_enclave_wait_certificate

--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_enclave/poet_enclave.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_enclave/poet_enclave.cpp
@@ -58,7 +58,8 @@ typedef struct {
     sgx_mc_uuid_t counterId;
 } ValidatorSignupData;
 
-static const std::string    NULL_IDENTIFIER = "0000000000000000";
+static const std::string    NULL_IDENTIFIER = "000000000000000000000000000000000000000000000000000000000000000000000" \
+    "00000000000000000000000000000000000000000000000000000000000";
 static const uint32_t       WAIT_CERTIFICATE_NONCE_LENGTH = 32;
 
 // Timers, once expired, should not be usuable indefinitely.

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 
-NULL_BLOCK_IDENTIFIER = "0000000000000000"
+NULL_BLOCK_IDENTIFIER = '0' * 128
 
 
 class BlockStatus(Enum):


### PR DESCRIPTION
Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>