### PR TITLE
Add Configurable Back Pressure to Batch queue

### DIFF
--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -114,6 +114,10 @@ Error Codes and Descriptions
      - Submitted Batches Invalid
      - The submitted BatchList failed initial validation by the validator. It
        may have a bad signature, or be poorly formed.
+   * - 31
+     - Unable to Accept Batches
+     - The validator cannot currently accept more batches, due to a full queue.
+       Please submit your request again.
    * - 34
      - No Batches Submitted
      - The BatchList Protobuf submitted was empty and contained no Batches. All

--- a/protos/client_batch_submit.proto
+++ b/protos/client_batch_submit.proto
@@ -62,12 +62,15 @@ message ClientBatchSubmitRequest {
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
+//   * QUEUE_FULL - the batch is unable to be queued for processing, due to
+//        a full processing queue.  The batch may be submitted again.
 message ClientBatchSubmitResponse {
     enum Status {
         STATUS_UNSET = 0;
         OK = 1;
         INTERNAL_ERROR = 2;
         INVALID_BATCH = 3;
+        QUEUE_FULL = 4;
     }
     Status status = 1;
 }

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -53,6 +53,8 @@ paths:
                 $ref: "#/definitions/Link"
         400:
           $ref: "#/responses/400BadRequest"
+        429:
+          $ref: "#/responses/429TooManyRequests"
         500:
           $ref: "#/responses/500ServerError"
         503:
@@ -472,6 +474,10 @@ responses:
       $ref: "#/definitions/Error"
   404NotFound:
     description: Address or id did not match any resource
+    schema:
+      $ref: "#/definitions/Error"
+  429TooManyRequests:
+    description: Too many requests have been made to process batches
     schema:
       $ref: "#/definitions/Error"
   500ServerError:

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -68,6 +68,11 @@ class BatchInvalidTrap(_ErrorTrap):
     error = errors.SubmittedBatchesInvalid
 
 
+class BatchQueueFullTrap(_ErrorTrap):
+    trigger = client_batch_submit_pb2.ClientBatchSubmitResponse.QUEUE_FULL
+    error = errors.BatchQueueFull
+
+
 class InvalidAddressTrap(_ErrorTrap):
     trigger = client_state_pb2.ClientStateGetResponse.INVALID_ADDRESS
     error = errors.InvalidStateAddress

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -128,6 +128,14 @@ class SubmittedBatchesInvalid(_ApiError):
                'poorly formed, or has an invalid signature.')
 
 
+class BatchQueueFull(_ApiError):
+    api_code = 31
+    status_code = 429
+    title = 'Unable to Accept Batches'
+    message = ('The validator cannot currently accept more batches, due to a '
+               'full queue.  Please submit your request again.')
+
+
 class NoBatchesSubmitted(_ApiError):
     api_code = 34
     status_code = 400

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -155,7 +155,8 @@ class RouteHandler(object):
             raise errors.BadProtobufSubmitted()
 
         # Query validator
-        error_traps = [error_handlers.BatchInvalidTrap]
+        error_traps = [error_handlers.BatchInvalidTrap,
+                       error_handlers.BatchQueueFullTrap]
         validator_query = client_batch_submit_pb2.ClientBatchSubmitRequest(
             batches=batch_list.batches)
 

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -162,6 +162,26 @@ class PostBatchTests(BaseApiTest):
         response = await request.json()
         self.assert_has_valid_error(response, 34)
 
+    @unittest_run_loop
+    async def test_post_rejected_due_to_full_queue(self):
+        """Verifies a POST /batches when the validator reports QUEUE_FULL
+        breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of QUEUE_FULL
+
+        It should send back a JSON response with:
+            - a response status of 429
+            - an error property with a code of 31
+        """
+        batches = Mocks.make_batches(ID_A)
+        self.connection.preset_response(self.status.QUEUE_FULL)
+
+        request = await self.post_batches(batches)
+        self.assertEqual(429, request.status)
+        response = await request.json()
+        self.assert_has_valid_error(response, 31)
+
 
 class ClientBatchStatusTests(BaseApiTest):
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
@@ -132,15 +132,17 @@ class IntKeyWorkload(Workload):
 
                 batch_list = batch_pb2.BatchList(batches=[batch])
 
-                post_batches(key.url, batch_list, auth_info=self._auth_info)
+                (code, _) = post_batches(key.url, batch_list,
+                                         auth_info=self._auth_info)
 
-                with self._lock:
-                    self._pending_batches[batch.header_signature] = \
-                        IntKeyState(
-                        name=key.name,
-                        url=key.url,
-                        value=key.value + 1)
-                self.delegate.on_new_batch(batch_id, key.url)
+                if code == 202:
+                    with self._lock:
+                        self._pending_batches[batch.header_signature] = \
+                            IntKeyState(
+                            name=key.name,
+                            url=key.url,
+                            value=key.value + 1)
+                    self.delegate.on_new_batch(batch_id, key.url)
 
         else:
             LOGGER.debug('Key %s completed', key.name)
@@ -171,13 +173,15 @@ class IntKeyWorkload(Workload):
             batch_id = batch.header_signature
 
             batch_list = batch_pb2.BatchList(batches=[batch])
-            post_batches(url, batch_list, auth_info=self._auth_info)
+            (code, _) = post_batches(url, batch_list,
+                                     auth_info=self._auth_info)
 
-            with self._lock:
-                self._pending_batches[batch_id] = \
-                    IntKeyState(name=name, url=url, value=0)
+            if code == 202:
+                with self._lock:
+                    self._pending_batches[batch_id] = \
+                        IntKeyState(name=name, url=url, value=0)
 
-            self.delegate.on_new_batch(batch_id, url)
+                self.delegate.on_new_batch(batch_id, url)
 
 
 def do_workload(args):

--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -89,3 +89,6 @@ minimum_peer_connectivity = 3
 
 # The maximum number of peers that will be accepted.
 maximum_peer_connectivity = 10
+
+# The maximum number of batches that will be queued for processing
+maximum_batch_queue_depth = 20

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -35,7 +35,8 @@ def load_default_validator_config():
         peering='static',
         scheduler='serial',
         minimum_peer_connectivity=3,
-        maximum_peer_connectivity=10)
+        maximum_peer_connectivity=10,
+        maximum_batch_queue_depth=20)
 
 
 def load_toml_validator_config(filename):
@@ -63,7 +64,7 @@ def load_toml_validator_config(filename):
          'network_private_key', 'scheduler', 'permissions', 'roles',
          'opentsdb_url', 'opentsdb_db', 'opentsdb_username',
          'opentsdb_password', 'minimum_peer_connectivity',
-         'maximum_peer_connectivity'])
+         'maximum_peer_connectivity', 'maximum_batch_queue_depth'])
     if invalid_keys:
         raise LocalConfigurationError(
             "Invalid keys in validator config: "
@@ -104,7 +105,9 @@ def load_toml_validator_config(filename):
          minimum_peer_connectivity=toml_config.get(
             "minimum_peer_connectivity", None),
          maximum_peer_connectivity=toml_config.get(
-            "maximum_peer_connectivity", None)
+            "maximum_peer_connectivity", None),
+         maximum_batch_queue_depth=toml_config.get(
+             'maximum_batch_queue_depth', None)
     )
 
     return config
@@ -133,6 +136,7 @@ def merge_validator_config(configs):
     opentsdb_password = None
     minimum_peer_connectivity = None
     maximum_peer_connectivity = None
+    maximum_batch_queue_depth = None
 
     for config in reversed(configs):
         if config.bind_network is not None:
@@ -169,6 +173,8 @@ def merge_validator_config(configs):
             minimum_peer_connectivity = config.minimum_peer_connectivity
         if config.maximum_peer_connectivity is not None:
             maximum_peer_connectivity = config.maximum_peer_connectivity
+        if config.maximum_batch_queue_depth is not None:
+            maximum_batch_queue_depth = config.maximum_batch_queue_depth
 
     return ValidatorConfig(
          bind_network=bind_network,
@@ -187,7 +193,8 @@ def merge_validator_config(configs):
          opentsdb_username=opentsdb_username,
          opentsdb_password=opentsdb_password,
          minimum_peer_connectivity=minimum_peer_connectivity,
-         maximum_peer_connectivity=maximum_peer_connectivity
+         maximum_peer_connectivity=maximum_peer_connectivity,
+         maximum_batch_queue_depth=maximum_batch_queue_depth
     )
 
 
@@ -236,7 +243,8 @@ class ValidatorConfig:
                  roles=None, opentsdb_url=None, opentsdb_db=None,
                  opentsdb_username=None, opentsdb_password=None,
                  minimum_peer_connectivity=None,
-                 maximum_peer_connectivity=None):
+                 maximum_peer_connectivity=None,
+                 maximum_batch_queue_depth=None):
 
         self._bind_network = bind_network
         self._bind_component = bind_component
@@ -255,6 +263,7 @@ class ValidatorConfig:
         self._opentsdb_password = opentsdb_password
         self._minimum_peer_connectivity = minimum_peer_connectivity
         self._maximum_peer_connectivity = maximum_peer_connectivity
+        self._maximum_batch_queue_depth = maximum_batch_queue_depth
 
     @property
     def bind_network(self):
@@ -324,6 +333,10 @@ class ValidatorConfig:
     def maximum_peer_connectivity(self):
         return self._maximum_peer_connectivity
 
+    @property
+    def maximum_batch_queue_depth(self):
+        return self._maximum_batch_queue_depth
+
     def __repr__(self):
         # not including  password for opentsdb
         return \
@@ -332,7 +345,8 @@ class ValidatorConfig:
             "network_public_key={}, network_private_key={}, " \
             "scheduler={}, permissions={}, roles={} " \
             "opentsdb_url={}, opentsdb_db={}, opentsdb_username={}, \
-            minimum_peer_connectivity={}, maximum_peer_connectivity={}\
+            minimum_peer_connectivity={}, maximum_peer_connectivity={}, \
+            maximum_batch_queue_depth={}\
             )".format(
                 self.__class__.__name__,
                 repr(self._bind_network),
@@ -350,7 +364,8 @@ class ValidatorConfig:
                 repr(self._opentsdb_db),
                 repr(self._opentsdb_username),
                 repr(self._minimum_peer_connectivity),
-                repr(self._maximum_peer_connectivity))
+                repr(self._maximum_peer_connectivity),
+                repr(self._maximum_batch_queue_depth))
 
     def to_dict(self):
         return collections.OrderedDict([
@@ -370,7 +385,8 @@ class ValidatorConfig:
             ('opentsdb_username', self._opentsdb_username),
             ('opentsdb_password', self._opentsdb_password),
             ('minimum_peer_connectivity', self._minimum_peer_connectivity),
-            ('maximum_peer_connectivity', self._maximum_peer_connectivity)
+            ('maximum_peer_connectivity', self._maximum_peer_connectivity),
+            ('maximum_batch_queue_depth', self._maximum_batch_queue_depth)
         ])
 
     def to_toml_string(self):

--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -72,3 +72,9 @@ class PossibleForkDetectedError(Exception):
     through the block store.
     """
     pass
+
+
+class BatchBackPressureException(Exception):
+    """Exception thrown when back pressure occurs when adding batches.
+    """
+    pass

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -203,6 +203,10 @@ class Dispatcher(InstrumentedThread):
             LOGGER.exception("Dispatcher timeout waiting on handler result.")
             raise
 
+        if res is None:
+            LOGGER.debug('Ignoring result previous error')
+            return
+
         if res.status == HandlerStatus.DROP:
             del self._message_information[message_id]
 

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -106,6 +106,10 @@ def parse_args(args):
                         stopping peer search')
     parser.add_argument('--maximum-peer-connectivity',
                         help='set the maximum number of peers to accept')
+    parser.add_argument('--maximum-batch-queue-depth',
+                        help='set the maximum number of batches that can be '
+                        'queued',
+                        type=int)
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version
@@ -199,7 +203,8 @@ def create_validator_config(opts):
         opentsdb_url=opts.opentsdb_url,
         opentsdb_db=opts.opentsdb_db,
         minimum_peer_connectivity=opts.minimum_peer_connectivity,
-        maximum_peer_connectivity=opts.maximum_peer_connectivity
+        maximum_peer_connectivity=opts.maximum_peer_connectivity,
+        maximum_batch_queue_depth=opts.maximum_batch_queue_depth
         )
 
 
@@ -329,24 +334,26 @@ def main(args=None):
             password=validator_config.opentsdb_password)
         metrics_reporter.start()
 
-    validator = Validator(bind_network,
-                          bind_component,
-                          endpoint,
-                          validator_config.peering,
-                          validator_config.seeds,
-                          validator_config.peers,
-                          path_config.data_dir,
-                          path_config.config_dir,
-                          identity_signer,
-                          validator_config.scheduler,
-                          validator_config.permissions,
-                          validator_config.minimum_peer_connectivity,
-                          validator_config.maximum_peer_connectivity,
-                          validator_config.network_public_key,
-                          validator_config.network_private_key,
-                          roles=validator_config.roles,
-                          metrics_registry=wrapped_registry
-                          )
+    validator = Validator(
+        bind_network,
+        bind_component,
+        endpoint,
+        validator_config.peering,
+        validator_config.seeds,
+        validator_config.peers,
+        path_config.data_dir,
+        path_config.config_dir,
+        identity_signer,
+        validator_config.scheduler,
+        validator_config.permissions,
+        validator_config.minimum_peer_connectivity,
+        validator_config.maximum_peer_connectivity,
+        validator_config.network_public_key,
+        validator_config.network_private_key,
+        roles=validator_config.roles,
+        metrics_registry=wrapped_registry,
+        maximum_batch_queue_depth=validator_config.maximum_batch_queue_depth
+    )
 
     # pylint: disable=broad-except
     try:


### PR DESCRIPTION
Add a configurable high water mark for the batch queue which will supply back pressure on batch submission.  This adds a new CLI parameter/toml parameter `--maximum-batch-queue-size`/`maximum_batch_queue_size` to configure this value. 

Batches are rejected during a batch submit, and a QUEUE_FULL status is returned via the ZMQ component interface.  Inbound (i.e. not requested by the completer) Gossip batch messages are dropped.

The REST API will return a `429: Too Many Requests` error.

This is a local configuration option, as node performance will vary based on local limitations, such as hardware configuration.

Additionally:

- Fixes an issue with the Dispatcher when a previous handler fails with an exception
- Fixes an issue with the intkey-workload, such that any non-202 status code is used to check the batch status later.