### PR TITLE
Fix REST API doc typos, punctuation, caps, & wording

### DIFF
--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -134,11 +134,6 @@ following commands:
    $ sudo sawadm keygen
    $ sudo -u sawtooth sawtooth-validator -vv
 
-.. note::
-
-  The `-vv` flag sets the log level. To run the validator with less logging
-  output, use `-v` or omit the flag.
-
 Logging output is displayed in the validator terminal window. The output
 ends with lines similar to these:
 
@@ -156,31 +151,29 @@ ends with lines similar to these:
 
 .. Tip::
 
-  If you want to stop the validator, enter CTRL-c in the validator's terminal
-  window. A single CTRL-c starts a graceful shutdown. Enter multiple CTRL-c
-  characters to force the validator to stop quickly.
+  If you want to stop the validator, enter CTRL-c several times
+  in the validator's terminal window.
 
-  You can stop any other running Sawtooth component by entering
-  CTRL-c in the appropriate window.
+Other Start-up Options for the Validator
+----------------------------------------
 
-.. note::
+In the ``sawtooth-validator`` command above, the `-vv` flag sets the log level
+to include DEBUG messages. To run the validator with less logging output,
+use `-v` or omit the flag.
 
-  By default, the validator listens on the loopback interface for both network
-  and component communications. To change the interface and port used, the
-  `--bind` flag can be used. (See :doc:`/cli/validator` for more information
-  on validator flags.) The following command is equivalent to the default
-  behavior::
+By default, the validator listens on the loopback interface for both network
+and component communications. To change the interface and port used, the
+`--bind` flag can be used. See :doc:`/cli/validator` for more information
+on the available flags.  The following command is equivalent to the default
+behavior::
 
     sudo -u sawtooth sawtooth-validator -vv --bind network:tcp://127.0.0.1:8800 --bind component:tcp://127.0.0.1:4004
 
-
-.. note::
-
-  The validator can process transactions in serial (the default) or parallel
-  with no difference in the state produced. To process in parallel, use the
-  option ``--scheduler parallel``. To get the most benefit from the parallel
-  option, start multiple transaction processors for the types of transactions
-  where there is an expected high volume.
+The validator can process transactions in serial (the default) or parallel
+with no difference in the state produced. To process in parallel, use the
+option ``--scheduler parallel``. To get the most benefit from the parallel
+option, start multiple transaction processors for the types of transactions
+where there is an expected high volume.
 
 
 Starting the REST API
@@ -196,21 +189,52 @@ REST API and connect to a local validator:
 
   $ sudo -u sawtooth sawtooth-rest-api -v
 
+Starting and Configuring the Transaction Processors
+===================================================
 
-Running a Transaction Processor
-===============================
+This section describes how to start the IntegerKey and Settings family
+transaction processors, confirm that the REST API is running, and tell
+the validator or validator network to accept transactions from these
+transaction families.
 
 Transaction processors can be started either before or after the validator is
 started.
 
-The IntegerKey transaction processor is provided as a simple example of a
-transaction family, which can also be used for testing purposes.
+Supported Transaction Families
+------------------------------
+
+Sawtooth supports multiple languages for transaction processor development and
+includes additional transaction processors written in several languages.
+Sawtooth includes following transaction processors:
+
+* settings-tp - A Settings family transaction processor written in Python
+
+* intkey-tp-go - An IntegerKey transaction processor written in Go
+
+* intkey-tp-java - An IntegerKey transaction processor written in Java
+
+* intkey-tp-javascript - An IntegerKey transaction processor written in
+  JavaScript (requires node.js)
+
+* intkey-tp-python - An IntegerKey transaction processor written in Python
+
+* poet-validator-registry-tp - A transaction family used by the PoET consensus
+  algorithm implementation to keep track of other validators
+
+* xo-tp-javascript - An XO transaction processor written in JavaScript
+  (requires node.js)
+
+* xo-tp-python - An XO transaction processor written in Python
 
 .. note::
 
   In a production environment, you should always run a transaction processor
   that supports the Settings transaction family.
-  See `Configuring the List of Transaction Families`_ for more information.
+
+Starting the IntegerKey Transaction Processor
+---------------------------------------------
+The IntegerKey transaction processor is provided as a simple example of a
+transaction family, which can also be used for testing purposes.
 
 To start an IntegerKey transaction processor, open a new terminal window, then
 run the following command:
@@ -235,50 +259,16 @@ The transaction processor produces the following output:
 
   [23:07:57 INFO    core] register attempt: OK
 
-Configuring the List of Transaction Families
-============================================
 
-This section describes how to start the Settings transaction family, confirm
-that the REST API is running, and tell the validator or validator network to
-accept transactions from the IntegerKey and Settings transaction families.
+Starting the Settings Family Transaction Processor
+--------------------------------------------------
 
 Sawtooth provides a :doc:`Settings transaction family
 <../transaction_family_specifications/settings_transaction_family>` that stores
 on-chain settings, along with a Settings family transaction processor written
 in Python.
 
-.. note::
-
-  Sawtooth supports multiple languages for transaction processor development and
-  includes additional transaction processors written in several languages.
-  The following lists the processors that are included:
-
-  * settings-tp - A Settings family transaction processor written in Python
-
-  * intkey-tp-go - An IntegerKey transaction processor written in Go
-
-  * intkey-tp-java - An IntegerKey transaction processor written in Java
-
-  * intkey-tp-javascript - An IntegerKey transaction processor written in JavaScript
-    (requires node.js)
-
-  * poet-validator-registry-tp - A transaction family used by the PoET consensus
-    algorithm implementation to keep track of other validators
-
-  * xo-tp-javascript - An XO transaction processor written in JavaScript
-    (requires node.js)
-
-  * xo-tp-python - An XO transaction processor written in Python
-
-One of the on-chain settings is the list of supported transaction families.
-To configure this setting, use the follow steps to start the Settings family
-transaction processor, start the REST API, and create and submit the batch
-to change the settings.
-
-Starting the Settings Family Processor
---------------------------------------
-
-To start the settings family transaction processor, open a new terminal window
+To start the Settings family transaction processor, open a new terminal window
 and run the following command:
 
 .. code-block:: console
@@ -293,7 +283,6 @@ following output:
 
   [21:03:55.955 INFO    processor_handlers] registered transaction processor: identity=b'6d2d80275ae280ea', family=sawtooth_settings, version=1.0, namespaces=<google.protobuf.pyext._message.RepeatedScalarContainer object at 0x7e1ff042f6c0>
   [21:03:55.956 DEBUG   interconnect] ServerThread sending TP_REGISTER_RESPONSE to b'6d2d80275ae280ea'
-
 
 Verifying that the REST API is Running
 --------------------------------------
@@ -314,22 +303,23 @@ If necessary, run the following command to start the REST API.
 
   $ sudo -u sawtooth sawtooth-rest-api -v
 
+Configuring the List of Transaction Families (Ubuntu version)
+-------------------------------------------------------------
 
-Changing the Transaction Family Settings
-----------------------------------------
+One of the on-chain settings is the list of supported transaction families.
+To configure this setting, use the following steps to
+create and submit the batch to change the transaction family settings.
 
-In the example below, a JSON array is submitted to the ``sawset``
-command, which creates and submits a batch of transactions containing the
-settings change.
+In this example, the ``sawset`` command specifies a JSON array
+which creates and submits a batch of transactions containing the
+settings change. This JSON array tells the validator or validator network
+to accept transactions of the following types:
 
-The JSON array used tells the validator or validator network to accept
-transactions of the following types:
-
-* intkey (IntegerKey transaction family)
-* sawtooth_settings (Settings transaction family)
+* ``intkey`` (IntegerKey transaction family)
+* ``sawtooth_settings`` (Settings transaction family)
 
 To create and submit the batch containing the new settings,
-enter the following commands:
+enter the following command:
 
 .. code-block:: console
 
@@ -519,9 +509,8 @@ The output of the command will be similar to this:
 Stopping Sawtooth Components
 ============================
 
-To stop the validator, enter CTRL-c in the validator's terminal
-window. A single CTRL-c starts a graceful shutdown.
-Enter multiple CTRL-c characters to force the validator to stop quickly.
+To stop the validator, enter CTRL-c several times in the validator's terminal
+window.
 
-Stop the REST API and transaction processors by by entering
-CTRL-c in the appropriate windows.
+Stop the REST API and transaction processors by entering a single CTRL-c in
+the appropriate windows.

--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -4,7 +4,7 @@ Error Responses
 
 When the REST API encounters a problem, or receives notification that the
 validator has encountered a problem, it will notify clients with both an
-appropriate HTTP status code, and a more detailed JSON response.
+appropriate HTTP status code and a more detailed JSON response.
 
 
 HTTP Status Codes
@@ -24,14 +24,14 @@ HTTP Status Codes
        details.
    * - 404
      - Not Found
-     - The request was well formed, but an identifier specified did not
+     - The request was well formed, but the specified identifier did not
        correspond to any resource in the validator. Returned by endpoints which
        fetch a single resource. Endpoints which return lists of resources will
        simply return an empty list.
    * - 500
      - Internal Server Error
      - Something is broken internally in the REST API or the validator. This may
-       be a bug, and if reproducible, should be reported.
+       be a bug; if it is reproducible, the bug should be reported.
    * - 503
      - Service Unavailable
      - The REST API is unable to communicate with the validator. It may be down.
@@ -46,12 +46,12 @@ include a single *error* property with three values:
 
    * *code* (integer) - a machine readable error code
    * *title* (string) - a short headline for the error
-   * *message* (string) - a longer human readable description of what went wrong
+   * *message* (string) - a longer, human-readable description of what went wrong
 
 .. note::
 
-   While the title and message may change in the future, **the error code is
-   fixed**, and will always refer to this particular problem.
+   While the title and message may change in the future, the error code
+   will **not** change; it will always refer to this particular problem.
 
 
 Example JSON Response
@@ -63,7 +63,7 @@ Example JSON Response
      "error": {
        "code": 30,
        "title": "Submitted Batches Invalid",
-       "message": "The submitted BatchList is invalid. It was poorly formed, or has an invalid signature."
+       "message": "The submitted BatchList is invalid. It was poorly formed or has an invalid signature."
      }
    }
 
@@ -81,7 +81,8 @@ Error Codes and Descriptions
    * - 10
      - Unknown Validator Error
      - An unknown error occurred with the validator while processing the
-       request. This may be a bug, and if reproducible, should be reported.
+       request. This may be a bug; if it is reproducible, the bug should be
+       reported.
    * - 15
      - Validator Not Ready
      - The validator has no genesis block, and so cannot be queried. Wait for
@@ -90,8 +91,8 @@ Error Codes and Descriptions
    * - 17
      - Validator Timed Out
      - The request timed out while waiting for a response from the validator. It
-       may not be running, or have encountered an internal error. The request
-       may or may not have been processed.
+       may not be running, or may have encountered an internal error. The
+       request may not have been processed.
    * - 18
      - Validator Disconnected
      - The validator sent a disconnect signal while processing the response, and
@@ -113,11 +114,11 @@ Error Codes and Descriptions
    * - 30
      - Submitted Batches Invalid
      - The submitted BatchList failed initial validation by the validator. It
-       may have a bad signature, or be poorly formed.
+       may have a bad signature or be poorly formed.
    * - 34
      - No Batches Submitted
-     - The BatchList Protobuf submitted was empty and contained no Batches. All
-       submissions to the validator must include at least one Batch.
+     - The BatchList Protobuf submitted was empty and contained no batches. All
+       submissions to the validator must include at least one batch.
    * - 35
      - Protobuf Not Decodable
      - The REST API was unable to decode the submitted Protobuf binary. It is

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -122,15 +122,15 @@ paths:
         `'COMMITTED'`, `'INVALID'`, `'PENDING'`, and `'UNKNOWN'`.
 
         The batch(es) you want to check can be specified using the `id` filter
-        parameter. If a `wait` time is specified in the url, the API will wait
+        parameter. If a `wait` time is specified in the URL, the API will wait
         to respond until all batches are committed, or the time in seconds has
-        elapsed. If the value of `wait` is not set (i.e. `?wait&id=...`), or
+        elapsed. If the value of `wait` is not set (i.e., `?wait&id=...`), or
         it is set to any non-integer value other than `false`, the wait time
-        will be just shy of the api's specified timeout (usually 300).
+        will be just under the API's specified timeout (usually 300).
 
-        Note that as this route does not return full resources, the response
-        will not be paginated, and there will be no `head` or `paging`
-        properties.
+        Note that because this route does not return full resources, the
+        response will not be paginated, and there will be no `head` or
+        `paging` properties.
       parameters:
         - name: id
           in: query
@@ -161,7 +161,7 @@ paths:
         formatted POST body rather than a query parameter. This allows for many
         more batches to be checked and should be used for more than 15 ids.
 
-        Note that since query information is not encoded in the URL, no `link`
+        Note that because query information is not encoded in the URL, no `link`
         will be returned with this query.
       consumes:
         - application/json
@@ -195,7 +195,7 @@ paths:
       summary: Fetches the data for the current state
       description: >
         Fetches a paginated list of entries for the current state, or relative
-        to a particular head block. Using the `address` filter parameter, will
+        to a particular head block. Using the `address` filter parameter will
         narrow the list to any entries that have an address beginning with the
         characters specified.
       parameters:
@@ -294,7 +294,7 @@ paths:
     parameters:
       - $ref: "#/parameters/block_id"
     get:
-      summary: Fetches a particlar block
+      summary: Fetches a particular block
       responses:
         200:
           description: Successfully retrieved block
@@ -412,7 +412,7 @@ paths:
         formatted POST body rather than a query parameter. This allows for many
         more receipts to be fetched and should be used with more than 15 ids.
 
-        Note that since query information is not encoded in the URL, no `link`
+        Note that because query information is not encoded in the URL, no `link`
         will be returned with this request.
       consumes:
         - application/json
@@ -507,7 +507,7 @@ parameters:
     in: path
     type: string
     required: true
-    description: Trainsaction id
+    description: Transaction id
   head:
     name: head
     in: query


### PR DESCRIPTION
Edited the RST doc and autogenerated content for the REST API documentation.

Note: This PR is based on #1211 - see that PR to review the changes in ubuntu.rst.