### PR TITLE
Cleanup poet base64 includes and licensing

### DIFF
--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/base64.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/base64.cpp
@@ -24,7 +24,9 @@ misrepresented as being the original source code.
 Ren� Nyffenegger rene.nyffenegger@adp-gmbh.ch
 
 */
-// source: http://www.adp-gmbh.ch/cpp/common/base64.html
+// source: https://github.com/ReneNyffenegger/cpp-base64
+// Notice: This version has been modified from the original
+
 #include "base64.h"
 #include <iostream>
 

--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/base64.h
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/base64.h
@@ -24,7 +24,9 @@ misrepresented as being the original source code.
 René Nyffenegger rene.nyffenegger@adp-gmbh.ch
 
 */
-// source: http://www.adp-gmbh.ch/cpp/common/base64.html
+// source: https://github.com/ReneNyffenegger/cpp-base64
+// Notice: This version has been modified from the original
+
 #pragma once
 #include <string>
 

--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/enclave.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/enclave.cpp
@@ -29,7 +29,6 @@
 #include "poet_enclave_u.h"
 #include "log.h"
 #include "error.h"
-#include "utils.h"
 #include "zero.h"
 #include "hex_string.h"
 

--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/poet.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/poet.cpp
@@ -30,7 +30,6 @@
 
 #include "error.h"
 
-#include "base64.h"
 #include "zero.h"
 #include "public_key_util.h"
 


### PR DESCRIPTION
Remove unneeded includes from poet.cpp and enclave.cpp
Add modification notice to base64 source file required for license
attribution.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>

See also STL-398