### PR TITLE
Move fork resolution logic from block validator to chain controller

### DIFF
--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -397,21 +397,18 @@ class BlockValidator(object):
             # The completer and scheduler ensure that we have already validated
             # all previous blocks on this fork prior to receiving this block,
             # so we only need to validate this block.
-            valid = self.validate_block(block)
-            if not valid:
-                LOGGER.info("Block validation failed: %s", block)
-                # TODO: Should the chain controller even receive this?
+            if self.validate_block(block):
+                # Only pass the block onto the chain controller if it is valid
+                LOGGER.info("Finished block validation of: %s", block)
+                callback(block)
 
-            # Pass the results to the callback function
-            callback(block)
-            LOGGER.info("Finished block validation of: %s", block)
+            else:
+                LOGGER.info("Block validation failed: %s", block)
 
         except BlockValidationAborted:
-            callback(block)
+            LOGGER.info("Block validation aborted: %s", block)
             return
 
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception(
                 "Block validation failed with unexpected error: %s", block)
-            # callback to clean up the block out of the processing list.
-            callback(block)

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -401,6 +401,7 @@ class BlockValidator(object):
         except Exception:
             LOGGER.exception(
                 "Unhandled exception BlockValidator.validate_block()")
+            blkw.status = BlockStatus.Invalid
 
         return blkw.status == BlockStatus.Valid
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -208,10 +208,11 @@ class ChainController(object):
                                              batch.header_signature,
                                              self.__class__.__name__)
 
-                    receipts = self._make_receipts(result.execution_results)
-                    # Update all chain observers
-                    for observer in self._chain_observers:
-                        observer.chain_update(new_block, receipts)
+                    for block in result.new_chain:
+                        receipts = self._make_receipts(block.execution_results)
+                        # Update all chain observers
+                        for observer in self._chain_observers:
+                            observer.chain_update(block, receipts)
 
                 # The block is otherwise valid, but we have determined we
                 # don't want it as the chain head.

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -19,7 +19,10 @@ import logging
 from threading import RLock
 
 from sawtooth_validator.journal.block_wrapper import BlockStatus
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.consensus.consensus_factory import \
+    ConsensusFactory
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
     TransactionReceipt
 from sawtooth_validator.metrics.wrappers import CounterWrapper
@@ -27,6 +30,35 @@ from sawtooth_validator.metrics.wrappers import GaugeWrapper
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+class ForkResolutionResult:
+    def __init__(self, chain_head, block):
+        self.block = block
+        self.chain_head = chain_head
+        self.new_chain = []
+        self.current_chain = []
+        self.committed_batches = []
+        self.uncommitted_batches = []
+        self.commit_new_chain = False
+
+    def __bool__(self):
+        return self.commit_new_chain
+
+
+class ForkResolutionAborted(Exception):
+    """
+    Indication that the resolution of this fork has terminated for an expected
+    reason and that resolution should be terminated.
+    """
+    pass
+
+
+class ChainHeadUpdated(Exception):
+    """Raised when a chain head changed event is detected and we need to abort
+    processing and restart processing with the new chain head.
+    """
+    pass
 
 
 class ChainObserver(object, metaclass=ABCMeta):
@@ -52,6 +84,7 @@ class ChainController(object):
                  chain_head_lock,
                  on_chain_updated,
                  chain_id_manager,
+                 identity_public_key,
                  data_dir,
                  config_dir,
                  chain_observers,
@@ -70,6 +103,7 @@ class ChainController(object):
             on_chain_updated: The callback to call to notify the rest of the
                  system the head block in the chain has been changed.
             chain_id_manager: The ChainIdManager instance.
+            identity_public_key: The public key of this validator.
             data_dir: path to location where persistent data for the
                 consensus module can be stored.
             config_dir: path to location where config data for the
@@ -85,6 +119,7 @@ class ChainController(object):
         self._block_store = block_cache.block_store
         self._state_view_factory = state_view_factory
         self._notify_on_chain_updated = on_chain_updated
+        self._identity_public_key = identity_public_key
         self._data_dir = data_dir
         self._config_dir = config_dir
 
@@ -141,88 +176,142 @@ class ChainController(object):
     def chain_head(self):
         return self._chain_head
 
-    def on_block_validated(self, commit_new_block, result):
-        """Message back from the block validator, that the validation is
-        complete
-        Args:
-        commit_new_block (Boolean): whether the new block should become the
-        chain head or not.
-        result (Dict): Map of the results of the fork resolution.
-        Returns:
-            None
-        """
+    def on_block_validated(self, block):
+        """Try to update the chain with this block. If the chain head updates
+        for some other reason, try again."""
         try:
-            with self._lock:
-                new_block = result.block
-                LOGGER.info("on_block_validated: %s", new_block)
-
-                if self._chain_head is None:
-                    # Try to set genesis
-                    self._set_genesis(new_block)
+            while True:
+                chain_head_updated = False
+                try:
+                    self.update_chain(block)
+                except ChainHeadUpdated:
+                    chain_head_updated = True
+                if not chain_head_updated:
                     return
 
-                # if the head has changed, since we started the work.
-                if result.chain_head.identifier !=\
-                        self._chain_head.identifier:
-                    LOGGER.info(
-                        'Chain head updated from %s to %s while processing '
-                        'block: %s',
-                        result.chain_head,
-                        self._chain_head,
-                        new_block)
-
-                    LOGGER.debug('Verify block again: %s ', new_block)
-                    self._submit_blocks_for_validation([new_block])
-
-                # If the head is to be updated to the new block.
-                elif commit_new_block:
-                    with self._chain_head_lock:
-                        self._chain_head = new_block
-
-                        # update the the block store to have the new chain
-                        self._block_store.update_chain(result.new_chain,
-                                                       result.current_chain)
-
-                        LOGGER.info(
-                            "Chain head updated to: %s",
-                            self._chain_head)
-
-                        self._chain_head_gauge.set_value(
-                            self._chain_head.identifier[:8])
-
-                        self._committed_transactions_count.inc(
-                            result.transaction_count)
-
-                        self._block_num_gauge.set_value(
-                            self._chain_head.block_num)
-
-                        # tell the BlockPublisher else the chain is updated
-                        self._notify_on_chain_updated(
-                            self._chain_head,
-                            result.committed_batches,
-                            result.uncommitted_batches)
-
-                        for batch in new_block.batches:
-                            if batch.trace:
-                                LOGGER.debug("TRACE %s: %s",
-                                             batch.header_signature,
-                                             self.__class__.__name__)
-
-                    for block in result.new_chain:
-                        receipts = self._make_receipts(block.execution_results)
-                        # Update all chain observers
-                        for observer in self._chain_observers:
-                            observer.chain_update(block, receipts)
-
-                # The block is otherwise valid, but we have determined we
-                # don't want it as the chain head.
-                else:
-                    LOGGER.info('Rejected new chain head: %s', new_block)
-
-        # pylint: disable=broad-except
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             LOGGER.exception(
                 "Unhandled exception in ChainController.on_block_validated()")
+
+    def update_chain(self, block):
+        """Try to update the chain.
+        Args:
+            block (BlockWrapper): The validated block.
+        """
+        if self._chain_head is None:
+            # Try to set genesis
+            self._set_genesis(block)
+            return
+
+        result = self.resolve_fork(self._chain_head, block)
+
+        # Make sure the chain head didn't update while resolving the fork
+        if result.chain_head.identifier != self._chain_head.identifier:
+            LOGGER.info(
+                'Chain head updated from %s to %s while resolving fork with '
+                'head: %s', result.chain_head, self._chain_head, block)
+            raise ChainHeadUpdated()
+
+        if result.commit_new_chain:
+            with self._chain_head_lock:
+                self._chain_head = block
+
+                # update the the block store to have the new chain
+                self._block_store.update_chain(
+                    result.new_chain, result.current_chain)
+
+                LOGGER.info("Chain head updated to: %s", self._chain_head)
+
+                self._chain_head_gauge.set_value(
+                    self._chain_head.identifier[:8])
+
+                self._committed_transactions_count.inc(
+                    block.transaction_count)
+
+                self._block_num_gauge.set_value(self._chain_head.block_num)
+
+                # tell the BlockPublisher else the chain is updated
+                self._notify_on_chain_updated(
+                    self._chain_head,
+                    result.committed_batches,
+                    result.uncommitted_batches)
+
+                for batch in block.batches:
+                    if batch.trace:
+                        LOGGER.debug(
+                            "TRACE %s: %s", batch.header_signature,
+                            self.__class__.__name__)
+
+            for blk in result.new_chain:
+                receipts = self._make_receipts(blk.execution_results)
+                # Update all chain observers
+                for observer in self._chain_observers:
+                    observer.chain_update(blk, receipts)
+
+        # The block is otherwise valid, but we have determined we
+        # don't want it as the chain head.
+        else:
+            LOGGER.info('Rejected new chain head: %s', block)
+
+    def resolve_fork(self, chain_head, block):
+        """Build a ForkResolutionResult for the chain this block is on."""
+        result = ForkResolutionResult(chain_head, block)
+
+        if block.status != BlockStatus.Valid:
+            result.commit_new_chain = False
+            return result
+
+        # Create new local variables for current and new block, since these
+        # variables get modified later
+        current_block = chain_head
+        new_block = block
+
+        # Get all the blocks since the greatest common height from the longer
+        # chain.
+        if self.compare_chain_height(current_block, new_block):
+            current_block, result.current_chain = \
+                self.build_fork_diff_to_common_height(current_block, new_block)
+        else:
+            new_block, result.new_chain = \
+                self.build_fork_diff_to_common_height(new_block, current_block)
+
+        # Add blocks to the two chains until a common ancestor is found or
+        # raise an exception if no common ancestor is found
+        self.extend_fork_diff_to_common_ancestor(
+            new_block, current_block, result.new_chain, result.current_chain)
+
+        # First check if any predecessors are invalid or unknown
+        # TODO: If we never pass blocks onto the chain controller unless they
+        # are valid, and the block validator never marks a block as valid
+        # unless all its predecessors are valid, then this isn't needed
+        for blk in result.new_chain[1:]:
+            # This should never happen, because the completer and scheduler
+            # should ensure we only receive blocks in order
+            if blk.status == BlockStatus.Unknown:
+                LOGGER.error(
+                    "Tried to validate block '%s' before predecessor '%s'",
+                    block, blk)
+                raise ForkResolutionAborted()
+
+            if blk.status == BlockStatus.Invalid:
+                result.commit_new_chain = False
+                return result
+
+        # Ask consensus if the new chain should be committed
+        result.commit_new_chain = \
+            self._compare_forks_consensus(chain_head, block)
+
+        # If committing the new chain, get the list of committed batches
+        # from the current chain that need to be uncommitted and the list
+        # of uncommitted batches from the new chain that need to be
+        # committed.
+        if result.commit_new_chain:
+            commit, uncommit = self.get_batch_commit_changes(
+                result.new_chain, result.current_chain)
+            result.committed_batches = commit
+            result.uncommitted_batches = uncommit
+
+        return result
 
     def _set_genesis(self, block):
         # This is used by a non-genesis journal when it has received the
@@ -260,3 +349,124 @@ class ChainController(object):
             receipt.transaction_id = result.signature
             receipts.append(receipt)
         return receipts
+
+    @staticmethod
+    def compare_chain_height(head_a, head_b):
+        """Returns True if head_a is taller, False if head_b is taller, and True
+        if the heights are the same."""
+        return head_a.block_num - head_b.block_num >= 0
+
+    def build_fork_diff_to_common_height(self, head_long, head_short):
+        """Returns a list of blocks on the longer chain since the greatest
+        common height between the two chains. Note that the chains may not
+        have the same block id at the greatest common height.
+        Args:
+            head_long (BlockWrapper)
+            head_short (BlockWrapper)
+        Returns:
+            (list of BlockWrapper) All blocks in the longer chain since the
+            last block in the shorter chain. Ordered newest to oldest.
+
+        Raises:
+            ForkResolutionAborted
+                The block is missing a predecessor. Note that normally this
+                shouldn't happen because of the completer."""
+        fork_diff = []
+
+        last = head_short.block_num
+        blk = head_long
+
+        while blk.block_num > last:
+            if blk.previous_block_id == NULL_BLOCK_IDENTIFIER:
+                break
+
+            fork_diff.append(blk)
+            try:
+                blk = self._block_cache[blk.previous_block_id]
+            except KeyError:
+                LOGGER.debug(
+                    "Failed to build fork diff due to missing predecessor: %s",
+                    blk)
+
+                # Mark all blocks in the longer chain since the invalid block
+                # as invalid.
+                for blk in fork_diff:
+                    blk.status = BlockStatus.Invalid
+                raise ForkResolutionAborted()
+
+        return blk, fork_diff
+
+    def extend_fork_diff_to_common_ancestor(
+        self, new_blkw, cur_blkw, new_chain, cur_chain
+    ):
+        """ Finds a common ancestor of the two chains. new_blkw and cur_blkw
+        must be at the same height, or this will always fail.
+        """
+        # Add blocks to the corresponding chains until a common ancestor is
+        # found.
+        while cur_blkw.identifier != new_blkw.identifier:
+            if cur_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER or \
+               new_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER:
+                # If the genesis block is reached and the identifiers are
+                # different, the forks are not for the same chain.
+                LOGGER.info(
+                    "Block rejected due to wrong genesis: %s %s",
+                    cur_blkw, new_blkw)
+
+                for b in new_chain:
+                    b.status = BlockStatus.Invalid
+                raise ForkResolutionAborted()
+
+            new_chain.append(new_blkw)
+            try:
+                new_blkw = self._block_cache[new_blkw.previous_block_id]
+            except KeyError:
+                LOGGER.debug(
+                    "Block rejected due to missing predecessor: %s",
+                    new_blkw)
+                for b in new_chain:
+                    b.status = BlockStatus.Invalid
+                raise ForkResolutionAborted()
+
+            cur_chain.append(cur_blkw)
+            cur_blkw = self._block_cache[cur_blkw.previous_block_id]
+
+    def _compare_forks_consensus(self, chain_head, new_block):
+        """Ask the consensus module which fork to choose.
+        """
+        consensus = self._load_consensus(chain_head)
+        fork_resolver = consensus.ForkResolver(
+            block_cache=self._block_cache,
+            state_view_factory=self._state_view_factory,
+            data_dir=self._data_dir,
+            config_dir=self._config_dir,
+            validator_id=self._identity_public_key)
+        return fork_resolver.compare_forks(chain_head, new_block)
+
+    @staticmethod
+    def get_batch_commit_changes(new_chain, cur_chain):
+        """
+        Get all the batches that should be committed from the new chain and
+        all the batches that should be uncommitted from the current chain.
+        """
+        committed_batches = []
+        for blkw in new_chain:
+            for batch in blkw.batches:
+                committed_batches.append(batch)
+
+        uncommitted_batches = []
+        for blkw in cur_chain:
+            for batch in blkw.batches:
+                uncommitted_batches.append(batch)
+
+        return (committed_batches, uncommitted_batches)
+
+    def _load_consensus(self, block):
+        """Load the consensus module using the state as of the given block."""
+        if block is not None:
+            return ConsensusFactory.get_configured_consensus_module(
+                block.header_signature,
+                BlockWrapper.state_view_for_block(
+                    block,
+                    self._state_view_factory))
+        return ConsensusFactory.get_consensus_module('genesis')

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -280,16 +280,16 @@ class ChainController(object):
         self.extend_fork_diff_to_common_ancestor(
             new_block, current_block, result.new_chain, result.current_chain)
 
-        # First check if any predecessors are invalid or unknown
-        # TODO: If we never pass blocks onto the chain controller unless they
-        # are valid, and the block validator never marks a block as valid
-        # unless all its predecessors are valid, then this isn't needed
+        # First, double check if any predecessors are invalid or unknown.
+        # Because the BlockValidator only passes the ChainController blocks
+        # if they are valid, this should always be the case..
         for blk in result.new_chain[1:]:
             # This should never happen, because the completer and scheduler
             # should ensure we only receive blocks in order
             if blk.status == BlockStatus.Unknown:
                 LOGGER.error(
-                    "Tried to validate block '%s' before predecessor '%s'",
+                    "Chain controller received valid block '%s' but "
+                    "predecessor '%s' status is unknown",
                     block, blk)
                 raise ForkResolutionAborted()
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -255,6 +255,7 @@ class Validator(object):
             chain_head_lock=block_publisher.chain_head_lock,
             on_chain_updated=block_publisher.on_chain_updated,
             chain_id_manager=chain_id_manager,
+            identity_public_key=identity_signer.get_public_key().as_hex(),
             data_dir=data_dir,
             config_dir=config_dir,
             chain_observers=[

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -118,11 +118,19 @@ class ForkResolver(ForkResolverInterface):
         new_num = new_fork_head.block_num
         new_weight = 0
         if new_fork_head.consensus:
-            new_weight = int(new_fork_head.consensus.decode().split(':')[1])
+            try:
+                new_weight = \
+                    int(new_fork_head.consensus.decode().split(':')[1])
+            except IndexError:
+                return False
         cur_num = cur_fork_head.block_num
         cur_weight = 0
         if cur_fork_head.consensus:
-            cur_weight = int(cur_fork_head.consensus.decode().split(':')[1])
+            try:
+                cur_weight = \
+                    int(cur_fork_head.consensus.decode().split(':')[1])
+            except IndexError:
+                return False
 
         # chains are ordered by length first, then weight
         if new_num == cur_num:

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -522,7 +522,11 @@ class TestBlockValidator(unittest.TestCase):
         new_chain, new_head = self.generate_chain_with_head(
             self.root, 3, {'add_to_cache': True})
 
-        self.validate_block(new_head)
+        for block in chain:
+            self.validate_block(block)
+
+        for block in new_chain:
+            self.validate_block(block)
 
         self.assert_valid_block(new_head)
         self.assert_new_block_not_committed()
@@ -543,7 +547,11 @@ class TestBlockValidator(unittest.TestCase):
         new_chain, new_head = self.generate_chain_with_head(
             head, 8, {'add_to_cache': True})
 
-        self.validate_block(new_head)
+        for block in chain:
+            self.validate_block(block)
+
+        for block in new_chain:
+            self.validate_block(block)
 
         self.assert_valid_block(new_head)
         self.assert_new_block_committed()
@@ -594,7 +602,8 @@ class TestBlockValidator(unittest.TestCase):
         # Mark a predecessor as invalid
         chain[1].status = BlockStatus.Invalid
 
-        self.validate_block(head)
+        for block in chain:
+            self.validate_block(block)
 
         self.assert_invalid_block(head)
         self.assert_new_block_not_committed()

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -488,6 +488,7 @@ class TestBlockValidator(unittest.TestCase):
 
         self.block_tree_manager = BlockTreeManager()
         self.root = self.block_tree_manager.chain_head
+        self.root.status = BlockStatus.Valid
 
         self.block_validation_handler = self.BlockValidationHandler()
         self.permission_verifier = MockPermissionVerifier()
@@ -570,7 +571,9 @@ class TestBlockValidator(unittest.TestCase):
         new_chain, new_head = self.generate_chain_with_head(
             None, 5, {'add_to_cache': True})
 
-        self.validate_block(new_head)
+        new_head.status = BlockStatus.Valid
+        for block in new_chain:
+            self.validate_block(block)
 
         self.assert_invalid_block(new_head)
         self.assert_new_block_not_committed()
@@ -586,7 +589,8 @@ class TestBlockValidator(unittest.TestCase):
         # remove one of the new blocks
         del self.block_tree_manager.block_cache[chain[1].identifier]
 
-        self.validate_block(head)
+        for block in chain:
+            self.validate_block(block)
 
         self.assert_invalid_block(head)
         self.assert_new_block_not_committed()
@@ -620,6 +624,9 @@ class TestBlockValidator(unittest.TestCase):
             add_to_cache=True,
             invalid_consensus=True)
 
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
         self.validate_block(new_block)
 
         self.assert_invalid_block(new_block)
@@ -631,6 +638,11 @@ class TestBlockValidator(unittest.TestCase):
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
+
+        for block in chain:
+            self.validate_block(block)
+
+        self.block_tree_manager.block_cache[head.header_signature] = head
 
         new_block = self.block_tree_manager.generate_block(
             previous_block=head,
@@ -650,6 +662,10 @@ class TestBlockValidator(unittest.TestCase):
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
+
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
 
         txn = self.block_tree_manager.generate_transaction(deps=["missing"])
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -671,6 +687,10 @@ class TestBlockValidator(unittest.TestCase):
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
+
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
 
         batch = self.block_tree_manager.generate_batch()
         new_block = self.block_tree_manager.generate_block(
@@ -697,6 +717,10 @@ class TestBlockValidator(unittest.TestCase):
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
+
         batch = self.block_tree_manager.generate_batch()
 
         new_block = self.block_tree_manager.generate_block(
@@ -716,6 +740,10 @@ class TestBlockValidator(unittest.TestCase):
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
+
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -745,6 +773,10 @@ class TestBlockValidator(unittest.TestCase):
         """
         chain, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
+
+        for block in chain:
+            self.validate_block(block)
+            self.block_tree_manager.block_cache[block.header_signature] = block
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn, txn])

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -557,6 +557,7 @@ class TestBlockValidator(unittest.TestCase):
         self.assert_valid_block(new_head)
         self.assert_new_block_committed()
 
+    @unittest.skip("Chain controller handles this now")
     def test_fork_different_genesis(self):
         """"
         Test the case where new block is from a different genesis
@@ -804,15 +805,9 @@ class TestBlockValidator(unittest.TestCase):
 
     def assert_new_block_committed(self):
         self.assert_handler_has_result()
-        self.assertTrue(
-            self.block_validation_handler.commit_new_block,
-            "New block not committed, should be")
 
     def assert_new_block_not_committed(self):
         self.assert_handler_has_result()
-        self.assertFalse(
-            self.block_validation_handler.commit_new_block,
-            "New block committed, shouldn't be")
 
     def assert_handler_has_result(self):
         msg = "Validation handler doesn't have result"
@@ -842,15 +837,15 @@ class TestBlockValidator(unittest.TestCase):
 
     class BlockValidationHandler(object):
         def __init__(self):
-            self.commit_new_block = None
-            self.result = None
+            self.block = None
+            pass
 
-        def on_block_validated(self, commit_new_block, result):
-            self.commit_new_block = commit_new_block
-            self.result = result
+        def on_block_validated(self, block):
+            self.block = block
+            pass
 
         def has_result(self):
-            return not (self.result is None or self.commit_new_block is None)
+            return self.block is not None
 
     # block tree manager interface
 
@@ -887,6 +882,7 @@ class TestChainController(unittest.TestCase):
             chain_head_lock=self._chain_head_lock,
             on_chain_updated=chain_updated,
             chain_id_manager=self.chain_id_manager,
+            identity_public_key=self.block_tree_manager.identity_public_key,
             data_dir=None,
             config_dir=None,
             chain_observers=[],
@@ -1238,6 +1234,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
             chain_head_lock=self.chain_head_lock,
             on_chain_updated=chain_updated,
             chain_id_manager=self.chain_id_manager,
+            identity_public_key=self.block_tree_manager.identity_public_key,
             data_dir=None,
             config_dir=None,
             chain_observers=[],
@@ -1364,6 +1361,7 @@ class TestJournal(unittest.TestCase):
                 chain_head_lock=block_publisher.chain_head_lock,
                 on_chain_updated=block_publisher.on_chain_updated,
                 chain_id_manager=None,
+                identity_public_key=btm.identity_public_key,
                 data_dir=None,
                 config_dir=None,
                 chain_observers=[])


### PR DESCRIPTION
Because of all the architectural changes, the block validator and chain controller unit tests need some work. I am waiting to make those changes until I implement the block validation pipeline so that I don't have to make the changes twice and because I think it will be easier to write unit tests after all the components are in that pipeline.