### PR TITLE
Lint Is Now Tamed

### DIFF
--- a/.pycodestyle
+++ b/.pycodestyle
@@ -14,5 +14,7 @@
 # ------------------------------------------------------------------------------
 
 [pycodestyle]
-ignore=W503
+# W503: line break before binary operator
+# E722 do not use bare except
+ignore=W503,E722
 exclude=build,docs,ECDSARecoverModule.py,poet0_enclave_simulator.py,poet1_enclave_simulator.py,*_pb2.py

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -13,6 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-[pep8]
+[pycodestyle]
 ignore=W503
 exclude=build,docs,ECDSARecoverModule.py,poet0_enclave_simulator.py,poet1_enclave_simulator.py,*_pb2.py

--- a/bin/battleship
+++ b/bin/battleship
@@ -24,16 +24,16 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'families', 'battleship'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'families', 'battleship'))
 
 from sawtooth_battleship.battleship_cli import main_wrapper
 

--- a/bin/battleship-tp-python
+++ b/bin/battleship-tp-python
@@ -24,14 +24,14 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'families', 'battleship'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'families', 'battleship'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 from sawtooth_battleship.processor.main import main
 

--- a/bin/get_version
+++ b/bin/get_version
@@ -52,8 +52,9 @@ def auto_version(default, strict):
             sys.exit(1)
         else:
             print("WARNING: " + msg, file=sys.stderr)
-            print("WARNING: using setup.py version {}".format(
-                  default), file=sys.stderr)
+            print(
+                "WARNING: using setup.py version {}".format(default),
+                file=sys.stderr)
             parts[0] = default
 
     if len(parts) > 1:

--- a/bin/intkey
+++ b/bin/intkey
@@ -24,8 +24,8 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),

--- a/bin/intkey-tp-python
+++ b/bin/intkey-tp-python
@@ -24,14 +24,14 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'examples', 'intkey_python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'examples', 'intkey_python'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 from sawtooth_intkey.processor.main import main
 

--- a/bin/make_templated_docs
+++ b/bin/make_templated_docs
@@ -32,7 +32,7 @@ template_abs = DOCS_ABS + TEMPLATE_REL
 
 # Comment chars
 comments = {
-    '.rst': {'start': '.. /', 'line':' '},
+    '.rst': {'start': '.. /', 'line': ' '},
     '.html': {'start': '<!---', 'end': '--->'},
     '.md': {'start': '<!---', 'end': '--->'},
     '.py': {'line': '#'},

--- a/bin/noop
+++ b/bin/noop
@@ -24,8 +24,8 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))),

--- a/bin/protogen
+++ b/bin/protogen
@@ -85,7 +85,8 @@ def main(args=None):
     # 7. Generate smallbank protos
     if "go" in args:
         proto_dir = JOIN(TOP_DIR, "families/smallbank/protos")
-        protoc(proto_dir, "families/smallbank", "smallbank_go/src/protobuf", "go")
+        protoc(proto_dir, "families/smallbank",
+               "smallbank_go/src/protobuf", "go")
 
 
 def protoc(src_dir, base_dir, pkg, language="python"):
@@ -144,15 +145,15 @@ def protoc_javascript(src_dir, base_dir, pkg):
     os.makedirs(pkg_dir, exist_ok=True)
 
     with open(JOIN(pkg_dir, 'protobuf_bundle.json'), 'w') as out:
-        p = subprocess.Popen(['node', 'compile_protobuf.js'],
-                             cwd=JOIN(TOP_DIR, base_dir),
-                             stdout=out)
+        p = subprocess.Popen(
+            ['node', 'compile_protobuf.js'],
+            cwd=JOIN(TOP_DIR, base_dir),
+            stdout=out)
         ret_code = p.wait()
         out.flush()
 
     if ret_code != 0:
-        raise AssertionError(
-            'Unable to compile protobuf messages for JS!')
+        raise AssertionError('Unable to compile protobuf messages for JS!')
 
 
 def protoc_go(src_dir, base_dir, pkg):
@@ -181,7 +182,8 @@ def protoc_go(src_dir, base_dir, pkg):
             with open(src, encoding='utf-8') as fin:
                 with open(dst, "w", encoding='utf-8') as fout:
                     src_contents = fin.read()
-                    fixed_contents = fix_import(src_contents, pkg, sub_dir=True)
+                    fixed_contents = fix_import(
+                        src_contents, pkg, sub_dir=True)
                     fout.write(fixed_contents)
 
             # Need to defer until the whole directory is setup
@@ -241,8 +243,7 @@ def fix_import(contents, pkg, sub_dir=False):
         pattern,
         lambda match: match.expand(template) % pkg,
         contents,
-        flags=re.MULTILINE
-    )
+        flags=re.MULTILINE)
 
 
 if __name__ == "__main__":

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -53,19 +53,28 @@ lint() {
     packages=$(find_packages "$subdir" "$since")
 
     if [ "$packages" != "" ]; then
-    [ $VERBOSE = 1 ] && (
-        echo "------------------------------------------------------------------------------"
-        echo "-- Running pycodestyle in $subdir..."
-    )
-    pycodestyle --config=$top_dir/.pycodestyle $packages || error=1
+        [ $VERBOSE = 0 ] && echo "$subdir"
+
+        [ $VERBOSE = 0 ] && echo "-- pycodestyle"
+
+        [ $VERBOSE = 1 ] && (
+            echo "------------------------------------------------------------------------------"
+            echo "-- Running pycodestyle in $subdir..."
+        )
+
+        pycodestyle --config=$top_dir/.pycodestyle $packages || error=1
+
+        [ $VERBOSE = 0 ] && echo "-- pylint"
 
         [ $VERBOSE = 1 ] && (
             echo "------------------------------------------------------------------------------"
             echo "-- Running $pylint_bin $pylintrc in $subdir..."
         )
+
         $pylint_bin \
             --rcfile=$pylintrc \
             --reports=no \
+            --score=no \
             --persistent=no \
             $packages || error=1
 
@@ -74,7 +83,9 @@ lint() {
             echo "------------------------------------------------------------------------------"
             echo "-- Checking for CRLF in $subdir..."
         )
+
         file $packages | grep CRLF && error=1
+
     else
         [ $VERBOSE = 1 ] && (
             echo "------------------------------------------------------------------------------"

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -155,6 +155,17 @@ fi
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 retval=0
 
+# Modules should be ranked in decreasing likelihood of having lint
+# errors. It would be nice if there was a more convenient way of
+# organizing these.
+
+# validator
+PYTHONPATH=$top_dir/signing
+PYTHONPATH=$PYTHONPATH:$top_dir/validator
+export PYTHONPATH
+lint validator "$SINCE" || retval=1
+
+# integration
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/cli
 PYTHONPATH=$PYTHONPATH:$top_dir/validator
@@ -165,10 +176,18 @@ PYTHONPATH=$PYTHONPATH:$top_dir/families/block_info
 export PYTHONPATH
 lint integration "$SINCE" || retval=1
 
+# cli
+PYTHONPATH=$top_dir/cli
+PYTHONPATH=$PYTHONPATH:$top_dir/signing
+export PYTHONPATH
+lint cli "$SINCE" || retval=1
+
+# signing
 PYTHONPATH=$top_dir/signing
 export PYTHONPATH
 lint signing "$SINCE" || retval=1
 
+# sdk, rest api, xo, intkey
 PYTHONPATH=$top_dir/sdk/python
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/intkey_python
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/xo_python
@@ -180,6 +199,7 @@ lint sdk/examples/intkey_python "$SINCE" || retval=1
 lint sdk/examples/xo_python "$SINCE" || retval=1
 lint rest_api "$SINCE" || retval=1
 
+# settings, identity
 PYTHONPATH=$top_dir/families/settings
 PYTHONPATH=$top_dir/families/identity
 PYTHONPATH=$top_dir/families/block_info
@@ -189,6 +209,7 @@ export PYTHONPATH
 lint families/settings "$SINCE" || retval=1
 lint families/identity "$SINCE" || retval=1
 
+# battleship
 PYTHONPATH=$top_dir/families/battleship
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
@@ -196,6 +217,7 @@ PYTHONPATH=$PYTHONPATH:$top_dir/validator
 export PYTHONPATH
 lint families/battleship "$SINCE" || retval=1
 
+# block info
 PYTHONPATH=$top_dir/families/block_info
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
@@ -203,11 +225,7 @@ PYTHONPATH=$PYTHONPATH:$top_dir/validator
 export PYTHONPATH
 lint families/block_info "$SINCE" || retval=1
 
-PYTHONPATH=$top_dir/signing
-PYTHONPATH=$PYTHONPATH:$top_dir/validator
-export PYTHONPATH
-lint validator "$SINCE" || retval=1
-
+# poet
 PYTHONPATH=$top_dir/consensus/poet/common
 PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/common/tests
 export PYTHONPATH
@@ -254,6 +272,7 @@ PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/core
 export PYTHONPATH
 lint consensus/poet/cli "$SINCE" || retval=1
 
+# utility
 PYTHONPATH=$PYTHONPATH:$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/utility/ias_proxy
 PYTHONPATH=$PYTHONPATH:$top_dir/utility/ias_proxy/tests
@@ -269,10 +288,5 @@ PYTHONPATH=$PYTHONPATH:$top_dir/utility/ias_client
 PYTHONPATH=$PYTHONPATH:$top_dir/utility/ias_client/tests
 export PYTHONPATH
 lint utility/ias_client "$SINCE" || retval=1
-
-PYTHONPATH=$top_dir/cli
-PYTHONPATH=$PYTHONPATH:$top_dir/signing
-export PYTHONPATH
-lint cli "$SINCE" || retval=1
 
 exit $retval

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -55,9 +55,9 @@ lint() {
     if [ "$packages" != "" ]; then
     [ $VERBOSE = 1 ] && (
         echo "------------------------------------------------------------------------------"
-        echo "-- Running pep8 in $subdir..."
+        echo "-- Running pycodestyle in $subdir..."
     )
-    pep8 --config=$topdir/.pep8 $packages || error=1
+    pycodestyle --config=$top_dir/.pycodestyle $packages || error=1
 
         [ $VERBOSE = 1 ] && (
             echo "------------------------------------------------------------------------------"

--- a/bin/run_lint
+++ b/bin/run_lint
@@ -155,6 +155,16 @@ fi
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 retval=0
 
+PYTHONPATH=$PYTHONPATH:$top_dir/signing
+PYTHONPATH=$PYTHONPATH:$top_dir/cli
+PYTHONPATH=$PYTHONPATH:$top_dir/validator
+PYTHONPATH=$PYTHONPATH:$top_dir/integration
+PYTHONPATH=$PYTHONPATH:$top_dir/sdk/python
+PYTHONPATH=$PYTHONPATH:$top_dir/sdk/examples/intkey_python
+PYTHONPATH=$PYTHONPATH:$top_dir/families/block_info
+export PYTHONPATH
+lint integration "$SINCE" || retval=1
+
 PYTHONPATH=$top_dir/signing
 export PYTHONPATH
 lint signing "$SINCE" || retval=1
@@ -168,7 +178,7 @@ export PYTHONPATH
 lint sdk/python "$SINCE" || retval=1
 lint sdk/examples/intkey_python "$SINCE" || retval=1
 lint sdk/examples/xo_python "$SINCE" || retval=1
-lint rest_api/sawtooth_rest_api "$SINCE" || retval=1
+lint rest_api "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/families/settings
 PYTHONPATH=$top_dir/families/identity
@@ -196,7 +206,7 @@ lint families/block_info "$SINCE" || retval=1
 PYTHONPATH=$top_dir/signing
 PYTHONPATH=$PYTHONPATH:$top_dir/validator
 export PYTHONPATH
-lint validator/sawtooth_validator "$SINCE" || retval=1
+lint validator "$SINCE" || retval=1
 
 PYTHONPATH=$top_dir/consensus/poet/common
 PYTHONPATH=$PYTHONPATH:$top_dir/consensus/poet/common/tests

--- a/bin/sawtooth-rest-api
+++ b/bin/sawtooth-rest-api
@@ -24,14 +24,14 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'rest_api'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'rest_api'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 from sawtooth_rest_api.rest_api import main
 

--- a/bin/sawtooth-validator
+++ b/bin/sawtooth-validator
@@ -24,12 +24,12 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'validator'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'validator'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 from sawtooth_validator.server.cli import main
 

--- a/bin/xo
+++ b/bin/xo
@@ -24,16 +24,16 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'examples', 'xo_python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'examples', 'xo_python'))
 
 from sawtooth_xo.xo_cli import main_wrapper
 

--- a/bin/xo-tp-python
+++ b/bin/xo-tp-python
@@ -24,16 +24,16 @@ build_str = "lib.{}-{}.{}".format(
     sys.version_info.major, sys.version_info.minor)
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'signing'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'signing'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'python'))
 
 sys.path.insert(0, os.path.join(
-        os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
-            'sdk', 'examples', 'xo_python'))
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'sdk', 'examples', 'xo_python'))
 
 from sawtooth_xo.processor.main import main
 

--- a/cli/sawtooth_cli/admin_command/config.py
+++ b/cli/sawtooth_cli/admin_command/config.py
@@ -33,10 +33,7 @@ def _get_config_dir():
     return '/etc/sawtooth'
 
 
-def _get_dir(toml_config_setting,
-             sawtooth_home_dir,
-             windows_dir,
-             default_dir):
+def _get_dir(toml_config_setting, sawtooth_home_dir, windows_dir, default_dir):
     """Determines the directory path based on configuration.
 
     Arguments:

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -103,8 +103,10 @@ def _validate_depedencies(batches):
             txn_header.ParseFromString(txn.header)
 
             if txn_header.dependencies:
-                unsatisfied_deps = [id for id in txn_header.dependencies
-                                    if id not in transaction_ids]
+                unsatisfied_deps = [
+                    id for id in txn_header.dependencies
+                    if id not in transaction_ids
+                ]
                 if unsatisfied_deps:
                     raise CliException(
                         'Unsatisfied dependency in given transactions:'

--- a/cli/sawtooth_cli/admin_command/keygen.py
+++ b/cli/sawtooth_cli/admin_command/keygen.py
@@ -75,8 +75,7 @@ def do_keygen(args):
     key_dir = get_key_dir()
 
     if not os.path.exists(key_dir):
-        raise CliException(
-            "Key directory does not exist: {}".format(key_dir))
+        raise CliException("Key directory does not exist: {}".format(key_dir))
 
     priv_filename = os.path.join(key_dir, key_name + '.priv')
     pub_filename = os.path.join(key_dir, key_name + '.pub')

--- a/cli/sawtooth_cli/format_utils.py
+++ b/cli/sawtooth_cli/format_utils.py
@@ -34,6 +34,7 @@ def format_terminal_row(headers, example_row):
     Returns
         string: A format string with a size for each column
     """
+
     def format_column(col):
         if isinstance(col, str):
             return '{{:{w}.{w}}}'

--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -250,8 +250,7 @@ def _do_identity_policy_create(args):
     """
     signer = _read_signer(args.key)
 
-    txns = [_create_policy_txn(signer, args.name,
-            args.rule)]
+    txns = [_create_policy_txn(signer, args.name, args.rule)]
 
     batch = _create_batch(signer, txns)
 
@@ -332,8 +331,8 @@ def _do_identity_policy_list(args):
             for policy in printable_policies:
                 output = [policy.name]
                 for entry in policy.entries:
-                    output.append(Policy.Type.Name(entry.type) + " " +
-                                  entry.key)
+                    output.append(
+                        Policy.Type.Name(entry.type) + " " + entry.key)
                 writer.writerow(output)
         except csv.Error:
             raise CliException('Error writing CSV')
@@ -367,7 +366,7 @@ def _do_identity_role_create(args):
     """
     signer = _read_signer(args.key)
     txns = [_create_role_txn(signer, args.name,
-            args.policy)]
+                             args.policy)]
 
     batch = _create_batch(signer, txns)
 
@@ -591,8 +590,7 @@ def _create_batch(signer, transactions):
     return Batch(
         header=batch_header,
         header_signature=signer.sign(batch_header),
-        transactions=transactions
-    )
+        transactions=transactions)
 
 
 def _to_hash(value):

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -112,18 +112,21 @@ def _do_config_proposal_list(args):
     Given a url, optional filters on prefix and public key, this command lists
     the current pending proposals for settings changes.
     """
+
     def _accept(candidate, public_key, prefix):
         # Check to see if the first public key matches the given public key
         # (if it is not None).  This public key belongs to the user that
         # created it.
-        has_pub_key = (not public_key or
-                       candidate.votes[0].public_key == public_key)
+        has_pub_key = (not public_key
+                       or candidate.votes[0].public_key == public_key)
         has_prefix = candidate.proposal.setting.startswith(prefix)
         return has_prefix and has_pub_key
 
     candidates_payload = _get_proposals(RestClient(args.url))
-    candidates = [c for c in candidates_payload.candidates
-                  if _accept(c, args.public_key, args.filter)]
+    candidates = [
+        c for c in candidates_payload.candidates
+        if _accept(c, args.public_key, args.filter)
+    ]
 
     if args.format == 'default':
         for candidate in candidates:
@@ -148,7 +151,7 @@ def _do_config_proposal_list(args):
             print(json.dumps(candidates_snapshot, indent=2, sort_keys=True))
         else:
             print(yaml.dump(candidates_snapshot,
-                  default_flow_style=False)[0:-1])
+                            default_flow_style=False)[0:-1])
     else:
         raise AssertionError('Unknown format {}'.format(args.format))
 
@@ -314,8 +317,7 @@ def _create_batch(signer, transactions):
     return Batch(
         header=batch_header,
         header_signature=signer.sign(batch_header),
-        transactions=transactions
-    )
+        transactions=transactions)
 
 
 def _create_propose_txn(signer, setting_key_value):

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -19,26 +19,22 @@ import subprocess
 
 from setuptools import setup, find_packages
 
-
-setup(name='sawtooth-cli',
-      version=subprocess.check_output(
-          ['../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth CLI',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'protobuf',
-          'sawtooth-signing',
-          'toml',
-          'PyYAML',
-          'requests'
-          ],
-      entry_points={
-          'console_scripts': [
-              'sawadm = sawtooth_cli.sawadm:main_wrapper',
-              'sawset = sawtooth_cli.sawset:main_wrapper',
-              'sawtooth = sawtooth_cli.main:main_wrapper'
-          ]
-      })
+setup(
+    name='sawtooth-cli',
+    version=subprocess.check_output(
+        ['../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth CLI',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog', 'protobuf', 'sawtooth-signing', 'toml', 'PyYAML',
+        'requests'
+    ],
+    entry_points={
+        'console_scripts': [
+            'sawadm = sawtooth_cli.sawadm:main_wrapper',
+            'sawset = sawtooth_cli.sawset:main_wrapper',
+            'sawtooth = sawtooth_cli.main:main_wrapper'
+        ]
+    })

--- a/cli/tests/test_genesis.py
+++ b/cli/tests/test_genesis.py
@@ -31,7 +31,6 @@ from sawtooth_cli.exceptions import CliException
 
 
 class TestGenesisDependencyValidation(unittest.TestCase):
-
     def __init__(self, test_name):
         super().__init__(test_name)
         self._temp_dir = None

--- a/consensus/poet/cli/sawtooth_poet_cli/registration.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/registration.py
@@ -198,8 +198,7 @@ def do_create(args):
         with open(args.output, 'wb') as batch_file:
             batch_file.write(batch_list.SerializeToString())
     except IOError as e:
-        raise CliException(
-            'Unable to write to batch file: {}'.format(str(e)))
+        raise CliException('Unable to write to batch file: {}'.format(str(e)))
 
 
 def _create_batch(signer, transactions):
@@ -222,8 +221,7 @@ def _create_batch(signer, transactions):
     return batch_pb.Batch(
         header=batch_header,
         header_signature=signer.sign(batch_header),
-        transactions=transactions
-    )
+        transactions=transactions)
 
 
 def _read_signer(key_filename):

--- a/consensus/poet/cli/setup.py
+++ b/consensus/poet/cli/setup.py
@@ -20,25 +20,23 @@ import subprocess
 
 from setuptools import setup, find_packages
 
-
-setup(name='sawtooth-poet-cli',
-      version=subprocess.check_output(
-          ['../../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth PoET CLI',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'protobuf',
-          'sawtooth-poet-common',
-          'sawtooth-poet-core',
-          'sawtooth-signing',
-          'sawtooth-validator',
-          'toml',
-          ],
-      entry_points={
-          'console_scripts': [
-              'poet = sawtooth_poet_cli.main:main_wrapper'
-          ]
-      })
+setup(
+    name='sawtooth-poet-cli',
+    version=subprocess.check_output(
+        ['../../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth PoET CLI',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog',
+        'protobuf',
+        'sawtooth-poet-common',
+        'sawtooth-poet-core',
+        'sawtooth-signing',
+        'sawtooth-validator',
+        'toml',
+    ],
+    entry_points={
+        'console_scripts': ['poet = sawtooth_poet_cli.main:main_wrapper']
+    })

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -28,7 +28,6 @@ import sawtooth_poet_common.protobuf.validator_registry_pb2 as vr_pb
 
 
 class TestValidatorRegistryGenesisTransaction(unittest.TestCase):
-
     def __init__(self, test_name):
         super().__init__(test_name)
         self._temp_dir = None

--- a/consensus/poet/cli/tests/test_genesis/tests.py
+++ b/consensus/poet/cli/tests/test_genesis/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=invalid-name
+
 import os
 import shutil
 import tempfile

--- a/consensus/poet/common/sawtooth_poet_common/validator_registry_view/validator_registry_view.py
+++ b/consensus/poet/common/sawtooth_poet_common/validator_registry_view/validator_registry_view.py
@@ -49,9 +49,11 @@ class ValidatorRegistryView(object):
         """
         validator_map_addr = ValidatorRegistryView._to_address('validator_map')
         leaves = self._state_view.leaves(_NAMESPACE)
-        infos = [ValidatorRegistryView._parse_validator_info(state_data)
-                 for address, state_data in leaves.items()
-                 if address != validator_map_addr]
+        infos = [
+            ValidatorRegistryView._parse_validator_info(state_data)
+            for address, state_data in leaves.items()
+            if address != validator_map_addr
+        ]
         return {info.id: info for info in infos}
 
     def has_validator_info(self, validator_id):

--- a/consensus/poet/common/setup.py
+++ b/consensus/poet/common/setup.py
@@ -20,15 +20,15 @@ import subprocess
 
 from setuptools import setup, find_packages
 
-
-setup(name='sawtooth-poet-common',
-      version=subprocess.check_output(
-          ['../../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth PoET Common Modules',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'protobuf',
-          ],
-      entry_points={})
+setup(
+    name='sawtooth-poet-common',
+    version=subprocess.check_output(
+        ['../../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth PoET Common Modules',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'protobuf',
+    ],
+    entry_points={})

--- a/consensus/poet/common/tests/test_sgx_structs/tests.py
+++ b/consensus/poet/common/tests/test_sgx_structs/tests.py
@@ -30,7 +30,6 @@ from sawtooth_poet_common import sgx_structs
 
 
 class TestSgxStructs(unittest.TestCase):
-
     @staticmethod
     def create_random_buffer(length):
         return os.urandom(length)

--- a/consensus/poet/common/tests/test_validator_registry_view/mocks.py
+++ b/consensus/poet/common/tests/test_validator_registry_view/mocks.py
@@ -36,6 +36,8 @@ class MockStateView(object):
 
     def leaves(self, prefix):
         """See sawtooth_validator.state.state_view.StateView.leaves"""
-        return {address: data
-                for address, data in self._state.items()
-                if address.startswith(prefix)}
+        return {
+            address: data
+            for address, data in self._state.items()
+            if address.startswith(prefix)
+        }

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_verifier.py
@@ -38,6 +38,7 @@ class PoetBlockVerifier(BlockVerifierInterface):
     considered as part of the fork being evaluated. BlockVerifier must be
     independent of block publishing activities.
     """
+
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/consensus/poet/core/setup.py
+++ b/consensus/poet/core/setup.py
@@ -34,5 +34,5 @@ setup(name='sawtooth-poet-core',
           'sawtooth-poet-simulator',
           'sawtooth-signing',
           'sawtooth-validator',
-          ],
+      ],
       entry_points={})

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -170,7 +170,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_signup_info,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher fails if
         a validator's signup info was not committed to
         the block chain within the allowed configured delay
@@ -296,7 +295,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_signup_info,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ K Policy: Test verifies that PoET Block Publisher fails if
             if a validator attempts to claim more blocks than is allowed
             by the key block claim limit
@@ -423,7 +421,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_signup_info,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ C Policy: Test verifies that PoET Block Publisher fails
         if a validator attempts to claim a block before
         the block claim delay block has passed
@@ -538,7 +535,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_signup_info,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Z Policy: Test verifies that PoET Block Publisher fails
         if a validator attempts to claim more blocks frequently than is allowed
         """
@@ -651,7 +647,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_signup_info,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher succeeds
         if a validator successfully passes all criteria necessary
         to publish a block
@@ -753,7 +748,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_wait_time,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher only claims
          readiness if the wait timer has expired
         """
@@ -865,7 +859,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_wait_time,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher doesn't
          claims readiness if the wait timer hasn't expired
         """

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher_finalize_block.py
@@ -76,7 +76,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_wait_certificate,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher doesn't finalize
             a candidate block that doesn't have a valid wait certificate.
         """
@@ -177,7 +176,6 @@ class TestPoetBlockPublisher(TestCase):
             mock_wait_certificate,
             mock_poet_settings_view,
             mock_block_wrapper):
-
         """ Test verifies that PoET Block Publisher finalizes the block,
             meaning that the candidate block is good and should be generated.
         """

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_verifier.py
@@ -182,7 +182,6 @@ class TestPoetBlockVerifier(TestCase):
                                                 mock_poet_settings_view,
                                                 mock_block_wrapper,
                                                 mock_consensus_state_store):
-
         """ Test verifies that PoET Block Verifier fails if a block is
         claimed by an unknown validator (the validator is not listed
         in the validator registry)
@@ -251,7 +250,6 @@ class TestPoetBlockVerifier(TestCase):
             mock_poet_settings_view,
             mock_block_wrapper,
             mock_consensus_state_store):
-
         """ Test verifies that PoET Block Verifier fails if
         a validator's signup info was not committed to
         the block chain within the allowed configured delay
@@ -324,7 +322,6 @@ class TestPoetBlockVerifier(TestCase):
                       mock_poet_settings_view,
                       mock_block_wrapper,
                       mock_consensus_state_store):
-
         """ Test verifies the K Policy: that PoET Block Verifier fails
         if a validator attempts to claim more blocks than is allowed
         by the key block claim limit
@@ -397,7 +394,6 @@ class TestPoetBlockVerifier(TestCase):
                       mock_poet_settings_view,
                       mock_block_wrapper,
                       mock_consensus_state_store):
-
         """ Test verifies the C Policy: that PoET Block Verifier fails
          if a validator attempts to claim a block before
          the block claim delay block has passed
@@ -471,7 +467,6 @@ class TestPoetBlockVerifier(TestCase):
                       mock_poet_settings_view,
                       mock_block_wrapper,
                       mock_consensus_state_store):
-
         """ Test verifies the Z Policy: that PoET Block Verifier fails
         if a validator attempts to claim more blocks frequently than is allowed
         """
@@ -544,7 +539,6 @@ class TestPoetBlockVerifier(TestCase):
             mock_poet_settings_view,
             mock_block_wrapper,
             mock_consensus_state_store):
-
         """ Test verifies that PoET Block Verifier succeeds if
         a validator successfully passes all criteria necessary
         to claim a block

--- a/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
@@ -60,7 +60,6 @@ class TestPoetForkResolver(TestCase):
             mock_consensus_state,
             mock_poet_enclave_factory,
             mock_consensus_state_store):
-
         """ Test verifies that if the new fork head is not a valid block,
             raises appropriate exception
         """
@@ -129,7 +128,6 @@ class TestPoetForkResolver(TestCase):
             mock_consensus_state,
             mock_poet_enclave_factory,
             mock_consensus_state_store):
-
         """ Test verifies that if the current fork head is not a valid block,
             and if new_fork_head.previous_block_id == cur_fork_head.identifier
             then the new fork head switches consensus. Otherwise, raises the
@@ -239,7 +237,6 @@ class TestPoetForkResolver(TestCase):
             mock_consensus_state,
             mock_poet_enclave_factory,
             mock_consensus_state_store):
-
         """ If both current and new fork heads are valid PoET blocks,
             the test checks if they share the same immediate previous block,
             then the one with the smaller wait duration is chosen
@@ -400,7 +397,6 @@ class TestPoetForkResolver(TestCase):
             mock_consensus_state,
             mock_poet_enclave_factory,
             mock_consensus_state_store):
-
         """ When both current and new fork heads are valid
             PoET blocks with different previous block ids,
             the test verifies that the one with

--- a/consensus/poet/core/tests/test_consensus/utils.py
+++ b/consensus/poet/core/tests/test_consensus/utils.py
@@ -25,6 +25,7 @@ CONTEXT = create_context('secp256k1')
 class AttrDict(dict):
     """ A simple mocking class.
      """
+
     def __init__(self, **kwargs):
         dict.__init__(self, *(), **kwargs)
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -56,6 +56,7 @@ def _config_short_hash(byte_str):
     # of an address part (see _config_key_to_address for information on
     return hashlib.sha256(byte_str).hexdigest()[:_CONFIG_ADDRESS_PART_SIZE]
 
+
 _CONFIG_ADDRESS_PADDING = _config_short_hash(byte_str=b'')
 
 

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/main.py
@@ -112,4 +112,5 @@ def main(args=None):
     finally:
         processor.stop()
 
+
 main()

--- a/consensus/poet/families/setup.py
+++ b/consensus/poet/families/setup.py
@@ -24,11 +24,14 @@ from setuptools import setup, find_packages
 data_files = []
 
 if os.path.exists("/etc/default"):
-    data_files.append(('/etc/default', ['packaging/systemd/sawtooth-poet-validator-registry-tp']))
+    data_files.append(
+        ('/etc/default',
+         ['packaging/systemd/sawtooth-poet-validator-registry-tp']))
 
 if os.path.exists("/lib/systemd/system"):
-    data_files.append(('/lib/systemd/system',
-                       ['packaging/systemd/sawtooth-poet-validator-registry-tp.service']))
+    data_files.append(
+        ('/lib/systemd/system',
+         ['packaging/systemd/sawtooth-poet-validator-registry-tp.service']))
 
 
 setup(name='sawtooth-poet-families',
@@ -44,7 +47,7 @@ setup(name='sawtooth-poet-families',
           'sawtooth-poet-common',
           'sawtooth-sdk',
           'sawtooth-signing',
-          ],
+      ],
       data_files=data_files,
       entry_points={
           'console_scripts': [

--- a/consensus/poet/sgx/setup.py
+++ b/consensus/poet/sgx/setup.py
@@ -57,22 +57,20 @@ include_dirs += ['sawtooth_poet_sgx/poet_enclave_sgx',
                  '../common/c11_support/{}'.format(platform_dir)]
 library_dirs = ['deps/lib']
 
-enclavemod = Extension('_poet_enclave',
-                       ['sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.i',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/common.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/poet.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/wait_certificate.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/wait_timer.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/signup_data.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/signup_info.cpp',
-                        'sawtooth_poet_sgx/poet_enclave_sgx/{}/platform_support.cpp'.format(
-                            platform_dir)
-                        ],
-                       swig_opts=['-c++'],
-                       extra_compile_args=extra_compile_args,
-                       include_dirs=include_dirs,
-                       libraries=libraries,
-                       library_dirs=library_dirs)
+enclavemod = Extension(
+    '_poet_enclave',
+    ['sawtooth_poet_sgx/poet_enclave_sgx/poet_enclave.i',
+     'sawtooth_poet_sgx/poet_enclave_sgx/common.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/poet.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/wait_certificate.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/wait_timer.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/signup_data.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/signup_info.cpp',
+     'sawtooth_poet_sgx/poet_enclave_sgx/{}/platform_support.cpp'.format(
+         platform_dir)],
+    swig_opts=['-c++'],
+    extra_compile_args=extra_compile_args, include_dirs=include_dirs,
+    libraries=libraries, library_dirs=library_dirs)
 
 
 class Build(build_module.build):
@@ -107,6 +105,7 @@ class Build(build_module.build):
         self.build_poet()
         build_module.build.run(self)
 
+
 if os.name == 'nt':
     conf_dir = "C:\\Program Files (x86)\\Intel\\sawtooth\\conf"
 else:
@@ -123,7 +122,7 @@ setup(name='sawtooth-poet-sgx',
           'toml',
           'sawtooth-ias-client',
           'sawtooth-poet-common'
-          ],
+      ],
       ext_modules=[enclavemod],
       py_modules=['sawtooth_poet_sgx.poet_enclave_sgx.poet_enclave'],
       data_files=[

--- a/consensus/poet/simulator/setup.py
+++ b/consensus/poet/simulator/setup.py
@@ -43,6 +43,6 @@ setup(name='sawtooth-poet-simulator',
           'sawtooth-poet-simulator',
           'sawtooth-signing',
           'sawtooth-validator',
-          ],
+      ],
       data_files=data_files,
       entry_points={})

--- a/docker/compose/run-lint.yaml
+++ b/docker/compose/run-lint.yaml
@@ -1,0 +1,10 @@
+version: "2.1"
+
+services:
+
+  client:
+    image: sawtooth-dev-python:latest
+    container_name: run-lint
+    volumes:
+      - ../../:/project/sawtooth-core
+    entrypoint: run_lint

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -45,7 +45,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
     inetutils-ping \
     libffi-dev \
     libssl-dev \
-    pep8 \
     python3-aiodns=1.1.1-1 \
     python3-aiohttp>=2.3.2-1 \
     python3-aiopg \
@@ -86,6 +85,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
     pylint \
+    pycodestyle \
     bandit \
     coverage --upgrade
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -166,7 +166,7 @@ html_theme = 'sphinx_rtd_theme'
 # Single values can also be put in this dictionary using the -A command-line
 # option of sphinx-build.
 html_context = {
-  'css_files': ['_static/theme_overrides.css']
+    'css_files': ['_static/theme_overrides.css']
 }
 
 # The name of an image file (relative to this directory) to place at the top
@@ -253,25 +253,25 @@ PREAMBLE = ''
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-'preamble': PREAMBLE,
+    # Additional stuff for the LaTeX preamble.
+    'preamble': PREAMBLE,
 
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'sawtooth.tex', u'Sawtooth Documentation',
-   u'Intel Corporation', 'manual')
+    (master_doc, 'sawtooth.tex', u'Sawtooth Documentation',
+     u'Intel Corporation', 'manual')
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -314,9 +314,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'SawtoothLake', u'Sawtooth Documentation',
-   author, 'SawtoothLake', 'One line description of project.',
-   'Miscellaneous'),
+    (master_doc, 'SawtoothLake', u'Sawtooth Documentation',
+     author, 'SawtoothLake', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/families/battleship/sawtooth_battleship/battleship_board.py
+++ b/families/battleship/sawtooth_battleship/battleship_board.py
@@ -166,6 +166,7 @@ class ShipPosition(object):
         column (int): First column on which the ship appears (starts at 0)
         orientation (str): Whether placed horizontal or vertical
     """
+
     def __init__(self, text, row, column, orientation):
         self.text = text
         self.row = row

--- a/families/block_info/sawtooth_block_info/injector.py
+++ b/families/block_info/sawtooth_block_info/injector.py
@@ -34,6 +34,7 @@ from sawtooth_block_info.common import BLOCK_INFO_NAMESPACE
 
 class BlockInfoInjector(BatchInjector):
     """Inject BlockInfo transactions at the beginning of blocks."""
+
     def __init__(self, block_store, state_view_factory, signer):
         self._block_store = block_store
         self._state_view_factory = state_view_factory

--- a/families/block_info/setup.py
+++ b/families/block_info/setup.py
@@ -27,21 +27,21 @@ if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',
                        ['packaging/systemd/sawtooth-block-info-tp.service']))
 
-setup(name='sawtooth-block-info',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Block Info Transaction Processor',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'protobuf',
-          'sawtooth-sdk',
-          ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'block-info-tp= sawtooth_block_info.processor.main:main'
-          ]
-      })
+setup(
+    name='sawtooth-block-info',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Block Info Transaction Processor',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog',
+        'protobuf',
+        'sawtooth-sdk',
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts':
+        ['block-info-tp= sawtooth_block_info.processor.main:main']
+    })

--- a/families/block_info/tests/test_tp_block_info.py
+++ b/families/block_info/tests/test_tp_block_info.py
@@ -32,19 +32,24 @@ from sawtooth_block_info.common import DEFAULT_TARGET_COUNT
 from sawtooth_block_info.common import create_block_address
 
 
-def create_block_info(block_num, signer_public_key="2" * 66,
-                      header_signature="1" * 128, timestamp=None,
+def create_block_info(block_num,
+                      signer_public_key="2" * 66,
+                      header_signature="1" * 128,
+                      timestamp=None,
                       previous_block_id="0" * 128):
     if timestamp is None:
         timestamp = int(time.time())
 
     return BlockInfo(
-        block_num=block_num, signer_public_key=signer_public_key,
-        header_signature=header_signature, timestamp=timestamp,
+        block_num=block_num,
+        signer_public_key=signer_public_key,
+        header_signature=header_signature,
+        timestamp=timestamp,
         previous_block_id=previous_block_id)
 
 
-def create_config(latest_block, oldest_block=None,
+def create_config(latest_block,
+                  oldest_block=None,
                   target_count=DEFAULT_TARGET_COUNT,
                   sync_tolerance=DEFAULT_SYNC_TOLERANCE):
     if oldest_block is None:
@@ -57,7 +62,6 @@ def create_config(latest_block, oldest_block=None,
 
 
 class TestBlockInfo(TransactionProcessorTestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -67,19 +71,22 @@ class TestBlockInfo(TransactionProcessorTestCase):
             namespace=NAMESPACE,
         )
 
-    def _send_request(self, block,
-                      sync_tolerance=None, target_count=None):
+    def _send_request(self, block, sync_tolerance=None, target_count=None):
         block_info_txn = BlockInfoTxn(
-            block=block, sync_tolerance=sync_tolerance,
+            block=block,
+            sync_tolerance=sync_tolerance,
             target_count=target_count)
 
-        self.validator.send(self.factory.create_tp_process_request(
-            payload=block_info_txn.SerializeToString(),
-            inputs=None, outputs=None, deps=None))
+        self.validator.send(
+            self.factory.create_tp_process_request(
+                payload=block_info_txn.SerializeToString(),
+                inputs=None,
+                outputs=None,
+                deps=None))
 
     def _expect_config_get(self, config=None):
-        received = self.validator.expect(self.factory.create_get_request(
-            addresses=[CONFIG_ADDRESS]))
+        received = self.validator.expect(
+            self.factory.create_get_request(addresses=[CONFIG_ADDRESS]))
 
         response = {} if config is None \
             else {CONFIG_ADDRESS: config.SerializeToString()}
@@ -87,27 +94,30 @@ class TestBlockInfo(TransactionProcessorTestCase):
             self.factory.create_get_response(response), received)
 
     def _expect_block_get(self, block):
-        received = self.validator.expect(self.factory.create_get_request(
-            addresses=[create_block_address(block.block_num)]))
+        received = self.validator.expect(
+            self.factory.create_get_request(
+                addresses=[create_block_address(block.block_num)]))
 
-        self.validator.respond(self.factory.create_get_response({
-            create_block_address(block.block_num): block.SerializeToString()
-        }), received)
+        self.validator.respond(
+            self.factory.create_get_response({
+                create_block_address(block.block_num):
+                block.SerializeToString()
+            }), received)
 
     def _expect_set(self, sets):
-        received = self.validator.expect(self.factory.create_set_request({
-            k: v.SerializeToString() for k, v in sets.items()
-        }))
-        self.validator.respond(self.factory.create_set_response(
-            addresses=sets.keys()), received)
+        received = self.validator.expect(
+            self.factory.create_set_request(
+                {k: v.SerializeToString()
+                 for k, v in sets.items()}))
+        self.validator.respond(
+            self.factory.create_set_response(addresses=sets.keys()), received)
 
     def _expect_delete(self, deletes):
-        received = self.validator.expect(self.factory.create_delete_request(
-            addresses=deletes
-        ))
+        received = self.validator.expect(
+            self.factory.create_delete_request(addresses=deletes))
 
-        self.validator.respond(self.factory.create_delete_response(
-            addresses=deletes), received)
+        self.validator.respond(
+            self.factory.create_delete_response(addresses=deletes), received)
 
     def _expect_response(self, status):
         self.validator.expect(self.factory.create_tp_response(status))

--- a/families/identity/sawtooth_identity/processor/handler.py
+++ b/families/identity/sawtooth_identity/processor/handler.py
@@ -166,8 +166,9 @@ def _set_policy(data, context):
 
         # sort all roles by using sorted(roles, policy.name)
         # if a policy with the same name exists, replace that policy
-        policies = [x for x in policy_list.policies if x.name !=
-                    new_policy.name]
+        policies = [
+            x for x in policy_list.policies if x.name != new_policy.name
+        ]
         policies.append(new_policy)
         policies = sorted(policies, key=lambda role: role.name)
     else:
@@ -177,8 +178,9 @@ def _set_policy(data, context):
 
     # Store policy in a PolicyList incase of hash collisions
     new_policy_list = PolicyList(policies=policies)
-    addresses = context.set_state(
-        {address: new_policy_list.SerializeToString()})
+    addresses = context.set_state({
+        address: new_policy_list.SerializeToString()
+    })
 
     if not addresses:
         LOGGER.warning('Failed to set policy %s at %s', new_policy.name,
@@ -206,8 +208,8 @@ def _set_role(data, context):
 
     if entries_list == []:
         raise InvalidTransaction(
-            "Cannot set Role: {}, the Policy: {} is not set."
-            .format(role.name, role.policy_name))
+            "Cannot set Role: {}, the Policy: {} is not set.".format(
+                role.name, role.policy_name))
     else:
         policy_list = PolicyList()
         policy_list.ParseFromString(entries_list[0].data)
@@ -219,8 +221,8 @@ def _set_role(data, context):
 
         if not exist:
             raise InvalidTransaction(
-                "Cannot set Role {}, the Policy {} is not set."
-                .format(role.name, role.policy_name))
+                "Cannot set Role {}, the Policy {} is not set.".format(
+                    role.name, role.policy_name))
 
     address = _get_role_address(role.name)
     entries_list = _get_data(address, context)
@@ -236,16 +238,17 @@ def _set_role(data, context):
     roles = sorted(roles, key=lambda role: role.name)
 
     # set RoleList at the address above.
-    addresses = context.set_state(
-        {address: RoleList(roles=roles).SerializeToString()})
+    addresses = context.set_state({
+        address:
+        RoleList(roles=roles).SerializeToString()
+    })
 
     if not addresses:
         LOGGER.warning('Failed to set role %s at %s', role.name, address)
         raise InternalError('Unable to save role {}'.format(role.name))
 
     context.add_event(
-        event_type="identity/update",
-        attributes=[("updated", role.name)])
+        event_type="identity/update", attributes=[("updated", role.name)])
     LOGGER.debug("Set role: \n%s", role)
 
 

--- a/families/identity/setup.py
+++ b/families/identity/setup.py
@@ -31,21 +31,21 @@ if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',
                        ['packaging/systemd/sawtooth-identity-tp.service']))
 
-setup(name='sawtooth-identity',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Identity Transaction Processor',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'protobuf',
-          'sawtooth-sdk',
-          ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'identity-tp= sawtooth_identity.processor.main:main'
-          ]
-      })
+setup(
+    name='sawtooth-identity',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Identity Transaction Processor',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog',
+        'protobuf',
+        'sawtooth-sdk',
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts':
+        ['identity-tp= sawtooth_identity.processor.main:main']
+    })

--- a/families/identity/tests/sawtooth_identity_test/identity_message_factory.py
+++ b/families/identity/tests/sawtooth_identity_test/identity_message_factory.py
@@ -34,7 +34,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IdentityMessageFactory(object):
-
     def __init__(self, signer=None):
         self._factory = MessageFactory(
             family_name="sawtooth_identity",
@@ -56,8 +55,9 @@ class IdentityMessageFactory(object):
 
         # compute the short hash of each part
         addr_parts = [self._to_hash(key_parts[0])[:_FIRST_ADDRESS_PART_SIZE]]
-        addr_parts += [self._to_hash(x)[:_ADDRESS_PART_SIZE] for x in
-                       key_parts[1:]]
+        addr_parts += [
+            self._to_hash(x)[:_ADDRESS_PART_SIZE] for x in key_parts[1:]
+        ]
         # pad the parts with the empty hash, if needed
         addr_parts.extend([_EMPTY_PART] * (_MAX_KEY_PARTS - len(addr_parts)))
         return self._factory.namespace + _ROLE_PREFIX + ''.join(addr_parts)
@@ -78,8 +78,10 @@ class IdentityMessageFactory(object):
         if payload.type == IdentityPayload.ROLE:
             role = Role()
             role.ParseFromString(payload.data)
-            inputs = [self._role_to_address(role.name),
-                      self._policy_to_address(role.policy_name)]
+            inputs = [
+                self._role_to_address(role.name),
+                self._policy_to_address(role.policy_name)
+            ]
 
             outputs = [self._role_to_address(role.name)]
         else:

--- a/families/settings/sawtooth_settings/processor/handler.py
+++ b/families/settings/sawtooth_settings/processor/handler.py
@@ -42,7 +42,6 @@ STATE_TIMEOUT_SEC = 10
 
 
 class SettingsTransactionHandler(TransactionHandler):
-
     @property
     def family_name(self):
         return 'sawtooth_settings'

--- a/families/settings/setup.py
+++ b/families/settings/setup.py
@@ -31,21 +31,21 @@ if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',
                        ['packaging/systemd/sawtooth-settings-tp.service']))
 
-setup(name='sawtooth-settings',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Settings Transaction Processor',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'protobuf',
-          'sawtooth-sdk',
-          ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'settings-tp= sawtooth_settings.processor.main:main'
-          ]
-      })
+setup(
+    name='sawtooth-settings',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Settings Transaction Processor',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog',
+        'protobuf',
+        'sawtooth-sdk',
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts':
+        ['settings-tp= sawtooth_settings.processor.main:main']
+    })

--- a/families/settings/tests/sawtooth_settings_test/settings_message_factory.py
+++ b/families/settings/tests/sawtooth_settings_test/settings_message_factory.py
@@ -24,14 +24,12 @@ _ADDRESS_PART_SIZE = 16
 
 
 class SettingsMessageFactory(object):
-
     def __init__(self, signer=None):
         self._factory = MessageFactory(
             family_name="sawtooth_settings",
             family_version="1.0",
             namespace="000000",
-            signer=signer
-        )
+            signer=signer)
 
     @property
     def public_key(self):

--- a/integration/sawtooth_integration/tests/integration_tools.py
+++ b/integration/sawtooth_integration/tests/integration_tools.py
@@ -170,8 +170,6 @@ class XoClient(RestClient):
             ]
         }
 
-        return data.decode().split('|')
-
     def make_xo_address(self, name):
         return self.namespace + hashlib.sha512(name.encode()).hexdigest()[0:64]
 

--- a/integration/sawtooth_integration/tests/integration_tools.py
+++ b/integration/sawtooth_integration/tests/integration_tools.py
@@ -236,7 +236,6 @@ def wait_for_rest_apis(endpoints, tries=5):
 
 
 class SetSawtoothHome(object):
-
     def __init__(self, sawtooth_home):
         self._sawtooth_home = sawtooth_home
 

--- a/integration/sawtooth_integration/tests/intkey_client.py
+++ b/integration/sawtooth_integration/tests/intkey_client.py
@@ -44,9 +44,7 @@ class IntkeyClient(RestClient):
     def calculate_tolerance(self):
         length = len(list(self.list_blocks()))
         # the most recent nth of the chain, at least 2 blocks
-        return max(
-            2,
-            length // 5)
+        return max(2, length // 5)
 
     def poll_for_batches(self, batch_ids):
         """Poll timeout seconds for a batch status to become
@@ -62,7 +60,8 @@ class IntkeyClient(RestClient):
 
             res = self._get(
                 '/batch_statuses',
-                id=','.join(batch_ids), wait=(self.wait - time_waited))
+                id=','.join(batch_ids),
+                wait=(self.wait - time_waited))
 
             if 'PENDING' not in [data['status'] for data in res['data']]:
                 return

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -32,24 +32,24 @@ def peer_with_genesis_only(num):
     if num > 0:
         return '--peers {}'.format(
             endpoint(0))
-    else:
-        return ''
+
+    return ''
 
 
 def peer_to_preceding_only(num):
     if num > 0:
         return '--peers {}'.format(
             endpoint(num - 1))
-    else:
-        return ''
+
+    return ''
 
 
 def everyone_peers_with_everyone(num):
     if num > 0:
         peers = ','.join(endpoint(i) for i in range(num))
         return '--peers {}'.format(peers)
-    else:
-        return ''
+
+    return ''
 
 
 # processor arrangements
@@ -226,7 +226,7 @@ def validator_cmds(num,
             os.path.join(sawtooth_home, 'data', 'poet.batch'))
     ])
 
-    validator_cmds = (
+    validator_cmd_list = (
         [keygen, validator] if num > 0
         else [
             keygen,
@@ -238,7 +238,7 @@ def validator_cmds(num,
         ]
     )
 
-    return validator_cmds
+    return validator_cmd_list
 
 
 def simple_validator_cmds(*args, **kwargs):
@@ -284,7 +284,7 @@ def processor_cmds(num, processor_func):
     '''
     processors = processor_func(num)
 
-    processor_cmds = [
+    processor_cmd_list = [
         '{p} {v} -C {a}'.format(
             p=processor,
             v=(processor_verbosity(processor)),
@@ -292,7 +292,7 @@ def processor_cmds(num, processor_func):
         for processor in processors
     ]
 
-    return processor_cmds
+    return processor_cmd_list
 
 
 def processor_verbosity(processor_name):

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -125,7 +125,7 @@ def stop_node(process_list):
     for _ in range(2):
         for process in process_list:
             pid = process.pid
-            LOGGER.debug('Stopping process {}'.format(pid))
+            LOGGER.debug('Stopping process %s', pid)
             process.send_signal(signal.SIGINT)
         time.sleep(15)
 
@@ -355,6 +355,6 @@ def bind_network(num):
 # execution
 
 def start_process(cmd):
-    LOGGER.debug('Running command {}'.format(cmd))
+    LOGGER.debug('Running command %s', cmd)
     return subprocess.Popen(
         shlex.split(cmd))

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -35,12 +35,14 @@ def peer_with_genesis_only(num):
     else:
         return ''
 
+
 def peer_to_preceding_only(num):
     if num > 0:
         return '--peers {}'.format(
             endpoint(num - 1))
     else:
         return ''
+
 
 def everyone_peers_with_everyone(num):
     if num > 0:
@@ -56,8 +58,15 @@ def intkey_config_registry(num):
     # all nodes get the same processors
     return 'intkey-tp-python', 'settings-tp', 'poet-validator-registry-tp'
 
+
 def intkey_config_identity_registry(num):
-    return 'intkey-tp-python', 'settings-tp', 'identity-tp', 'poet-validator-registry-tp'
+    return (
+        'intkey-tp-python',
+        'settings-tp',
+        'identity-tp',
+        'poet-validator-registry-tp',
+    )
+
 
 def intkey_xo_config_registry(num):
     # all nodes get the same processors
@@ -74,11 +83,14 @@ def intkey_xo_config_registry(num):
 def all_serial(num):
     return 'serial'
 
+
 def all_parallel(num):
     return 'parallel'
 
+
 def even_parallel_odd_serial(num):
     return 'parallel' if num % 2 == 0 else 'serial'
+
 
 def even_serial_odd_parallel(num):
     return 'parallel' if num % 2 == 1 else 'serial'
@@ -105,6 +117,7 @@ def start_node(num,
     wait_for_rest_apis(['127.0.0.1:{}'.format(8008 + num)], tries=20)
 
     return [rest_api] + processors + [validator]
+
 
 def stop_node(process_list):
     # This may seem a little dramatic, but seriously,
@@ -167,7 +180,7 @@ def validator_cmds(num,
 
     with open(
         '/project/sawtooth-core/consensus/poet/simulator/packaging/'
-        'simulator_rk_pub.pem') as fd:
+            'simulator_rk_pub.pem') as fd:
         public_key_pem = fd.read()
 
     # Use the poet CLI to get the enclave measurement so that we can put the
@@ -281,6 +294,7 @@ def processor_cmds(num, processor_func):
 
     return processor_cmds
 
+
 def processor_verbosity(processor_name):
     '''
     Transactions processors like intkey and xo are very talkative,
@@ -294,6 +308,7 @@ def processor_verbosity(processor_name):
             return '-v'
 
     return ''
+
 
 def start_processors(num, processor_func):
     return [
@@ -310,6 +325,7 @@ def rest_api_cmd(num):
         p=(8008 + num)
     )
 
+
 def start_rest_api(num):
     return start_process(
         rest_api_cmd(num))
@@ -319,14 +335,18 @@ def start_rest_api(num):
 def endpoint(num):
     return 'tcp://127.0.0.1:{}'.format(8800 + num)
 
+
 def connection_address(num):
     return 'tcp://127.0.0.1:{}'.format(4004 + num)
+
 
 def http_address(num):
     return 'http://127.0.0.1:{}'.format(8008 + num)
 
+
 def bind_component(num):
     return 'tcp://127.0.0.1:{}'.format(4004 + num)
+
 
 def bind_network(num):
     return 'tcp://127.0.0.1:{}'.format(8800 + num)

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=protected-access
+
 import unittest
 import logging
 import ssl

--- a/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_basic_auth_proxy.py
@@ -29,7 +29,6 @@ LOGGER.setLevel(logging.INFO)
 
 
 class TestBasicAuth(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         wait_until_status('http://rest-api:8008/blocks', status_code=200)

--- a/integration/sawtooth_integration/tests/test_block_info_injector.py
+++ b/integration/sawtooth_integration/tests/test_block_info_injector.py
@@ -62,7 +62,9 @@ def post_batch(batch):
     return response
 
 
-def query_rest_api(suffix='', data=None, headers={}):
+def query_rest_api(suffix='', data=None, headers=None):
+    if headers is None:
+        headers = {}
     url = 'http://rest-api:8008' + suffix
     return submit_request(urllib.request.Request(url, data, headers))
 
@@ -86,8 +88,8 @@ class TestBlockInfoInjector(unittest.TestCase):
         batches = make_batches('abcd')
 
         # Assert all block info transactions are committed
-        for i in range(len(batches)):
-            post_batch(batches[i])
+        for i, batch in enumerate(batches):
+            post_batch(batch)
             block_info = get_block_info(i)
             self.assertEqual(block_info.block_num, i)
 

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -35,7 +35,6 @@ TEST_PUBKEY = \
 
 
 class TestConfigSmoke(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         wait_for_rest_apis(['rest-api:8008'])
@@ -53,10 +52,11 @@ class TestConfigSmoke(unittest.TestCase):
     def _run(self, args):
         try:
             LOGGER.debug("Running %s", " ".join(args))
-            proc = subprocess.run(args,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.PIPE,
-                                  check=True)
+            proc = subprocess.run(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=True)
             LOGGER.debug(proc.stdout.decode())
         except subprocess.CalledProcessError as err:
             LOGGER.debug(err)
@@ -99,7 +99,8 @@ class TestConfigSmoke(unittest.TestCase):
         settings = self._read_from_stdout(command, args).split('\n')
 
         _expected_output = [
-            'sawtooth.settings.vote.authorized_keys: {:15}'.format(TEST_PUBKEY),
+            'sawtooth.settings.vote.authorized_keys: {:15}'.format(
+                TEST_PUBKEY),
             'x: 1',
             'y: 1']
         _fail_msg = 'Setting results did not match.'

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -19,10 +19,10 @@ import traceback
 import tempfile
 import os
 import subprocess
-from sawtooth_cli.main import main
 import sys
 from io import StringIO
 
+from sawtooth_cli.main import main
 from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 LOGGER = logging.getLogger(__name__)

--- a/integration/sawtooth_integration/tests/test_dynamic_network.py
+++ b/integration/sawtooth_integration/tests/test_dynamic_network.py
@@ -155,7 +155,7 @@ class TestDynamicNetwork(unittest.TestCase):
             client.poll_for_batches([batch_id])
 
     def send_increment_batch(self, client, batch_num, time_between_batches):
-        LOGGER.info('Sending batch {} @ {}'.format(batch_num, client.url))
+        LOGGER.info('Sending batch %s @ %s', batch_num, client.url)
         return client.send_txns(self.increment)
 
     def send_populate_batch(self, time_between_batches):
@@ -179,7 +179,7 @@ class TestDynamicNetwork(unittest.TestCase):
                    peering,
                    schedulers,
                    poet_kwargs):
-        LOGGER.info('Starting node {}'.format(num))
+        LOGGER.info('Starting node %s', num)
         sawtooth_home = mkdtemp()
         with SetSawtoothHome(sawtooth_home):
             processes = NodeController.start_node(
@@ -205,7 +205,7 @@ class TestDynamicNetwork(unittest.TestCase):
             self.clients.pop(num)
 
     def stop_node(self, num):
-        LOGGER.info('Stopping node {}'.format(num))
+        LOGGER.info('Stopping node %s', num)
         processes = self.nodes[num]
         NodeController.stop_node(processes)
         time.sleep(1)
@@ -222,12 +222,12 @@ class TestDynamicNetwork(unittest.TestCase):
     def in_consensus(self):
         tolerance = self.earliest_client().calculate_tolerance()
 
-        LOGGER.info('Verifying consensus @ tolerance {}'.format(tolerance))
+        LOGGER.info('Verifying consensus @ tolerance %s', tolerance)
 
         # for convenience, list the blocks
         for client in self.clients.values():
             url = client.url
-            LOGGER.info('Blocks @ {}'.format(url))
+            LOGGER.info('Blocks @ %s', url)
             subprocess.run(shlex.split(
                 'sawtooth block list --url {}'.format(url)))
 

--- a/integration/sawtooth_integration/tests/test_dynamic_network.py
+++ b/integration/sawtooth_integration/tests/test_dynamic_network.py
@@ -29,6 +29,7 @@ LOGGER.setLevel(logging.INFO)
 WAIT = 120
 ASSERT_CONSENSUS_TIMEOUT = 90
 
+
 class TestDynamicNetwork(unittest.TestCase):
     def setUp(self):
         self.nodes = {}
@@ -191,7 +192,8 @@ class TestDynamicNetwork(unittest.TestCase):
                 raise subprocess.CalledProcessError(proc.pid, proc.returncode)
 
         self.nodes[num] = processes
-        self.clients[num] = IntkeyClient(NodeController.http_address(num), WAIT)
+        self.clients[num] = IntkeyClient(
+            NodeController.http_address(num), WAIT)
         time.sleep(1)
 
     # nodes are stopped in FIFO order
@@ -244,6 +246,7 @@ class TestDynamicNetwork(unittest.TestCase):
     def earliest_client(self):
         earliest = min(self.clients.keys())
         return self.clients[earliest]
+
 
 def make_txns():
     jacksons = 'michael', 'tito', 'jackie', 'jermaine', 'marlon'

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -18,8 +18,6 @@ import logging
 import json
 import urllib.request
 import urllib.error
-import base64
-import sys
 
 import cbor
 

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -132,7 +132,7 @@ class TestEventsAndReceipts(unittest.TestCase):
             block_num = list(filter(
                 lambda attr: attr.key == "block_num",
                 block_commit_event.attributes))[0].value
-            self.assertEqual((block_num, block_id), blocks[i+1])
+            self.assertEqual((block_num, block_id), blocks[i + 1])
 
         self._unsubscribe()
 
@@ -189,7 +189,8 @@ class TestEventsAndReceipts(unittest.TestCase):
     def _subscribe(self, subscriptions=None, last_known_block_ids=None):
         if subscriptions is None:
             subscriptions = [
-                events_pb2.EventSubscription(event_type="sawtooth/block-commit"),
+                events_pb2.EventSubscription(
+                    event_type="sawtooth/block-commit"),
             ]
         if last_known_block_ids is None:
             last_known_block_ids = []
@@ -210,15 +211,17 @@ class TestEventsAndReceipts(unittest.TestCase):
 
     def assert_block_commit_event(self, event, block_num):
         self.assertEqual(event.event_type, "sawtooth/block-commit")
-        self.assertTrue(all([
-            any(attribute.key == "block_id" for attribute in event.attributes),
-            any(attribute.key == "block_num"
-                for attribute in event.attributes),
-            any(attribute.key == "previous_block_id"
-                for attribute in event.attributes),
-            any(attribute.key == "state_root_hash"
-                for attribute in event.attributes),
-        ]))
+        self.assertTrue(
+            all([
+                any(attribute.key == "block_id"
+                    for attribute in event.attributes),
+                any(attribute.key == "block_num"
+                    for attribute in event.attributes),
+                any(attribute.key == "previous_block_id"
+                    for attribute in event.attributes),
+                any(attribute.key == "state_root_hash"
+                    for attribute in event.attributes),
+            ]))
         for attribute in event.attributes:
             if attribute.key == "block_num":
                 self.assertEqual(attribute.value, str(block_num))
@@ -256,11 +259,11 @@ class TestEventsAndReceipts(unittest.TestCase):
             msg.message_type,
             validator_pb2.Message.CLIENT_EVENTS_SUBSCRIBE_RESPONSE)
 
-        subscription_response = client_event_pb2.ClientEventsSubscribeResponse()
-        subscription_response.ParseFromString(msg.content)
+        response = client_event_pb2.ClientEventsSubscribeResponse()
+        response.ParseFromString(msg.content)
 
         self.assertEqual(
-            subscription_response.status,
+            response.status,
             client_event_pb2.ClientEventsSubscribeResponse.OK)
 
     def assert_unsubscribe_response(self, msg):
@@ -268,11 +271,12 @@ class TestEventsAndReceipts(unittest.TestCase):
             msg.message_type,
             validator_pb2.Message.CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE)
 
-        subscription_response = client_event_pb2.ClientEventsUnsubscribeResponse()
-        subscription_response.ParseFromString(msg.content)
+        response = client_event_pb2.ClientEventsUnsubscribeResponse()
+
+        response.ParseFromString(msg.content)
 
         self.assertEqual(
-            subscription_response.status,
+            response.status,
             client_event_pb2.ClientEventsUnsubscribeResponse.OK)
 
 

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -165,9 +165,9 @@ class TestEventsAndReceipts(unittest.TestCase):
         if self.stream is not None:
             self.stream.close()
 
-    def _get_receipt(self, n):
+    def _get_receipt(self, num):
         txn_id = \
-            self.batch_submitter.batches[n].transactions[0].header_signature
+            self.batch_submitter.batches[num].transactions[0].header_signature
         request = client_receipt_pb2.ClientReceiptGetRequest(
             transaction_ids=[txn_id])
         response = self.stream.send(
@@ -295,21 +295,23 @@ class BatchSubmitter:
         return self._submit_request('{}&wait={}'.format(
             response['link'], self.timeout))
 
-    def _query_rest_api(self, suffix='', data=None, headers={},
+    def _query_rest_api(self, suffix='', data=None, headers=None,
                         expected_code=200):
+        if headers is None:
+            headers = {}
         url = 'http://rest-api:8008' + suffix
         return self._submit_request(urllib.request.Request(url, data, headers),
                                     expected_code=expected_code)
 
     def _submit_request(self, request, expected_code=200):
         conn = urllib.request.urlopen(request)
-        assert(expected_code == conn.getcode())
+        assert expected_code == conn.getcode()
 
         response = conn.read().decode('utf-8')
         return json.loads(response)
 
-    def make_batch(self, n):
-        return self.imf.create_batch([('set', str(n), 0)])
+    def make_batch(self, num):
+        return self.imf.create_batch([('set', str(num), 0)])
 
     def submit_next_batch(self):
         batch_list_bytes = self.make_batch(len(self.batches))

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -141,7 +141,9 @@ def _get_state():
     return response['data']
 
 
-def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
+def _query_rest_api(suffix='', data=None, headers=None, expected_code=200):
+    if headers is None:
+        headers = {}
     url = 'http://rest-api:8008' + suffix
     return _submit_request(urllib.request.Request(url, data, headers),
                            expected_code=expected_code)
@@ -149,7 +151,7 @@ def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
 
 def _submit_request(request, expected_code=200):
     conn = urllib.request.urlopen(request)
-    assert(expected_code == conn.getcode())
+    assert expected_code == conn.getcode()
 
     response = conn.read().decode('utf-8')
     return json.loads(response)

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable = attribute-defined-outside-init
+
 import unittest
 import logging
 import operator  # used by verifier

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -36,7 +36,6 @@ INTKEY_PREFIX = '1cf126'
 
 
 class TestIntkeySmoke(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         wait_for_rest_apis(['rest-api:8008'])

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -93,10 +93,10 @@ class TestIntkeySmoke(unittest.TestCase):
         self.verify_state_after_n_updates(how_many_updates)
 
     def verify_state_after_n_updates(self, num):
-        LOGGER.debug('Verifying state after {} updates'.format(num))
+        LOGGER.debug('Verifying state after %s updates', num)
         expected_state = self.verifier.state_after_n_updates(num)
         actual_state = _get_data()
-        LOGGER.info('Current state: {}'.format(actual_state))
+        LOGGER.info('Current state: %s', actual_state)
         self.assertEqual(
             expected_state,
             actual_state,

--- a/integration/sawtooth_integration/tests/test_namespace_permission.py
+++ b/integration/sawtooth_integration/tests/test_namespace_permission.py
@@ -77,6 +77,7 @@ def make_batches(keys):
     imf = IntkeyMessageFactory()
     return [imf.create_batch([('set', k, 0)]) for k in keys]
 
+
 class TestNamespacePermission(unittest.TestCase):
     def test_namespace_permission(self):
         """Tests that namespace permission onchain are letting block_info
@@ -92,7 +93,6 @@ class TestNamespacePermission(unittest.TestCase):
             block_info = get_block_info(i)
             self.assertEqual(block_info.block_num, i)
 
-
         # Assert block info batches are first in the block and
         # no other batch is included
         for block in get_blocks()[:-1]:
@@ -101,4 +101,3 @@ class TestNamespacePermission(unittest.TestCase):
                 block['batches'][0]['transactions'][0]['header']['family_name']
             self.assertEqual(family_name, 'block_info')
             self.assertEqual(len(block['batches']), 1)
-

--- a/integration/sawtooth_integration/tests/test_namespace_permission.py
+++ b/integration/sawtooth_integration/tests/test_namespace_permission.py
@@ -96,7 +96,7 @@ class TestNamespacePermission(unittest.TestCase):
         # Assert block info batches are first in the block and
         # no other batch is included
         for block in get_blocks()[:-1]:
-            print(block['header']['block_num'])
+            LOGGER.debug(block['header']['block_num'])
             family_name = \
                 block['batches'][0]['transactions'][0]['header']['family_name']
             self.assertEqual(family_name, 'block_info')

--- a/integration/sawtooth_integration/tests/test_namespace_permission.py
+++ b/integration/sawtooth_integration/tests/test_namespace_permission.py
@@ -63,7 +63,9 @@ def post_batch(batch):
     return response
 
 
-def query_rest_api(suffix='', data=None, headers={}):
+def query_rest_api(suffix='', data=None, headers=None):
+    if headers is None:
+        headers = {}
     url = 'http://rest-api:8080' + suffix
     return submit_request(urllib.request.Request(url, data, headers))
 
@@ -87,8 +89,8 @@ class TestNamespacePermission(unittest.TestCase):
         batches = make_batches('abcd')
 
         # Assert all block info transactions are committed
-        for i in range(len(batches)):
-            post_batch(batches[i])
+        for i, batch in enumerate(batches):
+            post_batch(batch)
             time.sleep(1)
             block_info = get_block_info(i)
             self.assertEqual(block_info.block_num, i)

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -532,7 +532,7 @@ def validator_genesis_init(sawtooth_home_genesis,
 
     priv_non = os.path.join(sawtooth_home_non_genesis,
                             'keys', 'validator.priv')
-    with open(priv, 'r') as infile:
+    with open(priv_non, 'r') as infile:
         priv_key_non = infile.read().strip('\n')
 
     subprocess.run([

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 from tempfile import mkdtemp
+import time
 import unittest
 from uuid import uuid4
 
@@ -33,8 +34,6 @@ from sawtooth_integration.tests.integration_tools import RestClient
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
-
-import time
 
 LOGGER = logging.getLogger(__name__)
 

--- a/integration/sawtooth_integration/tests/test_network_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_network_permissioning.py
@@ -79,7 +79,6 @@ class TestNetworkPermissioning(unittest.TestCase):
 
         """
 
-
         walter = Admin("http://127.0.0.1:{}".format(8008 + 0))
 
         sawtooth_home0 = mkdtemp()
@@ -93,15 +92,19 @@ class TestNetworkPermissioning(unittest.TestCase):
                 sawtooth_home0,
                 roles={"network": "trust"},
                 endpoint="tcp://127.0.0.1:{}".format(8800 + 0),
-                bind=["network:tcp://127.0.0.1:{}".format(8800 + 0),
-                      "component:tcp://127.0.0.1:{}".format(4004 + 0)],
+                bind=[
+                    "network:tcp://127.0.0.1:{}".format(8800 + 0),
+                    "component:tcp://127.0.0.1:{}".format(4004 + 0)
+                ],
                 seeds=["tcp://127.0.0.1:{}".format(8800 + 1)],
                 peering="dynamic",
                 scheduler='parallel')
             validator_non_genesis_init(sawtooth_home1)
-            validator_genesis_init(sawtooth_home0, sawtooth_home1,
-                                   identity_pub_key=walter.pub_key,
-                                   role="network")
+            validator_genesis_init(
+                sawtooth_home0,
+                sawtooth_home1,
+                identity_pub_key=walter.pub_key,
+                role="network")
             self.processes.extend(start_validator(0, sawtooth_home0))
             self.clients.append(Client(NodeController.http_address(0)))
 
@@ -110,8 +113,10 @@ class TestNetworkPermissioning(unittest.TestCase):
                 sawtooth_home1,
                 roles={"network": "trust"},
                 endpoint="tcp://127.0.0.1:{}".format(8800 + 1),
-                bind=["network:tcp://127.0.0.1:{}".format(8800 + 1),
-                      "component:tcp://127.0.0.1:{}".format(4004 + 1)],
+                bind=[
+                    "network:tcp://127.0.0.1:{}".format(8800 + 1),
+                    "component:tcp://127.0.0.1:{}".format(4004 + 1)
+                ],
                 peering="dynamic",
                 seeds=["tcp://127.0.0.1:{}".format(8800 + 0)],
                 scheduler='parallel')
@@ -119,9 +124,13 @@ class TestNetworkPermissioning(unittest.TestCase):
             self.processes.extend(start_validator(1, sawtooth_home1))
             self.clients.append(Client(NodeController.http_address(1)))
 
-        with open(os.path.join(self.sawtooth_home[1], 'keys', 'validator.pub'), 'r') as infile:
+        with open(
+                os.path.join(self.sawtooth_home[1], 'keys', 'validator.pub'),
+                'r') as infile:
             non_genesis_key = infile.read().strip('\n')
-        with open(os.path.join(self.sawtooth_home[0], 'keys', 'validator.pub'), 'r') as infile:
+        with open(
+                os.path.join(self.sawtooth_home[0], 'keys', 'validator.pub'),
+                'r') as infile:
             genesis_key = infile.read().strip('\n')
 
         wait_for_consensus(self.clients, amount=2)
@@ -202,15 +211,19 @@ class TestNetworkPermissioning(unittest.TestCase):
                 sawtooth_home0,
                 roles={"network": "challenge"},
                 endpoint="tcp://127.0.0.1:{}".format(8800 + 2),
-                bind=["network:tcp://127.0.0.1:{}".format(8800 + 2),
-                      "component:tcp://127.0.0.1:{}".format(4004 + 2)],
+                bind=[
+                    "network:tcp://127.0.0.1:{}".format(8800 + 2),
+                    "component:tcp://127.0.0.1:{}".format(4004 + 2)
+                ],
                 seeds=["tcp://127.0.0.1:{}".format(8800 + 3)],
                 peering="dynamic",
                 scheduler='parallel')
             validator_non_genesis_init(sawtooth_home1)
-            validator_genesis_init(sawtooth_home0, sawtooth_home1,
-                                   identity_pub_key=walter.pub_key,
-                                   role="network")
+            validator_genesis_init(
+                sawtooth_home0,
+                sawtooth_home1,
+                identity_pub_key=walter.pub_key,
+                role="network")
             processes.extend(start_validator(2, sawtooth_home0))
             self.clients.append(Client(NodeController.http_address(2)))
 
@@ -219,8 +232,10 @@ class TestNetworkPermissioning(unittest.TestCase):
                 sawtooth_home1,
                 roles={"network": "challenge"},
                 endpoint="tcp://127.0.0.1:{}".format(8800 + 3),
-                bind=["network:tcp://127.0.0.1:{}".format(8800 + 3),
-                      "component:tcp://127.0.0.1:{}".format(4004 + 3)],
+                bind=[
+                    "network:tcp://127.0.0.1:{}".format(8800 + 3),
+                    "component:tcp://127.0.0.1:{}".format(4004 + 3)
+                ],
                 peering="dynamic",
                 seeds=["tcp://127.0.0.1:{}".format(8800 + 2)],
                 scheduler='parallel')
@@ -277,10 +292,12 @@ class TestNetworkPermissioning(unittest.TestCase):
         show_blocks(self.clients[0].block_list())
         show_blocks(self.clients[1].block_list())
 
+
 def write_validator_config(sawtooth_home, **kwargs):
     with open(os.path.join(sawtooth_home, 'etc',
                            'validator.toml'), mode='w') as out:
         toml.dump(kwargs, out)
+
 
 def start_validator(num, sawtooth_home):
     return NodeController.start_node(
@@ -295,15 +312,14 @@ def start_validator(num, sawtooth_home):
 
 def show_blocks(block_list):
     blocks = [("Block Num", "Block ID", "Signer Key")] + block_list
-    output = "\n" + "\n".join(["{:^5} {:^21} {:^21}".format(item[0],
-                                            item[1][:10],
-                                            item[2][:10])
-               for item in blocks])
+    output = "\n" + "\n".join([
+        "{:^5} {:^21} {:^21}".format(item[0], item[1][:10], item[2][:10])
+        for item in blocks
+    ])
     LOGGER.warning(output)
 
 
 class Client(object):
-
     def __init__(self, rest_endpoint):
         context = create_context('secp256k1')
         private_key = context.new_random_private_key()
@@ -321,13 +337,21 @@ class Client(object):
 
     def send(self):
         name = uuid4().hex[:20]
-        txns = [self._factory.create_transaction(
-            cbor.dumps({'Name': name,
-                        'Verb': 'set',
-                        'Value': 1000}),
-            inputs=[self._namespace + self._factory.sha512(name.encode())[-64:]],
-            outputs=[self._namespace + self._factory.sha512(name.encode())[-64:]],
-            deps=[])]
+        txns = [
+            self._factory.create_transaction(
+                cbor.dumps({
+                    'Name': name,
+                    'Verb': 'set',
+                    'Value': 1000
+                }),
+                inputs=[
+                    self._namespace + self._factory.sha512(name.encode())[-64:]
+                ],
+                outputs=[
+                    self._namespace + self._factory.sha512(name.encode())[-64:]
+                ],
+                deps=[])
+        ]
         self._rest.send_batches(self._factory.create_batch(txns))
 
     def block_list(self):
@@ -507,7 +531,8 @@ def validator_genesis_init(sawtooth_home_genesis,
     with open(priv, 'r') as infile:
         priv_key = infile.read().strip('\n')
 
-    priv_non = os.path.join(sawtooth_home_non_genesis, 'keys', 'validator.priv')
+    priv_non = os.path.join(sawtooth_home_non_genesis,
+                            'keys', 'validator.priv')
     with open(priv, 'r') as infile:
         priv_key_non = infile.read().strip('\n')
 
@@ -520,7 +545,7 @@ def validator_genesis_init(sawtooth_home_genesis,
 
     with open(
         '/project/sawtooth-core/consensus/poet/simulator/packaging/'
-        'simulator_rk_pub.pem') as fd:
+            'simulator_rk_pub.pem') as fd:
         public_key_pem = fd.read().strip('\n')
 
     # Use the poet CLI to get the enclave measurement so that we can put the
@@ -544,7 +569,8 @@ def validator_genesis_init(sawtooth_home_genesis,
     subprocess.run([
         'sawset', 'proposal', 'create',
         '-k', priv,
-        'sawtooth.identity.allowed_keys={},{}'.format(identity_pub_key, priv_key),
+        'sawtooth.identity.allowed_keys={},{}'.format(
+            identity_pub_key, priv_key),
         'sawtooth.consensus.algorithm=poet',
         'sawtooth.poet.report_public_key_pem={}'.format(public_key_pem),
         'sawtooth.poet.valid_enclave_measurements={}'.format(
@@ -567,9 +593,11 @@ def validator_genesis_init(sawtooth_home_genesis,
                     'policy',
                     'create',
                     '-k', priv,
-                    '-o', os.path.join(sawtooth_home_genesis, 'data', 'policy.batch'),
+                    '-o', os.path.join(sawtooth_home_genesis,
+                                       'data', 'policy.batch'),
                     policy,
-                    "PERMIT_KEY {} PERMIT_KEY {}".format(priv_key, priv_key_non)],
+                    "PERMIT_KEY {} PERMIT_KEY {}".format(priv_key,
+                                                         priv_key_non)],
                    check=True)
 
     subprocess.run(['sawtooth',
@@ -593,5 +621,5 @@ def validator_genesis_init(sawtooth_home_genesis,
 def validator_non_genesis_init(sawtooth_home):
     os.mkdir(os.path.join(sawtooth_home, 'keys'))
     subprocess.run(['sawadm', 'keygen',
-        os.path.join(sawtooth_home, 'keys', 'validator')],
+                    os.path.join(sawtooth_home, 'keys', 'validator')],
                    check=True)

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=bare-except
+
 import time
 import unittest
 import logging

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -74,7 +74,7 @@ class TestPoetLive(unittest.TestCase):
 
 def get_block(node):
     try:
-        result = requests.get((URL % node)+"/blocks?count=1")
+        result = requests.get((URL % node) + "/blocks?count=1")
         result = result.json()
         try:
             return result["data"][0]
@@ -86,7 +86,7 @@ def get_block(node):
 
 def get_chain(node):
     try:
-        result = requests.get((URL % node)+"/blocks")
+        result = requests.get((URL % node) + "/blocks")
         result = result.json()
         try:
             return result["data"]
@@ -129,7 +129,7 @@ def check_consensus(chains, block_num):
     blocks = []
     for chain in chains:
         if chain is not None:
-            block = chain[-(block_num+1)]
+            block = chain[-(block_num + 1)]
             blocks.append(block)
         else:
             return False

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -62,7 +62,7 @@ class TestPoetLive(unittest.TestCase):
 
             time.sleep(15)
 
-        chains = [get_chain(i) for node in range(0, NODES)]
+        chains = [get_chain(node) for node in range(0, NODES)]
 
         # Ensure all nodes are in consensus on the target block
         self.assertTrue(check_consensus(chains, BLOCK_TO_CHECK_CONSENSUS))

--- a/integration/sawtooth_integration/tests/test_poet_liveness.py
+++ b/integration/sawtooth_integration/tests/test_poet_liveness.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import time
 import unittest
 import logging
-import yaml
 
-import time
 import requests
 
 

--- a/integration/sawtooth_integration/tests/test_poet_smoke.py
+++ b/integration/sawtooth_integration/tests/test_poet_smoke.py
@@ -67,13 +67,13 @@ class TestPoetSmoke(unittest.TestCase):
         # send txns to each validator in succession
         for i in range(BATCH_COUNT):
             for client in self.clients:
-                LOGGER.info('Sending batch {} @ {}'.format(i, client.url))
+                LOGGER.info('Sending batch %s @ %s', i, client.url)
                 client.send_txns(increment)
 
         # send txns to one validator at a time
         for client in self.clients:
             for i in range(BATCH_COUNT):
-                LOGGER.info('Sending batch {} @ {}'.format(i, client.url))
+                LOGGER.info('Sending batch %s @ %s', i, client.url)
                 client.send_txns(increment)
 
         # wait for validators to catch up
@@ -99,14 +99,14 @@ class TestPoetSmoke(unittest.TestCase):
     def _assert_consensus(self):
         tolerance = self.clients[0].calculate_tolerance()
 
-        LOGGER.info('Verifying consensus @ tolerance {}'.format(tolerance))
+        LOGGER.info('Verifying consensus @ tolerance %s', tolerance)
 
         # for convenience, list the blocks
         for client in self.clients:
             url = client.url
-            LOGGER.info('Blocks @ {}'.format(url))
+            LOGGER.info('Blocks @ %s', url)
             subprocess.run(shlex.split(
-                'sawtooth block list --url {}'.format(url)))
+                'sawtooth block list --url %s', url))
 
         list_of_sig_lists = [
             client.recent_block_signatures(tolerance)

--- a/integration/sawtooth_integration/tests/test_poet_smoke.py
+++ b/integration/sawtooth_integration/tests/test_poet_smoke.py
@@ -30,6 +30,7 @@ VALIDATOR_COUNT = 3
 BATCH_COUNT = 20
 WAIT = 120
 
+
 class TestPoetSmoke(unittest.TestCase):
     def setUp(self):
         endpoints = ['rest-api-{}:8008'.format(i)
@@ -89,11 +90,11 @@ class TestPoetSmoke(unittest.TestCase):
                 return
             except AssertionError:
                 LOGGER.info(
-                        'Blocks not yet in consensus after %d seconds' %
-                        time.time() - start_time)
+                    'Blocks not yet in consensus after %d seconds' %
+                    time.time() - start_time)
 
         raise AssertionError(
-                'Validators were not in consensus after %d seconds' % WAIT)
+            'Validators were not in consensus after %d seconds' % WAIT)
 
     def _assert_consensus(self):
         tolerance = self.clients[0].calculate_tolerance()
@@ -118,6 +119,7 @@ class TestPoetSmoke(unittest.TestCase):
             self.assertTrue(
                 any(sig in sig_list for sig in sig_list_0),
                 'Validators are not in consensus')
+
 
 def _make_txns():
     fruits = 'fig', 'quince', 'medlar', 'cornel', 'pomegranate'

--- a/integration/sawtooth_integration/tests/test_shutdown_smoke.py
+++ b/integration/sawtooth_integration/tests/test_shutdown_smoke.py
@@ -26,7 +26,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestShutdownSmoke(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls._sawtooth_core = cls._find_host_sawtooth_core()
@@ -51,7 +50,7 @@ class TestShutdownSmoke(unittest.TestCase):
             6) The validators' return codes are checked and asserted to be 0.
         """
 
-        #1)
+        # 1)
         containers = self._startup()
 
         try:
@@ -65,8 +64,7 @@ class TestShutdownSmoke(unittest.TestCase):
 
             end_time = time.time() - initial_time
             LOGGER.warning("Containers exited with sigint in %s seconds",
-                        end_time)
-
+                           end_time)
 
             self.assertEqual(len(sigint_exit_statuses), len(containers))
             for s in sigint_exit_statuses:
@@ -90,7 +88,7 @@ class TestShutdownSmoke(unittest.TestCase):
             3) The validators' return codes are checked and asserted to be 0.
         """
 
-            #1)
+        # 1)
         containers = self._startup()
 
         try:
@@ -104,7 +102,7 @@ class TestShutdownSmoke(unittest.TestCase):
                 containers)
             end_time = time.time() - initial_time
             LOGGER.warning("Containers exited with sigterm in %s seconds",
-                        end_time)
+                           end_time)
             self.assertEqual(len(sigterm_exit_statuses), len(containers))
             for s in sigterm_exit_statuses:
                 self.assertEqual(s, 0)
@@ -125,7 +123,7 @@ class TestShutdownSmoke(unittest.TestCase):
         # Not catching the CalledProcessError so the test errors and stops
         # if there is a problem calling docker.
         subprocess.run(
-                args, stdout=subprocess.PIPE,
+            args, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, check=True)
 
     def _log_and_clean_up(self, containers):
@@ -167,7 +165,7 @@ class TestShutdownSmoke(unittest.TestCase):
 
     def _docker_run(self, args):
         return subprocess.check_output(['docker', 'run'] + args,
-                                universal_newlines=True).strip('\n')
+                                       universal_newlines=True).strip('\n')
 
     def _run_genesis(self):
         return self._docker_run(
@@ -246,9 +244,10 @@ class TestShutdownSmoke(unittest.TestCase):
     @classmethod
     def _find_host_sawtooth_core(cls):
         hostname = socket.gethostname()
-        return subprocess.check_output(['docker', 'inspect',
-                                        '--format=\"{{ range .Mounts }}'
-                                        '{{ if and (eq .Destination "/project/sawtooth-core") '
-                                        '(eq .Type "bind") }}{{ .Source }}{{ end }}{{ end }}\"',
-                                        hostname],
-                                       universal_newlines=True).strip('\n').strip('\"')
+        return subprocess.check_output(
+            ['docker', 'inspect',
+             '--format=\"{{ range .Mounts }}'
+             '{{ if and (eq .Destination "/project/sawtooth-core") '
+             '(eq .Type "bind") }}{{ .Source }}{{ end }}{{ end }}\"',
+             hostname],
+            universal_newlines=True).strip('\n').strip('\"')

--- a/integration/sawtooth_integration/tests/test_shutdown_smoke.py
+++ b/integration/sawtooth_integration/tests/test_shutdown_smoke.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=broad-except
+
 import unittest
 
 import logging

--- a/integration/sawtooth_integration/tests/test_transactor_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_transactor_permissioning.py
@@ -29,11 +29,13 @@ from sawtooth_integration.tests.integration_tools import RestClient
 from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 
+REST_API = "rest-api:8008"
+
+
 class TestTransactorPermissioning(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        REST_API = "rest-api:8008"
         wait_for_rest_apis([REST_API])
         cls.REST_ENDPOINT = "http://" + REST_API
 
@@ -249,7 +251,7 @@ class Families(enum.Enum):
     XO = 2
 
 
-FamilyConfig = {
+FAMILY_CONFIG = {
     Families.INTKEY: {
         'family_name': 'intkey',
         'family_version': '1.0',
@@ -284,7 +286,7 @@ def make_xo_address(unique_value):
     return XO_NAMESPACE + MessageFactory.sha512(unique_value.encode())[:64]
 
 
-TransactionEncoder = {
+TRANSACTION_ENCODER = {
     Families.INTKEY: {
         'encoder': cbor.dumps,
         'payload_func': make_intkey_payload,
@@ -334,7 +336,7 @@ class Transactor(object):
                 transaction families.
         """
 
-        family_config = FamilyConfig[family_name]
+        family_config = FAMILY_CONFIG[family_name]
         self._factories[family_name] = MessageFactory(
             family_name=family_config['family_name'],
             family_version=family_config['family_version'],
@@ -343,11 +345,12 @@ class Transactor(object):
 
     def create_txn(self, family_name, batcher=None):
         unique_value = uuid4().hex[:20]
-        encoder = TransactionEncoder[family_name]['encoder']
+        encoder = TRANSACTION_ENCODER[family_name]['encoder']
         payload = encoder(
-            TransactionEncoder[family_name]['payload_func'](unique_value))
+            TRANSACTION_ENCODER[family_name]['payload_func'](unique_value))
 
-        address = TransactionEncoder[family_name]['address_func'](unique_value)
+        address = TRANSACTION_ENCODER[family_name]['address_func'](
+            unique_value)
 
         return self._factories[family_name].create_transaction(
             payload=payload,

--- a/integration/sawtooth_integration/tests/test_transactor_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_transactor_permissioning.py
@@ -117,8 +117,8 @@ class TestTransactorPermissioning(unittest.TestCase):
         #
         # transactor.batch_signer subsection
         #
-        # From local configuration both Alice and Bob are allowed batch_signers,
-        # while Dave is denied.
+        # From local configuration both Alice and Bob are allowed
+        # batch_signers, while Dave is denied.
 
         self.walter.set_public_key_for_role(
             "deny_alice_as_batcher_allow_bob",
@@ -268,7 +268,8 @@ def make_intkey_payload(unique_value):
 
 
 def make_intkey_address(unique_value):
-    return INTKEY_NAMESPACE + MessageFactory.sha512(unique_value.encode())[-64:]
+    return INTKEY_NAMESPACE + MessageFactory.sha512(
+        unique_value.encode())[-64:]
 
 
 def make_xo_payload(unique_value):
@@ -285,12 +286,12 @@ def make_xo_address(unique_value):
 
 TransactionEncoder = {
     Families.INTKEY: {
-        'encoder':      cbor.dumps,
+        'encoder': cbor.dumps,
         'payload_func': make_intkey_payload,
         'address_func': make_intkey_address
     },
     Families.XO: {
-        'encoder':      xo_encode,
+        'encoder': xo_encode,
         'payload_func': make_xo_payload,
         'address_func': make_xo_address
     }
@@ -298,7 +299,6 @@ TransactionEncoder = {
 
 
 class Transactor(object):
-
     def __init__(self, name, rest_endpoint):
         """
         Args:

--- a/integration/sawtooth_integration/tests/test_transactor_permissioning.py
+++ b/integration/sawtooth_integration/tests/test_transactor_permissioning.py
@@ -246,6 +246,7 @@ INTKEY_NAMESPACE = MessageFactory.sha512('intkey'.encode())[:6]
 XO_NAMESPACE = MessageFactory.sha512('xo'.encode())[:6]
 
 
+# pylint: disable=invalid-name
 class Families(enum.Enum):
     INTKEY = 1
     XO = 2

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=attribute-defined-outside-init
+
 import unittest
 import logging
 import operator

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -15,7 +15,6 @@
 
 import unittest
 import logging
-import time
 import operator
 import subprocess
 import shlex

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -183,7 +183,9 @@ def _get_state_prefix(prefix):
     return response['data']
 
 
-def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
+def _query_rest_api(suffix='', data=None, headers=None, expected_code=200):
+    if headers is None:
+        headers = {}
     url = 'http://rest-api:8008' + suffix
     return _submit_request(
         urllib.request.Request(url, data, headers),
@@ -192,7 +194,7 @@ def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
 
 def _submit_request(request, expected_code=200):
     conn = urllib.request.urlopen(request)
-    assert(expected_code == conn.getcode())
+    assert expected_code == conn.getcode()
 
     response = conn.read().decode('utf-8')
     return json.loads(response)

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -38,6 +38,7 @@ INTKEY_PREFIX = '1cf126'
 XO_PREFIX = '5b7349'
 WAIT = 300
 
+
 class TestTwoFamilies(unittest.TestCase):
 
     @classmethod
@@ -136,6 +137,7 @@ def _send_xo_cmd(cmd_str):
         stderr=subprocess.PIPE,
         check=True)
 
+
 def _send_intkey_cmd(txns):
     batch = IntkeyMessageFactory().create_batch(txns)
     LOGGER.info('Sending intkey txns')
@@ -143,19 +145,22 @@ def _send_intkey_cmd(txns):
 
 # rest_api calls
 
+
 def _post_batch(batch):
     headers = {'Content-Type': 'application/octet-stream'}
     response = _query_rest_api(
         '/batches', data=batch, headers=headers, expected_code=202)
     return _submit_request('{}&wait={}'.format(response['link'], WAIT))
 
+
 def _get_intkey_data():
     state = _get_intkey_state()
     # state is a list of dictionaries: { data: ..., address: ... }
     dicts = [cbor.loads(b64decode(entry['data'])) for entry in state]
     LOGGER.debug(dicts)
-    data = {k:v for d in dicts for k, v in d.items()} # merge dicts
+    data = {k: v for d in dicts for k, v in d.items()}  # merge dicts
     return data
+
 
 def _get_xo_data():
     state = _get_xo_state()
@@ -163,22 +168,27 @@ def _get_xo_data():
     game_name, board, turn, _, _ = data
     return board, turn, game_name
 
+
 def _get_intkey_state():
     state = _get_state_prefix(INTKEY_PREFIX)
     return state
+
 
 def _get_xo_state():
     state = _get_state_prefix(XO_PREFIX)
     return state
 
+
 def _get_state_prefix(prefix):
     response = _query_rest_api('/state?address=' + prefix)
     return response['data']
 
+
 def _query_rest_api(suffix='', data=None, headers={}, expected_code=200):
     url = 'http://rest-api:8008' + suffix
-    return _submit_request(urllib.request.Request(url, data, headers),
-                           expected_code=expected_code)
+    return _submit_request(
+        urllib.request.Request(url, data, headers),
+        expected_code=expected_code)
 
 
 def _submit_request(request, expected_code=200):
@@ -189,6 +199,7 @@ def _submit_request(request, expected_code=200):
     return json.loads(response)
 
 # verifiers
+
 
 class XoTestVerifier:
     def __init__(self):
@@ -213,6 +224,7 @@ class XoTestVerifier:
             return state[num]
         except KeyError:
             return ()
+
 
 class IntkeyTestVerifier:
     def __init__(self):

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -109,12 +109,12 @@ class TestTwoFamilies(unittest.TestCase):
             'Expected xo state to be empty')
 
     def verify_state_after_n_updates(self, num):
-        LOGGER.debug('Verifying state after {} updates'.format(num))
+        LOGGER.debug('Verifying state after %s updates', num)
 
         intkey_state = _get_intkey_data()
-        LOGGER.info('Current intkey state: {}'.format(intkey_state))
+        LOGGER.info('Current intkey state: %s', intkey_state)
         xo_data = _get_xo_data()
-        LOGGER.info('Current xo state: {}'.format(xo_data))
+        LOGGER.info('Current xo state: %s', xo_data)
 
         self.assertEqual(
             intkey_state,

--- a/integration/sawtooth_integration/tests/test_workload.py
+++ b/integration/sawtooth_integration/tests/test_workload.py
@@ -32,8 +32,8 @@ LOGGER.setLevel(logging.INFO)
 WORKLOAD_TIME = 5
 MINIMUM_BLOCK_COUNT = 3
 
-class TestWorkload(unittest.TestCase):
 
+class TestWorkload(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         url = 'rest-api:8008'

--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -32,7 +32,6 @@ REST_API = 'rest-api:8008'
 
 
 class TestXoSmoke(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.client = XoClient('http://' + REST_API)

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -53,7 +53,8 @@ class _ApiError(HTTPError):
         error = {
             'code': self.api_code,
             'title': self.title,
-            'message': self.message + additional_info}
+            'message': self.message + additional_info
+        }
 
         super().__init__(
             content_type='application/json',

--- a/rest_api/sawtooth_rest_api/messaging.py
+++ b/rest_api/sawtooth_rest_api/messaging.py
@@ -33,6 +33,7 @@ class _MessageRouter:
     """Manages message, routing them either to an incoming queue or to the
     futures for expected replies.
     """
+
     def __init__(self):
         self._queue = asyncio.Queue()
         self._futures = {}
@@ -172,6 +173,7 @@ class _Sender:
 class DisconnectError(Exception):
     """Raised when a connection disconnects.
     """
+
     def __init__(self):
         super().__init__("The connection was lost")
 
@@ -190,6 +192,7 @@ class ConnectionEvent(Enum):
 class Connection:
     """A connection, over which validator Message objects may be sent.
     """
+
     def __init__(self, url):
         self._url = url
 

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -130,9 +130,12 @@ def start_rest_api(host, port, connection, timeout, registry):
     # Start app
     LOGGER.info('Starting REST API on %s:%s', host, port)
 
-    web.run_app(app, host=host, port=port,
-                access_log=LOGGER,
-                access_log_format='%r: %s status, %b size, in %Tf s')
+    web.run_app(
+        app,
+        host=host,
+        port=port,
+        access_log=LOGGER,
+        access_log_format='%r: %s status, %b size, in %Tf s')
 
 
 def load_rest_api_config(first_config):

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -97,6 +97,7 @@ class RouteHandler(object):
         timeout (int, optional): The time in seconds before the Api should
             cancel a request and report that the validator is unavailable.
     """
+
     def __init__(
             self, loop, connection,
             timeout=DEFAULT_TIMEOUT, metrics_registry=None):
@@ -716,10 +717,11 @@ class RouteHandler(object):
         paging_response = response['paging']
         if head is None:
             head = response['head_id']
-        link = cls._build_url(request,
-                              head=head,
-                              start=paging_response['start'],
-                              limit=paging_response['limit'])
+        link = cls._build_url(
+            request,
+            head=head,
+            start=paging_response['start'],
+            limit=paging_response['limit'])
 
         paging = {}
         limit = controls.get('limit')
@@ -731,22 +733,29 @@ class RouteHandler(object):
             return cls._wrap_response(
                 request,
                 data=data,
-                metadata={'head': head, 'link': link, 'paging': paging})
+                metadata={
+                    'head': head,
+                    'link': link,
+                    'paging': paging
+                })
 
         next_id = paging_response['next']
         paging['next_position'] = next_id
 
         # Builds paging urls specific to this response
         def build_pg_url(start=None):
-            return cls._build_url(request, head=head, limit=limit,
-                                  start=start)
+            return cls._build_url(request, head=head, limit=limit, start=start)
 
         paging['next'] = build_pg_url(paging_response['next'])
 
         return cls._wrap_response(
             request,
             data=data,
-            metadata={'head': head, 'link': link, 'paging': paging})
+            metadata={
+                'head': head,
+                'link': link,
+                'paging': paging
+            })
 
     @classmethod
     def _get_metadata(cls, request, response, head=None):
@@ -947,8 +956,10 @@ class RouteHandler(object):
         if isinstance(item, list):
             return [self._drop_empty_props(i) for i in item]
         if isinstance(item, dict):
-            return {k: self._drop_empty_props(v)
-                    for k, v in item.items() if v != ''}
+            return {
+                k: self._drop_empty_props(v)
+                for k, v in item.items() if v != ''
+            }
         return item
 
     def _drop_id_prefixes(self, item):
@@ -957,8 +968,10 @@ class RouteHandler(object):
         if isinstance(item, list):
             return [self._drop_id_prefixes(i) for i in item]
         if isinstance(item, dict):
-            return {'id' if k.endswith('id') else k: self._drop_id_prefixes(v)
-                    for k, v in item.items()}
+            return {
+                'id' if k.endswith('id') else k: self._drop_id_prefixes(v)
+                for k, v in item.items()
+            }
         return item
 
     @classmethod

--- a/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
+++ b/rest_api/sawtooth_rest_api/state_delta_subscription_handler.py
@@ -49,6 +49,7 @@ class StateDeltaSubscriberHandler:
     all are fed state deltas from the incoming complete stream, filtered by
     this handler according to their preferred filters.
     """
+
     def __init__(self, connection):
         """
         Constructs this handler on a given validator connection.

--- a/rest_api/setup.py
+++ b/rest_api/setup.py
@@ -24,30 +24,27 @@ from setuptools import setup, find_packages
 data_files = []
 
 if os.path.exists("/etc/default"):
-    data_files.append(('/etc/default', ['packaging/systemd/sawtooth-rest-api']))
+    data_files.append(
+        ('/etc/default', ['packaging/systemd/sawtooth-rest-api']))
 
 if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',
                        ['packaging/systemd/sawtooth-rest-api.service']))
 
-setup(name='sawtooth-rest-api',
-      version=subprocess.check_output(
+setup(
+    name='sawtooth-rest-api',
+    version=subprocess.check_output(
         ['../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth REST API',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'aiodns',
-          'aiohttp>=2.3.2',
-          'cchardet',
-          'protobuf',
-          'sawtooth-sdk',
-          'pyformance'
-          ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'sawtooth-rest-api = sawtooth_rest_api.rest_api:main'
-          ]
-      })
+    description='Sawtooth REST API',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'aiodns', 'aiohttp>=2.3.2', 'cchardet', 'protobuf', 'sawtooth-sdk',
+        'pyformance'
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts':
+        ['sawtooth-rest-api = sawtooth_rest_api.rest_api:main']
+    })

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=attribute-defined-outside-init
+
 from base64 import b64decode
 
 from aiohttp import web

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import re
+from base64 import b64decode
+
 from aiohttp import web
 from aiohttp.test_utils import AioHTTPTestCase
-from base64 import b64decode
 
 from sawtooth_rest_api.route_handlers import RouteHandler
 from sawtooth_rest_api.protobuf import client_batch_submit_pb2

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -41,13 +41,14 @@ TEST_TIMEOUT = 5
 
 
 class MockConnection(object):
-    """Replaces a route handler's connection to allow tests to preset the response
-    to send back as well as run asserts on the protobufs sent to the
-    connection.
+    """Replaces a route handler's connection to allow tests to preset the
+    response to send back as well as run asserts on the protobufs sent
+    to the connection.
 
     Methods can be accessed using `self.connection` within a test case.
     MockConnection should not be initialized directly.
     """
+
     def __init__(self, test_case, request_type, request_proto, response_proto):
         self._tests = test_case
         self._request_type = request_type
@@ -70,7 +71,6 @@ class MockConnection(object):
         if status is None:
             status = proto.OK
         self._response.append(proto(status=status, **response_data))
-
 
     def assert_valid_request_sent(self, **request_data):
         """Asserts that the last sent request matches the expected data.
@@ -252,7 +252,6 @@ class BaseApiTest(AioHTTPTestCase):
         else:
             self.assertNotIn('next', js_paging)
 
-
     def assert_has_valid_error(self, response, expected_code):
         """Asserts a response has only an error dict with an expected code
         """
@@ -304,8 +303,8 @@ class BaseApiTest(AioHTTPTestCase):
         for pb_status, js_status in zip(proto_statuses, json_statuses):
             self.assertEqual(pb_status.batch_id, js_status['id'])
             pb_enum_name = \
-               client_batch_submit_pb2.ClientBatchStatus.Status.Name(
-                   pb_status.status)
+                client_batch_submit_pb2.ClientBatchStatus.Status.Name(
+                    pb_status.status)
             self.assertEqual(pb_enum_name, js_status['status'])
 
             if pb_status.invalid_transactions:
@@ -314,8 +313,10 @@ class BaseApiTest(AioHTTPTestCase):
                 for pb_txn, js_txn in txn_info:
                     self.assertEqual(pb_txn.transaction_id, js_txn['id'])
                     self.assertEqual(pb_txn.message, js_txn.get('message', ''))
-                    self.assertEqual(pb_txn.extended_data,
-                                     b64decode(js_txn.get('extended_data', b'')))
+                    self.assertEqual(
+                        pb_txn.extended_data, b64decode(
+                            js_txn.get(
+                                'extended_data', b'')))
 
     def assert_blocks_well_formed(self, blocks, *expected_ids):
         """Asserts a block dict or list of block dicts have expanded headers
@@ -329,7 +330,8 @@ class BaseApiTest(AioHTTPTestCase):
             self.assertIsInstance(block, dict)
             self.assertEqual(expected_id, block['header_signature'])
             self.assertIsInstance(block['header'], dict)
-            self.assertEqual(b'consensus', b64decode(block['header']['consensus']))
+            self.assertEqual(b'consensus', b64decode(
+                block['header']['consensus']))
 
             batches = block['batches']
             self.assertIsInstance(batches, list)
@@ -348,7 +350,8 @@ class BaseApiTest(AioHTTPTestCase):
         for batch, expected_id in zip(batches, expected_ids):
             self.assertEqual(expected_id, batch['header_signature'])
             self.assertIsInstance(batch['header'], dict)
-            self.assertEqual('public_key', batch['header']['signer_public_key'])
+            self.assertEqual(
+                'public_key', batch['header']['signer_public_key'])
 
             txns = batch['transactions']
             self.assertIsInstance(txns, list)
@@ -381,7 +384,7 @@ class Mocks(object):
         return ClientPagingControls(
             limit=limit,
             start=start
-            )
+        )
 
     @staticmethod
     def make_paging_response(next_id=None, start=None, limit=None):
@@ -391,7 +394,7 @@ class Mocks(object):
             next=next_id,
             start=start,
             limit=limit
-            )
+        )
 
     @staticmethod
     def make_sort_controls(keys, reverse=False):
@@ -401,7 +404,7 @@ class Mocks(object):
         return [ClientSortControls(
             keys=[keys],
             reverse=reverse
-            )]
+        )]
 
     @staticmethod
     def make_entries(**leaf_data):
@@ -423,11 +426,10 @@ class Mocks(object):
 
             blk_header = BlockHeader(
                 block_num=len(blocks),
-                previous_block_id=blocks[-1].header_signature if blocks else '',
-                signer_public_key='public_key',
+                previous_block_id=blocks[-1].header_signature
+                if blocks else '', signer_public_key='public_key',
                 batch_ids=[b.header_signature for b in batches],
-                consensus=b'consensus',
-                state_root_hash='root_hash')
+                consensus=b'consensus', state_root_hash='root_hash')
 
             block = Block(
                 header=blk_header.SerializeToString(),

--- a/rest_api/tests/unit/test_batch_requests.py
+++ b/rest_api/tests/unit/test_batch_requests.py
@@ -28,7 +28,6 @@ DEFAULT_LIMIT = 100
 
 
 class BatchListTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_BATCH_LIST_REQUEST,
@@ -53,21 +52,24 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/batches?start={}&limit=100&head={}'.format(ID_C, ID_C)
+            - a link property that ends in
+                '/batches?start={}&limit=100&head={}'.format(ID_C, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches')
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_C, ID_C))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
@@ -128,14 +130,17 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_B, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
+        self.connection.assert_valid_request_sent(
+            head_id=ID_B, paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_B, ID_B))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100'.format(ID_B, ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_B, ID_A)
@@ -152,7 +157,8 @@ class BatchListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/batches?head={}'.format(ID_D), 404)
+        response = await self.get_assert_status(
+            '/batches?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -173,21 +179,27 @@ class BatchListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C)
+                '/batches?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_A, ID_C)
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full batches with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_A, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?id={},{}'.format(ID_A, ID_C))
+        response = await self.get_assert_200('/batches?id={},{}'.format(
+            ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(batch_ids=[ID_A, ID_C], paging=controls)
+        self.connection.assert_valid_request_sent(
+            batch_ids=[ID_A, ID_C], paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_A, ID_C)
@@ -204,20 +216,21 @@ class BatchListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D)
+                '/batches?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_B, ID_D)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
-            self.status.NO_RESOURCE,
-            head_id=ID_C,
-            paging=paging)
-        response = await self.get_assert_200('/batches?id={},{}'.format(ID_B, ID_D))
+            self.status.NO_RESOURCE, head_id=ID_C, paging=paging)
+        response = await self.get_assert_200('/batches?id={},{}'.format(
+            ID_B, ID_D))
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -239,16 +252,19 @@ class BatchListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_B
             - a link property that ends in
-                '/batches?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A)
+                '/batches?head={}&start={}&limit=100&id={}'
+                    .format(ID_B, ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - and that dict is a full batch with an id of ID_A
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_A)
-        self.connection.preset_response(head_id=ID_B, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_B, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?id={}&head={}'.format(ID_A, ID_B))
+        response = await self.get_assert_200('/batches?id={}&head={}'.format(
+            ID_A, ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(
             head_id=ID_B,
@@ -257,7 +273,8 @@ class BatchListTests(BaseApiTest):
 
         self.assert_has_valid_head(response, ID_B)
         self.assert_has_valid_link(
-            response, '/batches?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
+            response, '/batches?head={}&start={}&limit=100&id={}'.format(
+                ID_B, ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_batches_well_formed(response['data'], ID_A)
@@ -268,7 +285,8 @@ class BatchListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of ID_D, next of ID_C and limit of 1
+            - a paging response with a start of ID_D, next of ID_C and
+              limit of 1
             - one batch with the id ID_C
 
         It should send a Protobuf request with:
@@ -282,19 +300,23 @@ class BatchListTests(BaseApiTest):
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
             - and that dict is a full batch with the id ID_C
+
         """
         paging = Mocks.make_paging_response(ID_C, ID_D, 1)
         batches = Mocks.make_batches(ID_C)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?start=1&limit=1')
         controls = Mocks.make_paging_controls(1, start="1")
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=1'.format(ID_D, ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&start={}&limit=1'.format(ID_D, ID_C))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=1'.format(ID_D, ID_D))
+        self.assert_has_valid_paging(
+            response, paging, '/batches?head={}&start={}&limit=1'.format(
+                ID_D, ID_C))
         self.assert_has_valid_data_list(response, 1)
         self.assert_batches_well_formed(response['data'], ID_C)
 
@@ -306,7 +328,8 @@ class BatchListTests(BaseApiTest):
             - a response status of 400
             - an error property with a code of 53
         """
-        response = await self.get_assert_status('/batches?start=2&limit=0', 400)
+        response = await self.get_assert_status('/batches?start=2&limit=0',
+                                                400)
 
         self.assert_has_valid_error(response, 53)
 
@@ -349,16 +372,19 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response(ID_B, ID_D, 2)
         batches = Mocks.make_batches(ID_D, ID_C)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?limit=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=2'.format(ID_D, ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/batches?head={}&start={}&limit=2'.format(ID_D, ID_B))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=2'.format(ID_D, ID_D))
+        self.assert_has_valid_paging(
+            response, paging, '/batches?head={}&start={}&limit=2'.format(
+                ID_D, ID_B))
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_D, ID_C)
 
@@ -385,14 +411,16 @@ class BatchListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?start={}'.format(ID_B))
         controls = Mocks.make_paging_controls(None, start=ID_B)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=100'.format(ID_D, ID_B))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100'.format(ID_D, ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_batches_well_formed(response['data'], ID_B, ID_A)
@@ -412,26 +440,29 @@ class BatchListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/batches?head={}&start={}&limit=5'.format(ID_D, ID_C)
+            - a link property that ends in
+                '/batches?head={}&start={}&limit=5'
+                    .format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response("", ID_C, 5)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_D, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, batches=batches)
 
-        response = await self.get_assert_200('/batches?start={}&limit=5'.format(ID_C))
+        response = await self.get_assert_200(
+            '/batches?start={}&limit=5'.format(ID_C))
         controls = Mocks.make_paging_controls(5, start=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/batches?head={}&start={}&limit=5'.format(ID_D, ID_C))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=5'.format(ID_D, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
-
-
 
     @unittest_run_loop
     async def test_batch_list_sorted_in_reverse(self):
@@ -450,14 +481,16 @@ class BatchListTests(BaseApiTest):
             - a status of 200
             - a head property of ID_C
             - a link property ending in
-                '/batches?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
+                '/batches?head={}&start={}&limit=100&reverse'
+                    .format(ID_C, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
             - and those dicts are full batches with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         batches = Mocks.make_batches(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, batches=batches)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, batches=batches)
 
         response = await self.get_assert_200('/batches?reverse')
         page_controls = Mocks.make_paging_controls()
@@ -467,15 +500,15 @@ class BatchListTests(BaseApiTest):
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/batches?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
+        self.assert_has_valid_link(
+            response, '/batches?head={}&start={}&limit=100&reverse'.format(
+                ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_batches_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
 class BatchGetTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_BATCH_GET_REQUEST,
@@ -483,7 +516,8 @@ class BatchGetTests(BaseApiTest):
             client_batch_pb2.ClientBatchGetResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        return self.build_app(self.loop, '/batches/{batch_id}', handlers.fetch_batch)
+        return self.build_app(
+            self.loop, '/batches/{batch_id}', handlers.fetch_batch)
 
     @unittest_run_loop
     async def test_batch_get(self):
@@ -523,7 +557,8 @@ class BatchGetTests(BaseApiTest):
             - an error property with a code of 10
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
-        response = await self.get_assert_status('/batches/{}'.format(ID_B), 500)
+        response = await self.get_assert_status('/batches/{}'.format(ID_B),
+                                                500)
 
         self.assert_has_valid_error(response, 10)
 
@@ -539,6 +574,7 @@ class BatchGetTests(BaseApiTest):
             - an error property with a code of 71
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
-        response = await self.get_assert_status('/batches/{}'.format(ID_D), 404)
+        response = await self.get_assert_status('/batches/{}'.format(ID_D),
+                                                404)
 
         self.assert_has_valid_error(response, 71)

--- a/rest_api/tests/unit/test_block_requests.py
+++ b/rest_api/tests/unit/test_block_requests.py
@@ -28,7 +28,6 @@ DEFAULT_LIMIT = 100
 
 
 class BlockListTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_BLOCK_LIST_REQUEST,
@@ -61,14 +60,16 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks')
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/blocks?head={}&start={}&limit=100'.format(ID_C, ID_C))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start={}&limit=100'.format(ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
@@ -129,14 +130,17 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_B, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_B, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
+        self.connection.assert_valid_request_sent(
+            head_id=ID_B, paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/blocks?head={}&start={}&limit=100'.format(ID_B, ID_B))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start={}&limit=100'.format(ID_B, ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_blocks_well_formed(response['data'], ID_B, ID_A)
@@ -153,7 +157,8 @@ class BlockListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/blocks?head={}'.format(ID_D), 404)
+        response = await self.get_assert_status('/blocks?head={}'.format(ID_D),
+                                                404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -174,22 +179,27 @@ class BlockListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/blocks?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
+                '/blocks?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_A, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_A, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?id={},{}'.format(ID_A, ID_C))
+        response = await self.get_assert_200('/blocks?id={},{}'.format(
+            ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(block_ids=[ID_A, ID_C], paging=controls)
+        self.connection.assert_valid_request_sent(
+            block_ids=[ID_A, ID_C], paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(
-            response, '/blocks?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
+            response, '/blocks?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_blocks_well_formed(response['data'], ID_A, ID_C)
@@ -206,19 +216,20 @@ class BlockListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/blocks?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
+                '/blocks?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_B, ID_D))
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
-            self.status.NO_RESOURCE,
-            head_id=ID_C,
-            paging=paging)
-        response = await self.get_assert_200('/blocks?id={},{}'.format(ID_B, ID_D))
+            self.status.NO_RESOURCE, head_id=ID_C, paging=paging)
+        response = await self.get_assert_200('/blocks?id={},{}'.format(
+            ID_B, ID_D))
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(
-            response, '/blocks?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
+            response, '/blocks?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -239,23 +250,28 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_B
-            - a link property that ends in '/blocks?head={}&id={}'.format(ID_B, ID_A)
+            - a link property that ends in
+                '/blocks?head={}&id={}'.format(ID_B, ID_A)
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - and that dict is a full block with an id of ID_A
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_A)
-        self.connection.preset_response(head_id=ID_B, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_B, paging=paging, blocks=blocks)
 
-        response = await self.get_assert_200('/blocks?id={}&head={}'.format(ID_A, ID_B))
+        response = await self.get_assert_200('/blocks?id={}&head={}'.format(
+            ID_A, ID_B))
         self.connection.assert_valid_request_sent(
             head_id=ID_B,
             block_ids=[ID_A],
             paging=Mocks.make_paging_controls())
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/blocks?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start={}&limit=100&id={}'.format(
+                ID_B, ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_blocks_well_formed(response['data'], ID_A)
@@ -266,7 +282,8 @@ class BlockListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a next of '0x0002', start of 0x0003 and limit of 1
+            - a paging response with a next of '0x0002', start of
+              0x0003 and limit of 1
             - one block with the id ID_C
 
         It should send a Protobuf request with:
@@ -276,26 +293,29 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/blocks?head={}&start=1&limit=1'.format(ID_D)
+            - a link property that ends in
+                '/blocks?head={}&start=1&limit=1'.format(ID_D)
             - paging that matches the response, with next and previous links
             - a data property that is a list of 1 dict
             - and that dict is a full block with the id ID_C
+
         """
         # Block list only returns a next id
         paging = Mocks.make_paging_response('0x0002', "0x0003", 1)
         blocks = Mocks.make_blocks(ID_C)
-        self.connection.preset_response(head_id=ID_D, paging=paging,
-                                        blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?start=0x0003&limit=1')
         controls = Mocks.make_paging_controls(1, start='0x0003')
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response,
-                                   '/blocks?head={}&start=0x0003&limit=1'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head={}&start=0x0002&limit=1'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start=0x0003&limit=1'.format(ID_D))
+        self.assert_has_valid_paging(
+            response, paging,
+            '/blocks?head={}&start=0x0002&limit=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
         self.assert_blocks_well_formed(response['data'], ID_C)
 
@@ -333,7 +353,8 @@ class BlockListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a next of 0x0002, start of 0x004 and limit of 2
+            - a paging response with a next of 0x0002, start of 0x004
+              and limit of 2
             - two blocks with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
@@ -342,25 +363,29 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in ''/blocks?head={}&start=0x0004&limit=2'.format(ID_D)
+            - a link property that ends in
+                '/blocks?head={}&start=0x0004&limit=2'.format(ID_D)
             - paging that matches the response with a next link
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids ID_D and ID_C
+
         """
         # Block list only returns a next id
         paging = Mocks.make_paging_response('0x0002', '0x0004', 2)
         blocks = Mocks.make_blocks(ID_D, ID_C)
-        self.connection.preset_response(head_id=ID_D, paging=paging,
-                                        blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?limit=2')
         controls = Mocks.make_paging_controls(2)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/blocks?head={}&start=0x0004&limit=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/blocks?head={}&start=0x0002&limit=2'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start=0x0004&limit=2'.format(ID_D))
+        self.assert_has_valid_paging(
+            response, paging,
+            '/blocks?head={}&start=0x0002&limit=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_blocks_well_formed(response['data'], ID_D, ID_C)
 
@@ -379,21 +404,24 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/blocks?head={}&start=0x0002&limit=100'.format(ID_D)
+            - a link property that ends in
+                '/blocks?head={}&start=0x0002&limit=100'.format(ID_D)
             - paging that matches the response, with a previous link
             - a data property that is a list of 2 dicts
             - and those dicts are full blocks with ids ID_D and ID_C
         """
         paging = Mocks.make_paging_response("", "0x0002", DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?start=0x0002')
         controls = Mocks.make_paging_controls(None, start="0x0002")
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/blocks?head={}&start=0x0002&limit=100'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start=0x0002&limit=100'.format(ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_blocks_well_formed(response['data'], ID_B, ID_A)
@@ -413,25 +441,27 @@ class BlockListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/blocks?head={}&start=0x0003&limit=5'.format(ID_C)
+            - a link property that ends in
+                '/blocks?head={}&start=0x0003&limit=5'.format(ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are full blocks with ids ID_C, ID_B, and ID_A
         """
         paging = Mocks.make_paging_response("", "0x0003", 5)
         blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_D, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_D, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?start=0x0003&limit=5')
         controls = Mocks.make_paging_controls(5, start="0x0003")
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/blocks?head={}&start=0x0003&limit=5'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start=0x0003&limit=5'.format(ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
-
 
     @unittest_run_loop
     async def test_block_list_sorted_in_reverse(self):
@@ -457,27 +487,25 @@ class BlockListTests(BaseApiTest):
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         blocks = Mocks.make_blocks(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, blocks=blocks)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, blocks=blocks)
 
         response = await self.get_assert_200('/blocks?reverse')
         page_controls = Mocks.make_paging_controls()
-        sorting = Mocks.make_sort_controls(
-            'block_num', reverse=True)
+        sorting = Mocks.make_sort_controls('block_num', reverse=True)
         self.connection.assert_valid_request_sent(
-            paging=page_controls,
-            sorting=sorting)
+            paging=page_controls, sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/blocks?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
+        self.assert_has_valid_link(
+            response, '/blocks?head={}&start={}&limit=100&reverse'.format(
+                ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_blocks_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
-
 class BlockGetTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_BLOCK_GET_BY_ID_REQUEST,
@@ -485,7 +513,8 @@ class BlockGetTests(BaseApiTest):
             client_block_pb2.ClientBlockGetResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        return self.build_app(self.loop, '/blocks/{block_id}', handlers.fetch_block)
+        return self.build_app(
+            self.loop, '/blocks/{block_id}', handlers.fetch_block)
 
     @unittest_run_loop
     async def test_block_get(self):

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -36,7 +36,7 @@ class TestRestApiConfig(unittest.TestCase):
 
         """
         config = load_default_rest_api_config()
-        self.assertEqual(config.bind , ["127.0.0.1:8008"])
+        self.assertEqual(config.bind, ["127.0.0.1:8008"])
         self.assertEqual(config.connect, "tcp://localhost:4004")
         self.assertEqual(config.timeout, 300)
 

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -78,10 +78,10 @@ class TestRestApiConfig(unittest.TestCase):
             self.assertEqual(config.bind, ["test:1234"])
             self.assertEqual(config.connect, "tcp://test:4004")
             self.assertEqual(config.timeout, 10)
-            self.assertEquals(config.opentsdb_db,  "data_base")
-            self.assertEquals(config.opentsdb_url, "http://data_base:0000")
-            self.assertEquals(config.opentsdb_username, "name")
-            self.assertEquals(config.opentsdb_password, "secret")
+            self.assertEqual(config.opentsdb_db, "data_base")
+            self.assertEqual(config.opentsdb_url, "http://data_base:0000")
+            self.assertEqual(config.opentsdb_username, "name")
+            self.assertEqual(config.opentsdb_password, "secret")
 
         finally:
             os.environ.clear()

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -15,7 +15,6 @@
 import os
 import unittest
 import shutil
-import sys
 import tempfile
 
 from sawtooth_rest_api.config import load_default_rest_api_config

--- a/rest_api/tests/unit/test_config.py
+++ b/rest_api/tests/unit/test_config.py
@@ -23,9 +23,6 @@ from sawtooth_rest_api.exceptions import RestApiConfigurationError
 
 
 class TestRestApiConfig(unittest.TestCase):
-    def __init__(self, test_name):
-        super().__init__(test_name)
-
     def test_rest_api_defaults_sawtooth_home(self):
         """Tests the default REST API configuration.
 

--- a/rest_api/tests/unit/test_peers_request.py
+++ b/rest_api/tests/unit/test_peers_request.py
@@ -53,4 +53,4 @@ class PeersGetRequestTests(BaseApiTest):
         self.connection.assert_valid_request_sent()
 
         self.assert_has_valid_link(response, '/peers')
-        self.assertEquals(["Peer1", "Peer2"], response['data'])
+        self.assertEqual(["Peer1", "Peer2"], response['data'])

--- a/rest_api/tests/unit/test_peers_request.py
+++ b/rest_api/tests/unit/test_peers_request.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-import json
 from aiohttp.test_utils import unittest_run_loop
-from components import Mocks, BaseApiTest
+
+from components import BaseApiTest
 from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_peers_pb2
 

--- a/rest_api/tests/unit/test_peers_request.py
+++ b/rest_api/tests/unit/test_peers_request.py
@@ -21,7 +21,6 @@ from sawtooth_rest_api.protobuf import client_peers_pb2
 
 
 class PeersGetRequestTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_PEERS_GET_REQUEST,

--- a/rest_api/tests/unit/test_receipt_requests.py
+++ b/rest_api/tests/unit/test_receipt_requests.py
@@ -14,11 +14,14 @@
 # ------------------------------------------------------------------------------
 
 import json
+
 from aiohttp.test_utils import unittest_run_loop
-from components import Mocks, BaseApiTest
+
+from components import BaseApiTest
 from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_receipt_pb2
-from sawtooth_rest_api.protobuf.transaction_receipt_pb2 import TransactionReceipt
+from sawtooth_rest_api.protobuf.transaction_receipt_pb2 import  \
+    TransactionReceipt
 
 
 ID_A = 'a' * 128

--- a/rest_api/tests/unit/test_receipt_requests.py
+++ b/rest_api/tests/unit/test_receipt_requests.py
@@ -28,7 +28,6 @@ ID_D = 'd' * 128
 
 
 class ReceiptGetRequestTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_RECEIPT_GET_REQUEST,
@@ -91,7 +90,8 @@ class ReceiptGetRequestTests(BaseApiTest):
             receipts=receipts,
             status=self.status.NO_RESOURCE)
 
-        response = await self.get_assert_status('/receipts?id={}'.format(ID_D), 404)
+        response = await self.get_assert_status('/receipts?id={}'.format(ID_D),
+                                                404)
         self.connection.assert_valid_request_sent(transaction_ids=[ID_D])
 
         self.assert_has_valid_error(response, 80)
@@ -110,7 +110,8 @@ class ReceiptGetRequestTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D)
+            - link property ending in
+                '/receipts?id={},{},{}' .format(ID_B, ID_C, ID_D)
             - a data property matching the batch statuses received
         """
         receipts = [
@@ -145,7 +146,8 @@ class ReceiptGetRequestTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D)
+            - link property ending in
+                '/receipts?id={},{},{}'.format(ID_B, ID_C, ID_D)
             - a data property matching the batch statuses received
         """
         receipts = [

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from unittest import mock
 from base64 import b64decode
+
 from aiohttp.test_utils import unittest_run_loop
+
 from components import Mocks, BaseApiTest
 from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_state_pb2

--- a/rest_api/tests/unit/test_state_requests.py
+++ b/rest_api/tests/unit/test_state_requests.py
@@ -83,7 +83,8 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100'.format(ID_C))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=a&limit=100'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -169,7 +170,8 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100'.format(ID_B))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=a&limit=100'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
@@ -189,7 +191,8 @@ class StateListTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block())
-        response = await self.get_assert_status('/state?head={}'.format(ID_D), 404)
+        response = await self.get_assert_status('/state?head={}'.format(ID_D),
+                                                404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -232,7 +235,9 @@ class StateListTests(BaseApiTest):
             state_root='beef', address='c', paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&address=c'.format(ID_C))
+        self.assert_has_valid_link(
+            response,
+            '/state?head={}&start=c&limit=100&address=c'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
@@ -248,7 +253,8 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_C
-            - a link property that ends in '/state?head={}&start=c&limit=100address=bad'.format(ID_C)
+            - a link property that ends in
+                '/state?head={}&start=c&limit=100address=bad'.format(ID_C)
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
@@ -266,7 +272,9 @@ class StateListTests(BaseApiTest):
         response = await self.get_assert_200('/state?address=bad')
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&address=bad'.format(ID_C))
+        self.assert_has_valid_link(
+            response,
+            '/state?head={}&start=c&limit=100&address=bad'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -304,14 +312,17 @@ class StateListTests(BaseApiTest):
                 header=block_pb2.BlockHeader(
                     state_root_hash='beef').SerializeToString()))
 
-        response = await self.get_assert_200('/state?address=a&head={}'.format(ID_B))
+        response = await self.get_assert_200(
+            '/state?address=a&head={}'.format(ID_B))
         self.connection.assert_valid_request_sent(
             state_root='beef',
             address='a',
             paging=Mocks.make_paging_controls())
 
         self.assert_has_valid_head(response, ID_B)
-        self.assert_has_valid_link(response, '/state?head={}&start=a&limit=100&address=a'.format(ID_B))
+        self.assert_has_valid_link(
+            response,
+            '/state?head={}&start=a&limit=100&address=a'.format(ID_B))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
@@ -356,8 +367,8 @@ class StateListTests(BaseApiTest):
         self.assert_has_valid_head(response, ID_D)
         self.assert_has_valid_link(
             response, '/state?head={}&start=c&limit=1'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&start=b&limit=1'.format(ID_D))
+        self.assert_has_valid_paging(
+            response, paging, '/state?head={}&start=b&limit=1'.format(ID_D))
         self.assert_has_valid_data_list(response, 1)
         self.assert_entries_match(entries, response['data'])
 
@@ -430,9 +441,10 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&start=d&limit=2'.format(ID_D))
-        self.assert_has_valid_paging(response, paging,
-                                     '/state?head={}&start=b&limit=2'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=d&limit=2'.format(ID_D))
+        self.assert_has_valid_paging(
+            response, paging, '/state?head={}&start=b&limit=2'.format(ID_D))
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
 
@@ -474,7 +486,8 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&start=b&limit=100'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=b&limit=100'.format(ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_entries_match(entries, response['data'])
@@ -494,7 +507,8 @@ class StateListTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 200
             - a head property of ID_D
-            - a link property that ends in '/state?head={}&start=c&limit=5'.format(ID_D, ID_C)
+            - a link property that ends in
+                '/state?head={}&start=c&limit=5'.format(ID_D, ID_C)
             - paging that matches the response, with a previous link
             - a data property that is a list of 3 dicts
             - and those dicts are entries that match those received
@@ -516,11 +530,11 @@ class StateListTests(BaseApiTest):
             state_root='beef', paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=5'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=c&limit=5'.format(ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
-
 
     @unittest_run_loop
     async def test_state_list_sorted_in_reverse(self):
@@ -567,7 +581,8 @@ class StateListTests(BaseApiTest):
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response, '/state?head={}&start=c&limit=100&reverse'.format(ID_C))
+        self.assert_has_valid_link(
+            response, '/state?head={}&start=c&limit=100&reverse'.format(ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_entries_match(entries, response['data'])
@@ -582,7 +597,8 @@ class StateGetTests(BaseApiTest):
             client_state_pb2.ClientStateGetResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        return self.build_app(self.loop, '/state/{address}', handlers.fetch_state)
+        return self.build_app(
+            self.loop, '/state/{address}', handlers.fetch_state)
 
     @unittest_run_loop
     async def test_state_get(self):
@@ -623,7 +639,8 @@ class StateGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_state_get_with_validator_error(self):
-        """Verifies a GET /state/{address} with a validator error breaks properly.
+        """Verifies a GET /state/{address} with a validator error breaks
+        properly.
 
         It will receive a Protobuf response with:
             - a status of INTERNAL_ERROR
@@ -642,7 +659,8 @@ class StateGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_state_get_with_no_genesis(self):
-        """Verifies a GET /state/{address} with validator not ready breaks properly.
+        """Verifies a GET /state/{address} with validator not ready breaks
+        properly.
 
         It will receive a Protobuf response with:
             - a status of NOT_READY
@@ -731,6 +749,7 @@ class StateGetTests(BaseApiTest):
         self.connection.preset_response(
             proto=client_block_pb2.ClientBlockGetResponse,
             block=block_pb2.Block())
-        response = await self.get_assert_status('/state/b?head={}'.format(ID_D), 404)
+        response = await self.get_assert_status(
+            '/state/b?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -14,7 +14,9 @@
 # ------------------------------------------------------------------------------
 
 import json
+
 from aiohttp.test_utils import unittest_run_loop
+
 from components import Mocks, BaseApiTest
 from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_batch_submit_pb2

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -29,7 +29,6 @@ ID_D = 'd' * 128
 
 
 class PostBatchTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_BATCH_SUBMIT_REQUEST,
@@ -63,7 +62,8 @@ class PostBatchTests(BaseApiTest):
 
         response = await request.json()
         self.assertNotIn('data', response)
-        self.assert_has_valid_link(response, '/batch_statuses?id={}'.format(ID_A))
+        self.assert_has_valid_link(
+            response, '/batch_statuses?id={}'.format(ID_A))
 
     @unittest_run_loop
     async def test_post_batch_with_validator_error(self):
@@ -135,7 +135,8 @@ class PostBatchTests(BaseApiTest):
         It should send back a JSON response with:
             - a response status of 202
             - no data property
-            - a link property that ends in '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C)
+            - a link property that ends in
+            '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C)
         """
         batches = Mocks.make_batches(ID_A, ID_B, ID_C)
         self.connection.preset_response()
@@ -146,7 +147,8 @@ class PostBatchTests(BaseApiTest):
 
         response = await request.json()
         self.assertNotIn('data', response)
-        self.assert_has_valid_link(response, '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C))
+        self.assert_has_valid_link(
+            response, '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C))
 
     @unittest_run_loop
     async def test_post_no_batches(self):
@@ -172,7 +174,8 @@ class ClientBatchStatusTests(BaseApiTest):
             client_batch_submit_pb2.ClientBatchStatusResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        return self.build_app(self.loop, '/batch_statuses', handlers.list_statuses)
+        return self.build_app(self.loop, '/batch_statuses',
+                              handlers.list_statuses)
 
     @unittest_run_loop
     async def test_batch_statuses_with_one_id(self):
@@ -193,10 +196,12 @@ class ClientBatchStatusTests(BaseApiTest):
             batch_id=ID_D, status=ClientBatchStatus.PENDING)]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_statuses?id={}'.format(ID_D))
+        response = await self.get_assert_200(
+            '/batch_statuses?id={}'.format(ID_D))
         self.connection.assert_valid_request_sent(batch_ids=[ID_D])
 
-        self.assert_has_valid_link(response, '/batch_statuses?id={}'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/batch_statuses?id={}'.format(ID_D))
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
@@ -218,24 +223,31 @@ class ClientBatchStatusTests(BaseApiTest):
             - a link property that ends in '/batch_statuses?id={}'.format(ID_D)
             - a data property matching the batch statuses received
         """
-        statuses = [ClientBatchStatus(
-            batch_id='bad-batch',
-            status=ClientBatchStatus.INVALID,
-            invalid_transactions=[ClientBatchStatus.InvalidTransaction(
-                transaction_id=ID_D,
-                message='error message',
-                extended_data=b'error data')])]
+        statuses = [
+            ClientBatchStatus(
+                batch_id='bad-batch',
+                status=ClientBatchStatus.INVALID,
+                invalid_transactions=[
+                    ClientBatchStatus.InvalidTransaction(
+                        transaction_id=ID_D,
+                        message='error message',
+                        extended_data=b'error data')
+                ])
+        ]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_statuses?id={}'.format(ID_D))
+        response = await self.get_assert_200(
+            '/batch_statuses?id={}'.format(ID_D))
         self.connection.assert_valid_request_sent(batch_ids=[ID_D])
 
-        self.assert_has_valid_link(response, '/batch_statuses?id={}'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/batch_statuses?id={}'.format(ID_D))
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
     async def test_batch_statuses_with_validator_error(self):
-        """Verifies a GET /batch_statuses with a validator error breaks properly.
+        """Verifies a GET /batch_statuses with a validator error breaks
+        properly.
 
         It will receive a Protobuf response with:
             - a status of INTERNAL_ERROR
@@ -281,20 +293,25 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - a link property that ends in '/batch_statuses?id={}&{}'.format(ID_C, ID_D)
+            - a link property that ends in
+              '/batch_statuses?id={}&{}'.format(ID_C, ID_D)
             - a data property matching the batch statuses received
         """
-        statuses = [ClientBatchStatus(
-            batch_id=ID_D, status=ClientBatchStatus.COMMITTED)]
+        statuses = [
+            ClientBatchStatus(
+                batch_id=ID_D, status=ClientBatchStatus.COMMITTED)
+        ]
         self.connection.preset_response(batch_statuses=statuses)
 
-        response = await self.get_assert_200('/batch_statuses?id={}&wait'.format(ID_D))
+        response = await self.get_assert_200(
+            '/batch_statuses?id={}&wait'.format(ID_D))
         self.connection.assert_valid_request_sent(
             batch_ids=[ID_D],
             wait=True,
             timeout=4)
 
-        self.assert_has_valid_link(response, '/batch_statuses?id={}&wait'.format(ID_D))
+        self.assert_has_valid_link(
+            response, '/batch_statuses?id={}&wait'.format(ID_D))
         self.assert_statuses_match(statuses, response['data'])
 
     @unittest_run_loop
@@ -312,7 +329,8 @@ class ClientBatchStatusTests(BaseApiTest):
 
         It should send back a JSON response with:
             - a response status of 200
-            - link property ending in '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C)
+            - link property ending in
+              '/batch_statuses?id={},{},{}'.format(ID_A, ID_B, ID_C)
             - a data property matching the batch statuses received
         """
         statuses = [

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 from aiohttp.test_utils import unittest_run_loop
+
 from components import Mocks, BaseApiTest
 from sawtooth_rest_api.protobuf.validator_pb2 import Message
 from sawtooth_rest_api.protobuf import client_transaction_pb2

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -28,7 +28,6 @@ DEFAULT_LIMIT = 100
 
 
 class TransactionListTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_TRANSACTION_LIST_REQUEST,
@@ -36,7 +35,8 @@ class TransactionListTests(BaseApiTest):
             client_transaction_pb2.ClientTransactionListResponse)
 
         handlers = self.build_handlers(self.loop, self.connection)
-        app = self.build_app(self.loop, '/transactions', handlers.list_transactions)
+        app = self.build_app(self.loop, '/transactions',
+                             handlers.list_transactions)
         return app
 
     @unittest_run_loop
@@ -138,9 +138,11 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns(ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?head={}'.format(ID_B))
+        response = await self.get_assert_200(
+            '/transactions?head={}'.format(ID_B))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(head_id=ID_B, paging=controls)
+        self.connection.assert_valid_request_sent(
+            head_id=ID_B, paging=controls)
         self.assert_has_valid_head(response, ID_B)
         self.assert_has_valid_link(
             response,
@@ -161,7 +163,8 @@ class TransactionListTests(BaseApiTest):
             - an error property with a code of 50
         """
         self.connection.preset_response(self.status.NO_ROOT)
-        response = await self.get_assert_status('/transactions?head={}'.format(ID_D), 404)
+        response = await self.get_assert_status(
+            '/transactions?head={}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 50)
 
@@ -182,22 +185,28 @@ class TransactionListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
+                '/transactions?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_A, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 2 dicts
             - those dicts are full transactions with ids ID_A and ID_C
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         transactions = Mocks.make_txns(ID_A, ID_C)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, transactions=transactions)
 
-        response = await self.get_assert_200('/transactions?id={},{}'.format(ID_A, ID_C))
+        response = await self.get_assert_200('/transactions?id={},{}'.format(
+            ID_A, ID_C))
         controls = Mocks.make_paging_controls()
-        self.connection.assert_valid_request_sent(transaction_ids=[ID_A, ID_C], paging=controls)
+        self.connection.assert_valid_request_sent(
+            transaction_ids=[ID_A, ID_C], paging=controls)
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(
-            response, '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_A, ID_C))
+            response,
+            '/transactions?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_A, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_A, ID_C)
@@ -214,21 +223,22 @@ class TransactionListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_C, the latest
             - a link property that ends in
-                '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
+                '/transactions?head={}&start={}&limit=100&id={},{}'
+                    .format(ID_C, ID_C, ID_B, ID_D))
             - a paging property with only a total_count of 0
             - a data property that is an empty list
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         self.connection.preset_response(
-            self.status.NO_RESOURCE,
-            head_id=ID_C,
-            paging=paging)
-        response = await self.get_assert_200('/transactions?id={},{}'.format(ID_B, ID_D))
+            self.status.NO_RESOURCE, head_id=ID_C, paging=paging)
+        response = await self.get_assert_200('/transactions?id={},{}'.format(
+            ID_B, ID_D))
 
         self.assert_has_valid_head(response, ID_C)
         self.assert_has_valid_link(
             response,
-            '/transactions?head={}&start={}&limit=100&id={},{}'.format(ID_C, ID_C, ID_B, ID_D))
+            '/transactions?head={}&start={}&limit=100&id={},{}'.format(
+                ID_C, ID_C, ID_B, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 0)
 
@@ -250,27 +260,26 @@ class TransactionListTests(BaseApiTest):
             - a response status of 200
             - a head property of ID_B
             - a link property that ends in
-                '/transactions?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
+                '/transactions?head={}&start={}&limit=100&id={}'
+                    .format(ID_B, ID_B, ID_A))
             - a paging property that matches the paging response
             - a data property that is a list of 1 dict
             - that dict is a full transaction with an id of ID_A
         """
         paging = Mocks.make_paging_response("", ID_B, DEFAULT_LIMIT)
         self.connection.preset_response(
-            head_id=ID_B,
-            paging=paging,
-            transactions=Mocks.make_txns(ID_A))
+            head_id=ID_B, paging=paging, transactions=Mocks.make_txns(ID_A))
 
-        response = await self.get_assert_200('/transactions?id={}&head={}'.format(ID_A, ID_B))
+        response = await self.get_assert_200(
+            '/transactions?id={}&head={}'.format(ID_A, ID_B))
         controls = Mocks.make_paging_controls()
         self.connection.assert_valid_request_sent(
-            head_id=ID_B,
-            transaction_ids=[ID_A],
-            paging=controls)
+            head_id=ID_B, transaction_ids=[ID_A], paging=controls)
 
         self.assert_has_valid_head(response, ID_B)
         self.assert_has_valid_link(
-            response, '/transactions?head={}&start={}&limit=100&id={}'.format(ID_B, ID_B, ID_A))
+            response, '/transactions?head={}&start={}&limit=100&id={}'.format(
+                ID_B, ID_B, ID_A))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 1)
         self.assert_txns_well_formed(response['data'], ID_A)
@@ -309,7 +318,8 @@ class TransactionListTests(BaseApiTest):
 
         It will receive a Protobuf response with:
             - a head id of ID_D
-            - a paging response with a start of ID_D, next of ID_B and limit of 2
+            - a paging response with a start of ID_D, next of ID_B and
+              limit of 2
             - two transactions with the ids ID_D and ID_C
 
         It should send a Protobuf request with:
@@ -335,11 +345,12 @@ class TransactionListTests(BaseApiTest):
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&start={}&limit=2'.format(ID_D, ID_D))
+        self.assert_has_valid_link(
+            response, '/transactions?head={}&start={}&limit=2'.format(
+                ID_D, ID_D))
         self.assert_has_valid_paging(
-            response, paging,
-            '/transactions?head={}&start={}&limit=2'.format(ID_D, ID_B))
+            response, paging, '/transactions?head={}&start={}&limit=2'.format(
+                ID_D, ID_B))
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_D, ID_C)
 
@@ -376,7 +387,8 @@ class TransactionListTests(BaseApiTest):
 
         self.assert_has_valid_head(response, ID_D)
         self.assert_has_valid_link(
-            response, '/transactions?head={}&start={}&limit=100'.format(ID_D, ID_D))
+            response, '/transactions?head={}&start={}&limit=100'.format(
+                ID_D, ID_D))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 2)
         self.assert_txns_well_formed(response['data'], ID_B, ID_A)
@@ -408,16 +420,18 @@ class TransactionListTests(BaseApiTest):
             paging=paging,
             transactions=Mocks.make_txns(ID_C, ID_B, ID_A))
 
-        response = await self.get_assert_200('/transactions?start={}&limit=5'.format(ID_C))
+        response = await self.get_assert_200(
+            '/transactions?start={}&limit=5'.format(ID_C))
         controls = Mocks.make_paging_controls(5, start=ID_C)
         self.connection.assert_valid_request_sent(paging=controls)
 
         self.assert_has_valid_head(response, ID_D)
-        self.assert_has_valid_link(response, '/transactions?head={}&start={}&limit=5'.format(ID_D, ID_C))
+        self.assert_has_valid_link(
+            response, '/transactions?head={}&start={}&limit=5'.format(
+                ID_D, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
-
 
     @unittest_run_loop
     async def test_txn_list_sorted_in_reverse(self):
@@ -436,14 +450,17 @@ class TransactionListTests(BaseApiTest):
             - a status of 200
             - a head property of ID_C
             - a link property ending in
-                '/transactions?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
+                '/transactions?head={}&start={}&limit=100&reverse'
+                    .format(ID_C, ID_C))
             - a paging property that matches the paging response
             - a data property that is a list of 3 dicts
-            - and those dicts are full transactions with ids ID_C, ID_B, and ID_A
+            - and those dicts are full transactions with ids ID_C,
+              ID_B, and ID_A
         """
         paging = Mocks.make_paging_response("", ID_C, DEFAULT_LIMIT)
         transactions = Mocks.make_txns(ID_C, ID_B, ID_A)
-        self.connection.preset_response(head_id=ID_C, paging=paging, transactions=transactions)
+        self.connection.preset_response(
+            head_id=ID_C, paging=paging, transactions=transactions)
         response = await self.get_assert_200('/transactions?reverse')
         page_controls = Mocks.make_paging_controls()
         sorting = Mocks.make_sort_controls("default", reverse=True)
@@ -452,15 +469,16 @@ class TransactionListTests(BaseApiTest):
             sorting=sorting)
 
         self.assert_has_valid_head(response, ID_C)
-        self.assert_has_valid_link(response,
-            '/transactions?head={}&start={}&limit=100&reverse'.format(ID_C, ID_C))
+        self.assert_has_valid_link(
+            response,
+            '/transactions?head={}&start={}&limit=100&reverse'.format(
+                ID_C, ID_C))
         self.assert_has_valid_paging(response, paging)
         self.assert_has_valid_data_list(response, 3)
         self.assert_txns_well_formed(response['data'], ID_C, ID_B, ID_A)
 
 
 class TransactionGetTests(BaseApiTest):
-
     async def get_application(self):
         self.set_status_and_connection(
             Message.CLIENT_TRANSACTION_GET_REQUEST,
@@ -501,7 +519,8 @@ class TransactionGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_txn_get_with_validator_error(self):
-        """Verifies GET /transactions/{transaction_id} w/ validator error breaks.
+        """Verifies GET /transactions/{transaction_id} w/ validator error
+        breaks.
 
         It will receive a Protobuf response with:
             - a status of INTERNAL_ERROR
@@ -511,7 +530,8 @@ class TransactionGetTests(BaseApiTest):
             - an error property with a code of 10
         """
         self.connection.preset_response(self.status.INTERNAL_ERROR)
-        response = await self.get_assert_status('/transactions/{}'.format(ID_B), 500)
+        response = await self.get_assert_status(
+            '/transactions/{}'.format(ID_B), 500)
 
         self.assert_has_valid_error(response, 10)
 
@@ -527,6 +547,7 @@ class TransactionGetTests(BaseApiTest):
             - an error property with a code of 72
         """
         self.connection.preset_response(self.status.NO_RESOURCE)
-        response = await self.get_assert_status('/transactions/{}'.format(ID_D), 404)
+        response = await self.get_assert_status(
+            '/transactions/{}'.format(ID_D), 404)
 
         self.assert_has_valid_error(response, 72)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
@@ -220,6 +220,5 @@ class IntkeyClient:
         batch = Batch(
             header=header,
             transactions=transactions,
-            header_signature=signature
-        )
+            header_signature=signature)
         return BatchList(batches=[batch])

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_workload.py
@@ -50,7 +50,7 @@ def post_batches(url, batches, auth_info=None):
         code, json_result = (result.status_code, result.json())
         if not (code == 200 or code == 201 or code == 202):
             LOGGER.warning("(%s): %s", code, json_result)
-        return(code, json_result)
+        return (code, json_result)
     except requests.exceptions.HTTPError as e:
         LOGGER.warning("(%s): %s", e.response.status_code, e.response.reason)
         return (e.response.status_code, e.response.reason)
@@ -79,6 +79,7 @@ class IntKeyWorkload(Workload):
         the simulator know that the old transaction should be put back in
         the queue to be checked again if it is pending.
     """
+
     def __init__(self, delegate, args):
         super(IntKeyWorkload, self).__init__(delegate, args)
         self._auth_info = args.auth_info

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/load.py
@@ -41,7 +41,7 @@ def post_batches(url, auth_info, batches):
         code, json_result = (result.status_code, result.json())
         if not (code == 200 or code == 201 or code == 202):
             LOGGER.warning("(%s): %s", code, json_result)
-        return(code, json_result)
+        return (code, json_result)
     except requests.exceptions.HTTPError as e:
         LOGGER.warning("(%s): %s", e.response.status_code, e.response.reason)
         return (e.response.status_code, e.response.reason)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/sawtooth_workload.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/sawtooth_workload.py
@@ -23,6 +23,7 @@ class Workload(object, metaclass=abc.ABCMeta):
        define the interface that the workload generator expects and
        hold onto one property for derived classes.
     """
+
     @abc.abstractmethod
     def __init__(self, delegate, args):
         """

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
@@ -38,6 +38,7 @@ class WorkloadGenerator(object):
     keeps track of submitted and committed batches. To run, it must first have
     a Workload set, as this is where the batches are created.
     """
+
     def __init__(self, args):
         self._workload = None
         self._auth_info = args.auth_info

--- a/sdk/examples/intkey_python/sawtooth_intkey/intkey_message_factory.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/intkey_message_factory.py
@@ -26,8 +26,7 @@ class IntkeyMessageFactory:
             family_name='intkey',
             family_version='1.0',
             namespace=INTKEY_ADDRESS_PREFIX,
-            signer=signer
-        )
+            signer=signer)
 
     def _dumps(self, obj):
         return cbor.dumps(obj, sort_keys=True)
@@ -57,8 +56,10 @@ class IntkeyMessageFactory:
         return self._create_txn(txn_function, verb, name, value)
 
     def create_batch(self, triples):
-        txns = [self.create_transaction(verb, name, value)
-                for verb, name, value in triples]
+        txns = [
+            self.create_transaction(verb, name, value)
+            for verb, name, value in triples
+        ]
 
         return self._factory.create_batch(txns)
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
@@ -81,8 +81,7 @@ def _decode_transaction(transaction):
     try:
         content = cbor.loads(transaction.payload)
     except:
-        raise InvalidTransaction(
-            'Invalid payload serialization')
+        raise InvalidTransaction('Invalid payload serialization')
 
     try:
         verb = content['Verb']
@@ -104,8 +103,7 @@ def _decode_transaction(transaction):
 
 def _validate_verb(verb):
     if verb not in VALID_VERBS:
-        raise InvalidTransaction(
-            'Verb must be "set", "inc", or "dec"')
+        raise InvalidTransaction('Verb must be "set", "inc", or "dec"')
 
 
 def _validate_name(name):
@@ -134,8 +132,7 @@ def _get_state_data(name, context):
     except IndexError:
         return {}
     except:
-        raise InternalError(
-            'Failed to load state data')
+        raise InternalError('Failed to load state data')
 
 
 def _set_state_data(name, state, context):
@@ -146,8 +143,7 @@ def _set_state_data(name, state, context):
     addresses = context.set_state({address: encoded})
 
     if not addresses:
-        raise InternalError(
-            'State error')
+        raise InternalError('State error')
 
 
 def _do_intkey(verb, name, value, state):
@@ -161,8 +157,7 @@ def _do_intkey(verb, name, value, state):
         return verbs[verb](name, value, state)
     except KeyError:
         # This would be a programming error.
-        raise InternalError(
-            'Unhandled verb: {}'.format(verb))
+        raise InternalError('Unhandled verb: {}'.format(verb))
 
 
 def _do_set(name, value, state):

--- a/sdk/examples/intkey_python/setup.py
+++ b/sdk/examples/intkey_python/setup.py
@@ -24,29 +24,32 @@ from setuptools import setup, find_packages
 data_files = []
 
 if os.path.exists("/etc/default"):
-    data_files.append(('/etc/default', ['packaging/systemd/sawtooth-intkey-tp-python']))
+    data_files.append(
+        ('/etc/default', ['packaging/systemd/sawtooth-intkey-tp-python']))
 
 if os.path.exists("/lib/systemd/system"):
-    data_files.append(('/lib/systemd/system',
-                       ['packaging/systemd/sawtooth-intkey-tp-python.service']))
+    data_files.append(
+        ('/lib/systemd/system',
+         ['packaging/systemd/sawtooth-intkey-tp-python.service']))
 
-setup(name='sawtooth-intkey',
-      version=subprocess.check_output(
-          ['../../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Intkey Python Example',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          "cbor",
-          "colorlog",
-          "sawtooth-sdk",
-          "sawtooth-signing",
-      ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'intkey = sawtooth_intkey.client_cli.intkey_cli:main_wrapper',
-              'intkey-tp-python = sawtooth_intkey.processor.main:main'
-          ]
-      })
+setup(
+    name='sawtooth-intkey',
+    version=subprocess.check_output(
+        ['../../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Intkey Python Example',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        "cbor",
+        "colorlog",
+        "sawtooth-sdk",
+        "sawtooth-signing",
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts': [
+            'intkey = sawtooth_intkey.client_cli.intkey_cli:main_wrapper',
+            'intkey-tp-python = sawtooth_intkey.processor.main:main'
+        ]
+    })

--- a/sdk/examples/intkey_python/tests/test_tp_intkey.py
+++ b/sdk/examples/intkey_python/tests/test_tp_intkey.py
@@ -29,7 +29,6 @@ MAX_NAME_LENGTH = 20
 
 
 class TestIntkey(TransactionProcessorTestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
@@ -34,7 +34,8 @@ LOGGER = logging.getLogger(__name__)
 
 class NoopPayload(object):
     def __init__(self):
-        self.nonce = binascii.b2a_hex(random.getrandbits(8*8).to_bytes(8,hbyteorder='little'))
+        self.nonce = binascii.b2a_hex(random.getrandbits(
+            8 * 8).to_bytes(8, hbyteorder='little'))
         self._sha512 = None
 
     def sha512(self):

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/workload.py
@@ -46,7 +46,7 @@ def post_batches(url, batches):
         code, json_result = (result.status_code, result.json())
         if not (code == 200 or code == 201 or code == 202):
             LOGGER.warning("(%s): %s", code, json_result)
-        return(code, json_result)
+        return (code, json_result)
     except requests.exceptions.HTTPError as e:
         LOGGER.warning("(%s): %s", e.response.status_code, e.response.reason)
         return (e.response.status_code, e.response.reason)
@@ -62,6 +62,7 @@ class NoopWorkload(Workload):
     """
     This workload is for the Sawtooth Noop transaction family.
     """
+
     def __init__(self, delegate, args):
         super(NoopWorkload, self).__init__(delegate, args)
         self._urls = []

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -125,8 +125,7 @@ def _validate_transaction(name, action, space):
 def _validate_game_data(action, space, signer, board, state, player1, player2):
     if action == 'create':
         if board is not None:
-            raise InvalidTransaction(
-                'Invalid action: Game already exists.')
+            raise InvalidTransaction('Invalid action: Game already exists.')
 
     elif action == 'take':
         if board is None:
@@ -134,8 +133,7 @@ def _validate_game_data(action, space, signer, board, state, player1, player2):
                 'Invalid action: Take requires an existing game.')
 
         if state in ('P1-WIN', 'P2-WIN', 'TIE'):
-            raise InvalidTransaction(
-                'Invalid Action: Game has ended.')
+            raise InvalidTransaction('Invalid Action: Game has ended.')
 
         if ((player1 and state == 'P1-NEXT' and player1 != signer)
                 or (player2 and state == 'P2-NEXT' and player2 != signer)):
@@ -148,8 +146,7 @@ def _validate_game_data(action, space, signer, board, state, player1, player2):
 
     elif action == 'delete':
         if board is None:
-            raise InvalidTransaction(
-                'Invalid action: game does not exist')
+            raise InvalidTransaction('Invalid action: game does not exist')
 
 
 def _make_xo_address(namespace_prefix, name):
@@ -223,8 +220,7 @@ def _play_xo(action, space, signer, board, state, player1, player2):
         return '---------', 'P1-NEXT', '', ''
 
     elif action == 'take':
-        upd_player1, upd_player2 = _update_players(
-            player1, player2, signer)
+        upd_player1, upd_player2 = _update_players(player1, player2, signer)
 
         upd_board = _update_board(board, space, state)
 
@@ -258,8 +254,10 @@ def _update_board(board, space, state):
     index = space - 1
 
     # replace the index-th space with mark, leave everything else the same
-    return ''.join([current if square != index else mark
-                    for square, current in enumerate(board)])
+    return ''.join([
+        current if square != index else mark
+        for square, current in enumerate(board)
+    ])
 
 
 def _update_state(state, board):
@@ -267,8 +265,7 @@ def _update_state(state, board):
     o_wins = _is_win(board, 'O')
 
     if x_wins and o_wins:
-        raise InternalError(
-            'Two winners (there can be only one)')
+        raise InternalError('Two winners (there can be only one)')
 
     elif x_wins:
         return 'P1-WIN'
@@ -289,8 +286,7 @@ def _update_state(state, board):
         return state
 
     else:
-        raise InternalError(
-            'Unhandled state: {}'.format(state))
+        raise InternalError('Unhandled state: {}'.format(state))
 
 
 def _is_win(board, letter):

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -68,19 +68,29 @@ class XoClient:
             .new_signer(private_key)
 
     def create(self, name, wait=None, auth_user=None, auth_password=None):
-        return self._send_xo_txn(name, "create", wait=wait,
-                                 auth_user=auth_user,
-                                 auth_password=auth_password)
+        return self._send_xo_txn(
+            name,
+            "create",
+            wait=wait,
+            auth_user=auth_user,
+            auth_password=auth_password)
 
     def delete(self, name, wait=None, auth_user=None, auth_password=None):
-        return self._send_xo_txn(name, "delete", wait=wait,
-                                 auth_user=auth_user,
-                                 auth_password=auth_password)
+        return self._send_xo_txn(
+            name,
+            "delete",
+            wait=wait,
+            auth_user=auth_user,
+            auth_password=auth_password)
 
     def take(self, name, space, wait=None, auth_user=None, auth_password=None):
-        return self._send_xo_txn(name, "take", space, wait=wait,
-                                 auth_user=auth_user,
-                                 auth_password=auth_password)
+        return self._send_xo_txn(
+            name,
+            "take",
+            space,
+            wait=wait,
+            auth_user=auth_user,
+            auth_password=auth_password)
 
     def list(self, auth_user=None, auth_password=None):
         xo_prefix = self._get_prefix()
@@ -88,8 +98,7 @@ class XoClient:
         result = self._send_request(
             "state?address={}".format(xo_prefix),
             auth_user=auth_user,
-            auth_password=auth_password
-        )
+            auth_password=auth_password)
 
         try:
             encoded_entries = yaml.safe_load(result)["data"]
@@ -104,9 +113,11 @@ class XoClient:
     def show(self, name, auth_user=None, auth_password=None):
         address = self._get_address(name)
 
-        result = self._send_request("state/{}".format(address), name=name,
-                                    auth_user=auth_user,
-                                    auth_password=auth_password)
+        result = self._send_request(
+            "state/{}".format(address),
+            name=name,
+            auth_user=auth_user,
+            auth_password=auth_password)
         try:
             return base64.b64decode(yaml.safe_load(result)["data"])
 
@@ -131,9 +142,13 @@ class XoClient:
         game_address = _sha512(name.encode('utf-8'))[0:64]
         return xo_prefix + game_address
 
-    def _send_request(
-            self, suffix, data=None,
-            content_type=None, name=None, auth_user=None, auth_password=None):
+    def _send_request(self,
+                      suffix,
+                      data=None,
+                      content_type=None,
+                      name=None,
+                      auth_user=None,
+                      auth_password=None):
         if self._base_url.startswith("http://"):
             url = "{}/{}".format(self._base_url, suffix)
         else:
@@ -171,8 +186,13 @@ class XoClient:
 
         return result.text
 
-    def _send_xo_txn(self, name, action, space="", wait=None,
-                     auth_user=None, auth_password=None):
+    def _send_xo_txn(self,
+                     name,
+                     action,
+                     space="",
+                     wait=None,
+                     auth_user=None,
+                     auth_password=None):
         # Serialization is just a delimited utf-8 encoded string
         payload = ",".join([name, action, str(space)]).encode()
 
@@ -209,15 +229,13 @@ class XoClient:
                 "batches", batch_list.SerializeToString(),
                 'application/octet-stream',
                 auth_user=auth_user,
-                auth_password=auth_password
-            )
+                auth_password=auth_password)
             while wait_time < wait:
                 status = self._get_status(
                     batch_id,
                     wait - int(wait_time),
                     auth_user=auth_user,
-                    auth_password=auth_password
-                )
+                    auth_password=auth_password)
                 wait_time = time.time() - start_time
 
                 if status != 'PENDING':
@@ -229,8 +247,7 @@ class XoClient:
             "batches", batch_list.SerializeToString(),
             'application/octet-stream',
             auth_user=auth_user,
-            auth_password=auth_password
-        )
+            auth_password=auth_password)
 
     def _create_batch_list(self, transactions):
         transaction_signatures = [t.header_signature for t in transactions]
@@ -245,6 +262,5 @@ class XoClient:
         batch = Batch(
             header=header,
             transactions=transactions,
-            header_signature=signature
-        )
+            header_signature=signature)
         return BatchList(batches=[batch])

--- a/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_message_factory.py
@@ -22,8 +22,7 @@ class XoMessageFactory:
             family_name="xo",
             family_version="1.0",
             namespace=MessageFactory.sha512("xo".encode("utf-8"))[0:6],
-            signer=signer
-        )
+            signer=signer)
 
     def _game_to_address(self, game):
         return self._factory.namespace + \

--- a/sdk/examples/xo_python/setup.py
+++ b/sdk/examples/xo_python/setup.py
@@ -23,31 +23,33 @@ from setuptools import setup, find_packages
 data_files = []
 
 if os.path.exists("/etc/default"):
-    data_files.append(('/etc/default', ['packaging/systemd/sawtooth-xo-tp-python']))
+    data_files.append(
+        ('/etc/default', ['packaging/systemd/sawtooth-xo-tp-python']))
 
 if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',
                        ['packaging/systemd/sawtooth-xo-tp-python.service']))
 
-setup(name='sawtooth-xo',
-      version=subprocess.check_output(
-          ['../../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth XO Example',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'aiohttp',
-          'colorlog',
-          'protobuf',
-          'sawtooth-sdk',
-          'sawtooth-signing',
-          'PyYAML',
-          ],
-      data_files=data_files,
-      entry_points={
-          'console_scripts': [
-              'xo = sawtooth_xo.xo_cli:main_wrapper',
-              'xo-tp-python = sawtooth_xo.processor.main:main',
-          ]
-      })
+setup(
+    name='sawtooth-xo',
+    version=subprocess.check_output(
+        ['../../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth XO Example',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'aiohttp',
+        'colorlog',
+        'protobuf',
+        'sawtooth-sdk',
+        'sawtooth-signing',
+        'PyYAML',
+    ],
+    data_files=data_files,
+    entry_points={
+        'console_scripts': [
+            'xo = sawtooth_xo.xo_cli:main_wrapper',
+            'xo-tp-python = sawtooth_xo.processor.main:main',
+        ]
+    })

--- a/sdk/examples/xo_python/tests/test_tp_xo.py
+++ b/sdk/examples/xo_python/tests/test_tp_xo.py
@@ -24,7 +24,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestXo(TransactionProcessorTestCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -60,8 +60,7 @@ def _signer():
 
 
 class MessageFactory(object):
-    def __init__(self, family_name, family_version,
-                 namespace, signer=None):
+    def __init__(self, family_name, family_version, namespace, signer=None):
         self.family_name = family_name
         self.family_version = family_version
         if isinstance(namespace, (list)):
@@ -93,8 +92,7 @@ class MessageFactory(object):
         return TpRegisterRequest(
             family=self.family_name,
             version=self.family_version,
-            namespaces=self.namespaces
-        )
+            namespaces=self.namespaces)
 
     def create_tp_response(self, status):
         responses = {
@@ -141,8 +139,7 @@ class MessageFactory(object):
         signature = self._create_signature(header.SerializeToString())
         return header, signature
 
-    def create_transaction(self, payload, inputs, outputs, deps,
-                           batcher=None):
+    def create_transaction(self, payload, inputs, outputs, deps, batcher=None):
         header, signature = self._create_header_and_sig(
             payload, inputs, outputs, deps, batcher=batcher)
 

--- a/sdk/python/sawtooth_processor_test/message_types.py
+++ b/sdk/python/sawtooth_processor_test/message_types.py
@@ -59,8 +59,7 @@ def to_protobuf_class(message_type):
         return _TYPE_TO_PROTO[message_type]
     else:
         raise UnknownMessageTypeException(
-            "Unknown message type: {}".format(message_type)
-        )
+            "Unknown message type: {}".format(message_type))
 
 
 def to_message_type(proto):
@@ -70,5 +69,4 @@ def to_message_type(proto):
         return _PROTO_TO_TYPE[proto_class]
     else:
         raise UnknownMessageTypeException(
-            "Unknown protobuf class: {}".format(proto_class)
-        )
+            "Unknown protobuf class: {}".format(proto_class))

--- a/sdk/python/sawtooth_processor_test/mock_validator.py
+++ b/sdk/python/sawtooth_processor_test/mock_validator.py
@@ -49,7 +49,6 @@ class UnexpectedMessageException(Exception):
 
 
 class MockValidator(object):
-
     def __init__(self):
         self._comparators = {}
 
@@ -156,8 +155,7 @@ class MockValidator(object):
         )
 
         return self._loop.run_until_complete(
-            self._send(self._tp_ident, message)
-        )
+            self._send(self._tp_ident, message))
 
     async def _send(self, ident, message):
         """

--- a/sdk/python/sawtooth_sdk/messaging/stream.py
+++ b/sdk/python/sawtooth_sdk/messaging/stream.py
@@ -159,11 +159,16 @@ class _SendReceiveThread(Thread):
         """
         if not self._ready_event.is_set():
             return
+
         with self._condition:
-            self._condition.wait_for(lambda: self._event_loop is not None
-                                     and self._send_queue is not None)
-        asyncio.run_coroutine_threadsafe(self._put_message(message),
-                                         self._event_loop)
+            self._condition.wait_for(
+                lambda: self._event_loop is not None
+                and self._send_queue is not None
+            )
+
+        asyncio.run_coroutine_threadsafe(
+            self._put_message(message),
+            self._event_loop)
 
     def get_message(self):
         """

--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -30,6 +30,7 @@ class Context(object):
         _context_id (str): the context_id passed in from the validator
 
     """
+
     def __init__(self, stream, context_id):
         self._stream = stream
         self._context_id = context_id
@@ -83,9 +84,10 @@ class Context(object):
         Raises:
             AuthorizationException
         """
-        state_entries = [state_context_pb2.TpStateEntry(
-            address=e,
-            data=entries[e]) for e in entries]
+        state_entries = [
+            state_context_pb2.TpStateEntry(address=e, data=entries[e])
+            for e in entries
+        ]
         request = state_context_pb2.TpStateSetRequest(
             entries=state_entries,
             context_id=self._context_id).SerializeToString()

--- a/sdk/python/sawtooth_sdk/processor/core.py
+++ b/sdk/python/sawtooth_sdk/processor/core.py
@@ -47,6 +47,7 @@ class TransactionProcessor(object):
     validator and routing transaction processing requests to a registered
     handler. It uses ZMQ and channels to handle requests concurrently.
     """
+
     def __init__(self, url):
         """
         Args:
@@ -77,8 +78,9 @@ class TransactionProcessor(object):
         :return: handler
         """
         try:
-            return next(handler for handler in self._handlers
-                        if self._matches(handler, header))
+            return next(
+                handler for handler in self._handlers
+                if self._matches(handler, header))
         except StopIteration:
             LOGGER.debug("Missing handler for header: %s", header)
             return None

--- a/sdk/python/sawtooth_sdk/processor/exceptions.py
+++ b/sdk/python/sawtooth_sdk/processor/exceptions.py
@@ -22,6 +22,7 @@ class _TpResponseError(Exception):
         extended_data (bytes, optional): Byte-encoded data to be parsed later
             by the app developer. Opaque to the validator and Sawtooth.
     """
+
     def __init__(self, message, extended_data=None):
         super().__init__(message)
 

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -37,20 +37,20 @@ data_files = [
     (log_dir, []),
 ]
 
-
-setup(name='sawtooth-sdk',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Python SDK',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      data_files=data_files,
-      install_requires=[
-          "colorlog",
-          "sawtooth-signing",
-          "protobuf",
-          "pyzmq",
-          "toml",
-          "PyYAML",
-      ])
+setup(
+    name='sawtooth-sdk',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Python SDK',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    data_files=data_files,
+    install_requires=[
+        "colorlog",
+        "sawtooth-signing",
+        "protobuf",
+        "pyzmq",
+        "toml",
+        "PyYAML",
+    ])

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -54,8 +54,10 @@ class ContextTest(unittest.TestCase):
 
     def _make_entries(self, protobuf=True):
         if protobuf:
-            return [TpStateEntry(address=a, data=d)
-                    for a, d in zip(self.addresses, self.data)]
+            return [
+                TpStateEntry(address=a, data=d)
+                for a, d in zip(self.addresses, self.data)
+            ]
 
         entries = OrderedDict()
         for a, d in zip(self.addresses, self.data):

--- a/signing/sawtooth_signing/__init__.py
+++ b/signing/sawtooth_signing/__init__.py
@@ -22,6 +22,7 @@ from sawtooth_signing.secp256k1 import Secp256k1Context
 class Signer:
     """A convenient wrapper of Context and PrivateKey
     """
+
     def __init__(self, context, private_key):
         """
         """
@@ -55,6 +56,7 @@ class Signer:
 class CryptoFactory:
     """Factory for generating Signers.
     """
+
     def __init__(self, context):
         self._context = context
 

--- a/signing/sawtooth_signing/core.py
+++ b/signing/sawtooth_signing/core.py
@@ -41,6 +41,7 @@ class PrivateKey(metaclass=ABCMeta):
 
     The underlying content is dependent on implementation.
     """
+
     @abstractmethod
     def get_algorithm_name(self):
         """Returns the algorithm name used for this private key.
@@ -65,6 +66,7 @@ class PublicKey(metaclass=ABCMeta):
 
     The underlying content is dependent on implementation.
     """
+
     @abstractmethod
     def get_algorithm_name(self):
         """Returns the algorithm name used for this public key.
@@ -87,6 +89,7 @@ class PublicKey(metaclass=ABCMeta):
 class Context(metaclass=ABCMeta):
     """A context for a cryptographic signing algorithm.
     """
+
     @abstractmethod
     def get_algorithm_name(self):
         """Returns the algorithm name.

--- a/signing/sawtooth_signing/secp256k1.py
+++ b/signing/sawtooth_signing/secp256k1.py
@@ -33,7 +33,6 @@ __PK__ = secp256k1.PublicKey(ctx=__CTX__)  # Cache object to use as factory
 
 
 class Secp256k1PrivateKey(PrivateKey):
-
     def __init__(self, secp256k1_private_key):
         self._private_key = secp256k1_private_key
 
@@ -106,7 +105,6 @@ class Secp256k1PublicKey(PublicKey):
 
 
 class Secp256k1Context(Context):
-
     def __init__(self):
         self._ctx = __CTX__
 

--- a/signing/tests/test_secp256k1_signer.py
+++ b/signing/tests/test_secp256k1_signer.py
@@ -46,7 +46,6 @@ MSG2_KEY2_SIG = ("d589c7b1fa5f8a4c5a389de80ae9582c2f7f2a5e21bab5450b670214e5b1"
 
 
 class Secp256k1SigningTest(unittest.TestCase):
-
     def test_hex_key(self):
         priv_key = Secp256k1PrivateKey.from_hex(KEY1_PRIV_HEX)
         self.assertEqual(priv_key.get_algorithm_name(), "secp256k1")

--- a/utility/ias_client/setup.py
+++ b/utility/ias_client/setup.py
@@ -25,14 +25,15 @@ if os.name == 'nt':
 else:
     conf_dir = "/etc/sawtooth"
 
-setup(name='sawtooth-ias-client',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Intel Attestation Service Client',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'requests',
-          ],
-      entry_points={})
+setup(
+    name='sawtooth-ias-client',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Intel Attestation Service Client',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'requests',
+    ],
+    entry_points={})

--- a/utility/ias_client/tests/unit/test_ias_client.py
+++ b/utility/ias_client/tests/unit/test_ias_client.py
@@ -25,7 +25,6 @@ URL = "http://127.0.0.1:8008"
 
 
 class TestIasClient(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.mock_server = mock_ias_server.create(URL)

--- a/utility/ias_proxy/sawtooth_ias_proxy/ias_proxy.py
+++ b/utility/ias_proxy/sawtooth_ias_proxy/ias_proxy.py
@@ -219,6 +219,7 @@ def main():
     relay = get_server()
     relay.run()
 
+
 if __name__ == '__main__':
     # pylint: disable=bare-except
     try:

--- a/utility/ias_proxy/sawtooth_ias_proxy/ias_proxy_cli.py
+++ b/utility/ias_proxy/sawtooth_ias_proxy/ias_proxy_cli.py
@@ -114,5 +114,6 @@ def main(args=None):
     server = ias_proxy.get_server()
     server.run()
 
+
 if __name__ == '__main__':
     main(args=sys.argv[1:])

--- a/utility/ias_proxy/sawtooth_ias_proxy/utils.py
+++ b/utility/ias_proxy/sawtooth_ias_proxy/utils.py
@@ -21,6 +21,7 @@ class LruCache(object):
     """
     A simple thread-safe lru cache.
     """
+
     def __init__(self, max_size=100):
         self.max_size = max_size
         self.order = deque(maxlen=self.max_size)

--- a/utility/ias_proxy/setup.py
+++ b/utility/ias_proxy/setup.py
@@ -29,19 +29,20 @@ data_files = [
     (conf_dir, ['packaging/ias_proxy.toml.example']),
 ]
 
-setup(name='sawtooth-ias-proxy',
-      version=subprocess.check_output(
-          ['../../bin/get_version']).decode('utf-8').strip(),
-      description='Sawtooth Intel Attestation Service Proxy',
-      author='Hyperledger Sawtooth',
-      url='https://github.com/hyperledger/sawtooth-core',
-      packages=find_packages(),
-      install_requires=[
-          'colorlog',
-          'requests',
-          'sawtooth-ias-client',
-          'sawtooth-sdk',
-          'toml',
-          ],
-      data_files=data_files,
-      entry_points={})
+setup(
+    name='sawtooth-ias-proxy',
+    version=subprocess.check_output(
+        ['../../bin/get_version']).decode('utf-8').strip(),
+    description='Sawtooth Intel Attestation Service Proxy',
+    author='Hyperledger Sawtooth',
+    url='https://github.com/hyperledger/sawtooth-core',
+    packages=find_packages(),
+    install_requires=[
+        'colorlog',
+        'requests',
+        'sawtooth-ias-client',
+        'sawtooth-sdk',
+        'toml',
+    ],
+    data_files=data_files,
+    entry_points={})

--- a/utility/ias_proxy/tests/test_ias_proxy/test_ias_proxy.py
+++ b/utility/ias_proxy/tests/test_ias_proxy/test_ias_proxy.py
@@ -32,7 +32,6 @@ from sawtooth_poet_sgx.poet_enclave_sgx import poet_enclave as poet
 
 
 class TestIasProxyClient(TestCase):
-
     @classmethod
     def setUpClass(cls):
 

--- a/validator/sawtooth_validator/concurrent/threadpool.py
+++ b/validator/sawtooth_validator/concurrent/threadpool.py
@@ -27,7 +27,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):
-
     def __init__(self, max_workers=None, name='', trace=None):
         if trace is None:
             self._trace = 'SAWTOOTH_TRACE_LOGGING' in os.environ
@@ -38,8 +37,7 @@ class InstrumentedThreadPoolExecutor(ThreadPoolExecutor):
         if name == '':
             self._name = 'Instrumented'
 
-        LOGGER.debug(
-            'Creating thread pool executor %s', self._name)
+        LOGGER.debug('Creating thread pool executor %s', self._name)
 
         self._workers_in_use = atomic.Counter()
 

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -72,9 +72,9 @@ def load_toml_validator_config(filename):
     bind_component = None
     for bind in toml_config.get("bind", []):
         if "network" in bind:
-            bind_network = bind[bind.find(":")+1:]
+            bind_network = bind[bind.find(":") + 1:]
         if "component" in bind:
-            bind_component = bind[bind.find(":")+1:]
+            bind_component = bind[bind.find(":") + 1:]
 
     network_public_key = None
     network_private_key = None
@@ -86,24 +86,24 @@ def load_toml_validator_config(filename):
         network_private_key = toml_config.get("network_private_key").encode()
 
     config = ValidatorConfig(
-         bind_network=bind_network,
-         bind_component=bind_component,
-         endpoint=toml_config.get("endpoint", None),
-         peering=toml_config.get("peering", None),
-         seeds=toml_config.get("seeds", None),
-         peers=toml_config.get("peers", None),
-         network_public_key=network_public_key,
-         network_private_key=network_private_key,
-         scheduler=toml_config.get("scheduler", None),
-         permissions=parse_permissions(toml_config.get("permissions", None)),
-         roles=toml_config.get("roles", None),
-         opentsdb_url=toml_config.get("opentsdb_url", None),
-         opentsdb_db=toml_config.get("opentsdb_db", None),
-         opentsdb_username=toml_config.get("opentsdb_username", None),
-         opentsdb_password=toml_config.get("opentsdb_password", None),
-         minimum_peer_connectivity=toml_config.get(
+        bind_network=bind_network,
+        bind_component=bind_component,
+        endpoint=toml_config.get("endpoint", None),
+        peering=toml_config.get("peering", None),
+        seeds=toml_config.get("seeds", None),
+        peers=toml_config.get("peers", None),
+        network_public_key=network_public_key,
+        network_private_key=network_private_key,
+        scheduler=toml_config.get("scheduler", None),
+        permissions=parse_permissions(toml_config.get("permissions", None)),
+        roles=toml_config.get("roles", None),
+        opentsdb_url=toml_config.get("opentsdb_url", None),
+        opentsdb_db=toml_config.get("opentsdb_db", None),
+        opentsdb_username=toml_config.get("opentsdb_username", None),
+        opentsdb_password=toml_config.get("opentsdb_password", None),
+        minimum_peer_connectivity=toml_config.get(
             "minimum_peer_connectivity", None),
-         maximum_peer_connectivity=toml_config.get(
+        maximum_peer_connectivity=toml_config.get(
             "maximum_peer_connectivity", None)
     )
 
@@ -171,24 +171,23 @@ def merge_validator_config(configs):
             maximum_peer_connectivity = config.maximum_peer_connectivity
 
     return ValidatorConfig(
-         bind_network=bind_network,
-         bind_component=bind_component,
-         endpoint=endpoint,
-         peering=peering,
-         seeds=seeds,
-         peers=peers,
-         network_public_key=network_public_key,
-         network_private_key=network_private_key,
-         scheduler=scheduler,
-         permissions=permissions,
-         roles=roles,
-         opentsdb_url=opentsdb_url,
-         opentsdb_db=opentsdb_db,
-         opentsdb_username=opentsdb_username,
-         opentsdb_password=opentsdb_password,
-         minimum_peer_connectivity=minimum_peer_connectivity,
-         maximum_peer_connectivity=maximum_peer_connectivity
-    )
+        bind_network=bind_network,
+        bind_component=bind_component,
+        endpoint=endpoint,
+        peering=peering,
+        seeds=seeds,
+        peers=peers,
+        network_public_key=network_public_key,
+        network_private_key=network_private_key,
+        scheduler=scheduler,
+        permissions=permissions,
+        roles=roles,
+        opentsdb_url=opentsdb_url,
+        opentsdb_db=opentsdb_db,
+        opentsdb_username=opentsdb_username,
+        opentsdb_password=opentsdb_password,
+        minimum_peer_connectivity=minimum_peer_connectivity,
+        maximum_peer_connectivity=maximum_peer_connectivity)
 
 
 def parse_permissions(permissions):

--- a/validator/sawtooth_validator/database/database.py
+++ b/validator/sawtooth_validator/database/database.py
@@ -169,6 +169,7 @@ class Cursor(metaclass=ABCMeta):
     manner.  Depending on underlying database implementation, the items may
     be consistent within the context of a database transaction.
     """
+
     def __enter__(self):
         """Context Manager: Enter"""
         self.open()

--- a/validator/sawtooth_validator/database/dict_database.py
+++ b/validator/sawtooth_validator/database/dict_database.py
@@ -21,12 +21,15 @@ class DictDatabase(database.Database):
     tests. Provides all of the interface methods that
     the MerkleTree requires.
     """
+
     def __init__(self, data=None, indexes=None):
         super(DictDatabase, self).__init__()
 
         if indexes:
-            self._indexes = {name: ({}, key_fn)
-                             for name, key_fn in indexes.items()}
+            self._indexes = {
+                name: ({}, key_fn)
+                for name, key_fn in indexes.items()
+            }
         else:
             self._indexes = {}
 
@@ -155,7 +158,6 @@ class DictCursor(database.Cursor):
     @staticmethod
     def _wrap_iter(data, start, reverse=False):
         class _WrapperIter:
-
             def __init__(self, start_pos):
                 self._pos = start_pos
 
@@ -222,7 +224,6 @@ class DictIndexCursor(database.Cursor):
     @staticmethod
     def _wrap_iter(index, start, data, reverse=False):
         class _WrapperIter:
-
             def __init__(self):
                 self._pos = start
 

--- a/validator/sawtooth_validator/database/indexed_database.py
+++ b/validator/sawtooth_validator/database/indexed_database.py
@@ -70,15 +70,16 @@ class IndexedDatabase(database.Database):
         self._serializer = serializer
         self._deserializer = deserializer
 
-        self._lmdb = lmdb.Environment(path=filename,
-                                      map_size=_size,
-                                      map_async=True,
-                                      writemap=True,
-                                      readahead=False,
-                                      subdir=False,
-                                      create=create,
-                                      max_dbs=len(indexes) + 1,
-                                      lock=True)
+        self._lmdb = lmdb.Environment(
+            path=filename,
+            map_size=_size,
+            map_async=True,
+            writemap=True,
+            readahead=False,
+            subdir=False,
+            create=create,
+            max_dbs=len(indexes) + 1,
+            lock=True)
 
         self._main_db = self._lmdb.open_db('main'.encode())
 
@@ -226,8 +227,10 @@ class IndexedDatabase(database.Database):
 
         db = self._indexes[index][0] if index else self._main_db
         with self._lmdb.begin(db=db) as txn:
-            return [key.decode()
-                    for key in txn.cursor().iternext(keys=True, values=False)]
+            return [
+                key.decode()
+                for key in txn.cursor().iternext(keys=True, values=False)
+            ]
 
 
 class ReferenceChainCursor(database.Cursor):
@@ -235,6 +238,7 @@ class ReferenceChainCursor(database.Cursor):
     reference_chain is key_1 -> key_2 mappings with the final entry in the
     chain being key_n -> value.
     """
+
     def __init__(self, lmdb_env, reference_chain, deserializer):
         self._lmdb_env = lmdb_env
         self._deserializer = deserializer
@@ -273,9 +277,9 @@ class ReferenceChainCursor(database.Cursor):
 
     def iter_rev(self):
         return ReferenceChainCursor._wrap_iterator(
-                self._lmdb_cursors[0].iterprev(keys=False),
-                self._lmdb_cursors[1:],
-                self._deserializer)
+            self._lmdb_cursors[0].iterprev(keys=False),
+            self._lmdb_cursors[1:],
+            self._deserializer)
 
     def first(self):
         return self._seek_curs().first()
@@ -328,7 +332,7 @@ def _read(initial_key, cursor_chain, deserializer):
         packed = curs.get(key)
         if not packed:
             raise IndexOutOfSyncError(
-               'Index is out of date for key {}'.format(key))
+                'Index is out of date for key {}'.format(key))
         key = packed
 
     return deserializer(packed)

--- a/validator/sawtooth_validator/database/lmdb_nolock_database.py
+++ b/validator/sawtooth_validator/database/lmdb_nolock_database.py
@@ -46,14 +46,15 @@ class LMDBNoLockDatabase(database.Database):
                 os.remove(filename)
             create = True
 
-        self._lmdb = lmdb.Environment(path=filename,
-                                      map_size=1024**4,
-                                      map_async=True,
-                                      writemap=True,
-                                      readahead=False,
-                                      subdir=False,
-                                      create=create,
-                                      lock=True)
+        self._lmdb = lmdb.Environment(
+            path=filename,
+            map_size=1024**4,
+            map_async=True,
+            writemap=True,
+            readahead=False,
+            subdir=False,
+            create=create,
+            lock=True)
 
     # pylint: disable=no-value-for-parameter
     def __len__(self):

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -471,6 +471,7 @@ class _ContextReader(InstrumentedThread):
         _inflated_addresses (queue.Queue): each item is a tuple
                                           (context_id, [(address, value), ...
     """
+
     def __init__(self, database, address_queue, inflated_addresses):
         super(_ContextReader, self).__init__(name='_ContextReader')
         self._database = database

--- a/validator/sawtooth_validator/execution/execution_context.py
+++ b/validator/sawtooth_validator/execution/execution_context.py
@@ -32,6 +32,7 @@ class ExecutionContext(object):
     """A thread-safe data structure holding address-_ContextFuture pairs and
     the addresses that can be written to and read from.
     """
+
     def __init__(self, state_hash, read_list, write_list, base_context_ids):
         """
 

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -233,6 +233,7 @@ class BatchExecutionResult(object):
             in the BatchExecutionResult for batches that were added to
             add_batch with a state hash.
     """
+
     def __init__(self, is_valid, state_hash):
         self.is_valid = is_valid
         self.state_hash = state_hash
@@ -258,6 +259,7 @@ class TxnExecutionResult:
         error_data (bytes): Error data that was returned while executing this
             transaction.
     """
+
     def __init__(self, signature, is_valid, context_id=None, state_hash=None,
                  state_changes=None, events=None, data=None, error_message="",
                  error_data=b""):
@@ -291,6 +293,7 @@ class TxnInformation(object):
         state_hash (str): the state hash that
                                  this txn should be applied against
     """
+
     def __init__(self, txn, state_hash, base_context_ids):
         self.txn = txn
         self.state_hash = state_hash

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -56,8 +56,10 @@ class PredecessorTree:
         return repr(self._root)
 
     def _tokenize_address(self, address):
-        return [address[i:i + self._token_size]
-                for i in range(0, len(address), self._token_size)]
+        return [
+            address[i:i + self._token_size]
+            for i in range(0, len(address), self._token_size)
+        ]
 
     def _get(self, address, create=False):
         tokens = self._tokenize_address(address)
@@ -455,26 +457,30 @@ class ParallelScheduler(Scheduler):
             state_hash = None
             if self._is_explicit_request_for_state_root(batch_signature):
                 contexts = self._get_contexts_for_squash(batch_signature)
-                state_hash = self._squash(self._first_state_hash,
-                                          contexts,
-                                          persist=False,
-                                          clean_up=False)
+                state_hash = self._squash(
+                    self._first_state_hash,
+                    contexts,
+                    persist=False,
+                    clean_up=False)
                 if self._is_state_hash_correct(state_hash, batch_signature):
-                    self._squash(self._first_state_hash,
-                                 contexts,
-                                 persist=True,
-                                 clean_up=True)
+                    self._squash(
+                        self._first_state_hash,
+                        contexts,
+                        persist=True,
+                        clean_up=True)
                 else:
-                    self._squash(self._first_state_hash,
-                                 contexts,
-                                 persist=False,
-                                 clean_up=True)
+                    self._squash(
+                        self._first_state_hash,
+                        contexts,
+                        persist=False,
+                        clean_up=True)
             elif self._is_implicit_request_for_state_root(batch_signature):
                 contexts = self._get_contexts_for_squash(batch_signature)
-                state_hash = self._squash(self._first_state_hash,
-                                          contexts,
-                                          persist=self._always_persist,
-                                          clean_up=True)
+                state_hash = self._squash(
+                    self._first_state_hash,
+                    contexts,
+                    persist=self._always_persist,
+                    clean_up=True)
             return BatchExecutionResult(is_valid=True, state_hash=state_hash)
 
     def get_transaction_execution_results(self, batch_signature):
@@ -500,7 +506,7 @@ class ParallelScheduler(Scheduler):
 
     def _is_in_same_batch(self, txn_id_1, txn_id_2):
         return self._batches_by_txn_id[txn_id_1] == \
-               self._batches_by_txn_id[txn_id_2]
+            self._batches_by_txn_id[txn_id_2]
 
     def _is_txn_to_replay(self, txn_id, possible_successor, already_seen):
         """Decide if possible_successor should be replayed.
@@ -588,9 +594,10 @@ class ParallelScheduler(Scheduler):
             return
             # Test to see if all batches from the least_batch to
             # the prior batch to the current batch have results.
-        if all(all(t.header_signature in self._txn_results
-                   for t in b.transactions)
-               for b in self._batches[least_index: current_index]):
+        if all(
+                all(t.header_signature in self._txn_results
+                    for t in b.transactions)
+                for b in self._batches[least_index:current_index]):
             all_prior = True
         if not all_prior:
             return
@@ -609,8 +616,8 @@ class ParallelScheduler(Scheduler):
             events=None, data=None, error_message="", error_data=b""):
         with self._condition:
             if txn_signature not in self._scheduled:
-                raise SchedulerError("transaction not scheduled: {}".format(
-                    txn_signature))
+                raise SchedulerError(
+                    "transaction not scheduled: {}".format(txn_signature))
             self._set_least_batch_id(txn_signature=txn_signature)
             if not is_valid:
                 self._remove_subsequent_result_because_of_batch_failure(
@@ -654,7 +661,7 @@ class ParallelScheduler(Scheduler):
 
     def _txn_result_is_invalid(self, sig):
         return sig in self._txn_results and \
-               not self._txn_results[sig].is_valid
+            not self._txn_results[sig].is_valid
 
     def _txn_is_in_valid_batch(self, txn_id):
         """Returns whether the transaction is in a valid batch.
@@ -803,8 +810,9 @@ class ParallelScheduler(Scheduler):
 
     def _all_in_batch_have_results(self, txn_id):
         batch = self._batches_by_txn_id[txn_id]
-        return all(t.header_signature in self._txn_results
-                   for t in list(batch.transactions))
+        return all(
+            t.header_signature in self._txn_results
+            for t in list(batch.transactions))
 
     def _any_in_batch_are_invalid(self, txn_id):
         batch = self._batches_by_txn_id[txn_id]
@@ -830,7 +838,7 @@ class ParallelScheduler(Scheduler):
 
     def _complete(self):
         return self._final and \
-                    len(self._txn_results) == len(self._batches_by_txn_id)
+            len(self._txn_results) == len(self._batches_by_txn_id)
 
     def complete(self, block=True):
         with self._condition:
@@ -858,12 +866,15 @@ class ParallelScheduler(Scheduler):
     def cancel(self):
         with self._condition:
             if not self._cancelled and not self._final:
-                contexts = [tr.context_id for tr in self._txn_results.values()
-                            if tr.context_id]
-                self._squash(self._first_state_hash,
-                             contexts,
-                             persist=False,
-                             clean_up=True)
+                contexts = [
+                    tr.context_id for tr in self._txn_results.values()
+                    if tr.context_id
+                ]
+                self._squash(
+                    self._first_state_hash,
+                    contexts,
+                    persist=False,
+                    clean_up=True)
                 self._cancelled = True
                 self._condition.notify_all()
 

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -36,6 +36,7 @@ class SerialScheduler(Scheduler):
     This scheduler is intended to be used for comparison to more complex
     schedulers - for tests related to performance, correctness, etc.
     """
+
     def __init__(self, squash_handler, first_state_hash, always_persist):
         self._txn_queue = SimpleQueue()
         self._scheduled_transactions = []
@@ -77,8 +78,8 @@ class SerialScheduler(Scheduler):
             self._in_progress_transaction = None
 
             if txn_signature not in self._txn_to_batch:
-                raise ValueError("transaction not in any batches: {}".format(
-                    txn_signature))
+                raise ValueError(
+                    "transaction not in any batches: {}".format(txn_signature))
 
             if txn_signature not in self._txn_results:
                 self._txn_results[txn_signature] = TxnExecutionResult(
@@ -233,9 +234,10 @@ class SerialScheduler(Scheduler):
             self._in_progress_transaction = txn.header_signature
             base_contexts = [] if self._previous_context_id is None \
                 else [self._previous_context_id]
-            txn_info = TxnInformation(txn=txn,
-                                      state_hash=self._previous_state_hash,
-                                      base_context_ids=base_contexts)
+            txn_info = TxnInformation(
+                txn=txn,
+                state_hash=self._previous_state_hash,
+                base_context_ids=base_contexts)
             self._scheduled_transactions.append(txn_info)
             return txn_info
 
@@ -261,7 +263,7 @@ class SerialScheduler(Scheduler):
         state_hash = None
         if self._previous_valid_batch_c_id is not None:
             publishing_or_genesis = self._always_persist or \
-                                    required_state_root is None
+                required_state_root is None
             state_hash = self._squash(
                 state_root=self._previous_state_hash,
                 context_ids=[self._previous_valid_batch_c_id],
@@ -303,7 +305,7 @@ class SerialScheduler(Scheduler):
 
     def _complete(self):
         return self._final and \
-               len(self._txn_results) == len(self._txn_to_batch)
+            len(self._txn_results) == len(self._txn_to_batch)
 
     def complete(self, block):
         with self._condition:
@@ -322,9 +324,11 @@ class SerialScheduler(Scheduler):
         with self._condition:
             if not self._cancelled and not self._final \
                     and self._previous_context_id:
-                self._squash(state_root=self._previous_state_hash,
-                             context_ids=[self._previous_context_id],
-                             persist=False, clean_up=True)
+                self._squash(
+                    state_root=self._previous_state_hash,
+                    context_ids=[self._previous_context_id],
+                    persist=False,
+                    clean_up=True)
                 self._cancelled = True
                 self._condition.notify_all()
 
@@ -334,7 +338,6 @@ class SerialScheduler(Scheduler):
 
 
 class SimpleQueue(object):
-
     def __init__(self):
         self._queue = deque()
 

--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -25,7 +25,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TpStateGetHandler(Handler):
-
     def __init__(self, context_manager):
         self._context_manager = context_manager
 
@@ -47,8 +46,10 @@ class TpStateGetHandler(Handler):
 
         return_list = return_values if return_values is not None else []
         LOGGER.debug("GET: %s", return_list)
-        entry_list = [state_context_pb2.TpStateEntry(address=a, data=d)
-                      for a, d in return_list]
+        entry_list = [
+            state_context_pb2.TpStateEntry(address=a, data=d)
+            for a, d in return_list
+        ]
         response = state_context_pb2.TpStateGetResponse(
             status=state_context_pb2.TpStateGetResponse.OK)
         response.entries.extend(entry_list)

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -53,6 +53,7 @@ class EndpointStatus(Enum):
     # Endpoint will be used to request peers
     TOPOLOGY = 2
 
+
 EndpointInfo = namedtuple('EndpointInfo',
                           ['status', 'time', "retry_threshold"])
 
@@ -303,11 +304,11 @@ class Gossip(object):
                 exclude = []
             for connection_id in self._peers.copy():
                 if connection_id not in exclude:
-                    self.send(message_type,
-                              gossip_message.SerializeToString(),
-                              connection_id,
-                              one_way=True
-                              )
+                    self.send(
+                        message_type,
+                        gossip_message.SerializeToString(),
+                        connection_id,
+                        one_way=True)
 
     def connect_success(self, connection_id):
         """
@@ -450,10 +451,8 @@ class ConnectionManager(InstrumentedThread):
                                 set(peered_endpoints) -
                                 set([self._endpoint]))
 
-                        LOGGER.debug("Number of peers: %s",
-                                     len(peers))
-                        LOGGER.debug("Peers are: %s",
-                                     list(peers.values()))
+                        LOGGER.debug("Number of peers: %s", len(peers))
+                        LOGGER.debug("Peers are: %s", list(peers.values()))
                         LOGGER.debug("Unpeered candidates are: %s",
                                      unpeered_candidates)
 
@@ -707,9 +706,10 @@ class ConnectionManager(InstrumentedThread):
                 validator_pb2.Message.GOSSIP_REGISTER,
                 register_request.SerializeToString(),
                 connection_id,
-                callback=partial(self._peer_callback,
-                                 endpoint=endpoint,
-                                 connection_id=connection_id))
+                callback=partial(
+                    self._peer_callback,
+                    endpoint=endpoint,
+                    connection_id=connection_id))
         except KeyError:
             # if the connection uri wasn't found in the network's
             # connections, it raises a KeyError and we need to add
@@ -807,12 +807,14 @@ class ConnectionManager(InstrumentedThread):
             endpoint=self._endpoint)
         self._connection_statuses[connection_id] = PeerStatus.TEMP
         try:
-            self._network.send(validator_pb2.Message.GOSSIP_REGISTER,
-                               register_request.SerializeToString(),
-                               connection_id,
-                               callback=partial(self._peer_callback,
-                                                connection_id=connection_id,
-                                                endpoint=endpoint))
+            self._network.send(
+                validator_pb2.Message.GOSSIP_REGISTER,
+                register_request.SerializeToString(),
+                connection_id,
+                callback=partial(
+                    self._peer_callback,
+                    connection_id=connection_id,
+                    endpoint=endpoint))
         except ValueError:
             LOGGER.debug("Connection disconnected: %s", connection_id)
 
@@ -825,10 +827,12 @@ class ConnectionManager(InstrumentedThread):
         def callback(request, result):
             # request, result are ignored, but required by the callback
             self._remove_temporary_connection(connection_id)
+
         try:
-            self._network.send(validator_pb2.Message.GOSSIP_GET_PEERS_REQUEST,
-                               get_peers_request.SerializeToString(),
-                               connection_id,
-                               callback=callback)
+            self._network.send(
+                validator_pb2.Message.GOSSIP_GET_PEERS_REQUEST,
+                get_peers_request.SerializeToString(),
+                connection_id,
+                callback=callback)
         except ValueError:
             LOGGER.debug("Connection disconnected: %s", connection_id)

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -182,7 +182,6 @@ class GossipBatchResponseHandler(Handler):
 
 
 class GossipBroadcastHandler(Handler):
-
     def __init__(self, gossip, completer):
         self._gossip = gossip
         self._completer = completer
@@ -206,6 +205,4 @@ class GossipBroadcastHandler(Handler):
         else:
             LOGGER.info("received %s, not BATCH or BLOCK",
                         gossip_message.content_type)
-        return HandlerResult(
-            status=HandlerStatus.PASS
-        )
+        return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/gossip/identity_observer.py
+++ b/validator/sawtooth_validator/gossip/identity_observer.py
@@ -29,6 +29,7 @@ class IdentityObserver(ChainObserver):
     The Identity Observer is used to update the local permission verifier's
     caches of identity data when an Identity transaction is committed.
     """
+
     def __init__(self, to_update, forked):
         # function to notify the permission verifier to update the caches
         self.to_update = to_update

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -38,7 +38,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PermissionVerifier(object):
-
     def __init__(self, permissions, current_root_func, identity_cache):
         # Off-chain permissions to be enforced
         self._permissions = permissions
@@ -91,8 +90,8 @@ class PermissionVerifier(object):
 
         if allowed:
             return self.is_transaction_signer_authorized(
-                        batch.transactions,
-                        state_root)
+                batch.transactions,
+                state_root)
         LOGGER.debug("Batch Signer: %s is not permitted.",
                      header.signer_public_key)
         return False
@@ -274,9 +273,7 @@ class PermissionVerifier(object):
         policy = self._cache.get_policy(policy_name, state_root)
         if policy is not None:
             if not self._allowed(public_key, policy):
-                LOGGER.debug(
-                    "Node is not permitted: %s.",
-                    public_key)
+                LOGGER.debug("Node is not permitted: %s.", public_key)
                 return False
         return True
 
@@ -337,6 +334,7 @@ class BatchListPermissionVerifier(Handler):
                 status=HandlerStatus.RETURN,
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
+
         try:
             request = client_batch_submit_pb2.ClientBatchSubmitRequest()
             request.ParseFromString(message_content)
@@ -344,12 +342,14 @@ class BatchListPermissionVerifier(Handler):
                 if batch.trace:
                     LOGGER.debug("TRACE %s: %s", batch.header_signature,
                                  self.__class__.__name__)
-            if not all(self._verifier.check_off_chain_batch_roles(batch)
-                       for batch in request.batches):
+            if not all(
+                    self._verifier.check_off_chain_batch_roles(batch)
+                    for batch in request.batches):
                 return make_response(response_proto.INVALID_BATCH)
 
-            if not all(self._verifier.is_batch_signer_authorized(batch)
-                       for batch in request.batches):
+            if not all(
+                    self._verifier.is_batch_signer_authorized(batch)
+                    for batch in request.batches):
                 return make_response(response_proto.INVALID_BATCH)
 
         except DecodeError:

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -219,7 +219,6 @@ class GossipBatchResponseSignatureVerifier(Handler):
 
 
 class BatchListSignatureVerifier(Handler):
-
     def handle(self, connection_id, message_content):
         response_proto = client_batch_submit_pb2.ClientBatchSubmitResponse
 
@@ -228,6 +227,7 @@ class BatchListSignatureVerifier(Handler):
                 status=HandlerStatus.RETURN,
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
+
         try:
             request = client_batch_submit_pb2.ClientBatchSubmitRequest()
             request.ParseFromString(message_content)

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -31,7 +31,6 @@ from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.protobuf.validator_pb2 import Message
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -157,6 +156,7 @@ class BatchListStructureVerifier(Handler):
                 status=HandlerStatus.RETURN,
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
+
         try:
             request = client_batch_submit_pb2.ClientBatchSubmitRequest()
             request.ParseFromString(message_content)

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -21,6 +21,7 @@ from sawtooth_validator.state.settings_view import SettingsView
 
 class BatchInjectorFactory(object, metaclass=abc.ABCMeta):
     """The interface to implement for constructing batch injectors"""
+
     @abc.abstractmethod
     def create_injectors(self, previous_block_id):
         """

--- a/validator/sawtooth_validator/journal/block_builder.py
+++ b/validator/sawtooth_validator/journal/block_builder.py
@@ -20,6 +20,7 @@ class BlockBuilder(object):
     """
     Utility class to assemble new blocks. Used by the block publisher.
     """
+
     def __init__(self, block_header):
         self._header_signature = None
         self.batches = []

--- a/validator/sawtooth_validator/journal/block_sender.py
+++ b/validator/sawtooth_validator/journal/block_sender.py
@@ -33,7 +33,6 @@ class BlockSender(object, metaclass=abc.ABCMeta):
 
 
 class BroadcastBlockSender(BlockSender):
-
     def __init__(self, completer, gossip):
         self._completer = completer
         self._gossip = gossip

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -28,13 +28,15 @@ class BlockStore(MutableMapping):
     objects are correctly wrapped and unwrapped as they are stored and
     retrieved.
     """
+
     def __init__(self, block_db):
         self._block_store = block_db
 
     def __setitem__(self, key, value):
         if key != value.identifier:
-            raise KeyError("Invalid key to store block under: {} expected {}".
-                           format(key, value.identifier))
+            raise KeyError(
+                "Invalid key to store block under: {} expected {}".format(
+                    key, value.identifier))
         self._block_store.put(key, value)
 
     def __getitem__(self, key):
@@ -184,8 +186,8 @@ class BlockStore(MutableMapping):
                 start_block_num = BlockStore.block_num_to_hex(
                     start_block.block_num)
                 if not curs.seek(start_block_num):
-                    raise ValueError('block {} is not a valid block'.format(
-                        start_block))
+                    raise ValueError(
+                        'block {} is not a valid block'.format(start_block))
             elif start_block_num:
                 if not curs.seek(start_block_num):
                     raise ValueError('Block number {} does not reference a '
@@ -393,8 +395,10 @@ class BlockStore(MutableMapping):
         """
         blocks = self._block_store.get_multi(batch_ids, index='batch')
 
-        return [BlockStore._get_batch_from_block(block, batch_id)
-                for batch_id, block in blocks]
+        return [
+            BlockStore._get_batch_from_block(block, batch_id)
+            for batch_id, block in blocks
+        ]
 
     @staticmethod
     def _get_batch_from_block(block, batch_id):
@@ -425,8 +429,10 @@ class BlockStore(MutableMapping):
         blocks = self._block_store.get_multi(transaction_ids,
                                              index='transaction')
 
-        return [BlockStore._get_txn_from_block(block, txn_id)
-                for txn_id, block in blocks]
+        return [
+            BlockStore._get_txn_from_block(block, txn_id)
+            for txn_id, block in blocks
+        ]
 
     @staticmethod
     def _get_txn_from_block(block, txn_id):

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -37,6 +37,7 @@ class BlockWrapper(object):
     components to track the state of a block. This is the object type
     stored in the Block Cache.
     """
+
     def __init__(self, block, weight=0, status=BlockStatus.Unknown):
         self.block = block
         self._block_header = None

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -257,8 +257,8 @@ class BlockValidator(object):
             try:
                 state_root = self._get_previous_block_root_state_hash(blkw)
             except KeyError:
-                LOGGER.debug("Block rejected due to missing" +
-                             " predecessor: %s", blkw)
+                LOGGER.debug(
+                    "Block rejected due to missing" + " predecessor: %s", blkw)
                 return False
             for batch in blkw.batches:
                 if not self._permission_verifier.is_batch_signer_authorized(
@@ -276,8 +276,8 @@ class BlockValidator(object):
             try:
                 state_root = self._get_previous_block_root_state_hash(blkw)
             except KeyError:
-                LOGGER.debug("Block rejected due to missing" +
-                             " predecessor: %s", blkw)
+                LOGGER.debug(
+                    "Block rejected due to missing" + " predecessor: %s", blkw)
                 return False
             return self._validation_rule_enforcer.validate(blkw, state_root)
         return True
@@ -355,8 +355,9 @@ class BlockValidator(object):
                         self._block_cache[
                             new_blkw.previous_block_id]
                 except KeyError:
-                    LOGGER.debug("Block rejected due to missing" +
-                                 " predecessor: %s", new_blkw)
+                    LOGGER.debug(
+                        "Block rejected due to missing" + " predecessor: %s",
+                        new_blkw)
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
                     raise BlockValidationAborted()
@@ -394,8 +395,9 @@ class BlockValidator(object):
                     self._block_cache[
                         new_blkw.previous_block_id]
             except KeyError:
-                LOGGER.debug("Block rejected due to missing" +
-                             " predecessor: %s", new_blkw)
+                LOGGER.debug(
+                    "Block rejected due to missing" + " predecessor: %s",
+                    new_blkw)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
                 raise BlockValidationAborted()
@@ -441,8 +443,7 @@ class BlockValidator(object):
         so that the change over can be made if necessary.
         """
         try:
-            LOGGER.info("Starting block validation of : %s",
-                        self._new_block)
+            LOGGER.info("Starting block validation of : %s", self._new_block)
             cur_chain = self._result["cur_chain"]  # ordered list of the
             # current chain blocks
             new_chain = self._result["new_chain"]  # ordered list of the new
@@ -475,8 +476,9 @@ class BlockValidator(object):
                         valid = False
                     self._result["num_transactions"] += block.num_transactions
                 else:
-                    LOGGER.info("Block marked invalid(invalid predecessor): " +
-                                "%s", block)
+                    LOGGER.info(
+                        "Block marked invalid(invalid predecessor): " + "%s",
+                        block)
                     block.status = BlockStatus.Invalid
 
             if not valid:
@@ -557,6 +559,7 @@ class ChainController(object):
     To evaluating new blocks to determine if they should extend or replace
     the current chain. If they are valid extend the chain.
     """
+
     def __init__(self,
                  block_cache,
                  block_sender,

--- a/validator/sawtooth_validator/journal/chain_commit_state.py
+++ b/validator/sawtooth_validator/journal/chain_commit_state.py
@@ -23,6 +23,7 @@ class _CommitCache(object):
     committed state at a previous state of the BlockStore and we allow for the
     identifiers to be re-committed.
     """
+
     def __init__(self, block_store_check):
         self.block_store_check = block_store_check
         self._committed = set()  # the set of items
@@ -54,6 +55,7 @@ class ChainCommitState(object):
     chain. This is used to to detect duplicate batches, duplicate transactions,
     and missing transactions dependencies when evaluating a new chain.
     """
+
     def __init__(self, block_store, uncommitted_blocks):
         self._batch_commit_state = _CommitCache(block_store.has_batch)
         self._transaction_commit_state = _CommitCache(
@@ -95,6 +97,7 @@ class TransactionCommitCache(_CommitCache):
     blockchain. This is used to detect duplicate transactions or missing
     dependencies when building a block.
     """
+
     def __init__(self, block_store):
         super(TransactionCommitCache, self).__init__(
             block_store.has_transaction)

--- a/validator/sawtooth_validator/journal/chain_id_manager.py
+++ b/validator/sawtooth_validator/journal/chain_id_manager.py
@@ -25,6 +25,7 @@ class ChainIdManager(object):
     The ChainIdManager is in charge of of keeping track of the block-chain-id
     stored in the data_dir.
     """
+
     def __init__(self, data_dir):
         self._data_dir = data_dir
 

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -45,6 +45,7 @@ class Completer(object):
     have their dependencies satisifed, otherwise it will request the batch that
     has the missing transaction.
     """
+
     def __init__(self,
                  block_store,
                  gossip,
@@ -348,7 +349,6 @@ class Completer(object):
 
 
 class CompleterBatchListBroadcastHandler(Handler):
-
     def __init__(self, completer, gossip):
         self._completer = completer
         self._gossip = gossip
@@ -366,7 +366,6 @@ class CompleterBatchListBroadcastHandler(Handler):
 
 
 class CompleterGossipHandler(Handler):
-
     def __init__(self, completer):
         self._completer = completer
 
@@ -381,8 +380,7 @@ class CompleterGossipHandler(Handler):
             batch = Batch()
             batch.ParseFromString(gossip_message.content)
             self._completer.add_batch(batch)
-        return HandlerResult(
-            status=HandlerStatus.PASS)
+        return HandlerResult(status=HandlerStatus.PASS)
 
 
 class CompleterGossipBlockResponseHandler(Handler):

--- a/validator/sawtooth_validator/journal/consensus/batch_publisher.py
+++ b/validator/sawtooth_validator/journal/consensus/batch_publisher.py
@@ -21,6 +21,7 @@ class BatchPublisher(object):
     """ Utility class to help BlockPublisher provide transaction publishing
     services to the consensus implementations.
     """
+
     def __init__(self, identity_signer, batch_sender):
         """Initialize the BatchPublisher.
         :param identity_signer: the validator's cryptographic signer.

--- a/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py
@@ -39,6 +39,7 @@ class BlockPublisher(BlockPublisherInterface):
      DevMode Consensus (BlockPublisher) will read these settings
      from the StateView when Constructed.
     """
+
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -140,7 +141,9 @@ class BlockPublisher(BlockPublisherInterface):
 class BlockVerifier(BlockVerifierInterface):
     """DevMode BlockVerifier implementation
     """
+
     # pylint: disable=useless-super-delegation
+
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -162,7 +165,9 @@ class ForkResolver(ForkResolverInterface):
     """Provides the fork resolution interface for the BlockValidator to use
     when deciding between 2 forks.
     """
+
     # pylint: disable=useless-super-delegation
+
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -26,6 +26,7 @@ class BlockPublisher(BlockPublisherInterface):
     production of a genesis block. This block is marked with consensus field of
     `'Genesis'` and finalized as such.
     """
+
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -69,7 +70,9 @@ class BlockVerifier(BlockVerifierInterface):
     other case, verification will fail.  This requires that any block beyond
     the genesis block must use a proper consensus module.
     """
+
     # pylint: disable=useless-super-delegation
+
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -93,6 +96,7 @@ class ForkResolver(ForkResolverInterface):
     """The genesis ForkResolver should not ever be used.
     """
     # pylint: disable=useless-super-delegation
+
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -175,8 +175,7 @@ class GenesisController(object):
                     .format(batch.header_signature))
             if result.state_hash is not None:
                 state_hash = result.state_hash
-        LOGGER.debug('Produced state hash %s for genesis block.',
-                     state_hash)
+        LOGGER.debug('Produced state hash %s for genesis block.', state_hash)
 
         block_builder = self._generate_genesis_block()
         block_builder.add_batches(genesis_batches)

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -43,6 +43,7 @@ class PendingBatchObserver(metaclass=abc.ABCMeta):
     """An interface class for components wishing to be notified when a Batch
     has begun being processed.
     """
+
     @abc.abstractmethod
     def notify_batch_pending(self, batch):
         """This method will be called when a Batch has passed initial
@@ -101,6 +102,7 @@ class _CandidateBlock(object):
     This allows the BlockPublisher to focus on when to create and finalize
     a block and not worry about how the block is built.
     """
+
     def __init__(self,
                  block_store,
                  consensus,
@@ -354,8 +356,10 @@ class _CandidateBlock(object):
                     # one in the list.
                     bad_batches.append(batch)
                     pending_batches.clear()
-                    pending_batches.extend([x for x in self._pending_batches
-                                            if x not in bad_batches])
+                    pending_batches.extend([
+                        x for x in self._pending_batches
+                        if x not in bad_batches
+                    ])
                     return None
                 else:
                     builder.add_batch(batch)
@@ -390,6 +394,7 @@ class BlockPublisher(object):
     Responsible for generating new blocks and publishing them when the
     Consensus deems it appropriate.
     """
+
     def __init__(self,
                  transaction_executor,
                  block_cache,
@@ -659,8 +664,8 @@ class BlockPublisher(object):
                     self._build_candidate_block(self._chain_head)
 
                 if self._candidate_block and (
-                            force or
-                            self._candidate_block.has_pending_batches()) and \
+                    force or
+                    self._candidate_block.has_pending_batches()) and \
                         self._candidate_block.check_publish_block():
 
                     pending_batches = []  # will receive the list of batches

--- a/validator/sawtooth_validator/journal/receipt_store.py
+++ b/validator/sawtooth_validator/journal/receipt_store.py
@@ -66,8 +66,7 @@ class TransactionReceiptStore(ChainObserver):
             KeyError: if the transaction id is unknown.
         """
         if txn_id not in self._receipt_db:
-            raise KeyError(
-                'Unknown transaction id {}'.format(txn_id))
+            raise KeyError('Unknown transaction id {}'.format(txn_id))
 
         txn_receipt_bytes = self._receipt_db[txn_id]
         txn_receipt = TransactionReceipt()

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -206,7 +206,7 @@ class BatchByBatchIdResponderHandler(Handler):
 
             batch_response = network_pb2.GossipBatchResponse(
                 content=batch.SerializeToString(),
-                )
+            )
 
             self._gossip.send(validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
                               batch_response.SerializeToString(),
@@ -288,7 +288,7 @@ class BatchByTransactionIdResponderHandler(Handler):
 
                 batch_response = network_pb2.GossipBatchResponse(
                     content=batch.SerializeToString(),
-                    )
+                )
 
                 self._gossip.send(validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
                                   batch_response.SerializeToString(),

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -155,8 +155,7 @@ class Dispatcher(InstrumentedThread):
 
             queue_size = self._in_queue.qsize()
             if queue_size > 10:
-                LOGGER.debug("Dispatch incoming queue size: %s",
-                             queue_size)
+                LOGGER.debug("Dispatch incoming queue size: %s", queue_size)
         else:
             LOGGER.info("received a message of type %s "
                         "from %s but have no handler for that type",
@@ -313,6 +312,7 @@ class _ManagerCollection(object):
     """Wraps a list of _HandlerManagers and
     keeps track of which handler_manager is next
     """
+
     def __init__(self, handler_managers):
         self._chain = handler_managers
         self._index = 0
@@ -344,7 +344,6 @@ class HandlerStatus(enum.Enum):
 
 
 class Handler(object, metaclass=abc.ABCMeta):
-
     @abc.abstractmethod
     def handle(self, connection_id, message_content):
         """

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -77,8 +77,7 @@ class ConnectHandler(Handler):
         """
         message = ConnectionRequest()
         message.ParseFromString(message_content)
-        LOGGER.debug("got connect message from %s. sending ack",
-                     connection_id)
+        LOGGER.debug("got connect message from %s. sending ack", connection_id)
 
         # Need to use join here to get the string "0.0.0.0". Otherwise,
         # bandit thinks we are binding to all interfaces and returns a
@@ -99,8 +98,7 @@ class ConnectHandler(Handler):
                     message_type=validator_pb2.Message.
                     AUTHORIZATION_CONNECTION_RESPONSE)
 
-        LOGGER.debug("Endpoint of connecting node is %s",
-                     message.endpoint)
+        LOGGER.debug("Endpoint of connecting node is %s", message.endpoint)
         self._network.update_connection_endpoint(connection_id,
                                                  message.endpoint)
 
@@ -137,8 +135,7 @@ class ConnectHandler(Handler):
 
         if not is_outbound_connection:
             if self._network.allow_inbound_connection():
-                LOGGER.debug("Allowing incoming connection: %s",
-                             connection_id)
+                LOGGER.debug("Allowing incoming connection: %s", connection_id)
                 connection_response.status = connection_response.OK
             else:
                 connection_response.status = connection_response.ERROR
@@ -236,7 +233,6 @@ class PingHandler(Handler):
 
 
 class AuthorizationTrustRequestHandler(Handler):
-
     def __init__(self, network, permission_verifier, gossip):
         self._network = network
         self._permission_verifier = permission_verifier
@@ -453,7 +449,7 @@ class AuthorizationChallengeSubmitHandler(Handler):
                         auth_challenge_submit.public_key)
                 if not permitted:
                     return AuthorizationChallengeSubmitHandler \
-                            ._network_violation_result()
+                        ._network_violation_result()
 
         self._network.update_connection_public_key(
             connection_id,

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -216,12 +216,15 @@ class _SendReceive(object):
                                 content=ping.SerializeToString(),
                                 message_type=validator_pb2.Message.PING_REQUEST
                             )
-                            fut = future.Future(message.correlation_id,
-                                                message.content,
-                                                )
+                            fut = future.Future(
+                                message.correlation_id,
+                                message.content,
+                            )
                             self._futures.put(fut)
-                            message_frame = [bytes(zmq_identity),
-                                             message.SerializeToString()]
+                            message_frame = [
+                                bytes(zmq_identity),
+                                message.SerializeToString()
+                            ]
                             yield from self._send_message_frame(message_frame)
                 elif self._socket.getsockopt(zmq.TYPE) == zmq.DEALER:
                     if self._last_message_time and \
@@ -295,9 +298,10 @@ class _SendReceive(object):
                 try:
                     self._futures.set_result(
                         message.correlation_id,
-                        future.FutureResult(message_type=message.message_type,
-                                            content=message.content,
-                                            connection_id=connection_id))
+                        future.FutureResult(
+                            message_type=message.message_type,
+                            content=message.content,
+                            connection_id=connection_id))
                 except future.FutureCollectionKeyError:
                     self._dispatcher.dispatch(self._connection,
                                               message,
@@ -802,11 +806,13 @@ class Interconnect(object):
         self._add_connection(conn, uri)
 
         connect_message = ConnectionRequest(endpoint=self._public_endpoint)
-        conn.send(validator_pb2.Message.NETWORK_CONNECT,
-                  connect_message.SerializeToString(),
-                  callback=partial(self._connect_callback,
-                                   connection=conn,
-                                   ))
+        conn.send(
+            validator_pb2.Message.NETWORK_CONNECT,
+            connect_message.SerializeToString(),
+            callback=partial(
+                self._connect_callback,
+                connection=conn,
+            ))
 
         return conn
 
@@ -816,16 +822,15 @@ class Interconnect(object):
         the validator to be authorized by the incoming connection.
         """
         connect_message = ConnectionRequest(endpoint=self._public_endpoint)
-        self._safe_send(validator_pb2.Message.NETWORK_CONNECT,
-                        connect_message.SerializeToString(),
-                        connection_id,
-                        callback=partial(
-                            self._inbound_connection_request_callback,
-                            connection_id=connection_id
-                            ))
+        self._safe_send(
+            validator_pb2.Message.NETWORK_CONNECT,
+            connect_message.SerializeToString(),
+            connection_id,
+            callback=partial(
+                self._inbound_connection_request_callback,
+                connection_id=connection_id))
 
-    def _connect_callback(self, request, result,
-                          connection=None):
+    def _connect_callback(self, request, result, connection=None):
         connection_response = ConnectionResponse()
         connection_response.ParseFromString(result.content)
 
@@ -857,8 +862,7 @@ class Interconnect(object):
                         auth_trust_request.SerializeToString(),
                         callback=partial(
                             self._check_trust_success,
-                            connection_id=connection.connection_id)
-                        )
+                            connection_id=connection.connection_id))
 
                 if auth_type["challenge"]:
                     auth_challenge_request = AuthorizationChallengeRequest()
@@ -897,7 +901,7 @@ class Interconnect(object):
                 connection_id,
                 callback=partial(self._check_trust_success,
                                  connection_id=connection_id)
-                )
+            )
 
         if auth_type["challenge"]:
             auth_challenge_request = AuthorizationChallengeRequest()
@@ -908,7 +912,7 @@ class Interconnect(object):
                 callback=partial(
                     self._inbound_challenge_authorization_callback,
                     connection_id=connection_id)
-                )
+            )
 
     def _challenge_authorization_callback(self, request, result,
                                           connection=None,
@@ -928,7 +932,7 @@ class Interconnect(object):
             public_key=self._signer.get_public_key().as_hex(),
             signature=signature,
             roles=[RoleType.Value("NETWORK")]
-            )
+        )
 
         connection.send(
             validator_pb2.Message.AUTHORIZATION_CHALLENGE_SUBMIT,
@@ -983,8 +987,7 @@ class Interconnect(object):
         :return: future.Future
         """
         if connection_id not in self._connections:
-            raise ValueError("Unknown connection id: %s",
-                             connection_id)
+            raise ValueError("Unknown connection id: %s", connection_id)
         connection_info = self._connections.get(connection_id)
         if connection_info.connection_type == \
                 ConnectionType.ZMQ_IDENTITY:
@@ -995,8 +998,11 @@ class Interconnect(object):
 
             timer_tag = get_enum_name(message.message_type)
             timer_ctx = self._get_send_response_timer(timer_tag).time()
-            fut = future.Future(message.correlation_id, message.content,
-                                callback, timer_ctx=timer_ctx)
+            fut = future.Future(
+                message.correlation_id,
+                message.content,
+                callback,
+                timer_ctx=timer_ctx)
             if not one_way:
                 self._futures.put(fut)
 
@@ -1158,8 +1164,7 @@ class Interconnect(object):
         :return: future.Future
         """
         if connection_id not in self._connections:
-            raise ValueError("Unknown connection id: %s",
-                             connection_id)
+            raise ValueError("Unknown connection id: %s", connection_id)
         connection_info = self._connections.get(connection_id)
         if connection_info.connection_type == \
                 ConnectionType.ZMQ_IDENTITY:
@@ -1204,7 +1209,7 @@ class Interconnect(object):
                 message,
                 connection_id,
                 callback=callback
-                )
+            )
         except ValueError:
             LOGGER.debug("Connection disconnected: %s", connection_id)
 

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -184,9 +184,9 @@ def create_validator_config(opts):
     if opts.bind:
         for bind in opts.bind:
             if "network" in bind:
-                bind_network = bind[bind.find(":")+1:]
+                bind_network = bind[bind.find(":") + 1:]
             if "component" in bind:
-                bind_component = bind[bind.find(":")+1:]
+                bind_component = bind[bind.find(":") + 1:]
     return ValidatorConfig(
         bind_network=bind_network,
         bind_component=bind_component,
@@ -200,7 +200,7 @@ def create_validator_config(opts):
         opentsdb_db=opts.opentsdb_db,
         minimum_peer_connectivity=opts.minimum_peer_connectivity,
         maximum_peer_connectivity=opts.maximum_peer_connectivity
-        )
+    )
 
 
 def main(args=None):
@@ -329,24 +329,24 @@ def main(args=None):
             password=validator_config.opentsdb_password)
         metrics_reporter.start()
 
-    validator = Validator(bind_network,
-                          bind_component,
-                          endpoint,
-                          validator_config.peering,
-                          validator_config.seeds,
-                          validator_config.peers,
-                          path_config.data_dir,
-                          path_config.config_dir,
-                          identity_signer,
-                          validator_config.scheduler,
-                          validator_config.permissions,
-                          validator_config.minimum_peer_connectivity,
-                          validator_config.maximum_peer_connectivity,
-                          validator_config.network_public_key,
-                          validator_config.network_private_key,
-                          roles=validator_config.roles,
-                          metrics_registry=wrapped_registry
-                          )
+    validator = Validator(
+        bind_network,
+        bind_component,
+        endpoint,
+        validator_config.peering,
+        validator_config.seeds,
+        validator_config.peers,
+        path_config.data_dir,
+        path_config.config_dir,
+        identity_signer,
+        validator_config.scheduler,
+        validator_config.permissions,
+        validator_config.minimum_peer_connectivity,
+        validator_config.maximum_peer_connectivity,
+        validator_config.network_public_key,
+        validator_config.network_private_key,
+        roles=validator_config.roles,
+        metrics_registry=wrapped_registry)
 
     # pylint: disable=broad-except
     try:

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -46,9 +46,20 @@ LOGGER = logging.getLogger(__name__)
 
 
 def add(
-    dispatcher, gossip, context_manager, executor, completer, block_store,
-    batch_tracker, merkle_db, get_current_root, receipt_store,
-    event_broadcaster, permission_verifier, thread_pool, sig_pool,
+        dispatcher,
+        gossip,
+        context_manager,
+        executor,
+        completer,
+        block_store,
+        batch_tracker,
+        merkle_db,
+        get_current_root,
+        receipt_store,
+        event_broadcaster,
+        permission_verifier,
+        thread_pool,
+        sig_pool,
 ):
 
     # -- Transaction Processor -- #

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -60,14 +60,24 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Validator(object):
-
-    def __init__(self, bind_network, bind_component, endpoint,
-                 peering, seeds_list, peer_list, data_dir, config_dir,
-                 identity_signer, scheduler_type, permissions,
-                 minimum_peer_connectivity, maximum_peer_connectivity,
-                 network_public_key=None, network_private_key=None,
-                 roles=None, metrics_registry=None
-                 ):
+    def __init__(self,
+                 bind_network,
+                 bind_component,
+                 endpoint,
+                 peering,
+                 seeds_list,
+                 peer_list,
+                 data_dir,
+                 config_dir,
+                 identity_signer,
+                 scheduler_type,
+                 permissions,
+                 minimum_peer_connectivity,
+                 maximum_peer_connectivity,
+                 network_public_key=None,
+                 network_private_key=None,
+                 roles=None,
+                 metrics_registry=None):
         """Constructs a validator instance.
 
         Args:

--- a/validator/sawtooth_validator/server/events/broadcaster.py
+++ b/validator/sawtooth_validator/server/events/broadcaster.py
@@ -248,22 +248,26 @@ class EventBroadcaster(ChainObserver):
         with self._subscribers_cv:
             # Copy the subscribers
             subscribers = {
-                conn: sub.copy() for conn, sub in self._subscribers.items()
+                conn: sub.copy()
+                for conn, sub in self._subscribers.items()
             }
 
         if subscribers:
             for connection_id, subscriber in subscribers.items():
                 if subscriber.is_listening():
-                    subscriber_events = [event for event in events
-                                         if subscriber.is_subscribed(event)]
+                    subscriber_events = [
+                        event for event in events
+                        if subscriber.is_subscribed(event)
+                    ]
                     event_list = EventList(events=subscriber_events)
                     self._send(connection_id, event_list.SerializeToString())
 
     def _send(self, connection_id, message_bytes):
-        self._service.send(validator_pb2.Message.CLIENT_EVENTS,
-                           message_bytes,
-                           connection_id=connection_id,
-                           one_way=True)
+        self._service.send(
+            validator_pb2.Message.CLIENT_EVENTS,
+            message_bytes,
+            connection_id=connection_id,
+            one_way=True)
 
 
 class EventSubscriber:

--- a/validator/sawtooth_validator/server/events/subscription.py
+++ b/validator/sawtooth_validator/server/events/subscription.py
@@ -25,6 +25,7 @@ class EventSubscription:
     if its type matches the type of the subscription and, if any filters are
     included in the subscription, it passes all filters.
     """
+
     def __init__(self, event_type, filters=None):
         self.event_type = event_type
         if filters:
@@ -134,6 +135,7 @@ class RegexAnyFilter(EventFilter):
 
     Because it matches one of the two attributes with the key "address".
     """
+
     def __init__(self, key, match_string):
         super().__init__(key, match_string)
         try:
@@ -170,6 +172,7 @@ class RegexAllFilter(EventFilter):
 
     Because it does not match all attributes with the key "address".
     """
+
     def __init__(self, key, match_string):
         super().__init__(key, match_string)
         try:

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -64,9 +64,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 def add(
-    dispatcher, interconnect, gossip, completer, responder,
-    thread_pool, sig_pool, has_block, has_batch,
-    permission_verifier,
+        dispatcher,
+        interconnect,
+        gossip,
+        completer,
+        responder,
+        thread_pool,
+        sig_pool,
+        has_block,
+        has_batch,
+        permission_verifier,
 ):
 
     # -- Basic Networking -- #

--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -44,6 +44,7 @@ class BatchTracker(ChainObserver,
         cache_keep_time (float): Time in seconds to keep values in TimedCaches
         cache_purge_frequency (float): Time between purging the TimedCaches
     """
+
     def __init__(self,
                  block_store,
                  cache_keep_time=600,
@@ -200,6 +201,7 @@ class BatchFinishObserver(metaclass=abc.ABCMeta):
     Observers register what batches they are interested in by calling  a
     BatchTracker's "watch_statuses" method.
     """
+
     @abc.abstractmethod
     def notify_batches_finished(self, statuses):
         """This method will be called when every Batch in a set of Batches is

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -60,6 +60,7 @@ class _ResponseFailed(BaseException):
     Attributes:
         status (enum): Status to be sent with the incomplete response
     """
+
     def __init__(self, status):
         super().__init__()
         self.status = status
@@ -282,8 +283,9 @@ class _ClientRequestHandler(Handler, metaclass=abc.ABCMeta):
         # If filtering by head AND ids, the traverse results must be winnowed
         if request.head_id and filter_ids:
             matches = {
-                r.header_signature: r for r in resources
-                if r.header_signature in filter_ids}
+                r.header_signature: r
+                for r in resources if r.header_signature in filter_ids
+            }
             resources = [matches[i] for i in filter_ids if i in matches]
 
         return resources
@@ -339,6 +341,7 @@ class _Pager(object):
     resource by its id (either address or header_signature), or conversely
     to fetch the id by an index.
     """
+
     @classmethod
     def paginate_resources(cls, request, resources, on_fail_status):
         """Truncates a list of resources based on ClientPagingControls
@@ -426,6 +429,7 @@ class _Sorter(object):
     """A static class containing a method to sort lists of resources based on
     ClientSortControls sent with the request.
     """
+
     @classmethod
     def sort_resources(cls, request, resources, fail_enum, header_proto=None):
         """Sorts a list of resources based on a list of sort controls
@@ -483,6 +487,7 @@ class _Sorter(object):
             fail_status (integer, enum): Status to send when controls are bad
             header_proto (class): Class to decode the resource header
         """
+
         def __init__(self, controls, fail_status, header_proto=None):
             self._keys = controls.keys
             self._fail_status = fail_status
@@ -546,10 +551,11 @@ def _format_batch_statuses(statuses, batch_ids, tracker):
         else:
             invalid_txns = None
 
-        proto_statuses.append(client_batch_submit_pb2.ClientBatchStatus(
-            batch_id=batch_id,
-            status=statuses[batch_id],
-            invalid_transactions=invalid_txns))
+        proto_statuses.append(
+            client_batch_submit_pb2.ClientBatchStatus(
+                batch_id=batch_id,
+                status=statuses[batch_id],
+                invalid_transactions=invalid_txns))
 
     return proto_statuses
 
@@ -563,6 +569,7 @@ class _BatchWaiter(BatchFinishObserver):
             BatchWaiter that all of the batches it is interested in are no
             longer PENDING.
     """
+
     def __init__(self, batch_tracker):
         self._batch_tracker = batch_tracker
         self._wait_condition = Condition()
@@ -805,7 +812,7 @@ class BlockListRequest(_ClientRequestHandler):
                 next=next_block_num,
                 limit=limit,
                 start=BlockStore.block_num_to_hex(start)
-                )
+            )
 
         if not blocks:
             return self._wrap_response(
@@ -1057,7 +1064,7 @@ class PeersGetRequest(_ClientRequestHandler):
             client_peers_pb2.ClientPeersGetRequest,
             client_peers_pb2.ClientPeersGetResponse,
             validator_pb2.Message.CLIENT_PEERS_GET_RESPONSE
-            )
+        )
         self._gossip = gossip
 
     def _respond(self, request):

--- a/validator/sawtooth_validator/state/identity_view.py
+++ b/validator/sawtooth_validator/state/identity_view.py
@@ -42,9 +42,10 @@ def _create_role_address(name):
 
     parts = name.split(".", maxsplit=_NUM_PARTS - 1)
 
-    hashed_parts = [_short_hash(d.encode()) if i is not 0
-                    else _short_hash(d.encode(), 14)
-                    for i, d in enumerate(parts)]
+    hashed_parts = [
+        _short_hash(d.encode()) if i is not 0 else _short_hash(d.encode(), 14)
+        for i, d in enumerate(parts)
+    ]
     hashed_parts.extend([_NULL_HASH] * (_NUM_PARTS - len(parts)))
     return prefix + "".join(hashed_parts)
 
@@ -72,7 +73,6 @@ def _create_from_bytes(data, protobuf_klass):
 
 
 class IdentityView(object):
-
     def __init__(self, state_view):
         """Creates an IdentityView from a StateView that is passed in.
 
@@ -118,8 +118,10 @@ class IdentityView(object):
 
         prefix = _IDENTITY_NS + _ROLE_NS
         role_list_bytes_dict = self._state_view.leaves(prefix=prefix)
-        rolelist_list = [_create_from_bytes(d, identity_pb2.RoleList)
-                         for d in role_list_bytes_dict.values()]
+        rolelist_list = [
+            _create_from_bytes(d, identity_pb2.RoleList)
+            for d in role_list_bytes_dict.values()
+        ]
         roles = []
         for role_list in rolelist_list:
             for role in role_list.roles:
@@ -162,8 +164,10 @@ class IdentityView(object):
 
         prefix = _IDENTITY_NS + _POLICY_NS
         policy_list_bytes_dict = self._state_view.leaves(prefix=prefix)
-        policylist_list = [_create_from_bytes(d, identity_pb2.PolicyList)
-                           for d in policy_list_bytes_dict.values()]
+        policylist_list = [
+            _create_from_bytes(d, identity_pb2.PolicyList)
+            for d in policy_list_bytes_dict.values()
+        ]
         policies = []
         for policy_list in policylist_list:
             for policy in policy_list.policies:
@@ -172,7 +176,6 @@ class IdentityView(object):
 
 
 class IdentityViewFactory(object):
-
     def __init__(self, state_view_factory):
         """Creates a factory for producing IdentityViews based on the passed
         in StateViewFactory.

--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -109,8 +109,10 @@ class MerkleDatabase(object):
         return self._set_by_addr(address, value)
 
     def _tokenize_address(self, address):
-        return [address[i:i + TOKEN_SIZE]
-                for i in range(0, len(address), TOKEN_SIZE)]
+        return [
+            address[i:i + TOKEN_SIZE]
+            for i in range(0, len(address), TOKEN_SIZE)
+        ]
 
     def _get_by_addr(self, address):
         tokens = self._tokenize_address(address)

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -29,14 +29,17 @@ else:
     log_dir = "/var/log/sawtooth"
 
 data_files = [
-    (conf_dir, ['packaging/path.toml.example', 'packaging/log_config.toml.example', 'packaging/validator.toml.example']),
+    (conf_dir, ['packaging/path.toml.example',
+                'packaging/log_config.toml.example',
+                'packaging/validator.toml.example']),
     (os.path.join(conf_dir, "keys"), []),
     (data_dir, []),
     (log_dir, []),
 ]
 
 if os.path.exists("/etc/default"):
-    data_files.append(('/etc/default', ['packaging/systemd/sawtooth-validator']))
+    data_files.append(
+        ('/etc/default', ['packaging/systemd/sawtooth-validator']))
 
 if os.path.exists("/lib/systemd/system"):
     data_files.append(('/lib/systemd/system',

--- a/validator/tests/test_authorization_handlers/mock.py
+++ b/validator/tests/test_authorization_handlers/mock.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+
 class MockNetwork():
     def __init__(self, roles, allow_inbound=True, is_outbound=False,
                  connection_status=None):
@@ -48,12 +49,14 @@ class MockNetwork():
     def remove_connection(self, connection_id):
         pass
 
+
 class MockPermissionVerifier():
     def __init__(self, allow=True):
         self.allow = allow
 
     def check_network_role(self, public_key):
         return self.allow
+
 
 class MockGossip():
     def __init_(self):

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -49,7 +49,6 @@ from test_authorization_handlers.mock import MockGossip
 
 
 class TestAuthorizationHandlers(unittest.TestCase):
-
     def test_connect(self):
         """
         Test the ConnectHandler correctly responds to a ConnectionRequest.
@@ -135,9 +134,11 @@ class TestAuthorizationHandlers(unittest.TestCase):
         has finished authorization.
         """
         ping = PingRequest()
-        network = MockNetwork({},
-                              connection_status={"connection_id":
-                                                 ConnectionStatus.CONNECTED})
+        network = MockNetwork(
+            {},
+            connection_status={
+                "connection_id": ConnectionStatus.CONNECTED
+            })
         handler = PingHandler(network)
         handler_status = handler.handle("connection_id",
                                         ping.SerializeToString())
@@ -271,8 +272,9 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         network = MockNetwork(
             roles,
-            connection_status={"connection_id":
-                               ConnectionStatus.CONNECTION_REQUEST})
+            connection_status={
+                "connection_id": ConnectionStatus.CONNECTION_REQUEST
+            })
         handler = AuthorizationChallengeRequestHandler(network)
         handler_status = handler.handle(
             "connection_id",
@@ -327,8 +329,9 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         network = MockNetwork(
             roles,
-            connection_status={"connection_id":
-                               ConnectionStatus.AUTH_CHALLENGE_REQUEST})
+            connection_status={
+                "connection_id": ConnectionStatus.AUTH_CHALLENGE_REQUEST
+            })
         permission_verifer = MockPermissionVerifier()
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(
@@ -403,8 +406,9 @@ class TestAuthorizationHandlers(unittest.TestCase):
 
         network = MockNetwork(
             roles,
-            connection_status={"connection_id":
-                               ConnectionStatus.AUTH_CHALLENGE_REQUEST})
+            connection_status={
+                "connection_id": ConnectionStatus.AUTH_CHALLENGE_REQUEST
+            })
         permission_verifer = MockPermissionVerifier()
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -147,10 +147,10 @@ class TestAuthorizationHandlers(unittest.TestCase):
             handler_status.message_type,
             validator_pb2.Message.PING_RESPONSE)
 
-    def test_ping_handler(self):
+    def test_ping_rate_limiting(self):
         """
         Test the PingHandler allows a ping from a connection who has not
-        finished authorization and returns a NetworkAck. Also test that
+        finished authorization and returns a PingResponse. Also test that
         if that connection sends another ping in a short time period, the
         connection is deemed malicious, an AuthorizationViolation is returned,
         and the connection is closed.
@@ -335,7 +335,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         permission_verifer = MockPermissionVerifier()
         gossip = MockGossip()
         handler = AuthorizationChallengeSubmitHandler(
-            network, permission_verifer, gossip)
+            network, permission_verifer, gossip, {"connection_id": payload})
         handler_status = handler.handle(
             "connection_id",
             auth_challenge_submit.SerializeToString())
@@ -421,7 +421,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
             handler_status.message_type,
             validator_pb2.Message.AUTHORIZATION_VIOLATION)
 
-    def test_authorization_challenge_submit(self):
+    def test_authorizaiton_challenge_submit_not_permitted(self):
         """
         Test the AuthorizationChallengeSubmitHandler returns an
         AuthorizationViolation and closes the connection if the permission

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+# pylint: disable=invalid-name
+
 import unittest
 import os
 

--- a/validator/tests/test_block_cache/tests.py
+++ b/validator/tests/test_block_cache/tests.py
@@ -18,7 +18,6 @@ import unittest
 import time
 
 from sawtooth_validator.journal.block_cache import BlockCache
-from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 
 from sawtooth_validator.protobuf.block_pb2 import Block

--- a/validator/tests/test_block_cache/tests.py
+++ b/validator/tests/test_block_cache/tests.py
@@ -36,15 +36,15 @@ class BlockCacheTest(unittest.TestCase):
 
         header1 = BlockHeader(previous_block_id="000")
         block1 = BlockWrapper(Block(header=header1.SerializeToString(),
-                              header_signature="ABC"))
+                                    header_signature="ABC"))
 
         header2 = BlockHeader(previous_block_id="ABC")
         block2 = BlockWrapper(Block(header=header2.SerializeToString(),
-                              header_signature="DEF"))
+                                    header_signature="DEF"))
 
         header3 = BlockHeader(previous_block_id="BCA")
         block3 = BlockWrapper(Block(header=header3.SerializeToString(),
-                              header_signature="FED"))
+                                    header_signature="FED"))
 
         cache[block1.header_signature] = block1
         cache[block2.header_signature] = block2

--- a/validator/tests/test_block_store/tests.py
+++ b/validator/tests/test_block_store/tests.py
@@ -249,8 +249,8 @@ class BlockStorePredecessorIteratorTest(unittest.TestCase):
             ids)
 
     def test_iterate_chain_on_empty_block_store(self):
-        """Given a block store with no blocks, iterate using predecessor iterator
-        and verify that it results in an empty list.
+        """Given a block store with no blocks, iterate using predecessor
+        iterator and verify that it results in an empty list.
         """
         block_store = BlockStore(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
@@ -267,7 +267,7 @@ class BlockStorePredecessorIteratorTest(unittest.TestCase):
                       header=BlockHeader(
                           block_num=i,
                           previous_block_id=previous_block_id
-                      ).SerializeToString()))
+                ).SerializeToString()))
 
             previous_block_id = block.identifier
 

--- a/validator/tests/test_block_store/tests.py
+++ b/validator/tests/test_block_store/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=pointless-statement
+
 import logging
 import unittest
 

--- a/validator/tests/test_block_store/tests.py
+++ b/validator/tests/test_block_store/tests.py
@@ -17,7 +17,6 @@ import logging
 import unittest
 
 from sawtooth_validator.database.dict_database import DictDatabase
-from sawtooth_validator.exceptions import PossibleForkDetectedError
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.block_wrapper import BlockWrapper

--- a/validator/tests/test_client_request_handlers/base_case.py
+++ b/validator/tests/test_client_request_handlers/base_case.py
@@ -21,6 +21,7 @@ class ClientHandlerTestCase(unittest.TestCase):
     """Parent for Client Request Handler tests that simplifies making requests.
     Run initialize as part of setUp, and then call make_request in each test.
     """
+
     def initialize(self, handler, request_proto, response_proto,
                    store=None, roots=None, tracker=None):
         self._identity = '1234567'
@@ -37,19 +38,21 @@ class ClientHandlerTestCase(unittest.TestCase):
         return self._handle(self._serialize(**kwargs))
 
     def make_paged_request(self, **kwargs):
-        """Parses out paging kwargs and adds them into a ClientPagingControls object,
-        before sending it all on to `make_request`
+        """Parses out paging kwargs and adds them into a ClientPagingControls
+        object, before sending it all on to `make_request`
         """
         paging_keys = ['start', 'limit']
         paging_args = {k: kwargs.pop(k) for k in paging_keys if k in kwargs}
-        paging_request = client_list_control_pb2.ClientPagingControls(**paging_args)
+        paging_request = client_list_control_pb2.ClientPagingControls(
+            **paging_args)
         return self.make_request(paging=paging_request, **kwargs)
 
     def make_sort_controls(self, *keys, reverse=False):
         """Creates a ClientSortControls object and returns it in a list. Use
         concatenation to combine multiple ClientSortControls.
         """
-        return [client_list_control_pb2.ClientSortControls(keys=keys, reverse=reverse)]
+        return [client_list_control_pb2.ClientSortControls(
+            keys=keys, reverse=reverse)]
 
     def _serialize(self, **kwargs):
         request = self._request_proto(**kwargs)
@@ -87,7 +90,8 @@ class ClientHandlerTestCase(unittest.TestCase):
         """Checks that a response's ClientPagingResponse is set properly.
         Defaults to expecting a single page with all mock resources.
         """
-        self.assertIsInstance(response.paging, client_list_control_pb2.ClientPagingResponse)
+        self.assertIsInstance(
+            response.paging, client_list_control_pb2.ClientPagingResponse)
         self.assertEqual(response.paging.start, start)
         self.assertEqual(response.paging.limit, limit)
         self.assertEqual(response.paging.next, next_id)

--- a/validator/tests/test_client_request_handlers/base_case.py
+++ b/validator/tests/test_client_request_handlers/base_case.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=attribute-defined-outside-init
+
 import unittest
 from sawtooth_validator.protobuf import client_list_control_pb2
 

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -29,6 +29,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
+
 def _increment_key(key, offset=1):
     if type(key) == int:
         return key + offset
@@ -36,6 +37,7 @@ def _increment_key(key, offset=1):
         return str(int(key) + offset)
     except ValueError:
         return chr(ord(key) + offset)
+
 
 def _make_mock_transaction(base_id='id', payload='payload'):
     txn_id = 'c' * (128 - len(base_id)) + base_id
@@ -50,6 +52,7 @@ def _make_mock_transaction(base_id='id', payload='payload'):
         header=header.SerializeToString(),
         header_signature=txn_id,
         payload=payload.encode())
+
 
 def make_mock_batch(base_id='id'):
     batch_id = 'a' * (128 - len(base_id)) + base_id
@@ -67,12 +70,14 @@ def make_mock_batch(base_id='id'):
 
 class MockBlockStore(BlockStore):
     """
-    Creates a block store with a preseeded chain of blocks.
-    With defaults, creates three blocks with ids ranging from 'bbb...0' to 'bbb...2',
-    with a single batch, and single transaction in each, with ids prefixed by
-    'aaa...'' or 'ccc...'. Using the optional root parameter for add_block, it is
-    possible to save meaningful state_root_hashes to a block.
+    Creates a block store with a preseeded chain of blocks. With defaults,
+    creates three blocks with ids ranging from 'bbb...0' to 'bbb...2',
+    with a single batch, and single transaction in each, with ids
+    prefixed by 'aaa...'' or 'ccc...'. Using the optional root
+    parameter for add_block, it is possible to save meaningful
+    state_root_hashes to a block.
     """
+
     def __init__(self, size=3, start='0'):
         super().__init__(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
@@ -120,10 +125,11 @@ def make_db_and_store(size=3):
         * 0 - {'000...1': b'1'}
         * 1 - {'000...1': b'2', '000...2': b'4'}
         * 2 - {'000...1': b'3', '000...2': b'5', '000...3': b'7'}
-        * 3 - {'000...1': b'4', '000...2': b'6', '000...3': b'8', '000...4': b'10'}
+        * 3 - {'000...1': b'4', '000...2': b'6',
+               '000...3': b'8', '000...4': b'10'}
     """
     database = DictDatabase()
-    store = MockBlockStore(size=0);
+    store = MockBlockStore(size=0)
     roots = []
 
     merkle = MerkleDatabase(database)
@@ -153,7 +159,9 @@ def make_store_and_tracker(size=3):
     """
     Creates and returns two related objects for testing:
         * store - a mock block store, with a default start
-        * tracker - a batch tracker attached to the store, with one pending batch
+
+        * tracker - a batch tracker attached to the store, with one
+          pending batch
 
     With defaults, the three block ids in the store will be:
         * 'bbb...0', 'bbb...1', 'bbb...2'
@@ -169,6 +177,7 @@ def make_store_and_tracker(size=3):
     tracker.notify_txn_invalid('c' * 127 + 'f', 'error message', b'error data')
 
     return store, tracker
+
 
 class MockGossip:
     def get_peers(self):

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=attribute-defined-outside-init,abstract-method
+
 import logging
 
 from sawtooth_validator.protobuf.block_pb2 import Block

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import logging
+
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.batch_pb2 import Batch
@@ -24,8 +26,6 @@ from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.state.batch_tracker import BatchTracker
-
-import logging
 
 LOGGER = logging.getLogger(__name__)
 

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _increment_key(key, offset=1):
-    if type(key) == int:
+    if isinstance(key, int):
         return key + offset
     try:
         return str(int(key) + offset)

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -41,9 +41,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for batch lists without parameters work properly.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -95,8 +104,14 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of batches work properly with a head id.
 
         Queries the default mock block store with '1' as the head:
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -133,9 +148,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for lists of batches work filtered by batch ids.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -160,9 +184,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests break when ids are not found.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of NO_RESOURCE
@@ -180,9 +213,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests work filtered by good and bad ids.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -218,8 +260,14 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests work with both head and batch ids.
 
         Queries the default mock block store with '1' as the head:
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -242,7 +290,10 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests break when ids not found with head.
 
         Queries the default mock block store with '0' as the head:
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of NO_RESOURCE
@@ -260,9 +311,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies requests for batch lists work when paginated just by limit.
 
         Queries the default mock block store:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -281,13 +341,22 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_2, response.batches[0].header_signature)
 
-    def test_batch_list_paginated_by_start_id (self):
+    def test_batch_list_paginated_by_start_id(self):
         """Verifies batch list requests work paginated by limit and start_id.
 
         Queries the default mock block store:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -310,9 +379,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch requests break when paging specifies missing batches.
 
         Queries the default mock block store:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of INVALID_PAGING
@@ -325,12 +403,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
-    def test_batch_list_paginated_with_head (self):
+    def test_batch_list_paginated_with_head(self):
         """Verifies batch list requests work with both paging and a head id.
 
         Queries the default mock block store with 'bbb...1' as the head:
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK
@@ -353,9 +437,18 @@ class TestBatchListRequests(ClientHandlerTestCase):
         """Verifies batch list requests work sorted in reverse.
 
         Queries the default mock block store with three blocks:
-            {header_signature: 'bbb...2', batches: [{header_signature: 'aaa...2' ...}] ...}
-            {header_signature: 'bbb...1', batches: [{header_signature: 'aaa...1' ...}] ...}
-            {header_signature: 'bbb...0', batches: [{header_signature: 'aaa...0' ...}] ...}
+            {
+                header_signature: 'bbb...2',
+                 batches: [{header_signature: 'aaa...2' ...}] ...
+            }
+            {
+                header_signature: 'bbb...1',
+                 batches: [{header_signature: 'aaa...1' ...}] ...
+            }
+            {
+                header_signature: 'bbb...0',
+                 batches: [{header_signature: 'aaa...0' ...}] ...
+            }
 
         Expects to find:
             - a status of OK

--- a/validator/tests/test_client_request_handlers/test_batch_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_batch_handlers.py
@@ -71,7 +71,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.batches, Batch)
         self.assertEqual(A_2, response.batches[0].header_signature)
 
-    def test_batch_list_bad_request(self):
+    def test_batch_list_bad_protobufs(self):
         """Verifies requests for lists of batches break with bad protobufs.
 
         Expects to find:
@@ -85,7 +85,7 @@ class TestBatchListRequests(ClientHandlerTestCase):
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.batches)
 
-    def test_batch_list_bad_request(self):
+    def test_batch_list_no_genesis(self):
         """Verifies requests for lists of batches break with no genesis.
 
         Expects to find:

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -62,7 +62,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.blocks, Block)
         self.assertEqual(B_2, response.blocks[0].header_signature)
 
-    def test_block_list_bad_request(self):
+    def test_block_list_bad_protobufs(self):
         """Verifies requests for lists of blocks break with bad protobufs.
 
         Expects to find:
@@ -76,7 +76,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.blocks)
 
-    def test_block_list_bad_request(self):
+    def test_block_list_no_genesis(self):
         """Verifies requests for lists of blocks break with no genesis.
 
         Expects to find:

--- a/validator/tests/test_client_request_handlers/test_block_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_block_handlers.py
@@ -27,6 +27,7 @@ B_2 = 'b' * 127 + '2'
 A_1 = 'a' * 127 + '1'
 C_1 = 'c' * 127 + '1'
 
+
 class TestBlockListRequests(ClientHandlerTestCase):
     def setUp(self):
         store = MockBlockStore()
@@ -56,7 +57,7 @@ class TestBlockListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response, '0x0000000000000002',100)
+        self.assert_valid_paging(response, '0x0000000000000002', 100)
         self.assertEqual(3, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
         self.assertEqual(B_2, response.blocks[0].header_signature)
@@ -278,8 +279,11 @@ class TestBlockListRequests(ClientHandlerTestCase):
         self.assertEqual(2, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
         self.assertEqual(B_2, response.blocks[0].header_signature)
-        self.assert_valid_paging(response, '0x0000000000000002', 2,
-                                 next_id=BlockStore.block_num_to_hex(0))
+        self.assert_valid_paging(
+            response,
+            '0x0000000000000002',
+            2,
+            next_id=BlockStore.block_num_to_hex(0))
 
     def test_block_list_paginated_by_start(self):
         """Verifies block list requests work paginated by limit and start.
@@ -305,9 +309,11 @@ class TestBlockListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(B_2, response.head_id)
-        self.assert_valid_paging(response,
-                                 '0x0000000000000001', 1,
-                                 next_id=BlockStore.block_num_to_hex(0))
+        self.assert_valid_paging(
+            response,
+            '0x0000000000000001',
+            1,
+            next_id=BlockStore.block_num_to_hex(0))
         self.assertEqual(1, len(response.blocks))
         self.assert_all_instances(response.blocks, Block)
         self.assertEqual(B_1, response.blocks[0].header_signature)

--- a/validator/tests/test_client_request_handlers/test_peer_handler.py
+++ b/validator/tests/test_client_request_handlers/test_peer_handler.py
@@ -26,7 +26,7 @@ class TestPeerRequests(ClientHandlerTestCase):
             handlers.PeersGetRequest(gossip),
             client_peers_pb2.ClientPeersGetRequest,
             client_peers_pb2.ClientPeersGetResponse,
-            )
+        )
 
     def test_peer_request(self):
         """Verifies requests for peers work properly.

--- a/validator/tests/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_state_handlers.py
@@ -55,8 +55,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual(self.roots[2], response.state_root)
         self.assert_valid_paging(response, "0" * 69 + '1', 100)
         self.assertEqual(3, len(response.entries))
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual(
             b'3', self._find_value(response.entries, '0' * 69 + '1'))
 
@@ -111,8 +112,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assert_valid_paging(response, '0' * 69 + '1', 100)
         self.assertEqual(1, len(response.entries))
 
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '1', response.entries[0].address)
         self.assertEqual(b'1', response.entries[0].data)
 
@@ -139,8 +141,8 @@ class TestStateListRequests(ClientHandlerTestCase):
             - a status of NO_ROOT
             - that state_root, paging, and entries are missing
         """
-        # Since it is hard to predict what the state root will be ahead of time,
-        # just search for one we know is missing.
+        # Since it is hard to predict what the state root will be
+        # ahead of time, just search for one we know is missing.
         i = 0
         missing_root = format(i, 'x').zfill(64)
         while missing_root in self.roots:
@@ -175,8 +177,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assert_valid_paging(response, '0' * 69 + '3', 100)
         self.assertEqual(1, len(response.entries))
 
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '3', response.entries[0].address)
         self.assertEqual(b'7', response.entries[0].data)
 
@@ -221,19 +224,23 @@ class TestStateListRequests(ClientHandlerTestCase):
             - the state_root from block 'bbb...1'
             - a paging response with start of b'4' and limit 100
             - a list of entries with 1 item
-            - that the list contains instances of ClientStateListResponse.Entry
-            - that ClientStateListResponse.Entry matches the address of '00..2',
-              and has data of b'4'
+            - that the list contains instances of
+              ClientStateListResponse.Entry
+            - that ClientStateListResponse.Entry matches the address
+              of '00..2', and has data of b'4'
+
         """
-        response = self.make_request(state_root=self.roots[1], address='0' * 69 + '2')
+        response = self.make_request(
+            state_root=self.roots[1], address='0' * 69 + '2')
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(self.roots[1], response.state_root)
         self.assert_valid_paging(response, '0' * 69 + '2', 100)
         self.assertEqual(1, len(response.entries))
 
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '2', response.entries[0].address)
         self.assertEqual(b'4', response.entries[0].data)
 
@@ -248,7 +255,8 @@ class TestStateListRequests(ClientHandlerTestCase):
             - the state_root from block 'bbb...1'
             - that paging and entries are missing
         """
-        response = self.make_request(address='0' * 69 + '3', state_root=self.roots[1])
+        response = self.make_request(
+            address='0' * 69 + '3', state_root=self.roots[1])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertEqual(self.roots[1], response.state_root)
@@ -273,10 +281,12 @@ class TestStateListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(self.roots[2], response.state_root)
-        self.assert_valid_paging(response, '0' * 69 + '1', 2, next_id='0' * 69 + '3')
+        self.assert_valid_paging(
+            response, '0' * 69 + '1', 2, next_id='0' * 69 + '3')
         self.assertEqual(2, len(response.entries))
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
 
     def test_state_list_paginated_by_start_id(self):
         """Verifies data list requests work paginated by limit and start_id.
@@ -302,8 +312,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual(self.roots[2], response.state_root)
         self.assert_valid_paging(response, '0' * 69 + '2', 1, '0' * 69 + '3')
         self.assertEqual(1, len(response.entries))
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '2', response.entries[0].address)
         self.assertEqual(b'5', response.entries[0].data)
 
@@ -345,7 +356,7 @@ class TestStateListRequests(ClientHandlerTestCase):
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(self.roots[1], response.state_root)
-        self.assert_valid_paging(response, '0' * 69 + '2',  1)
+        self.assert_valid_paging(response, '0' * 69 + '2', 1)
         self.assertEqual(1, len(response.entries))
         self.assert_all_instances(
             response.entries,
@@ -374,8 +385,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual(self.roots[2], response.state_root)
         self.assert_valid_paging(response, '0' * 69 + '2', 1)
         self.assertEqual(1, len(response.entries))
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '2', response.entries[0].address)
         self.assertEqual(b'5', response.entries[0].data)
 
@@ -403,8 +415,9 @@ class TestStateListRequests(ClientHandlerTestCase):
         self.assertEqual(self.roots[2], response.state_root)
         self.assert_valid_paging(response, '0' * 69 + '3', 100)
         self.assertEqual(3, len(response.entries))
-        self.assert_all_instances(response.entries,
-                                  client_state_pb2.ClientStateListResponse.Entry)
+        self.assert_all_instances(
+            response.entries,
+            client_state_pb2.ClientStateListResponse.Entry)
         self.assertEqual('0' * 69 + '3', response.entries[0].address)
         self.assertEqual(b'7', response.entries[0].data)
         self.assertEqual('0' * 69 + '1', response.entries[2].address)
@@ -503,7 +516,8 @@ class TestStateGetRequests(ClientHandlerTestCase):
             - that state_root is missing (queried by root)
             - a value of b'4'
         """
-        response = self.make_request(address='0' * 69 + '2', state_root=self.roots[1])
+        response = self.make_request(
+            address='0' * 69 + '2', state_root=self.roots[1])
 
         self.assertEqual(self.status.OK, response.status)
         self.assertEqual(self.roots[1], response.state_root)
@@ -529,13 +543,14 @@ class TestStateGetRequests(ClientHandlerTestCase):
             - a status of NO_ROOT
             - that value and state_root are missing
         """
-        # Since it is hard to predict what the state root will be ahead of time,
-        # just search for one we know is missing.
+        # Since it is hard to predict what the state root will be
+        # ahead of time, just search for one we know is missing.
         i = 0
         missing_root = format(i, 'x').zfill(64)
         while missing_root in self.roots:
             missing_root = format(i, 'x').zfill(64)
-        response = self.make_request(address='0' * 69 + '2', state_root=missing_root)
+        response = self.make_request(
+            address='0' * 69 + '2', state_root=missing_root)
 
         self.assertEqual(self.status.NO_ROOT, response.status)
         self.assertFalse(response.value)
@@ -551,7 +566,8 @@ class TestStateGetRequests(ClientHandlerTestCase):
             - a status of NO_RESOURCE
             - that value and state_root are missing
         """
-        response = self.make_request(address='0' * 69 + '3', state_root=self.roots[1])
+        response = self.make_request(
+            address='0' * 69 + '3', state_root=self.roots[1])
 
         self.assertEqual(self.status.NO_RESOURCE, response.status)
         self.assertFalse(response.state_root)

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -78,9 +78,18 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies requests for status of a batch in the block store work.
 
         Queries the default mock block store with three blocks/batches:
-            {header: {batch_ids: ['aaa...2'] ...}, header_signature: 'bbb...2' ...},
-            {header: {batch_ids: ['aaa...1'] ...}, header_signature: 'bbb...1' ...},
-            {header: {batch_ids: ['aaa...0'] ...}, header_signature: 'bbb...0' ...}
+            {
+                header: {batch_ids: ['aaa...2'] ...},
+                 header_signature: 'bbb...2' ...}
+            ,
+            {
+                header: {batch_ids: ['aaa...1'] ...},
+                 header_signature: 'bbb...1' ...}
+            ,
+            {
+                header: {batch_ids: ['aaa...0'] ...},
+                 header_signature: 'bbb...0' ...
+            }
 
         Expects to find:
             - a response status of OK
@@ -189,9 +198,18 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
         """Verifies requests for status of many batches work properly.
 
         Queries the default mock block store with three blocks/batches:
-            {header: {batch_ids: ['aaa...2'] ...}, header_signature: 'bbb...2' ...},
-            {header: {batch_ids: ['aaa...1'] ...}, header_signature: 'bbb...1' ...},
-            {header: {batch_ids: ['aaa...0'] ...}, header_signature: 'bbb...0' ...}
+            {
+                header: {batch_ids: ['aaa...2'] ...},
+                 header_signature: 'bbb...2' ...}
+            ,
+            {
+                header: {batch_ids: ['aaa...1'] ...},
+                 header_signature: 'bbb...1' ...}
+            ,
+            {
+                header: {batch_ids: ['aaa...0'] ...},
+                 header_signature: 'bbb...0' ...
+            }
 
         ...and the default mock batch tracker with pending batch ids of:
             - 'aaa...d'
@@ -235,6 +253,7 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
             sleep(1)
             self._store.add_block('e')
             self._tracker.chain_update(None, [])
+
         Thread(target=delayed_add).start()
 
         response = self.make_request(

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -73,7 +73,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_2, response.transactions[0].header_signature)
 
-    def test_txn_list_bad_request(self):
+    def test_txn_list_bad_protobufs(self):
         """Verifies requests for txn lists break with bad protobufs.
 
         Expects to find:
@@ -87,7 +87,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.transactions)
 
-    def test_txn_list_bad_request(self):
+    def test_txn_list_no_genesis(self):
         """Verifies requests for txn lists break with no genesis.
 
         Expects to find:

--- a/validator/tests/test_client_request_handlers/test_txn_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_txn_handlers.py
@@ -372,7 +372,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_2, response.transactions[0].header_signature)
 
-    def test_txn_list_paginated_by_start_id (self):
+    def test_txn_list_paginated_by_start_id(self):
         """Verifies txn list requests work paginated by limit and start_id.
 
         Queries the default mock block store:
@@ -411,7 +411,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assert_all_instances(response.transactions, Transaction)
         self.assertEqual(C_1, response.transactions[0].header_signature)
 
-    def test_txn_list_paginated_by_index (self):
+    def test_txn_list_paginated_by_index(self):
         """Verifies txn list requests work paginated by limit and min_index.
 
         Queries the default mock block store:
@@ -477,7 +477,7 @@ class TestTransactionListRequests(ClientHandlerTestCase):
         self.assertFalse(response.paging.SerializeToString())
         self.assertFalse(response.transactions)
 
-    def test_txn_list_paginated_with_head (self):
+    def test_txn_list_paginated_with_head(self):
         """Verifies txn list requests work with both paging and a head id.
 
         Queries the default mock block store with 'bbb...1' as the head:

--- a/validator/tests/test_completer/mock.py
+++ b/validator/tests/test_completer/mock.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+
 class MockGossip():
     def __init__(self):
         self.requested_blocks = []

--- a/validator/tests/test_completer/mock.py
+++ b/validator/tests/test_completer/mock.py
@@ -18,7 +18,7 @@ class MockGossip():
     def __init__(self):
         self.requested_blocks = []
         self.requested_batches = []
-        self.requested_batches_by_transactin_id = []
+        self.requested_batches_by_txn_id = []
 
     def broadcast_block_request(self, block_id):
         self.requested_blocks.append(block_id)
@@ -28,4 +28,4 @@ class MockGossip():
 
     def broadcast_batch_by_transaction_id_request(self, transaction_ids):
         for txn_id in transaction_ids:
-            self.requested_batches_by_transactin_id.append(txn_id)
+            self.requested_batches_by_txn_id.append(txn_id)

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+# pylint: disable=protected-access
+
 import unittest
 import random
 import hashlib

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -62,9 +62,11 @@ class TestCompleter(unittest.TestCase):
         txn_list = []
 
         for i in range(count):
-            payload = {'Verb': 'set',
-                       'Name': 'name' + str(random.randint(0, 100)),
-                       'Value': random.randint(0, 100)}
+            payload = {
+                'Verb': 'set',
+                'Name': 'name' + str(random.randint(0, 100)),
+                'Value': random.randint(0, 100)
+            }
             intkey_prefix = \
                 hashlib.sha512('intkey'.encode('utf-8')).hexdigest()[0:6]
 
@@ -117,16 +119,20 @@ class TestCompleter(unittest.TestCase):
 
             signature = self.signer.sign(header_bytes)
 
-            batch = Batch(header=header_bytes,
-                          transactions=txn_list,
-                          header_signature=signature)
+            batch = Batch(
+                header=header_bytes,
+                transactions=txn_list,
+                header_signature=signature)
 
             batch_list.append(batch)
 
         return batch_list
 
-    def _create_blocks(self, block_count, batch_count,
-                       missing_predecessor=False, missing_batch=False,
+    def _create_blocks(self,
+                       block_count,
+                       batch_count,
+                       missing_predecessor=False,
+                       missing_batch=False,
                        find_batch=True):
         block_list = []
         pred = 0
@@ -137,7 +143,7 @@ class TestCompleter(unittest.TestCase):
             if missing_predecessor:
                 predecessor = "Missing"
             else:
-                predecessor = (block_list[i-1].header_signature if i > 0 else
+                predecessor = (block_list[i - 1].header_signature if i > 0 else
                                NULL_BLOCK_IDENTIFIER)
 
             block_header = BlockHeader(
@@ -155,9 +161,10 @@ class TestCompleter(unittest.TestCase):
                     self.completer.add_batch(batch_list[-1])
                 batch_list = batch_list[:-1]
 
-            block = Block(header=header_bytes,
-                          batches=batch_list,
-                          header_signature=signature)
+            block = Block(
+                header=header_bytes,
+                batches=batch_list,
+                header_signature=signature)
 
             block_list.append(block)
 
@@ -168,7 +175,7 @@ class TestCompleter(unittest.TestCase):
         Add completed block to completer. Block should be passed to
         on_block_recieved.
         """
-        block = self._create_blocks(1,1)[0]
+        block = self._create_blocks(1, 1)[0]
         self.completer.add_block(block)
         self.assertIn(block.header_signature, self.blocks)
 
@@ -223,7 +230,6 @@ class TestCompleter(unittest.TestCase):
         self.assertEqual(
             block,
             self.completer.get_block(block.header_signature).get_block())
-
 
     def test_block_missing_batch_not_in_cache(self):
         """
@@ -289,10 +295,10 @@ class TestCompleter(unittest.TestCase):
                       self.gossip.requested_batches_by_transactin_id)
 
         missing = Transaction(header_signature="Missing")
-        missing_batch= Batch(header_signature="Missing_batch",
-                             transactions=[missing])
+        missing_batch = Batch(header_signature="Missing_batch",
+                              transactions=[missing])
         self.completer.add_batch(missing_batch)
-        self.assertIn(missing_batch.header_signature, self.batches )
+        self.assertIn(missing_batch.header_signature, self.batches)
         self.assertIn(batch.header_signature, self.batches)
         self.assertEqual(missing_batch,
                          self.completer.get_batch_by_transaction("Missing"))

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -15,6 +15,7 @@
 import unittest
 import random
 import hashlib
+
 import cbor
 
 from sawtooth_signing import create_context

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -293,7 +293,7 @@ class TestCompleter(unittest.TestCase):
         batch = self._create_batches(1, 1, missing_dep=True)[0]
         self.completer.add_batch(batch)
         self.assertIn("Missing",
-                      self.gossip.requested_batches_by_transactin_id)
+                      self.gossip.requested_batches_by_txn_id)
 
         missing = Transaction(header_signature="Missing")
         missing_batch = Batch(header_signature="Missing_batch",

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -62,7 +62,7 @@ class TestCompleter(unittest.TestCase):
     def _create_transactions(self, count, missing_dep=False):
         txn_list = []
 
-        for i in range(count):
+        for _ in range(count):
             payload = {
                 'Verb': 'set',
                 'Name': 'name' + str(random.randint(0, 100)),
@@ -107,7 +107,7 @@ class TestCompleter(unittest.TestCase):
 
         batch_list = []
 
-        for i in range(batch_count):
+        for _ in range(batch_count):
             txn_list = self._create_transactions(txn_count,
                                                  missing_dep=missing_dep)
             txn_sig_list = [txn.header_signature for txn in txn_list]
@@ -136,7 +136,7 @@ class TestCompleter(unittest.TestCase):
                        missing_batch=False,
                        find_batch=True):
         block_list = []
-        pred = 0
+
         for i in range(0, block_count):
             batch_list = self._create_batches(batch_count, 2)
             batch_ids = [batch.header_signature for batch in batch_list]

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -180,7 +180,7 @@ class TestCompleter(unittest.TestCase):
         self.completer.add_block(block)
         self.completer.add_block(block)
         self.assertIn(block.header_signature, self.blocks)
-        self.assertEquals(len(self.blocks), 1)
+        self.assertEqual(len(self.blocks), 1)
 
     def test_block_missing_predecessor(self):
         """
@@ -189,7 +189,7 @@ class TestCompleter(unittest.TestCase):
         block = self._create_blocks(1, 1, missing_predecessor=True)[0]
         self._has_block_value = False
         self.completer.add_block(block)
-        self.assertEquals(len(self.blocks), 0)
+        self.assertEqual(len(self.blocks), 0)
         self.assertIn("Missing", self.gossip.requested_blocks)
         header = BlockHeader(previous_block_id=NULL_BLOCK_IDENTIFIER)
         missing_block = Block(header_signature="Missing",
@@ -197,7 +197,7 @@ class TestCompleter(unittest.TestCase):
         self._has_block_value = True
         self.completer.add_block(missing_block)
         self.assertIn(block.header_signature, self.blocks)
-        self.assertEquals(
+        self.assertEqual(
             block,
             self.completer.get_block(block.header_signature).get_block())
 
@@ -209,7 +209,7 @@ class TestCompleter(unittest.TestCase):
         batches = self._create_batches(1, 1, True)
         block.batches.extend(batches)
         self.completer.add_block(block)
-        self.assertEquals(len(self.blocks), 0)
+        self.assertEqual(len(self.blocks), 0)
 
     def test_block_missing_batch(self):
         """
@@ -220,7 +220,7 @@ class TestCompleter(unittest.TestCase):
         block = self._create_blocks(1, 2, missing_batch=True)[0]
         self.completer.add_block(block)
         self.assertIn(block.header_signature, self.blocks)
-        self.assertEquals(
+        self.assertEqual(
             block,
             self.completer.get_block(block.header_signature).get_block())
 
@@ -263,7 +263,7 @@ class TestCompleter(unittest.TestCase):
         batches[-1] = batch
         block.batches.extend(batches)
         self.completer.add_block(block)
-        self.assertEquals(len(self.blocks), 0)
+        self.assertEqual(len(self.blocks), 0)
 
     def test_good_batch(self):
         """
@@ -273,8 +273,8 @@ class TestCompleter(unittest.TestCase):
         batch = self._create_batches(1, 1)[0]
         self.completer.add_batch(batch)
         self.assertIn(batch.header_signature, self.batches)
-        self.assertEquals(batch,
-                          self.completer.get_batch(batch.header_signature))
+        self.assertEqual(batch,
+                         self.completer.get_batch(batch.header_signature))
 
     def test_batch_with_missing_dep(self):
         """
@@ -294,5 +294,5 @@ class TestCompleter(unittest.TestCase):
         self.completer.add_batch(missing_batch)
         self.assertIn(missing_batch.header_signature, self.batches )
         self.assertIn(batch.header_signature, self.batches)
-        self.assertEquals(missing_batch,
-                          self.completer.get_batch_by_transaction("Missing"))
+        self.assertEqual(missing_batch,
+                         self.completer.get_batch_by_transaction("Missing"))

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -16,7 +16,6 @@
 import os
 import unittest
 import shutil
-import sys
 import tempfile
 
 from sawtooth_validator.config.path import load_path_config

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -146,7 +146,6 @@ class TestPathConfig(unittest.TestCase):
 
 
 class TestValidatorConfig(unittest.TestCase):
-
     def test_validator_config_defaults(self):
         """Tests the default validator configuration when no other configs.
         The defaults should be as follows:
@@ -239,12 +238,14 @@ class TestValidatorConfig(unittest.TestCase):
         """Tests detecting invalid settings defined in a TOML configuration
         file.
 
-        Creates a temporary directory and writes a validator.toml config file
-        with an invalid setting inside, then loads that config and verifies an exception is thrown.
+        Creates a temporary directory and writes a validator.toml
+        config file with an invalid setting inside, then loads that
+        config and verifies an exception is thrown.
 
 
-        The test also attempts to avoid environment variables from interfering
-        with the test by clearing os.environ and restoring it after the test.
+        The test also attempts to avoid environment variables from
+        interfering with the test by clearing os.environ and restoring
+        it after the test.
         """
         orig_environ = dict(os.environ)
         os.environ.clear()

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -156,13 +156,13 @@ class TestValidatorConfig(unittest.TestCase):
             - endpoint = None
         """
         config = load_default_validator_config()
-        self.assertEquals(config.bind_network, "tcp://127.0.0.1:8800")
-        self.assertEquals(config.bind_component, "tcp://127.0.0.1:4004")
-        self.assertEquals(config.endpoint, None)
-        self.assertEquals(config.peering, "static")
-        self.assertEquals(config.scheduler, "serial")
-        self.assertEquals(config.minimum_peer_connectivity, 3)
-        self.assertEquals(config.maximum_peer_connectivity, 10)
+        self.assertEqual(config.bind_network, "tcp://127.0.0.1:8800")
+        self.assertEqual(config.bind_component, "tcp://127.0.0.1:4004")
+        self.assertEqual(config.endpoint, None)
+        self.assertEqual(config.peering, "static")
+        self.assertEqual(config.scheduler, "serial")
+        self.assertEqual(config.minimum_peer_connectivity, 3)
+        self.assertEqual(config.maximum_peer_connectivity, 10)
 
     def test_validator_config_load_from_file(self):
         """Tests loading config settings from a TOML configuration file.
@@ -222,14 +222,13 @@ class TestValidatorConfig(unittest.TestCase):
             self.assertEqual(config.peers, ["tcp://peer:8801"])
             self.assertEqual(config.seeds, ["tcp://peer:8802"])
             self.assertEqual(config.scheduler, "serial")
-            self.assertEquals(config.roles, {"network": "trust"})
-            self.assertEquals(config.opentsdb_db,  "data_base")
-            self.assertEquals(config.opentsdb_url, "http://data_base:0000")
-            self.assertEquals(config.opentsdb_username, "name")
-            self.assertEquals(config.opentsdb_password, "secret")
-            self.assertEquals(config.minimum_peer_connectivity, 1)
-            self.assertEquals(config.maximum_peer_connectivity, 100)
-
+            self.assertEqual(config.roles, {"network": "trust"})
+            self.assertEqual(config.opentsdb_db, "data_base")
+            self.assertEqual(config.opentsdb_url, "http://data_base:0000")
+            self.assertEqual(config.opentsdb_username, "name")
+            self.assertEqual(config.opentsdb_password, "secret")
+            self.assertEqual(config.minimum_peer_connectivity, 1)
+            self.assertEqual(config.maximum_peer_connectivity, 100)
 
         finally:
             os.environ.clear()

--- a/validator/tests/test_config/tests.py
+++ b/validator/tests/test_config/tests.py
@@ -25,9 +25,6 @@ from sawtooth_validator.config.validator import load_toml_validator_config
 
 
 class TestPathConfig(unittest.TestCase):
-    def __init__(self, test_name):
-        super().__init__(test_name)
-
     def test_path_config_defaults_sawtooth_home(self):
         """Tests the default path configuration settings when SAWTOOTH_HOME
         is set.

--- a/validator/tests/test_config_view/tests.py
+++ b/validator/tests/test_config_view/tests.py
@@ -64,7 +64,7 @@ class TestSettingsView(unittest.TestCase):
         settings_view = self._settings_view_factory.create_settings_view(
             self._current_root_hash)
         self.assertEqual(10, settings_view.get_setting('my.setting',
-                                                     value_type=int))
+                                                       value_type=int))
 
     def test_get_setting_not_found(self):
         """Verifies the correct operation of get_setting() by using it to
@@ -84,7 +84,7 @@ class TestSettingsView(unittest.TestCase):
 
         self.assertEqual('default',
                          settings_view.get_setting('non-existant.setting',
-                                                 default_value='default'))
+                                                   default_value='default'))
 
     def test_get_setting_list(self):
         """Verifies the correct operation of get_setting_list() by using it to
@@ -120,7 +120,7 @@ class TestSettingsView(unittest.TestCase):
         self.assertEqual(
             [],
             settings_view.get_setting_list('non-existant.list',
-                                         default_value=[]))
+                                           default_value=[]))
 
     def test_get_setting_list_alternate_delimiter(self):
         """Verifies the correct operation of get_setting_list() by using it to

--- a/validator/tests/test_config_view/tests.py
+++ b/validator/tests/test_config_view/tests.py
@@ -161,11 +161,11 @@ _MAX_KEY_PARTS = 4
 _ADDRESS_PART_SIZE = 16
 
 
-def _short_hash(s):
-    return hashlib.sha256(s.encode()).hexdigest()[:_ADDRESS_PART_SIZE]
+def _short_hash(name):
+    return hashlib.sha256(name.encode()).hexdigest()[:_ADDRESS_PART_SIZE]
 
 
-def _key_to_address(k):
-    key_parts = k.split('.', maxsplit=_MAX_KEY_PARTS - 1)
+def _key_to_address(key):
+    key_parts = key.split('.', maxsplit=_MAX_KEY_PARTS - 1)
     key_parts.extend([''] * (_MAX_KEY_PARTS - len(key_parts)))
     return ''.join(_short_hash(x) for x in key_parts)

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -1223,7 +1223,7 @@ class TestContextManager(unittest.TestCase):
             }])
 
         try:
-            sh1 = squash(
+            squash(
                 state_root=sh0,
                 context_ids=[ctx_1, ctx_2],
                 persist=True,

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -31,7 +31,6 @@ TestAddresses = namedtuple('TestAddresses',
 
 
 class TestContextManager(unittest.TestCase):
-
     def setUp(self):
         self.database_of_record = dict_database.DictDatabase()
         self.context_manager = context_manager.ContextManager(
@@ -112,10 +111,14 @@ class TestContextManager(unittest.TestCase):
         context_id = self.context_manager.create_context(
             state_hash=self.first_state_hash,
             base_contexts=[context_id_1, context_id_2, context_id_3],
-            inputs=[self._create_address(a)
-                    for a in ['llaa', 'yyyy', 'tttt', 'zzoo']],
-            outputs=[self._create_address(a)
-                     for a in ['llaa', 'yyyy', 'tttt', 'zzoo', 'aeio']])
+            inputs=[
+                self._create_address(a)
+                for a in ['llaa', 'yyyy', 'tttt', 'zzoo']
+            ],
+            outputs=[
+                self._create_address(a)
+                for a in ['llaa', 'yyyy', 'tttt', 'zzoo', 'aeio']
+            ])
         return context_id
 
     def _create_txn_inputs_outputs(self, start=None):
@@ -158,28 +161,40 @@ class TestContextManager(unittest.TestCase):
         """
         if start is None:
             start = 0
-        iorw = [self._create_address(str(i)) for i in range(start,
-                                                            start + 10)]
-        i_r_ = [self._create_address(str(i)) for i in range(start + 10,
-                                                            start + 20)]
-        ior_ = [self._create_address(str(i)) for i in range(start + 20,
-                                                            start + 30)]
-        io__ = [self._create_address(str(i)) for i in range(start + 30,
-                                                            start + 40)]
-        io_w = [self._create_address(str(i)) for i in range(start + 40,
-                                                            start + 50)]
-        _o_w = [self._create_address(str(i)) for i in range(start + 50,
-                                                            start + 60)]
-        _o__ = [self._create_address(str(i)) for i in range(start + 60,
-                                                            start + 70)]
-        i___ = [self._create_address(str(i)) for i in range(start + 70,
-                                                            start + 80)]
+        iorw = [self._create_address(str(i)) for i in range(start, start + 10)]
+        i_r_ = [
+            self._create_address(str(i))
+            for i in range(start + 10, start + 20)
+        ]
+        ior_ = [
+            self._create_address(str(i))
+            for i in range(start + 20, start + 30)
+        ]
+        io__ = [
+            self._create_address(str(i))
+            for i in range(start + 30, start + 40)
+        ]
+        io_w = [
+            self._create_address(str(i))
+            for i in range(start + 40, start + 50)
+        ]
+        _o_w = [
+            self._create_address(str(i))
+            for i in range(start + 50, start + 60)
+        ]
+        _o__ = [
+            self._create_address(str(i))
+            for i in range(start + 60, start + 70)
+        ]
+        i___ = [
+            self._create_address(str(i))
+            for i in range(start + 70, start + 80)
+        ]
         addresses = TestAddresses(
             inputs=iorw + ior_ + io__ + io_w + i___,
             outputs=ior_ + io__ + io_w + _o__ + _o_w,
             reads=i_r_ + ior_,
-            writes=io_w + _o_w
-        )
+            writes=io_w + _o_w)
         return addresses
 
     def test_execution_results(self):
@@ -193,10 +208,12 @@ class TestContextManager(unittest.TestCase):
             outputs=[addr1, addr2])
 
         sets = {addr1: b'1'}
-        events = [Event(
-            event_type=teststr,
-            attributes=[Event.Attribute(key=teststr, value=teststr)],
-            data=teststr.encode()) for teststr in ("test1", "test2")]
+        events = [
+            Event(
+                event_type=teststr,
+                attributes=[Event.Attribute(key=teststr, value=teststr)],
+                data=teststr.encode()) for teststr in ("test1", "test2")
+        ]
         deletes = {addr2: None}
         data = [(teststr.encode()) for teststr in ("test1", "test2")]
 
@@ -208,7 +225,6 @@ class TestContextManager(unittest.TestCase):
         for datum in data:
             self.context_manager.add_execution_data(
                 context_id, datum)
-
 
         results = self.context_manager.get_execution_results(context_id)
         self.assertEqual(sets, results[0])
@@ -446,9 +462,11 @@ class TestContextManager(unittest.TestCase):
         ctx_2 = self.context_manager.create_context(
             state_hash=state_hash_1,
             base_contexts=[ctx_1a, ctx_1b],
-            inputs=[self._create_address('z')[:10],
-                    self._create_address('c')[:10],
-                    self._create_address('b')[:10]],
+            inputs=[
+                self._create_address('z')[:10],
+                self._create_address('c')[:10],
+                self._create_address('b')[:10]
+            ],
             outputs=[self._create_address('w')])
 
         self.assertEqual(
@@ -482,9 +500,9 @@ class TestContextManager(unittest.TestCase):
              ['llaa', 'yyyy', 'tttt', 'zzoo']]),
             [(self._create_address(a), v) for a, v in
              [('llaa', b'1'),
-             ('yyyy', b'11'),
-             ('tttt', b'12'),
-             ('zzoo', b'27')]])
+              ('yyyy', b'11'),
+              ('tttt', b'12'),
+              ('zzoo', b'27')]])
 
     def test_squash(self):
         """Tests that squashing a context based on state from other
@@ -639,6 +657,7 @@ class TestContextManager(unittest.TestCase):
 
         squash = self.context_manager.get_squash_handler()
         test_addresses = self._create_txn_inputs_outputs()
+
         # 1)
         context_id1 = self.context_manager.create_context(
             state_hash=self.first_state_hash,
@@ -655,6 +674,7 @@ class TestContextManager(unittest.TestCase):
             context_ids=[context_id1],
             persist=True,
             clean_up=True)
+
         # 2)
         context_a = self.context_manager.create_context(
             state_hash=sh1,
@@ -664,10 +684,9 @@ class TestContextManager(unittest.TestCase):
         )
 
         address_values = self.context_manager.get(
-                context_a,
-                list(test_addresses.writes)
-            )
-
+            context_a,
+            list(test_addresses.writes)
+        )
         self.assertEqual(
             address_values,
             [(a, v) for a, v in zip(test_addresses.writes, values1)]
@@ -687,6 +706,7 @@ class TestContextManager(unittest.TestCase):
             outputs=test_addresses.outputs,
             base_contexts=[context_a]
         )
+
         # 5)
         c_ida1_address_values = self.context_manager.get(
             context_id=context_id_a1,
@@ -711,6 +731,7 @@ class TestContextManager(unittest.TestCase):
             address_value_list=[{a: v} for
                                 a, v in zip(test_addresses2.writes, values3)],
         )
+
         # 7)
         context_id_b = self.context_manager.create_context(
             state_hash=sh1,
@@ -788,21 +809,20 @@ class TestContextManager(unittest.TestCase):
             state_hash=sh1,
             base_contexts=[],
             inputs=[self._create_address('abcd')],
-            outputs=[self._create_address('aaaa')]
-        )
+            outputs=[self._create_address('aaaa')])
         context_2 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[],
             inputs=[self._create_address('bacd')],
-            outputs=[self._create_address('bbbb')]
-        )
+            outputs=[self._create_address('bbbb')])
         context_3 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[],
             inputs=[self._create_address('abcd')],
-            outputs=[self._create_address('cccc'),
-                     self._create_address('dddd')]
-        )
+            outputs=[
+                self._create_address('cccc'),
+                self._create_address('dddd')
+            ])
 
         # 3)
         self.context_manager.set(
@@ -822,16 +842,22 @@ class TestContextManager(unittest.TestCase):
         context_n = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[context_1, context_2, context_3],
-            inputs=[self._create_address('bbbb'), self._create_address('aaaa')],
-            outputs=[self._create_address('cccc'), self._create_address('llll')]
-        )
+            inputs=[
+                self._create_address('bbbb'),
+                self._create_address('aaaa')
+            ],
+            outputs=[
+                self._create_address('cccc'),
+                self._create_address('llll')
+            ])
 
         # 5)
         self.context_manager.set(
             context_id=context_n,
-            address_value_list=[{self._create_address('cccc'): b'4',
-                                 self._create_address('llll'): b'8'}]
-        )
+            address_value_list=[{
+                self._create_address('cccc'): b'4',
+                self._create_address('llll'): b'8'
+            }])
 
         # 6)
         cm_state_root = squash(
@@ -841,10 +867,12 @@ class TestContextManager(unittest.TestCase):
             clean_up=True)
 
         tree = MerkleDatabase(self.database_results)
-        calc_state_root = tree.update({self._create_address('aaaa'): b'1',
-                                       self._create_address('bbbb'): b'2',
-                                       self._create_address('cccc'): b'4',
-                                       self._create_address('llll'): b'8'})
+        calc_state_root = tree.update({
+            self._create_address('aaaa'): b'1',
+            self._create_address('bbbb'): b'2',
+            self._create_address('cccc'): b'4',
+            self._create_address('llll'): b'8'
+        })
         self.assertEqual(calc_state_root, cm_state_root)
 
     def test_complex_basecontext_squash(self):
@@ -937,39 +965,52 @@ class TestContextManager(unittest.TestCase):
         )
 
         # 3)
-        inputs_3_2a_1 = [self._create_address('qq'),
-                         self._create_address('dd')]
-        outputs_3_2a_1 = [self._create_address('dd'),
-                          self._create_address('pp')]
+        inputs_3_2a_1 = [
+            self._create_address('qq'),
+            self._create_address('dd')
+        ]
+        outputs_3_2a_1 = [
+            self._create_address('dd'),
+            self._create_address('pp')
+        ]
         context_3_2a_1 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[context_2a],
             inputs=inputs_3_2a_1,
-            outputs=outputs_3_2a_1
-        )
+            outputs=outputs_3_2a_1)
         inputs_3_2a_2 = [self._create_address('aa')]
-        outputs_3_2a_2 = [self._create_address('aa'),
-                          self._create_address('ll')]
+        outputs_3_2a_2 = [
+            self._create_address('aa'),
+            self._create_address('ll')
+        ]
         context_3_2a_2 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[context_2a],
             inputs=inputs_3_2a_2,
             outputs=outputs_3_2a_2)
 
-        inputs_3_2b_1 = [self._create_address('nn'),
-                         self._create_address('ab')]
-        outputs_3_2b_1 = [self._create_address('mm'),
-                          self._create_address('ba')]
+        inputs_3_2b_1 = [
+            self._create_address('nn'),
+            self._create_address('ab')
+        ]
+        outputs_3_2b_1 = [
+            self._create_address('mm'),
+            self._create_address('ba')
+        ]
         context_3_2b_1 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[context_2b],
             inputs=inputs_3_2b_1,
             outputs=outputs_3_2b_1)
 
-        inputs_3_2b_2 = [self._create_address('nn'),
-                         self._create_address('oo')]
-        outputs_3_2b_2 = [self._create_address('ab'),
-                          self._create_address('oo')]
+        inputs_3_2b_2 = [
+            self._create_address('nn'),
+            self._create_address('oo')
+        ]
+        outputs_3_2b_2 = [
+            self._create_address('ab'),
+            self._create_address('oo')
+        ]
         context_3_2b_2 = self.context_manager.create_context(
             state_hash=sh1,
             base_contexts=[context_2b],
@@ -1011,21 +1052,25 @@ class TestContextManager(unittest.TestCase):
                                             [bytes(i)
                                              for i in range(len(outputs_1))])},
             virtual=False)
+
         self.assertEqual(state_hash_from_1, sh1,
                          "The manually calculated state hash from the first "
                          "context and the one calculated by squashing that "
                          "state hash should be the same")
         tree.set_merkle_root(state_hash_from_1)
-        test_sh2 = tree.update(set_items={self._create_address('aa'): bytes(0),
-                                          self._create_address('ab'): bytes(0),
-                                          self._create_address('ba'): bytes(1),
-                                          self._create_address('dd'): bytes(0),
-                                          self._create_address('ll'): bytes(1),
-                                          self._create_address('mm'): bytes(0),
-                                          self._create_address('oo'): bytes(1),
-                                          self._create_address('pp'): bytes(1),
-                                          self._create_address('nn'): bytes(0),
-                                          self._create_address('cc'): bytes(0)})
+
+        test_sh2 = tree.update(
+            set_items={
+                self._create_address('aa'): bytes(0),
+                self._create_address('ab'): bytes(0),
+                self._create_address('ba'): bytes(1),
+                self._create_address('dd'): bytes(0),
+                self._create_address('ll'): bytes(1),
+                self._create_address('mm'): bytes(0),
+                self._create_address('oo'): bytes(1),
+                self._create_address('pp'): bytes(1),
+                self._create_address('nn'): bytes(0),
+                self._create_address('cc'): bytes(0)})
 
         self.assertEqual(sh2, test_sh2, "Manually calculated and context "
                          "manager calculated merkle hashes "
@@ -1037,10 +1082,11 @@ class TestContextManager(unittest.TestCase):
         Notes:
             1. Create a context with a wildcarded input and output and
                another non-wildcarded input and output.
-            2. Get an address under the wildcard and set to both the non-wildcarded
-               address and an address under the wildcard.
-            3. Squash the context and compare to a manually generated state
-               hash.
+            2. Get an address under the wildcard and set to both the
+               non-wildcarded address and an address under the
+               wildcard.
+            3. Squash the context and compare to a manually generated
+               state hash.
         """
 
         # 1
@@ -1062,8 +1108,10 @@ class TestContextManager(unittest.TestCase):
 
         self.context_manager.set(
             context_id=ctx_1,
-            address_value_list=[{self._create_address('a'): b'1',
-                                 self._create_address('b'): b'2'}])
+            address_value_list=[{
+                self._create_address('a'): b'1',
+                self._create_address('b'): b'2'
+            }])
 
         # 3
         squash = self.context_manager.get_squash_handler()
@@ -1075,10 +1123,11 @@ class TestContextManager(unittest.TestCase):
             set_items={self._create_address('a'): b'1',
                        self._create_address('b'): b'2'})
 
-        state_root = squash(state_root=self.first_state_hash,
-                            context_ids=[ctx_1],
-                            persist=True,
-                            clean_up=True)
+        state_root = squash(
+            state_root=self.first_state_hash,
+            context_ids=[ctx_1],
+            persist=True,
+            clean_up=True)
 
         self.assertEqual(state_root, calculated_state_root)
 
@@ -1167,12 +1216,12 @@ class TestContextManager(unittest.TestCase):
             state_hash=sh0,
             base_contexts=[],
             inputs=inputs_2,
-            outputs=outputs_2
-        )
+            outputs=outputs_2)
         self.context_manager.set(
             context_id=ctx_2,
-            address_value_list=[{self._create_address('b'): b'2'}]
-        )
+            address_value_list=[{
+                self._create_address('b'): b'2'
+            }])
 
         try:
             sh1 = squash(
@@ -1276,9 +1325,11 @@ class TestContextManager(unittest.TestCase):
         ctx_4 = self.context_manager.create_context(
             state_hash=sh0,
             base_contexts=[ctx_3],
-            inputs=[self._create_address('a'),
-                    self._create_address('b'),
-                    self._create_address('c')],
+            inputs=[
+                self._create_address('a'),
+                self._create_address('b'),
+                self._create_address('c')
+            ],
             outputs=[self._create_address('c')])
 
         self.assertEqual(self.context_manager.get(
@@ -1302,8 +1353,10 @@ class TestContextManager(unittest.TestCase):
 
         tree = MerkleDatabase(self.database_results)
 
-        sh1_assertion = tree.update({self._create_address('a'): b'1',
-                                     self._create_address('c'): b'4' })
+        sh1_assertion = tree.update({
+            self._create_address('a'): b'1',
+            self._create_address('c'): b'4'
+        })
 
         self.assertEqual(sh1, sh1_assertion,
                          "The context manager must "
@@ -1361,10 +1414,11 @@ class TestContextManager(unittest.TestCase):
 
         self.context_manager.set(ctx_1c, [{self._create_address('d'): b'3'}])
 
-        sh1 = squash(state_root=sh0,
-                     context_ids=[ctx_1c, ctx_1b, ctx_1a],
-                     persist=True,
-                     clean_up=True)
+        sh1 = squash(
+            state_root=sh0,
+            context_ids=[ctx_1c, ctx_1b, ctx_1a],
+            persist=True,
+            clean_up=True)
 
         ctx_2 = self.context_manager.create_context(
             state_hash=sh1,
@@ -1404,9 +1458,9 @@ class TestContextManager(unittest.TestCase):
             outputs=[""])
 
         self.assertEqual(
-            self.context_manager.get(ctx_4,[self._create_address('b'),
-                                            self._create_address('c'),
-                                            self._create_address('d')]),
+            self.context_manager.get(ctx_4, [self._create_address('b'),
+                                             self._create_address('c'),
+                                             self._create_address('d')]),
             [(self._create_address('b'), None),
              (self._create_address('c'), None),
              (self._create_address('d'), None)],
@@ -1420,10 +1474,13 @@ class TestContextManager(unittest.TestCase):
 
         tree = MerkleDatabase(self.database_results)
 
-        sh1_assertion = tree.update({self._create_address('b'): b'1',
-                                     self._create_address('c'): b'2',
-                                     self._create_address('d'): b'3'},
-                                    virtual=False)
+        sh1_assertion = tree.update(
+            {
+                self._create_address('b'): b'1',
+                self._create_address('c'): b'2',
+                self._create_address('d'): b'3'
+            },
+            virtual=False)
 
         self.assertEqual(sh1, sh1_assertion,
                          "The middle state hash must be correct.")
@@ -1431,10 +1488,14 @@ class TestContextManager(unittest.TestCase):
         tree.set_merkle_root(sh1)
 
         sh2_assertion = tree.update(
-            {self._create_address('e'): b'2'},
-            delete_items=[self._create_address('b'),
-                          self._create_address('c'),
-                          self._create_address('d')],
+            {
+                self._create_address('e'): b'2'
+            },
+            delete_items=[
+                self._create_address('b'),
+                self._create_address('c'),
+                self._create_address('d')
+            ],
             virtual=False)
         self.assertEqual(sh2, sh2_assertion,
                          "The final state hash must be correct")

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -22,7 +22,6 @@ import time
 from sawtooth_validator.database import dict_database
 from sawtooth_validator.execution import context_manager
 from sawtooth_validator.state.merkle import MerkleDatabase
-from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChange
 from sawtooth_validator.protobuf.events_pb2 import Event
 
 

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -416,7 +416,7 @@ class TestContextManager(unittest.TestCase):
             base_contexts=[],
             inputs=[self._create_address('a')[:10]],
             outputs=[self._create_address('c')])
-        self.assertEquals(
+        self.assertEqual(
             self.context_manager.get(
                 context_id=ctx_1a,
                 address_list=[self._create_address('a')]),
@@ -427,7 +427,7 @@ class TestContextManager(unittest.TestCase):
             base_contexts=[],
             inputs=[self._create_address('b')[:6]],
             outputs=[self._create_address('z')])
-        self.assertEquals(
+        self.assertEqual(
             self.context_manager.get(
                 context_id=ctx_1b,
                 address_list=[self._create_address('b')]),
@@ -451,7 +451,7 @@ class TestContextManager(unittest.TestCase):
                     self._create_address('b')[:10]],
             outputs=[self._create_address('w')])
 
-        self.assertEquals(
+        self.assertEqual(
             self.context_manager.get(
                 context_id=ctx_2,
                 address_list=[self._create_address('z'),
@@ -558,7 +558,7 @@ class TestContextManager(unittest.TestCase):
                                       persist=True, clean_up=True)
         # 2
         self.assertIsNotNone(resulting_state_hash)
-        self.assertEquals(resulting_state_hash, self.first_state_hash)
+        self.assertEqual(resulting_state_hash, self.first_state_hash)
 
     def test_squash_deletes_no_update(self):
         """Tests that squashing a context that has no state updates,
@@ -598,7 +598,7 @@ class TestContextManager(unittest.TestCase):
                                       persist=True, clean_up=True)
         # 3)
         self.assertIsNotNone(resulting_state_hash)
-        self.assertEquals(resulting_state_hash, self.first_state_hash)
+        self.assertEqual(resulting_state_hash, self.first_state_hash)
 
     def test_reads_from_context_w_several_writes(self):
         """Tests that those context values that have been written to the
@@ -667,10 +667,11 @@ class TestContextManager(unittest.TestCase):
                 context_a,
                 list(test_addresses.writes)
             )
-        self.assertEquals(
+
+        self.assertEqual(
             address_values,
             [(a, v) for a, v in zip(test_addresses.writes, values1)]
-            )
+        )
 
         # 3)
         values2 = [bytes(v.encode()) for v in test_addresses.outputs]
@@ -691,7 +692,7 @@ class TestContextManager(unittest.TestCase):
             context_id=context_id_a1,
             address_list=list(test_addresses.outputs)
         )
-        self.assertEquals(
+        self.assertEqual(
             c_ida1_address_values,
             [(a, v) for a, v in zip(test_addresses.outputs, values2)]
         )
@@ -719,7 +720,7 @@ class TestContextManager(unittest.TestCase):
         )
 
         # 8)
-        self.assertEquals(
+        self.assertEqual(
             self.context_manager.get(
                 context_id_b,
                 list(test_addresses2.writes + test_addresses.outputs)
@@ -844,7 +845,7 @@ class TestContextManager(unittest.TestCase):
                                        self._create_address('bbbb'): b'2',
                                        self._create_address('cccc'): b'4',
                                        self._create_address('llll'): b'8'})
-        self.assertEquals(calc_state_root, cm_state_root)
+        self.assertEqual(calc_state_root, cm_state_root)
 
     def test_complex_basecontext_squash(self):
         """Tests complex context basing and squashing.
@@ -1007,13 +1008,13 @@ class TestContextManager(unittest.TestCase):
         tree = MerkleDatabase(self.database_results)
         state_hash_from_1 = tree.update(
             set_items={a: v for a, v in zip(outputs_1,
-                                        [bytes(i)
-                                         for i in range(len(outputs_1))])},
-                                        virtual=False)
-        self.assertEquals(state_hash_from_1, sh1,
-                          "The manually calculated state hash from the first "
-                          "context and the one calculated by squashing that "
-                          "state hash should be the same")
+                                            [bytes(i)
+                                             for i in range(len(outputs_1))])},
+            virtual=False)
+        self.assertEqual(state_hash_from_1, sh1,
+                         "The manually calculated state hash from the first "
+                         "context and the one calculated by squashing that "
+                         "state hash should be the same")
         tree.set_merkle_root(state_hash_from_1)
         test_sh2 = tree.update(set_items={self._create_address('aa'): bytes(0),
                                           self._create_address('ab'): bytes(0),
@@ -1026,9 +1027,9 @@ class TestContextManager(unittest.TestCase):
                                           self._create_address('nn'): bytes(0),
                                           self._create_address('cc'): bytes(0)})
 
-        self.assertEquals(sh2, test_sh2, "Manually calculated and context "
-                                         "manager calculated merkle hashes "
-                                         "are the same")
+        self.assertEqual(sh2, test_sh2, "Manually calculated and context "
+                         "manager calculated merkle hashes "
+                         "are the same")
 
     def test_wildcarded_inputs_outputs(self):
         """Tests the context manager with wildcarded inputs and outputs.

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=too-many-lines,broad-except
+
 import unittest
 
 from collections import namedtuple

--- a/validator/tests/test_devmode_consensus/tests.py
+++ b/validator/tests/test_devmode_consensus/tests.py
@@ -30,9 +30,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TestCheckPublishBlock(unittest.TestCase):
-    def __init__(self, test_name):
-        super().__init__(test_name)
-
     def create_block_header(self, signer_public_key=None):
         return BlockHeader(signer_public_key=signer_public_key)
 

--- a/validator/tests/test_dispatcher/mock.py
+++ b/validator/tests/test_dispatcher/mock.py
@@ -21,7 +21,6 @@ from sawtooth_validator.protobuf import validator_pb2
 
 
 class MockHandler1(dispatch.Handler):
-
     def __init__(self):
         self._time_to_sleep = 2.0
 
@@ -34,7 +33,6 @@ class MockHandler1(dispatch.Handler):
 
 
 class MockHandler2(dispatch.Handler):
-
     def handle(self, connection_id, message_content):
         request = validator_pb2.Message()
         request.ParseFromString(message_content)
@@ -47,7 +45,6 @@ class MockHandler2(dispatch.Handler):
 
 
 class MockSendMessage(object):
-
     def __init__(self, connections):
         self.message_ids = []
         self.identities = []

--- a/validator/tests/test_dispatcher/tests.py
+++ b/validator/tests/test_dispatcher/tests.py
@@ -41,26 +41,30 @@ class TestDispatcherIdentityMessageMatch(unittest.TestCase):
 
         self._message_ids = [str(i) for i in range(10)]
         self._identities = [str(i) for i in range(10)]
-        self._connections = { chr(int(x)+65):x for x in self._identities}
+        self._connections = {chr(int(x) + 65): x for x in self._identities}
 
         self.mock_send_message = MockSendMessage(self._connections)
         self._dispatcher.add_send_message(self._connection,
                                           self.mock_send_message.send_message)
 
-
-        self._messages = [validator_pb2.Message(
-            content=validator_pb2.Message(correlation_id=m_id).SerializeToString(),
-            message_type=validator_pb2.Message.DEFAULT)
-            for m_id in self._message_ids]
+        self._messages = [
+            validator_pb2.Message(
+                content=validator_pb2.Message(
+                    correlation_id=m_id).SerializeToString(),
+                message_type=validator_pb2.Message.DEFAULT)
+            for m_id in self._message_ids
+        ]
 
     def test_correct_identity(self):
         """Tests that if a message is dispatched with a particular identity --
-        having dispatcher.dispatch(connection, message, connection_id) called --
-        that identity will be sent back to the zmq interface with the message.
+        having dispatcher.dispatch(connection, message, connection_id)
+        called -- that identity will be sent back to the zmq interface
+        with the message.
 
         Each message gets an id 0-9 along with an identity 0-9. These will
         be returned to send_message together no matter the ordering of the
         returns of the handlers.
+
         """
         self._dispatcher.start()
         for connection_id, message in zip(self._connections, self._messages):

--- a/validator/tests/test_duplicate_handler/mock.py
+++ b/validator/tests/test_duplicate_handler/mock.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+
 class MockCompleter:
     def __init__(self):
         self.blocks = {}
@@ -42,6 +43,7 @@ class MockChainController:
 
     def add_block(self, block_id):
         self.blocks[block_id] = 1
+
 
 class MockPublisher:
     def __init__(self):

--- a/validator/tests/test_duplicate_handler/mock.py
+++ b/validator/tests/test_duplicate_handler/mock.py
@@ -19,11 +19,9 @@ class MockCompleter:
         self.batches = {}
 
     def get_block(self, block_id):
-        print(self.blocks)
         return self.blocks.get(block_id)
 
     def get_batch(self, batch_id):
-        print(self.batches)
         return self.batches.get(batch_id)
 
     def add_block(self, block_id):
@@ -38,7 +36,6 @@ class MockChainController:
         self.blocks = {}
 
     def has_block(self, block_id):
-        print(self.blocks)
         if block_id in self.blocks:
             return True
         return False
@@ -51,7 +48,6 @@ class MockPublisher:
         self.batches = []
 
     def has_batch(self, batch_id):
-        print(self.batches)
         if batch_id in self.batches:
             return True
         return False

--- a/validator/tests/test_duplicate_handler/tests.py
+++ b/validator/tests/test_duplicate_handler/tests.py
@@ -50,7 +50,7 @@ class TestDuplicateHandler(unittest.TestCase):
         Test that if the block does not exist yet in the completer or the
         chain controller, the gossip message is passed.
         """
-        batch= Batch(header_signature="Batch1")
+        batch = Batch(header_signature="Batch1")
         message = GossipMessage(content_type=GossipMessage.BATCH,
                                 content=batch.SerializeToString())
         handler_status = self.handler.handle(

--- a/validator/tests/test_duplicate_handler/tests.py
+++ b/validator/tests/test_duplicate_handler/tests.py
@@ -17,12 +17,13 @@ import unittest
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.batch_pb2 import Batch
+from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.gossip.gossip_handlers import \
     GossipMessageDuplicateHandler
+
 from test_duplicate_handler.mock import MockCompleter
 from test_duplicate_handler.mock import MockChainController
 from test_duplicate_handler.mock import MockPublisher
-from sawtooth_validator.networking.dispatch import HandlerStatus
 
 
 class TestDuplicateHandler(unittest.TestCase):

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -62,10 +62,11 @@ def create_block(block_num=85,
         block_num=block_num,
         state_root_hash="0987654321fedcba",
         previous_block_id=previous_block_id)
-    block = BlockWrapper(block_pb2.Block(
-        header_signature=block_id,
-        header=block_header.SerializeToString(),
-        batches=batches))
+    block = BlockWrapper(
+        block_pb2.Block(
+            header_signature=block_id,
+            header=block_header.SerializeToString(),
+            batches=batches))
     return block
 
 
@@ -80,9 +81,14 @@ def create_chain(num=10):
     blocks = []
     while counter <= num:
         current_block_id = uuid4().hex
-        txns = [t[0] for t in [create_transaction(
-                payload=uuid4().hex.encode(),
-                signer=signer) for _ in range(20)]]
+        txns = [
+            t[0]
+            for t in [
+                create_transaction(
+                    payload=uuid4().hex.encode(), signer=signer)
+                for _ in range(20)
+            ]
+        ]
 
         txn_ids = [t.header_signature for t in txns]
         batch = create_batch(
@@ -143,11 +149,14 @@ class EventSubscriptionTest(unittest.TestCase):
     def test_subscription(self):
         """Test that an event correctly matches against a subscription."""
         self.assertIn(
-            events_pb2.Event(event_type="test", attributes=[
-                events_pb2.Event.Attribute(key="test", value="test")]),
+            events_pb2.Event(
+                event_type="test", attributes=[
+                    events_pb2.Event.Attribute(
+                        key="test", value="test")]),
             EventSubscription(
-                event_type="test",
-                filters=[FILTER_FACTORY.create(key="test", match_string="test")]))
+                event_type="test", filters=[
+                    FILTER_FACTORY.create(
+                        key="test", match_string="test")]))
 
 
 class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
@@ -162,16 +171,17 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
         handler = \
             ClientEventsSubscribeValidationHandler(mock_event_broadcaster)
         request = client_event_pb2.ClientEventsSubscribeRequest(
-            subscriptions=[events_pb2.EventSubscription(
-                event_type="test_event",
-                filters=[
-                    events_pb2.EventFilter(
-                        key="test",
-                        match_string="test",
-                        filter_type=events_pb2.EventFilter.SIMPLE_ANY
-                    )
-                ],
-            )],
+            subscriptions=[
+                events_pb2.EventSubscription(
+                    event_type="test_event",
+                    filters=[
+                        events_pb2.EventFilter(
+                            key="test",
+                            match_string="test",
+                            filter_type=events_pb2.EventFilter.SIMPLE_ANY)
+                    ],
+                )
+            ],
             last_known_block_ids=["0" * 128]).SerializeToString()
 
         response = handler.handle("test_conn_id", request)
@@ -195,12 +205,17 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
         handler = \
             ClientEventsSubscribeValidationHandler(mock_event_broadcaster)
         request = client_event_pb2.ClientEventsSubscribeRequest(
-            subscriptions=[events_pb2.EventSubscription(
-                event_type="test_event",
-                filters=[events_pb2.EventFilter(
-                    key="test", match_string="???",
-                    filter_type=events_pb2.EventFilter.REGEX_ANY)],
-            )],
+            subscriptions=[
+                events_pb2.EventSubscription(
+                    event_type="test_event",
+                    filters=[
+                        events_pb2.EventFilter(
+                            key="test",
+                            match_string="???",
+                            filter_type=events_pb2.EventFilter.REGEX_ANY)
+                    ],
+                )
+            ],
             last_known_block_ids=["0" * 128]).SerializeToString()
 
         response = handler.handle("test_conn_id", request)
@@ -209,11 +224,10 @@ class ClientEventsSubscribeValidationHandlerTest(unittest.TestCase):
         self.assertEqual(HandlerStatus.RETURN, response.status)
         self.assertEqual(
             client_event_pb2.ClientEventsSubscribeResponse.INVALID_FILTER,
-             response.message_out.status)
+            response.message_out.status)
 
 
 class ClientEventsSubscribeHandlersTest(unittest.TestCase):
-
     def test_subscribe(self):
         """Tests that the handler turns on the subscriber."""
         mock_event_broadcaster = Mock()
@@ -235,8 +249,10 @@ class ClientEventsUnsubscribeHandlerTest(unittest.TestCase):
         mock_event_broadcaster = Mock()
         handler = ClientEventsUnsubscribeHandler(mock_event_broadcaster)
 
-        request = \
-            client_event_pb2.ClientEventsUnsubscribeRequest().SerializeToString()
+        request = (
+            client_event_pb2.ClientEventsUnsubscribeRequest()
+            .SerializeToString()
+        )
 
         response = handler.handle('test_conn_id', request)
 
@@ -319,10 +335,14 @@ class EventBroadcasterTest(unittest.TestCase):
         event_broadcaster = EventBroadcaster(mock_service,
                                              mock_block_store,
                                              mock_receipt_store)
-        subscriptions = [EventSubscription(
-            event_type="test_event",
-            filters=[FILTER_FACTORY.create(key="test", match_string="test")],
-        )]
+        subscriptions = [
+            EventSubscription(
+                event_type="test_event",
+                filters=[
+                    FILTER_FACTORY.create(key="test", match_string="test")
+                ],
+            )
+        ]
         event_broadcaster.add_subscriber("test_conn_id", subscriptions, [])
 
         self.assertTrue(
@@ -338,8 +358,9 @@ class EventBroadcasterTest(unittest.TestCase):
 
     def test_broadcast_events(self):
         """Test that broadcast_events works with a single subscriber to the
-        sawtooth/block-commit event type and that the subscriber does not receive events
-        until it is enabled.
+        sawtooth/block-commit event type and that the subscriber does
+        not receive events until it is enabled.
+
         """
         mock_service = Mock()
         mock_block_store = Mock()
@@ -374,7 +395,8 @@ class TpEventAddHandlerTest(unittest.TestCase):
         event = events_pb2.Event(event_type="add_event")
         mock_context_manager = Mock()
         handler = TpEventAddHandler(mock_context_manager)
-        request = state_context_pb2.TpEventAddRequest(event=event).SerializeToString()
+        request = state_context_pb2.TpEventAddRequest(
+            event=event).SerializeToString()
 
         response = handler.handle("test_conn_id", request)
 

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=protected-access
+
 import unittest
 from unittest.mock import Mock
 from uuid import uuid4

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -57,7 +57,9 @@ from test_scheduler.yaml_scheduler_tester import create_transaction
 def create_block(block_num=85,
                  previous_block_id="0000000000000000",
                  block_id="abcdef1234567890",
-                 batches=[]):
+                 batches=None):
+    if batches is None:
+        batches = []
     block_header = block_pb2.BlockHeader(
         block_num=block_num,
         state_root_hash="0987654321fedcba",

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -291,7 +291,7 @@ class ClientEventsGetRequestHandlerTest(unittest.TestCase):
             Mock(),
             block_store=self.block_store,
             receipt_store=self.receipt_store)
-        for block_id, txn_ids in self._txn_ids_by_block_id.items():
+        for block_id, _ in self._txn_ids_by_block_id.items():
             request = client_event_pb2.ClientEventsGetRequest()
             request.block_ids.extend([block_id])
             subscription = request.subscriptions.add()

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=invalid-name
+
 import os
 import shutil
 import tempfile

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -54,8 +54,9 @@ class TestGenesisController(unittest.TestCase):
 
     @staticmethod
     def make_block_store(data=None):
-        return BlockStore(DictDatabase(
-            data, indexes=BlockStore.create_index_configuration()))
+        return BlockStore(
+            DictDatabase(
+                data, indexes=BlockStore.create_index_configuration()))
 
     def test_requires_genesis(self):
         self._with_empty_batch_file()
@@ -70,8 +71,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         self.assertEqual(True, genesis_ctrl.requires_genesis())
 
@@ -91,8 +91,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -111,8 +110,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -136,8 +134,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -152,9 +149,7 @@ class TestGenesisController(unittest.TestCase):
         self._with_empty_batch_file()
 
         block = self._create_block()
-        block_store = self.make_block_store({
-            block.header_signature: block
-        })
+        block_store = self.make_block_store({block.header_signature: block})
 
         genesis_ctrl = GenesisController(
             Mock('context_manager'),
@@ -166,8 +161,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         with self.assertRaises(InvalidGenesisStateError):
             genesis_ctrl.requires_genesis()
@@ -195,8 +189,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         with self.assertRaises(InvalidGenesisStateError):
             genesis_ctrl.requires_genesis()
@@ -237,8 +230,7 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender')
-        )
+            batch_sender=Mock('batch_sender'))
 
         on_done_fn = Mock(return_value='')
         genesis_ctrl.start(on_done_fn)
@@ -272,9 +264,9 @@ class TestGenesisController(unittest.TestCase):
 
     def _create_block(self):
         return BlockWrapper.wrap(
-            Block(header_signature='some_block_id',
-                  batches=[],
-                  header=BlockHeader(
-                      block_num=0,
-                      previous_block_id=NULL_BLOCK_IDENTIFIER
-                  ).SerializeToString()))
+            Block(
+                header_signature='some_block_id',
+                batches=[],
+                header=BlockHeader(
+                    block_num=0, previous_block_id=NULL_BLOCK_IDENTIFIER)
+                .SerializeToString()))

--- a/validator/tests/test_genesis_consensus/tests.py
+++ b/validator/tests/test_genesis_consensus/tests.py
@@ -27,10 +27,6 @@ from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 
 
 class TestGenesisBlockPublisher(unittest.TestCase):
-
-    def __init__(self, test_name):
-        super().__init__(test_name)
-
     def test_initialize_block(self):
         """
         Create a block header and initialize it using the genesis consensus
@@ -177,10 +173,6 @@ class TestGenesisBlockPublisher(unittest.TestCase):
 
 
 class TestGenesisBlockVerifier(unittest.TestCase):
-
-    def __init__(self, test_name):
-        super().__init__(test_name)
-
     def test_verify_genesis_block(self):
         """This test should verify that a block with the NULL_BLOCK_IDENTIFIER
         should be considered a valid block using this consensus module.

--- a/validator/tests/test_identity_view/tests.py
+++ b/validator/tests/test_identity_view/tests.py
@@ -24,7 +24,6 @@ from sawtooth_validator.state.state_view import StateViewFactory
 
 
 class TestIdentityView(unittest.TestCase):
-
     def setUp(self):
         self._database = DictDatabase()
         self._tree = MerkleDatabase(self._database)
@@ -61,9 +60,11 @@ class TestIdentityView(unittest.TestCase):
         role1.name = role1_name
         role1.policy_name = "this_is_an_example"
 
-        state_root1 = self._tree.update(set_items={
-            _get_role_address(role1_name): role_list.SerializeToString()
-        }, virtual=False)
+        state_root1 = self._tree.update(
+            set_items={
+                _get_role_address(role1_name): role_list.SerializeToString()
+            },
+            virtual=False)
 
         # 2.
         identity_view1 = identity_view_factory.create_identity_view(
@@ -74,9 +75,10 @@ class TestIdentityView(unittest.TestCase):
             "IdentityView().get_role returns the correct Role by name.")
 
         # 3.
-        self.assertIsNone(identity_view1.get_role("Not-a-Role"),
-                          "IdentityView().get_role returns None if there is "
-                          "no Role with that name.")
+        self.assertIsNone(
+            identity_view1.get_role("Not-a-Role"),
+            "IdentityView().get_role returns None if there is "
+            "no Role with that name.")
 
         # 4.
         self.assertEqual(identity_view1.get_roles(),
@@ -94,9 +96,11 @@ class TestIdentityView(unittest.TestCase):
 
         self._tree.set_merkle_root(merkle_root=state_root1)
 
-        state_root2 = self._tree.update({
-            _get_role_address(role2_name): role_list2.SerializeToString()
-        }, virtual=False)
+        state_root2 = self._tree.update(
+            {
+                _get_role_address(role2_name): role_list2.SerializeToString()
+            },
+            virtual=False)
 
         # 6.
         identity_view2 = identity_view_factory.create_identity_view(
@@ -153,9 +157,12 @@ class TestIdentityView(unittest.TestCase):
 
         policy1.name = policy1_name
 
-        state_root1 = self._tree.update(set_items={
-            _get_policy_address(policy1_name): policy_list.SerializeToString()
-        }, virtual=False)
+        state_root1 = self._tree.update(
+            set_items={
+                _get_policy_address(policy1_name):
+                policy_list.SerializeToString()
+            },
+            virtual=False)
 
         # 2.
         identity_view1 = identity_view_factory.create_identity_view(
@@ -166,9 +173,10 @@ class TestIdentityView(unittest.TestCase):
             "IdentityView().get_policy returns the correct Policy by name.")
 
         # 3.
-        self.assertIsNone(identity_view1.get_policy("Not-a-Policy"),
-                          "IdentityView().get_policy returns None if "
-                          "there is no Policy with that name.")
+        self.assertIsNone(
+            identity_view1.get_policy("Not-a-Policy"),
+            "IdentityView().get_policy returns None if "
+            "there is no Policy with that name.")
 
         # 4.
         self.assertEqual(identity_view1.get_policies(),
@@ -185,9 +193,12 @@ class TestIdentityView(unittest.TestCase):
 
         self._tree.set_merkle_root(merkle_root=state_root1)
 
-        state_root2 = self._tree.update({
-            _get_policy_address(policy2_name): policy_list2.SerializeToString()
-        }, virtual=False)
+        state_root2 = self._tree.update(
+            {
+                _get_policy_address(policy2_name):
+                policy_list2.SerializeToString()
+            },
+            virtual=False)
 
         # 6.
         identity_view2 = identity_view_factory.create_identity_view(

--- a/validator/tests/test_indexing/tests.py
+++ b/validator/tests/test_indexing/tests.py
@@ -36,13 +36,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test that a database with three records, plus an index will
         return the correct count of primary key/values, using `len`.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -57,13 +57,13 @@ class IndexedDatabaseTest(unittest.TestCase):
          - a non-existent key will return False for both of those methods
          - an index key will return True for `contains_key`, using the index
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -86,13 +86,13 @@ class IndexedDatabaseTest(unittest.TestCase):
          - ignores keys that do not exist (i.e. no error is thrown)
          - it works with index keys in the same manor
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -123,13 +123,13 @@ class IndexedDatabaseTest(unittest.TestCase):
     def test_indexing(self):
         """Test basic indexing around name
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -145,13 +145,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test iteration on over the items in a database, using the natural
         order of the primary keys.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -174,9 +174,9 @@ class IndexedDatabaseTest(unittest.TestCase):
                              _serialize_tuple, _deserialize_tuple,
                              indexes={
                                  'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        },
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -197,13 +197,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         - not change the results
         - not interrupt the iteration with an error
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -227,13 +227,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         test that the cursor can be properly position to the first element in
         the natural order of the keys
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "alice", "Alice's data"))
         db.put('2', (2, "bob", "Bob's data"))
@@ -265,13 +265,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         test that the cursor can be properly position to the last element in
         the natural order of the keys
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "alice", "Alice's data"))
         db.put('2', (2, "bob", "Bob's data"))
@@ -303,13 +303,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         test that the cursor can be properly position to an arbitrary element
         in the natural order of the keys
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "alice", "Alice's data"))
         db.put('2', (2, "bob", "Bob's data"))
@@ -328,13 +328,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Given an empty database, show that the cursor will return a value of
         None for the first position.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         with db.cursor(index='name') as curs:
             curs.first()
@@ -348,13 +348,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test iteration over the items in a database, using the natural order
         of the index keys.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -373,13 +373,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test reverse iteration over the items in a database, using the
         reverse natural order of the index keys.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -400,13 +400,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         - not change the results
         - not interrupt the iteration with an error
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -432,13 +432,13 @@ class IndexedDatabaseTest(unittest.TestCase):
             'key_fn': lambda tup: [struct.pack('I', tup[0])],
             'integerkey': True
         }
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'age': int_index_config
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'age': int_index_config},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (30, "alice", "Alice's data"))
@@ -460,19 +460,20 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test that an index that uses hex-encoded keys will properly order
         the keys (i.e. the natural order of the keys is in numerical order).
         """
+
         def to_hex(num):
             return "{0:#0{1}x}".format(num, 18)
 
         def age_index_key_fn(tup):
             return [to_hex(tup[0]).encode()]
 
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'age': age_index_key_fn
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'age': age_index_key_fn},
+            flag='c',
+            _size=1024**2)
 
         entry_count = 100
         for i in range(1, entry_count):
@@ -485,13 +486,13 @@ class IndexedDatabaseTest(unittest.TestCase):
     def test_delete(self):
         """Test that items are deleted, including their index references.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -520,13 +521,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         """Test that a database will commit both inserts and deletes using the
         update method.
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
 
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
@@ -543,13 +544,13 @@ class IndexedDatabaseTest(unittest.TestCase):
         - inserted items index should be correct
         - deleted items should be removed
         """
-        db = IndexedDatabase(os.path.join(self._temp_dir, 'test_db'),
-                             _serialize_tuple, _deserialize_tuple,
-                             indexes={
-                                 'name': lambda tup: [tup[1].encode()]
-                             },
-                             flag='c',
-                             _size=1024**2)
+        db = IndexedDatabase(
+            os.path.join(self._temp_dir, 'test_db'),
+            _serialize_tuple,
+            _deserialize_tuple,
+            indexes={'name': lambda tup: [tup[1].encode()]},
+            flag='c',
+            _size=1024**2)
         db.put('1', (1, "foo", "bar"))
         db.put('2', (2, "alice", "Alice's data"))
         db.put('3', (3, "bob", "Bob's data"))

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -155,7 +155,7 @@ class BlockTreeManager(object):
         header = BlockHeader(
             previous_block_id=previous.identifier,
             signer_public_key=self.identity_signer.get_public_key().as_hex(),
-            block_num=previous.block_num+1)
+            block_num=previous.block_num + 1)
 
         block_builder = BlockBuilder(header)
         if batches:
@@ -170,7 +170,7 @@ class BlockTreeManager(object):
             block_builder.add_batches(
                 [self._generate_batch_from_payload('BAD')])
 
-        block_builder.set_state_hash('0'*70)
+        block_builder.set_state_hash('0' * 70)
 
         consensus = mock_consensus.BlockPublisher()
         consensus.finalize_block(block_builder.block_header, weight=weight)
@@ -244,7 +244,7 @@ class BlockTreeManager(object):
         block_builder.add_batches(
             [self._generate_batch_from_payload(payload)
                 for _ in range(batch_count)])
-        block_builder.set_state_hash('0'*70)
+        block_builder.set_state_hash('0' * 70)
 
         header_bytes = block_builder.block_header.SerializeToString()
         signature = self.identity_signer.sign(header_bytes)

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=no-else-return
+# pylint: disable=no-value-for-parameter
+# pylint: disable=abstract-class-instantiated
+
 import logging
 import hashlib
 import random

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -16,7 +16,6 @@
 import logging
 import hashlib
 import logging
-import pprint
 import random
 import string
 
@@ -49,9 +48,6 @@ from test_journal.mock import MockBlockSender
 from test_journal.mock import MockStateViewFactory
 from test_journal.mock import MockTransactionExecutor
 from test_journal.mock import MockPermissionVerifier
-
-
-pp = pprint.PrettyPrinter(indent=4)
 
 
 LOGGER = logging.getLogger(__name__)

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -15,7 +15,6 @@
 
 import logging
 import hashlib
-import logging
 import random
 import string
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -28,6 +28,7 @@ from sawtooth_validator.protobuf.setting_pb2 import Setting
 
 from sawtooth_validator.state.settings_view import SettingsView
 
+
 class SynchronousExecutor(Executor):
     def __init__(self):
         self._work_queue = []
@@ -102,7 +103,7 @@ class MockScheduler(Scheduler):
 
         return BatchExecutionResult(
             is_valid=result,
-            state_hash='0'*70)
+            state_hash='0' * 70)
 
     def get_transaction_execution_results(self, batch_signature):
         return []
@@ -153,14 +154,15 @@ class MockBlockSender(BlockSender):
         self.new_block = None
 
     def send(self, block):
-         self.new_block = block
+        self.new_block = block
+
 
 class MockBatchSender(BatchSender):
     def __init__(self):
         self.new_batch = None
 
     def send(self, batch):
-         self.new_batch = batch
+        self.new_batch = batch
 
 
 class MockStateViewFactory(object):
@@ -180,7 +182,6 @@ class MockStateViewFactory(object):
         self._database = database
         if self._database is None:
             self._database = {}
-
 
     def create_view(self, state_root_hash=None):
         """Creates a StateView for the given state root hash.
@@ -237,6 +238,7 @@ class MockChainIdManager(object):
     """Mock for the ChainIdManager, which provides the value of the
     block-chain-id stored in the data_dir.
     """
+
     def __init__(self):
         self._block_chain_id = None
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -41,7 +41,7 @@ class SynchronousExecutor(Executor):
         job()
 
     def process_all(self):
-        while len(self._work_queue):
+        while self._work_queue:
             self.process_next()
 
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+# pylint: disable=arguments-differ
+
 from concurrent.futures import Executor
 
 from sawtooth_validator.execution.scheduler import Scheduler
@@ -249,6 +252,7 @@ class MockChainIdManager(object):
         return self._block_chain_id
 
 
+# pylint: disable=invalid-name
 def CreateSetting(key, value):
     """
     Create a setting object to include in a MockStateFactory.

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-from sawtooth_validator.journal.consensus.consensus\
+
+from sawtooth_validator.journal.consensus.consensus \
     import BlockPublisherInterface
-from sawtooth_validator.journal.consensus.consensus\
+from sawtooth_validator.journal.consensus.consensus \
     import BlockVerifierInterface
-from sawtooth_validator.journal.consensus.consensus\
+from sawtooth_validator.journal.consensus.consensus \
     import ForkResolverInterface
 
 
 class BlockPublisher(BlockPublisherInterface):
     """ MockConsensus BlockPublisher
     """
+
     def __init__(self,
                  block_cache=None,
                  state_view_factory=None,
@@ -71,6 +73,7 @@ class BlockPublisher(BlockPublisherInterface):
 class BlockVerifier(BlockVerifierInterface):
     """MockConsensus BlockVerifier implementation
     """
+
     def __init__(self,
                  block_cache,
                  state_view_factory,
@@ -91,6 +94,7 @@ class BlockVerifier(BlockVerifierInterface):
 class ForkResolver(ForkResolverInterface):
     """MockConsensus ForkResolver implementation
     """
+
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -13,6 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=abstract-method
+# pylint: disable=arguments-differ
+# pylint: disable=useless-super-delegation
+
 from sawtooth_validator.journal.consensus.consensus \
     import BlockPublisherInterface
 from sawtooth_validator.journal.consensus.consensus \

--- a/validator/tests/test_journal/mock_consensus.py
+++ b/validator/tests/test_journal/mock_consensus.py
@@ -131,5 +131,5 @@ class ForkResolver(ForkResolverInterface):
         # chains are ordered by length first, then weight
         if new_num == cur_num:
             return new_weight > cur_weight
-        else:
-            return new_num > cur_num
+
+        return new_num > cur_num

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -1100,12 +1100,14 @@ class TestChainController(unittest.TestCase):
             block_sig[:8],
             'Not chain head')
 
-    def generate_chain(self, root_block, num_blocks,
-                       params={'add_to_cache': True}):
+    def generate_chain(self, root_block, num_blocks, params=None):
         '''Returns (chain, chain_head).
         Usually only the head is needed,
         but occasionally the chain itself is used.
         '''
+        if params is None:
+            params = {'add_to_cache': True}
+
         chain = self.block_tree_manager.generate_chain(
             root_block, num_blocks, params)
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -503,13 +503,13 @@ class TestBlockValidator(unittest.TestCase):
         as the current chain.
         """
         # create a new valid chain 5 long from the current root
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         self.block_tree_manager.set_chain_head(head)
 
         # generate candidate chain 3 long from the same root
-        new_chain, new_head = self.generate_chain_with_head(
+        _, new_head = self.generate_chain_with_head(
             self.root, 3, {'add_to_cache': True})
 
         self.validate_block(new_head)
@@ -524,13 +524,13 @@ class TestBlockValidator(unittest.TestCase):
         a different code path when finding the common root )
         """
         # create a new valid chain 5 long from the current root
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         self.block_tree_manager.set_chain_head(head)
 
         # generate candidate chain 8 long from the same root
-        new_chain, new_head = self.generate_chain_with_head(
+        _, new_head = self.generate_chain_with_head(
             head, 8, {'add_to_cache': True})
 
         self.validate_block(new_head)
@@ -543,13 +543,13 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where new block is from a different genesis
         """
         # create a new valid chain 5 long from the current root
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         self.block_tree_manager.set_chain_head(head)
 
         # generate candidate chain 5 long from its own genesis
-        new_chain, new_head = self.generate_chain_with_head(
+        _, new_head = self.generate_chain_with_head(
             None, 5, {'add_to_cache': True})
 
         self.validate_block(new_head)
@@ -593,7 +593,7 @@ class TestBlockValidator(unittest.TestCase):
         """
         Test the case where the new block has a bad batch
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         new_block = self.block_tree_manager.generate_block(
@@ -610,7 +610,7 @@ class TestBlockValidator(unittest.TestCase):
         """
         Test the case where the new block has a bad batch
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         new_block = self.block_tree_manager.generate_block(
@@ -628,7 +628,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a batch that is missing a
         dependency.
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         txn = self.block_tree_manager.generate_transaction(deps=["missing"])
@@ -649,7 +649,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a batch that already committed to
         the chain.
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         batch = self.block_tree_manager.generate_batch()
@@ -674,7 +674,7 @@ class TestBlockValidator(unittest.TestCase):
         """
         Test the case where the new block has a duplicate batches.
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         batch = self.block_tree_manager.generate_batch()
@@ -694,7 +694,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a transaction that is already
         committed.
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         txn = self.block_tree_manager.generate_transaction()
@@ -723,7 +723,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a batch that contains duplicate
         transactions.
         """
-        chain, head = self.generate_chain_with_head(
+        _, head = self.generate_chain_with_head(
             self.root, 5, {'add_to_store': True})
 
         txn = self.block_tree_manager.generate_transaction()
@@ -863,7 +863,7 @@ class TestChainController(unittest.TestCase):
     def test_alternate_genesis(self):
         '''Tests a fork extending an alternate genesis block
         '''
-        chain, head = self.generate_chain(None, 5)
+        chain, _ = self.generate_chain(None, 5)
 
         for block in chain:
             self.receive_and_process_blocks(block)
@@ -975,7 +975,7 @@ class TestChainController(unittest.TestCase):
         '''Tests a fork with a bad block in the middle
         '''
         # make two chains extending chain
-        good_chain, good_head = self.generate_chain(self.init_head, 5)
+        _, good_head = self.generate_chain(self.init_head, 5)
         bad_chain, bad_head = self.generate_chain(self.init_head, 5)
 
         self.chain_ctrl.on_block_received(bad_head)

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=too-many-lines
+# pylint: disable=pointless-statement
+# pylint: disable=protected-access
+# pylint: disable=unbalanced-tuple-unpacking
+
 import logging
 from threading import RLock
 import unittest

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -48,13 +48,7 @@ from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChange
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChangeList
 from sawtooth_validator.protobuf.events_pb2 import Event
-from sawtooth_validator.protobuf.events_pb2 import EventList
 from sawtooth_validator.protobuf.events_pb2 import EventFilter
-
-from sawtooth_validator.state.merkle import MerkleDatabase
-
-from sawtooth_validator.state.state_view import StateViewFactory
-from sawtooth_validator.state.settings_view import SettingsView
 
 from test_journal.block_tree_manager import BlockTreeManager
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -358,7 +358,7 @@ class TestBlockPublisher(unittest.TestCase):
         self.batches = self.make_batches_with_duplicate_txn()
         self.receive_batches()
         self.publish_block()
-        self.assert_no_block_published() # block should be empty after batch
+        self.assert_no_block_published()  # block should be empty after batch
         # with duplicate transaction is dropped.
 
     def test_batch_injection_start_block(self):
@@ -628,7 +628,6 @@ class TestBlockValidator(unittest.TestCase):
 
         self.assert_invalid_block(new_block)
         self.assert_new_block_not_committed()
-
 
     def test_block_missing_batch_dependency(self):
         """
@@ -1108,7 +1107,7 @@ class TestChainController(unittest.TestCase):
             'Not chain head')
 
     def generate_chain(self, root_block, num_blocks,
-                                 params={'add_to_cache': True}):
+                       params={'add_to_cache': True}):
         '''Returns (chain, chain_head).
         Usually only the head is needed,
         but occasionally the chain itself is used.
@@ -1352,7 +1351,6 @@ class TestTimedCache(unittest.TestCase):
 
 
 class TestChainCommitState(unittest.TestCase):
-
     def setUp(self):
         self.commit_state = None
         self.block_tree_manager = BlockTreeManager()
@@ -1378,7 +1376,7 @@ class TestChainCommitState(unittest.TestCase):
         commit_state = self.create_chain_commit_state(
             blocks=blocks,
             uncommitted_blocks=[uncommitted_block],
-            )
+        )
         self.commit_state = commit_state
 
         # the first block is still present
@@ -1397,7 +1395,7 @@ class TestChainCommitState(unittest.TestCase):
         commit_state = self.create_chain_commit_state(
             blocks=blocks,
             uncommitted_blocks=[uncommitted_block],
-            )
+        )
         self.commit_state = commit_state
 
         # the first block is still present
@@ -1478,6 +1476,7 @@ class TestChainCommitState(unittest.TestCase):
         self.assertFalse(self.commit_state.has_batch("missing"))
         self.assertFalse(self.commit_state.has_transaction("missing"))
 
+
 class TestBlockEventExtractor(unittest.TestCase):
     def test_block_event_extractor(self):
         """Test that a sawtooth/block-commit event is generated correctly."""
@@ -1495,13 +1494,14 @@ class TestBlockEventExtractor(unittest.TestCase):
             Event(
                 event_type="sawtooth/block-commit",
                 attributes=[
-                    Event.Attribute(key="block_id",value="abcdef1234567890"),
+                    Event.Attribute(key="block_id", value="abcdef1234567890"),
                     Event.Attribute(key="block_num", value="85"),
                     Event.Attribute(
                         key="state_root_hash", value="0987654321fedcba"),
                     Event.Attribute(
                         key="previous_block_id",
                         value="0000000000000000")])])
+
 
 class TestReceiptEventExtractor(unittest.TestCase):
     def test_tf_events(self):

--- a/validator/tests/test_merkle_trie/tests.py
+++ b/validator/tests/test_merkle_trie/tests.py
@@ -80,14 +80,13 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
 
         values = {}
         key_hashes = {
-            key: _hash(key) for key in
-            (_random_string(10) for _ in range(1000))
+            key: _hash(key)
+            for key in (_random_string(10) for _ in range(1000))
         }
 
         for key, hashed in key_hashes.items():
             value = {key: _random_string(512)}
-            new_root = self.set(
-                hashed, value, ishash=True)
+            new_root = self.set(hashed, value, ishash=True)
             values[hashed] = value
             self.set_merkle_root(new_root)
 
@@ -98,13 +97,15 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
                 address, value, ishash=True)
 
         set_items = {
-            hashed: {key: 5.0} for key, hashed in
-            random.sample(key_hashes.items(), 50)
+            hashed: {
+                key: 5.0
+            }
+            for key, hashed in random.sample(key_hashes.items(), 50)
         }
         values.update(set_items)
         delete_items = {
-            hashed for hashed in
-            random.sample(list(key_hashes.values()), 50)
+            hashed
+            for hashed in random.sample(list(key_hashes.values()), 50)
         }
 
         # make sure there are no sets and deletes of the same key

--- a/validator/tests/test_message_validation/tests.py
+++ b/validator/tests/test_message_validation/tests.py
@@ -50,9 +50,11 @@ class TestMessageValidation(unittest.TestCase):
         txn_list = []
 
         for i in range(count):
-            payload = {'Verb': 'set',
-                       'Name': 'name' + str(random.randint(0, 100)),
-                       'Value': random.randint(0, 100)}
+            payload = {
+                'Verb': 'set',
+                'Name': 'name' + str(random.randint(0, 100)),
+                'Value': random.randint(0, 100)
+            }
             intkey_prefix = \
                 hashlib.sha512('intkey'.encode('utf-8')).hexdigest()[0:6]
 
@@ -122,9 +124,10 @@ class TestMessageValidation(unittest.TestCase):
             else:
                 signature = "bad_signature"
 
-            batch = Batch(header=header_bytes,
-                          transactions=txn_list,
-                          header_signature=signature)
+            batch = Batch(
+                header=header_bytes,
+                transactions=txn_list,
+                header_signature=signature)
 
             batch_list.append(batch)
 

--- a/validator/tests/test_message_validation/tests.py
+++ b/validator/tests/test_message_validation/tests.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 import unittest
-import cbor
 import hashlib
 import random
 import string
+
+import cbor
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory

--- a/validator/tests/test_message_validation/tests.py
+++ b/validator/tests/test_message_validation/tests.py
@@ -50,7 +50,7 @@ class TestMessageValidation(unittest.TestCase):
                              valid_batcher=True):
         txn_list = []
 
-        for i in range(count):
+        for _ in range(count):
             payload = {
                 'Verb': 'set',
                 'Name': 'name' + str(random.randint(0, 100)),
@@ -108,7 +108,7 @@ class TestMessageValidation(unittest.TestCase):
 
         batch_list = []
 
-        for i in range(batch_count):
+        for _ in range(batch_count):
             txn_list = self._create_transactions(txn_count, valid_txn,
                                                  valid_batcher)
             txn_sig_list = [txn.header_signature for txn in txn_list]
@@ -138,7 +138,7 @@ class TestMessageValidation(unittest.TestCase):
                        valid_block=True, valid_batch=True):
         block_list = []
 
-        for i in range(block_count):
+        for _ in range(block_count):
             batch_list = self._create_batches(
                 batch_count, 2, valid_batch=valid_batch)
             batch_ids = [batch.header_signature for batch in batch_list]

--- a/validator/tests/test_permission_verifier/mocks.py
+++ b/validator/tests/test_permission_verifier/mocks.py
@@ -16,6 +16,7 @@
 from sawtooth_validator.protobuf.identity_pb2 import Policy
 from sawtooth_validator.protobuf.identity_pb2 import Role
 
+
 class MockIdentityViewFactory(object):
     def __init__(self):
         self.roles = {}

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -13,10 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 import unittest
-import cbor
 import hashlib
-import random
-import string
+
+import cbor
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -475,18 +475,18 @@ class TestIdentityObserver(unittest.TestCase):
         receipts = TransactionReceipt(events=[event])
         self._identity_obsever.chain_update(block2, [receipts])
         # Check that only "network" was invalidated
-        self.assertEquals(self._identity_cache["network"], None)
+        self.assertEqual(self._identity_cache["network"], None)
         self.assertNotEqual(self._identity_cache["policy1"], None)
 
         # check that the correct values can be fetched from state.
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_role("network", "state_root"),
             identity_view.get_role("network"))
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_policy("policy1", "state_root"),
             identity_view.get_policy("policy1"))
 
@@ -499,17 +499,17 @@ class TestIdentityObserver(unittest.TestCase):
         self._identity_obsever.chain_update(block, [])
         # Check that all items are invalid
         for key in self._identity_cache:
-            self.assertEquals(self._identity_cache[key], None)
+            self.assertEqual(self._identity_cache[key], None)
 
         # Check that the items can be fetched from state.
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_role("network", "state_root"),
             identity_view.get_role("network"))
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_policy("policy1", "state_root"),
             identity_view.get_policy("policy1"))
 
@@ -536,7 +536,7 @@ class TestIdentityCache(unittest.TestCase):
 
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_role("network", "state_root"),
             identity_view.get_role("network"))
 
@@ -552,7 +552,7 @@ class TestIdentityCache(unittest.TestCase):
 
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_policy("policy1", "state_root"),
             identity_view.get_policy("policy1"))
 
@@ -565,11 +565,11 @@ class TestIdentityCache(unittest.TestCase):
                 "network",
                 "policy1")
         self._identity_cache.invalidate("network")
-        self.assertEquals(self._identity_cache["network"], None)
+        self.assertEqual(self._identity_cache["network"], None)
 
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_role("network", "state_root"),
             identity_view.get_role("network"))
 
@@ -586,7 +586,7 @@ class TestIdentityCache(unittest.TestCase):
 
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_policy("policy1", "state_root"),
             identity_view.get_policy("policy1"))
 
@@ -606,16 +606,16 @@ class TestIdentityCache(unittest.TestCase):
         self._identity_cache.get_policy("policy1", "state_root")
         self._identity_cache.get_role("network", "state_root")
 
-        self.assertEquals(len(self._identity_cache), 2)
+        self.assertEqual(len(self._identity_cache), 2)
         self._identity_cache.forked()
 
-        self.assertEquals(self._identity_cache["network"], None)
-        self.assertEquals(self._identity_cache["policy1"], None)
+        self.assertEqual(self._identity_cache["network"], None)
+        self.assertEqual(self._identity_cache["policy1"], None)
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_policy("policy1", "state_root"),
             identity_view.get_policy("policy1"))
 
-        self.assertEquals(
+        self.assertEqual(
             self._identity_cache.get_role("network", "state_root"),
             identity_view.get_role("network"))

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -27,12 +27,13 @@ from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.events_pb2 import Event
-from sawtooth_validator.protobuf.transaction_receipt_pb2 import TransactionReceipt
+from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
+    TransactionReceipt
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.gossip.permission_verifier import PermissionVerifier
 from sawtooth_validator.gossip.permission_verifier import IdentityCache
 from sawtooth_validator.gossip.identity_observer import IdentityObserver
-from test_permission_verifier.mocks import  MockIdentityViewFactory
+from test_permission_verifier.mocks import MockIdentityViewFactory
 from test_permission_verifier.mocks import make_policy
 
 
@@ -62,10 +63,14 @@ class TestPermissionVerifier(unittest.TestCase):
 
     def _create_transactions(self, count):
         txn_list = []
+
         for i in range(count):
-            payload = {'Verb': 'set',
-                       'Name': 'name' ,
-                       'Value': 1}
+            payload = {
+                'Verb': 'set',
+                'Name': 'name',
+                'Value': 1,
+            }
+
             intkey_prefix = \
                 hashlib.sha512('intkey'.encode('utf-8')).hexdigest()[0:6]
 
@@ -114,9 +119,10 @@ class TestPermissionVerifier(unittest.TestCase):
 
             signature = self.signer.sign(header_bytes)
 
-            batch = Batch(header=header_bytes,
-                          transactions=txn_list,
-                          header_signature=signature)
+            batch = Batch(
+                header=header_bytes,
+                transactions=txn_list,
+                header_signature=signature)
 
             batch_list.append(batch)
 
@@ -154,8 +160,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +  \
-                                               self.public_key])
+        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
+                                                           self.public_key])
         self._identity_view_factory.add_role("transactor", "policy1")
         batch = self._create_batches(1, 1)[0]
         allowed = self.permission_verifier.is_batch_signer_authorized(batch)
@@ -174,8 +180,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +  \
-                                               self.public_key])
+        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
+                                                           self.public_key])
         self._identity_view_factory.add_role("transactor.batch_signer",
                                              "policy1")
         batch = self._create_batches(1, 1)[0]
@@ -196,8 +202,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +  \
-                                               self.public_key])
+        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
+                                                           self.public_key])
         self._identity_view_factory.add_role("transactor.transaction_signer",
                                              "policy1")
         batch = self._create_batches(1, 1)[0]
@@ -219,8 +225,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +  \
-                                               self.public_key])
+        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
+                                                           self.public_key])
         self._identity_view_factory.add_role(
             "transactor.transaction_signer.intkey",
             "policy1")
@@ -284,10 +290,11 @@ class TestPermissionVerifier(unittest.TestCase):
 
     def test_off_chain_transactor_transaction_signer(self):
         """
-        Test that role:"transactor.transaction_signer" is checked properly if in
-        permissions.
+        Test that role:"transactor.transaction_signer" is checked
+        properly if in permissions.
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
+
         """
         policy = make_policy("policy1", ["PERMIT_KEY " + self.public_key])
         self.permissions["transactor.transaction_signer"] = policy
@@ -354,8 +361,8 @@ class TestPermissionVerifier(unittest.TestCase):
             "policy1", ["PERMIT_KEY " + self.public_key])
 
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
 
         allowed = self.permission_verifier.check_network_role(self.public_key)
         self.assertTrue(allowed)
@@ -363,8 +370,8 @@ class TestPermissionVerifier(unittest.TestCase):
         self._identity_cache.forked()
         self._identity_view_factory.add_policy("policy2", ["PERMIT_KEY other"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy2")
+            "network",
+            "policy2")
         allowed = self.permission_verifier.check_network_role(self.public_key)
         self.assertFalse(allowed)
 
@@ -405,8 +412,8 @@ class TestPermissionVerifier(unittest.TestCase):
             "policy1", ["PERMIT_KEY " + self.public_key])
 
         self._identity_view_factory.add_role(
-                "network.consensus",
-                "policy1")
+            "network.consensus",
+            "policy1")
 
         allowed = self.permission_verifier.check_network_consensus_role(
             self.public_key)
@@ -415,8 +422,8 @@ class TestPermissionVerifier(unittest.TestCase):
         self._identity_cache.forked()
         self._identity_view_factory.add_policy("policy2", ["PERMIT_KEY other"])
         self._identity_view_factory.add_role(
-                "network.consensus",
-                "policy2")
+            "network.consensus",
+            "policy2")
         allowed = self.permission_verifier.check_network_consensus_role(
             self.public_key)
         self.assertFalse(allowed)
@@ -436,8 +443,8 @@ class TestIdentityObserver(unittest.TestCase):
         # Make sure IdentityCache has populated roles and policy
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
         self._identity_cache.get_role("network", "state_root")
         self._identity_cache.get_policy("policy1", "state_root")
 
@@ -449,9 +456,10 @@ class TestIdentityObserver(unittest.TestCase):
             block_num=85,
             state_root_hash="0987654321fedcba",
             previous_block_id=previous_block_id)
-        block = BlockWrapper(Block(
-            header_signature="abcdef1234567890",
-            header=block_header.SerializeToString()))
+        block = BlockWrapper(
+            Block(
+                header_signature="abcdef1234567890",
+                header=block_header.SerializeToString()))
         return block
 
     def test_chain_update(self):
@@ -469,9 +477,9 @@ class TestIdentityObserver(unittest.TestCase):
 
         # Add next block and event that says network was updated.
         block2 = self.create_block("abcdef1234567890")
-        event = Event(event_type="identity/update",
-                      attributes=[Event.Attribute(key="updated",
-                                                  value="network")])
+        event = Event(
+            event_type="identity/update",
+            attributes=[Event.Attribute(key="updated", value="network")])
         receipts = TransactionReceipt(events=[event])
         self._identity_obsever.chain_update(block2, [receipts])
         # Check that only "network" was invalidated
@@ -530,8 +538,8 @@ class TestIdentityCache(unittest.TestCase):
         """
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
         self.assertIsNone(self._identity_cache["network"])
 
         identity_view = \
@@ -546,8 +554,8 @@ class TestIdentityCache(unittest.TestCase):
         """
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
         self.assertIsNone(self._identity_cache["policy1"])
 
         identity_view = \
@@ -562,8 +570,8 @@ class TestIdentityCache(unittest.TestCase):
         """
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
         self._identity_cache.invalidate("network")
         self.assertEqual(self._identity_cache["network"], None)
 
@@ -579,8 +587,8 @@ class TestIdentityCache(unittest.TestCase):
         """
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
         self._identity_cache.invalidate("policy1")
         self.assertEqual(self._identity_cache["policy1"], None)
 
@@ -597,8 +605,8 @@ class TestIdentityCache(unittest.TestCase):
         """
         self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY key"])
         self._identity_view_factory.add_role(
-                "network",
-                "policy1")
+            "network",
+            "policy1")
 
         identity_view = \
             self._identity_view_factory.create_identity_view("state_root")

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+# pylint: disable=invalid-name
+
 import unittest
 import hashlib
 

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -63,7 +63,7 @@ class TestPermissionVerifier(unittest.TestCase):
     def _create_transactions(self, count):
         txn_list = []
 
-        for i in range(count):
+        for _ in range(count):
             payload = {
                 'Verb': 'set',
                 'Name': 'name',
@@ -106,7 +106,7 @@ class TestPermissionVerifier(unittest.TestCase):
 
         batch_list = []
 
-        for i in range(batch_count):
+        for _ in range(batch_count):
             txn_list = self._create_transactions(txn_count)
             txn_sig_list = [txn.header_signature for txn in txn_list]
 

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -28,22 +28,24 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.execution.tp_state_handlers import TpReceiptAddDataHandler
 
 from sawtooth_validator.protobuf import processor_pb2
-from sawtooth_validator.protobuf.transaction_receipt_pb2 import TransactionReceipt
+from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
+    TransactionReceipt
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChange
 from sawtooth_validator.protobuf.client_receipt_pb2 import \
     ClientReceiptGetRequest
 from sawtooth_validator.protobuf.client_receipt_pb2 import \
     ClientReceiptGetResponse
 from sawtooth_validator.protobuf.events_pb2 import Event
-from sawtooth_validator.protobuf.state_context_pb2 import TpReceiptAddDataRequest
+from sawtooth_validator.protobuf.state_context_pb2 import \
+    TpReceiptAddDataRequest
 
 
 class ReceiptStoreTest(unittest.TestCase):
     def test_receipt_store_get_and_set(self):
         """Tests that we correctly get and set state changes to a ReceiptStore.
 
-        This test sets a list of receipts and then gets them back, ensuring that
-        the data is the same.
+        This test sets a list of receipts and then gets them back,
+        ensuring that the data is the same.
         """
 
         receipt_store = TransactionReceiptStore(DictDatabase())
@@ -58,20 +60,22 @@ class ReceiptStoreTest(unittest.TestCase):
                 string = str(j)
                 byte = string.encode()
 
-                state_changes.append(StateChange(
-                    address='a100000' + string,
-                    value=byte,
-                    type=StateChange.SET))
-                events.append(Event(
-                    event_type="test",
-                    data=byte,
-                    attributes=[Event.Attribute(key=string, value=string)]))
+                state_changes.append(
+                    StateChange(
+                        address='a100000' + string,
+                        value=byte,
+                        type=StateChange.SET))
+                events.append(
+                    Event(
+                        event_type="test",
+                        data=byte,
+                        attributes=[Event.Attribute(key=string,
+                                                    value=string)]))
                 data.append(byte)
 
-            receipts.append(TransactionReceipt(
-                state_changes=state_changes,
-                events=events,
-                data=data))
+            receipts.append(
+                TransactionReceipt(
+                    state_changes=state_changes, events=events, data=data))
 
         for i in range(len(receipts)):
             receipt_store.put(str(i), receipts[i])
@@ -79,7 +83,8 @@ class ReceiptStoreTest(unittest.TestCase):
         for i in range(len(receipts)):
             stored_receipt = receipt_store.get(str(i))
 
-            self.assertEqual(stored_receipt.state_changes, receipts[i].state_changes)
+            self.assertEqual(stored_receipt.state_changes,
+                             receipts[i].state_changes)
             self.assertEqual(stored_receipt.events, receipts[i].events)
             self.assertEqual(stored_receipt.data, receipts[i].data)
 
@@ -90,6 +95,7 @@ class ReceiptStoreTest(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             receipt_store.get('unknown')
+
 
 class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
     def test_get_receipts(self):
@@ -115,7 +121,6 @@ class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
 
         self.assertEqual([receipt], [r for r in response.message_out.receipts])
 
-
         request = ClientReceiptGetRequest(
             transaction_ids=['unknown']).SerializeToString()
 
@@ -123,6 +128,7 @@ class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
         self.assertEqual(HandlerStatus.RETURN, response.status)
         self.assertEqual(ClientReceiptGetResponse.NO_RESOURCE,
                          response.message_out.status)
+
 
 class TpReceiptAddDataHandlerTest(unittest.TestCase):
     def test_add_event(self):

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -74,16 +74,16 @@ class ReceiptStoreTest(unittest.TestCase):
                 TransactionReceipt(
                     state_changes=state_changes, events=events, data=data))
 
-        for i in range(len(receipts)):
-            receipt_store.put(str(i), receipts[i])
+        for i, receipt in enumerate(receipts):
+            receipt_store.put(str(i), receipt)
 
-        for i in range(len(receipts)):
+        for i, receipt in enumerate(receipts):
             stored_receipt = receipt_store.get(str(i))
 
             self.assertEqual(stored_receipt.state_changes,
-                             receipts[i].state_changes)
-            self.assertEqual(stored_receipt.events, receipts[i].events)
-            self.assertEqual(stored_receipt.data, receipts[i].data)
+                             receipt.state_changes)
+            self.assertEqual(stored_receipt.events, receipt.events)
+            self.assertEqual(stored_receipt.data, receipt.data)
 
     def test_raise_key_error_on_missing_receipt(self):
         """Tests that we correctly raise key error on a missing receipt

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -25,9 +25,6 @@ from sawtooth_validator.journal.receipt_store import \
 
 from sawtooth_validator.networking.dispatch import HandlerStatus
 
-from sawtooth_validator.execution.tp_state_handlers import TpReceiptAddDataHandler
-
-from sawtooth_validator.protobuf import processor_pb2
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
     TransactionReceipt
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChange

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+
 from sawtooth_validator.protobuf import network_pb2
 from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.protobuf import block_pb2

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -83,7 +83,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_1",
             message_type=validator_pb2.Message.GOSSIP_BLOCK_RESPONSE
-            )
+        )
 
     def test_block_responder_handler_requested(self):
         """
@@ -135,7 +135,6 @@ class TestResponder(unittest.TestCase):
             requested_id="ABC", connection_id="Connection_2")
         self.assert_message_not_sent(connection_id="Connection_2")
 
-
     def test_responder_block_response_handler(self):
         """
         Test that the ResponderBlockResponseHandler, after receiving a Block
@@ -175,7 +174,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_2",
             message_type=validator_pb2.Message.GOSSIP_BLOCK_RESPONSE
-            )
+        )
         # The request for block "ABC" from "Connection_2" is no longer pending
         # it should be removed from the pending request cache.
         self.assert_request_not_pending(requested_id="ABC")
@@ -214,7 +213,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_1",
             message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
-            )
+        )
 
     def test_batch_by_id_responder_handler_requested(self):
         """
@@ -264,7 +263,6 @@ class TestResponder(unittest.TestCase):
             requested_id="abc", connection_id="Connection_2")
         self.assert_message_not_sent(connection_id="Connection_2")
 
-
     def test_batch_by_transaction_id_response_handler(self):
         """
         Test that the BatchByTransactionIdResponderHandler correctly broadcasts
@@ -284,7 +282,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_was_broadcasted(
             message,
             validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST
-            )
+        )
         self.assert_request_pending(
             requested_id="123", connection_id="Connection_1")
         self.assert_message_not_sent(connection_id="Connection_1")
@@ -305,7 +303,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_1",
             message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
-            )
+        )
 
     def test_batch_by_transaction_id_response_handler_requested(self):
         """
@@ -325,7 +323,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_was_broadcasted(
             message,
             validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST
-            )
+        )
         self.assert_request_pending(
             requested_id="123", connection_id="Connection_1")
         self.assert_message_not_sent(connection_id="Connection_1")
@@ -340,7 +338,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_was_not_broadcasted(
             message,
             validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST
-            )
+        )
 
         self.assert_request_not_pending(
             requested_id="123", connection_id="Connection_2")
@@ -354,12 +352,10 @@ class TestResponder(unittest.TestCase):
         self.assert_message_was_not_broadcasted(
             message,
             validator_pb2.Message.GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST
-            )
+        )
         self.assert_request_pending(
             requested_id="123", connection_id="Connection_2")
         self.assert_message_not_sent(connection_id="Connection_2")
-
-
 
     def test_batch_by_transaction_id_multiple_txn_ids(self):
         """
@@ -385,7 +381,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_1",
             message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
-            )
+        )
 
         # Broadcast a BatchByTransactionIdRequest for just 456
         request_message = \
@@ -439,7 +435,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_2",
             message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
-            )
+        )
         # The request for batch "abc" from "Connection_2" is no longer pending
         # it should be removed from the pending request cache.
         self.assert_request_not_pending(requested_id="abc")
@@ -481,7 +477,7 @@ class TestResponder(unittest.TestCase):
         self.assert_message_sent(
             connection_id="Connection_2",
             message_type=validator_pb2.Message.GOSSIP_BATCH_RESPONSE
-            )
+        )
         # The request for transaction_id "123" from "Connection_2" is no
         # longer pending it should be removed from the pending request cache.
         self.assert_request_not_pending(requested_id="123")
@@ -501,8 +497,8 @@ class TestResponder(unittest.TestCase):
 
     def assert_message_sent(self, connection_id, message_type):
         self.assertIsNotNone(self.gossip.sent.get(connection_id))
-        self.assertTrue(self.gossip.sent.get(connection_id)[0][0] == \
-            message_type)
+        self.assertTrue(self.gossip.sent.get(connection_id)[0][0] ==
+                        message_type)
 
     def assert_request_pending(self, requested_id, connection_id):
         self.assertIn(connection_id, self.responder.get_request(requested_id))

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=invalid-name
+
 import unittest
 
 from sawtooth_validator.protobuf import network_pb2

--- a/validator/tests/test_scheduler/test_predecessor_tree.py
+++ b/validator/tests/test_scheduler/test_predecessor_tree.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+# pylint: disable=too-many-lines,protected-access
+
 import unittest
 
 import logging

--- a/validator/tests/test_scheduler/test_predecessor_tree.py
+++ b/validator/tests/test_scheduler/test_predecessor_tree.py
@@ -108,26 +108,26 @@ class TestPredecessorTree(unittest.TestCase):
         #             c: Readers: [5]
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([], None, {'o', 'i'}),
-            'radi':     ([], None, {'s', 'x'}),
-            'radix':    ([1], None, {}),
-            'radish':   ([2], None, {}),
-            'radon':    ([3], None, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([], None, {'i'}),
-            'rustic':   ([5], None, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([], None, {'o', 'i'}),
+            'radi': ([], None, {'s', 'x'}),
+            'radix': ([1], None, {}),
+            'radish': ([2], None, {}),
+            'radon': ([3], None, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([], None, {'i'}),
+            'rustic': ([5], None, {}),
         })
 
         self.assert_rw_count(5, 0)
 
         self.assert_rw_preds_at_addresses({
-            'r':        ({}, {1, 2, 3, 4, 5}),
-            'rad':      ({}, {1, 2, 3}),
-            'radi':     ({}, {1, 2}),
-            'radix':    ({}, {1}),
+            'r': ({}, {1, 2, 3, 4, 5}),
+            'rad': ({}, {1, 2, 3}),
+            'radi': ({}, {1, 2}),
+            'radix': ({}, {1}),
         })
 
         # 2) Add readers at addresses that are initial segments
@@ -159,24 +159,24 @@ class TestPredecessorTree(unittest.TestCase):
         #             c: Readers: [5]
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([6], None, {'o', 'i'}),
-            'radi':     ([], None, {'s', 'x'}),
-            'radix':    ([1], None, {}),
-            'radish':   ([2], None, {}),
-            'radon':    ([3], None, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([7], None, {'i'}),
-            'rustic':   ([5], None, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([6], None, {'o', 'i'}),
+            'radi': ([], None, {'s', 'x'}),
+            'radix': ([1], None, {}),
+            'radish': ([2], None, {}),
+            'radon': ([3], None, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([7], None, {'i'}),
+            'rustic': ([5], None, {}),
         })
 
         self.assert_rw_count(7, 0)
 
         self.assert_rw_preds_at_addresses({
-            'ra':       ({}, {1, 2, 3, 4, 6}),
-            'ru':       ({}, {5, 7}),
+            'ra': ({}, {1, 2, 3, 4, 6}),
+            'ru': ({}, {5, 7}),
         })
 
         # 3) Add a writer in the middle of the tree.
@@ -206,23 +206,23 @@ class TestPredecessorTree(unittest.TestCase):
         )
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([6], None, {'o', 'i'}),
-            'radi':     ([], 8, {}),
-            'radon':    ([3], None, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([7], None, {'i'}),
-            'rustic':   ([5], None, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([6], None, {'o', 'i'}),
+            'radi': ([], 8, {}),
+            'radon': ([3], None, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([7], None, {'i'}),
+            'rustic': ([5], None, {}),
         })
 
         self.assert_rw_count(5, 1)
 
         self.assert_rw_preds_at_addresses({
-            'rad':      ({8}, {3, 6, 8}),
-            'radi':     ({8}, {6, 8}),
-            'radical':  ({8}, {6, 8}),
+            'rad': ({8}, {3, 6, 8}),
+            'radi': ({8}, {6, 8}),
+            'radical': ({8}, {6, 8}),
         })
 
         # 4) Add readers to existing nodes.
@@ -254,23 +254,23 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([6, 9], None, {'o', 'i'}),
-            'radi':     ([10], 8, {'o'}),
-            'radio':    ([11], None, {}),
-            'radon':    ([3, 12], None, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([7, 13], None, {'i'}),
-            'rustic':   ([5], None, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([6, 9], None, {'o', 'i'}),
+            'radi': ([10], 8, {'o'}),
+            'radio': ([11], None, {}),
+            'radon': ([3, 12], None, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([7, 13], None, {'i'}),
+            'rustic': ([5], None, {}),
         })
 
         self.assert_rw_count(10, 1)
 
         self.assert_rw_preds_at_addresses({
-            'rad':      ({8}, {6, 9, 10, 8, 11, 3, 12}),
-            'ru':       ({}, {7, 13, 5}),
+            'rad': ({8}, {6, 9, 10, 8, 11, 3, 12}),
+            'ru': ({}, {7, 13, 5}),
         })
 
         # 5) Add a writer to a new node.
@@ -297,25 +297,25 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([6, 9], None, {'o', 'i'}),
-            'radi':     ([10], 8, {'o', 'i'}),
-            'radii':    ([], 14, {}),
-            'radio':    ([11], None, {}),
-            'radon':    ([3, 12], None, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([7, 13], None, {'i'}),
-            'rustic':   ([5], None, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([6, 9], None, {'o', 'i'}),
+            'radi': ([10], 8, {'o', 'i'}),
+            'radii': ([], 14, {}),
+            'radio': ([11], None, {}),
+            'radon': ([3, 12], None, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([7, 13], None, {'i'}),
+            'rustic': ([5], None, {}),
         })
 
         self.assert_rw_count(10, 2)
 
         self.assert_rw_preds_at_addresses({
-            'radi':     ({8, 14}, {6, 9, 10, 8, 14, 11}),
-            'radii':    ({14}, {6, 9, 10, 14}),
-            'radio':    ({8}, {6, 9, 10, 8, 11}),
+            'radi': ({8, 14}, {6, 9, 10, 8, 14, 11}),
+            'radii': ({14}, {6, 9, 10, 14}),
+            'radio': ({8}, {6, 9, 10, 8, 11}),
         })
 
         # 6) Add writers in the middle of the tree.
@@ -346,21 +346,21 @@ class TestPredecessorTree(unittest.TestCase):
         )
 
         self.assert_rwc_at_addresses({
-            'r':        ([], None, {'a', 'u'}),
-            'ra':       ([], None, {'z', 'd'}),
-            'rad':      ([], 16, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([], None, {'s'}),
-            'rust':     ([], 15, {}),
+            'r': ([], None, {'a', 'u'}),
+            'ra': ([], None, {'z', 'd'}),
+            'rad': ([], 16, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([], None, {'s'}),
+            'rust': ([], 15, {}),
         })
 
         self.assert_rw_count(1, 2)
 
         self.assert_rw_preds_at_addresses({
-            'r':        ({16, 15}, {16, 4, 15}),
-            'ru':       ({15}, {15}),
-            'rust':     ({15}, {15}),
-            'rustic':   ({15}, {15}),
+            'r': ({16, 15}, {16, 4, 15}),
+            'ru': ({15}, {15}),
+            'rust': ({15}, {15}),
+            'rustic': ({15}, {15}),
         })
 
         # 7) Add readers to upper nodes.
@@ -384,19 +384,19 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            'r':        ([17], None, {'a', 'u'}),
-            'ra':       ([18], None, {'z', 'd'}),
-            'rad':      ([], 16, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([19], None, {'s'}),
-            'rust':     ([], 15, {}),
+            'r': ([17], None, {'a', 'u'}),
+            'ra': ([18], None, {'z', 'd'}),
+            'rad': ([], 16, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([19], None, {'s'}),
+            'rust': ([], 15, {}),
         })
 
         self.assert_rw_count(4, 2)
 
         self.assert_rw_preds_at_addresses({
-            'r':        ({15, 16}, {17, 19, 15, 18, 16, 4}),
-            'ru':       ({15}, {17, 19, 15}),
+            'r': ({15, 16}, {17, 19, 15, 18, 16, 4}),
+            'ru': ({15}, {17, 19, 15}),
         })
 
         # 8) Add readers to nodes with writers.
@@ -419,21 +419,21 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'r'}),
-            'r':        ([17], None, {'a', 'u'}),
-            'ra':       ([18], None, {'z', 'd'}),
-            'rad':      ([20], 16, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([19], None, {'s'}),
-            'rust':     ([21], 15, {}),
+            '': ([], None, {'r'}),
+            'r': ([17], None, {'a', 'u'}),
+            'ra': ([18], None, {'z', 'd'}),
+            'rad': ([20], 16, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([19], None, {'s'}),
+            'rust': ([21], 15, {}),
         })
 
         self.assert_rw_count(6, 2)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
-            'rad':      ({16}, {17, 18, 20, 16}),
-            'rust':     ({15}, {17, 19, 21, 15}),
+            '': ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
+            'rad': ({16}, {17, 18, 20, 16}),
+            'rust': ({15}, {17, 19, 21, 15}),
         })
 
         # 9) Add readers to new top nodes.
@@ -458,23 +458,23 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'r', 's', 't'}),
-            'r':        ([17], None, {'a', 'u'}),
-            'ra':       ([18], None, {'z', 'd'}),
-            'rad':      ([20], 16, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([19], None, {'s'}),
-            'rust':     ([21], 15, {}),
-            's':        ([22], None, {}),
-            't':        ([23], None, {}),
+            '': ([], None, {'r', 's', 't'}),
+            'r': ([17], None, {'a', 'u'}),
+            'ra': ([18], None, {'z', 'd'}),
+            'rad': ([20], 16, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([19], None, {'s'}),
+            'rust': ([21], 15, {}),
+            's': ([22], None, {}),
+            't': ([23], None, {}),
         })
 
         self.assert_rw_count(8, 2)
 
         self.assert_rw_preds_at_addresses({
-            's':        ({}, {22}),
-            't':        ({}, {23}),
-            'r':        ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
+            's': ({}, {22}),
+            't': ({}, {23}),
+            'r': ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
         })
 
         # 10) Add writer to top node.
@@ -496,22 +496,22 @@ class TestPredecessorTree(unittest.TestCase):
         #             e: Readers: [4]
 
         self.assert_rwc_at_addresses({
-            'r':        ([17], None, {'a', 'u'}),
-            'ra':       ([18], None, {'z', 'd'}),
-            'rad':      ([20], 16, {}),
-            'razzle':   ([4], None, {}),
-            'ru':       ([19], None, {'s'}),
-            'rust':     ([21], 15, {}),
-            's':        ([], 24, {}),
-            't':        ([23], None, {}),
+            'r': ([17], None, {'a', 'u'}),
+            'ra': ([18], None, {'z', 'd'}),
+            'rad': ([20], 16, {}),
+            'razzle': ([4], None, {}),
+            'ru': ([19], None, {'s'}),
+            'rust': ([21], 15, {}),
+            's': ([], 24, {}),
+            't': ([23], None, {}),
         })
 
         self.assert_rw_count(7, 3)
 
         self.assert_rw_preds_at_addresses({
-            's':       ({24}, {24}),
-            't':       ({}, {23}),
-            'r':       ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
+            's': ({24}, {24}),
+            't': ({}, {23}),
+            'r': ({16, 15}, {17, 18, 20, 16, 4, 19, 21, 15}),
         })
 
         # 11) Add readers to upper nodes, then add writers.
@@ -534,11 +534,11 @@ class TestPredecessorTree(unittest.TestCase):
         #     a: Writer: 27
 
         self.assert_rwc_at_addresses({
-            'r':        ([17], None, {'a', 'u'}),
-            'ra':       ([], 27, {}),
-            'ru':       ([], 28, {}),
-            's':        ([], 24, {}),
-            't':        ([23], None, {}),
+            'r': ([17], None, {'a', 'u'}),
+            'ra': ([], 27, {}),
+            'ru': ([], 28, {}),
+            's': ([], 24, {}),
+            't': ([23], None, {}),
         })
 
         self.assert_no_nodes_at_addresses(
@@ -548,9 +548,9 @@ class TestPredecessorTree(unittest.TestCase):
         )
 
         self.assert_rw_preds_at_addresses({
-            'r':        ({27, 28}, {17, 27, 28}),
-            'ra':       ({27}, {17, 27}),
-            'rad':      ({27}, {17, 27}),
+            'r': ({27, 28}, {17, 27, 28}),
+            'ra': ({27}, {17, 27}),
+            'rad': ({27}, {17, 27}),
         })
 
         # 12) Add writer to top node, then add reader.
@@ -564,10 +564,10 @@ class TestPredecessorTree(unittest.TestCase):
         #   r: Writer: 29 Readers: [30]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'r', 's', 't'}),
-            'r':        ([30], 29, {}),
-            's':        ([], 24, {}),
-            't':        ([23], None, {}),
+            '': ([], None, {'r', 's', 't'}),
+            'r': ([30], 29, {}),
+            's': ([], 24, {}),
+            't': ([23], None, {}),
         })
 
         self.assert_no_nodes_at_addresses(
@@ -578,9 +578,9 @@ class TestPredecessorTree(unittest.TestCase):
         self.assert_rw_count(2, 2)
 
         self.assert_rw_preds_at_addresses({
-            'r':        ({29}, {30, 29}),
-            'roger':    ({29}, {30, 29}),
-            'ebert':   ({}, {}),
+            'r': ({29}, {30, 29}),
+            'roger': ({29}, {30, 29}),
+            'ebert': ({}, {}),
         })
 
         # 13) Add writer to root
@@ -590,7 +590,7 @@ class TestPredecessorTree(unittest.TestCase):
         # ROOT: Writer: 0
 
         self.assert_rwc_at_addresses({
-            '':        ([], 0, {})
+            '': ([], 0, {})
         })
 
         self.assert_no_nodes_at_addresses(
@@ -602,10 +602,10 @@ class TestPredecessorTree(unittest.TestCase):
         self.assert_rw_count(0, 1)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({0}, {0}),
-            'r':        ({0}, {0}),
-            's':        ({0}, {0}),
-            'rabbit':   ({0}, {0}),
+            '': ({0}, {0}),
+            'r': ({0}, {0}),
+            's': ({0}, {0}),
+            'rabbit': ({0}, {0}),
         })
 
     def test_initial_segment_addresses(self):
@@ -628,10 +628,10 @@ class TestPredecessorTree(unittest.TestCase):
         #       t: Writer: 3 Readers: [3]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'c'}),
-            'c':        ([1], 1, {'a'}),
-            'ca':       ([2], 2, {'t'}),
-            'cat':      ([3], 3, {}),
+            '': ([], None, {'c'}),
+            'c': ([1], 1, {'a'}),
+            'ca': ([2], 2, {'t'}),
+            'cat': ([3], 3, {}),
         })
 
         self.assert_rw_count(3, 3)
@@ -640,11 +640,11 @@ class TestPredecessorTree(unittest.TestCase):
         # the same predecessors as 'cat'
 
         self.assert_rw_preds_at_addresses({
-            '':         ({1, 2, 3}, {1, 2, 3}),
-            'c':        ({1, 2, 3}, {1, 2, 3}),
-            'ca':       ({2, 3}, {1, 2, 3}),
-            'cat':      ({3}, {1, 2, 3}),
-            'cath':     ({3}, {1, 2, 3}),
+            '': ({1, 2, 3}, {1, 2, 3}),
+            'c': ({1, 2, 3}, {1, 2, 3}),
+            'ca': ({2, 3}, {1, 2, 3}),
+            'cat': ({3}, {1, 2, 3}),
+            'cath': ({3}, {1, 2, 3}),
         })
 
         # add reader and writer at an address with a common initial segment
@@ -660,22 +660,22 @@ class TestPredecessorTree(unittest.TestCase):
         #       t: Writer: 3 Readers: [3]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'c'}),
-            'c':        ([1], 1, {'a'}),
-            'ca':       ([2], 2, {'t', 'r'}),
-            'cat':      ([3], 3, {}),
-            'carp':     ([4], 4, {}),
+            '': ([], None, {'c'}),
+            'c': ([1], 1, {'a'}),
+            'ca': ([2], 2, {'t', 'r'}),
+            'cat': ([3], 3, {}),
+            'carp': ([4], 4, {}),
         })
 
         self.assert_rw_count(4, 4)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({1, 2, 3, 4}, {1, 2, 3, 4}),
-            'c':        ({1, 2, 3, 4}, {1, 2, 3, 4}),
-            'ca':       ({2, 3, 4}, {1, 2, 3, 4}),
-            'cat':      ({3}, {1, 2, 3}),
-            'cath':     ({3}, {1, 2, 3}),
-            'carp':     ({4}, {1, 2, 4}),
+            '': ({1, 2, 3, 4}, {1, 2, 3, 4}),
+            'c': ({1, 2, 3, 4}, {1, 2, 3, 4}),
+            'ca': ({2, 3, 4}, {1, 2, 3, 4}),
+            'cat': ({3}, {1, 2, 3}),
+            'cath': ({3}, {1, 2, 3}),
+            'carp': ({4}, {1, 2, 4}),
         })
 
         # add reader and writer at an address with no common initial segment
@@ -694,30 +694,30 @@ class TestPredecessorTree(unittest.TestCase):
         #       g: Writer: 5 Readers: [5]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'c', 'd'}),
-            'c':        ([1], 1, {'a'}),
-            'ca':       ([2], 2, {'t', 'r'}),
-            'cat':      ([3], 3, {}),
-            'carp':     ([4], 4, {}),
-            'dog':      ([5], 5, {}),
+            '': ([], None, {'c', 'd'}),
+            'c': ([1], 1, {'a'}),
+            'ca': ([2], 2, {'t', 'r'}),
+            'cat': ([3], 3, {}),
+            'carp': ([4], 4, {}),
+            'dog': ([5], 5, {}),
         })
 
         self.assert_rw_count(5, 5)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-            'c':        ({1, 2, 3, 4}, {1, 2, 3, 4}),
-            'ca':       ({2, 3, 4}, {1, 2, 3, 4}),
-            'cat':      ({3}, {1, 2, 3}),
-            'cath':     ({3}, {1, 2, 3}),
-            'carp':     ({4}, {1, 2, 4}),
-            'dog':      ({5}, {5}),
+            '': ({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+            'c': ({1, 2, 3, 4}, {1, 2, 3, 4}),
+            'ca': ({2, 3, 4}, {1, 2, 3, 4}),
+            'cat': ({3}, {1, 2, 3}),
+            'cath': ({3}, {1, 2, 3}),
+            'carp': ({4}, {1, 2, 4}),
+            'dog': ({5}, {5}),
         })
 
         # check predecessors of an address that isn't on the tree at all
 
         self.assert_rw_preds_at_addresses({
-            'yak':      ({}, {}),
+            'yak': ({}, {}),
         })
 
         # add readers to root and check again
@@ -736,25 +736,25 @@ class TestPredecessorTree(unittest.TestCase):
         #       g: Writer: 5 Readers: [5]
 
         self.assert_rwc_at_addresses({
-            '':         ([6, 7], None, {'c', 'd'}),
-            'c':        ([1], 1, {'a'}),
-            'ca':       ([2], 2, {'t', 'r'}),
-            'cat':      ([3], 3, {}),
-            'carp':     ([4], 4, {}),
-            'dog':      ([5], 5, {}),
+            '': ([6, 7], None, {'c', 'd'}),
+            'c': ([1], 1, {'a'}),
+            'ca': ([2], 2, {'t', 'r'}),
+            'cat': ([3], 3, {}),
+            'carp': ([4], 4, {}),
+            'dog': ([5], 5, {}),
         })
 
         self.assert_rw_count(7, 5)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5, 6, 7}),
-            'c':        ({1, 2, 3, 4}, {1, 2, 3, 4, 6, 7}),
-            'ca':       ({2, 3, 4}, {1, 2, 3, 4, 6, 7}),
-            'cat':      ({3}, {1, 2, 3, 6, 7}),
-            'cath':     ({3}, {1, 2, 3, 6, 7}),
-            'carp':     ({4}, {1, 2, 4, 6, 7}),
-            'dog':      ({5}, {5, 6, 7}),
-            'yak':      ({}, {6, 7}),
+            '': ({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5, 6, 7}),
+            'c': ({1, 2, 3, 4}, {1, 2, 3, 4, 6, 7}),
+            'ca': ({2, 3, 4}, {1, 2, 3, 4, 6, 7}),
+            'cat': ({3}, {1, 2, 3, 6, 7}),
+            'cath': ({3}, {1, 2, 3, 6, 7}),
+            'carp': ({4}, {1, 2, 4, 6, 7}),
+            'dog': ({5}, {5, 6, 7}),
+            'yak': ({}, {6, 7}),
         })
 
     def test_add_writers_to_same_node(self):
@@ -775,20 +775,20 @@ class TestPredecessorTree(unittest.TestCase):
             #         m: Writer: ,num
 
             self.assert_rwc_at_addresses({
-                '':     ([], None, {'p'}),
-                'p':    ([], None, {'l'}),
-                'pl':   ([], None, {'u'}),
-                'plu':  ([], None, {'m'}),
+                '': ([], None, {'p'}),
+                'p': ([], None, {'l'}),
+                'pl': ([], None, {'u'}),
+                'plu': ([], None, {'m'}),
                 'plum': ([], num, {}),
             })
 
             self.assert_rw_count(0, 1)
 
             self.assert_rw_preds_at_addresses({
-                '':     ({num}, {num}),
-                'p':    ({num}, {num}),
-                'pl':   ({num}, {num}),
-                'plu':  ({num}, {num}),
+                '': ({num}, {num}),
+                'p': ({num}, {num}),
+                'pl': ({num}, {num}),
+                'plu': ({num}, {num}),
                 'plum': ({num}, {num}),
             })
 
@@ -807,10 +807,10 @@ class TestPredecessorTree(unittest.TestCase):
         #       g: Writer: 0 Readers: [1, 2, 3]
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'p'}),
-            'p':        ([1, 2, 3], 0, {'u'}),
-            'pu':       ([1, 2, 3], 0, {'g'}),
-            'pug':      ([1, 2, 3], 0, {}),
+            '': ([], None, {'p'}),
+            'p': ([1, 2, 3], 0, {'u'}),
+            'pu': ([1, 2, 3], 0, {'g'}),
+            'pug': ([1, 2, 3], 0, {}),
         })
 
         self.assert_no_nodes_at_addresses('pugs')
@@ -818,11 +818,11 @@ class TestPredecessorTree(unittest.TestCase):
         self.assert_rw_count(9, 3)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({0}, {0, 1, 2, 3}),
-            'p':        ({0}, {0, 1, 2, 3}),
-            'pu':       ({0}, {0, 1, 2, 3}),
-            'pug':      ({0}, {0, 1, 2, 3}),
-            'pugs':     ({0}, {0, 1, 2, 3}),
+            '': ({0}, {0, 1, 2, 3}),
+            'p': ({0}, {0, 1, 2, 3}),
+            'pu': ({0}, {0, 1, 2, 3}),
+            'pug': ({0}, {0, 1, 2, 3}),
+            'pugs': ({0}, {0, 1, 2, 3}),
         })
 
         # add a writer and verify that downstream readers are gone
@@ -834,9 +834,9 @@ class TestPredecessorTree(unittest.TestCase):
         #     u: Writer: 4
 
         self.assert_rwc_at_addresses({
-            '':         ([], None, {'p'}),
-            'p':        ([1, 2, 3], 0, {'u'}),
-            'pu':       ([], 4, {}),
+            '': ([], None, {'p'}),
+            'p': ([1, 2, 3], 0, {'u'}),
+            'pu': ([], 4, {}),
         })
 
         self.assert_no_nodes_at_addresses('pug', 'pugs')
@@ -844,9 +844,9 @@ class TestPredecessorTree(unittest.TestCase):
         self.assert_rw_count(3, 2)
 
         self.assert_rw_preds_at_addresses({
-            '':         ({0, 4}, {0, 1, 2, 3, 4}),
-            'p':        ({0, 4}, {0, 1, 2, 3, 4}),
-            'pu':       ({4}, {1, 2, 3, 4}),
+            '': ({0, 4}, {0, 1, 2, 3, 4}),
+            'p': ({0, 4}, {0, 1, 2, 3, 4}),
+            'pu': ({4}, {1, 2, 3, 4}),
         })
 
     def test_long_addresses(self):
@@ -866,8 +866,8 @@ class TestPredecessorTree(unittest.TestCase):
         })
 
         self.assert_rwc_at_addresses({
-            address_a:  (['txn1'], None, {}),
-            address_b:  (['txn2'], None, {})
+            address_a: (['txn1'], None, {}),
+            address_b: (['txn2'], None, {})
         })
 
         # Set a writer for address_a.
@@ -879,8 +879,8 @@ class TestPredecessorTree(unittest.TestCase):
         # Verify address_b didn't change when address_a was modified.
 
         self.assert_rwc_at_addresses({
-            address_a:  ([], 'txn1', {}),
-            address_b:  (['txn2'], None, {})
+            address_a: ([], 'txn1', {}),
+            address_b: (['txn2'], None, {})
         })
 
         # Set a writer for a prefix of address_b.
@@ -893,8 +893,8 @@ class TestPredecessorTree(unittest.TestCase):
 
         # Verify address_a didn't change when address_c was modified.
         self.assert_rwc_at_addresses({
-            address_a:  ([], 'txn1', {}),
-            address_c:  ([], 'txn3', {})
+            address_a: ([], 'txn1', {}),
+            address_c: ([], 'txn3', {})
         })
 
         # Verify address_b now returns None
@@ -909,19 +909,18 @@ class TestPredecessorTree(unittest.TestCase):
         # Verify address_c now contains txn3 as the writer, with
         # no readers set and 'e8' as a child.
         self.assert_rwc_at_addresses({
-            address_a:  (['txn1'], 'txn1', {}),
-            address_b:  (['txn2'], None, {}),
-            address_c:  ([], 'txn3', ['e8'])
+            address_a: (['txn1'], 'txn1', {}),
+            address_b: (['txn2'], None, {}),
+            address_c: ([], 'txn3', ['e8'])
         })
 
         self.assert_rw_preds_at_addresses({
-            address_a:  ({'txn1'}, {'txn1'}),
-            address_b:  ({'txn3'}, {'txn3', 'txn2'}),
-            address_c:  ({'txn3'}, {'txn3', 'txn2'}),
+            address_a: ({'txn1'}, {'txn1'}),
+            address_b: ({'txn3'}, {'txn3', 'txn2'}),
+            address_c: ({'txn3'}, {'txn3', 'txn2'}),
         })
 
         self.assert_rw_count(2, 2)
-
 
     # assertions
 
@@ -934,7 +933,6 @@ class TestPredecessorTree(unittest.TestCase):
 
         self.show_tree()
 
-
         for address, rwc in expected_dict.items():
             error_msg = 'Address "{}": '.format(address) + 'incorrect {}'
 
@@ -942,14 +940,17 @@ class TestPredecessorTree(unittest.TestCase):
             node = self.get_node(address)
 
             self.assertIsNotNone(node)
+
             self.assertEqual(
                 readers,
                 node.readers,
                 error_msg.format('readers'))
+
             self.assertEqual(
                 writer,
                 node.writer,
                 error_msg.format('writer'))
+
             self.assertEqual(
                 set(children),
                 set(node.children.keys()),
@@ -969,7 +970,7 @@ class TestPredecessorTree(unittest.TestCase):
 
         def count_readers(node=None):
             if node is None:
-                node = self.get_node('') # root node
+                node = self.get_node('')  # root node
             count = len(node.readers)
             for child in node.children:
                 next_node = node.children[child]
@@ -978,7 +979,7 @@ class TestPredecessorTree(unittest.TestCase):
 
         def count_writers(node=None):
             if node is None:
-                node = self.get_node('') # root node
+                node = self.get_node('')  # root node
             count = 1 if node.writer is not None else 0
             for child in node.children:
                 next_node = node.children[child]
@@ -987,8 +988,15 @@ class TestPredecessorTree(unittest.TestCase):
 
         error_msg = 'Incorrect {} count'
 
-        self.assertEqual(reader_count, count_readers(), error_msg.format('reader'))
-        self.assertEqual(writer_count, count_writers(), error_msg.format('writer'))
+        self.assertEqual(
+            reader_count,
+            count_readers(),
+            error_msg.format('reader'))
+
+        self.assertEqual(
+            writer_count,
+            count_writers(),
+            error_msg.format('writer'))
 
     def assert_rw_preds_at_addresses(self, rw_pred_dict):
         '''
@@ -998,7 +1006,8 @@ class TestPredecessorTree(unittest.TestCase):
         '''
 
         for address, rw_preds in rw_pred_dict.items():
-            error_msg = 'Address "{}": '.format(address) + 'incorrect {} predecesors'
+            error_msg = 'Address "{}": '.format(
+                address) + 'incorrect {} predecesors'
 
             read_preds, write_preds = rw_preds
 
@@ -1051,6 +1060,7 @@ class TestPredecessorTree(unittest.TestCase):
 
 def tree_to_string(tree):
     return node_to_string(tree._root)
+
 
 def node_to_string(node, indent=2):
     string = '\nROOT:' if indent == 2 else ''

--- a/validator/tests/test_scheduler/test_schedulers_with_yaml.py
+++ b/validator/tests/test_scheduler/test_schedulers_with_yaml.py
@@ -14,7 +14,6 @@
 # ----------------------------------------------------------------------------
 
 import unittest
-from unittest.mock import Mock
 
 import os
 

--- a/validator/tests/test_scheduler/test_schedulers_with_yaml.py
+++ b/validator/tests/test_scheduler/test_schedulers_with_yaml.py
@@ -338,7 +338,6 @@ class TestSchedulersWithYaml(unittest.TestCase):
                          batch_results,
                          txns_to_assert_state, name)
 
-
     def _assertions(self, tester, defined_batch_results_dict,
                     batch_results, txns_to_assert_state, name):
         self.assert_batch_validity(
@@ -423,8 +422,8 @@ class TestSchedulersWithYaml(unittest.TestCase):
 
         state_roots = self._get_state_roots(batch_results=batch_results)
         self.assertEqual(len(state_roots), 1,
-                          "The scheduler calculated more than one state "
-                          "root when only one was expected")
+                         "The scheduler calculated more than one state "
+                         "root when only one was expected")
 
     def _path_to_yaml_file(self, name):
         parent_dir = os.path.dirname(__file__)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -45,7 +45,6 @@ def _get_address_from_txn(txn_info):
 
 
 class TestSchedulers(unittest.TestCase):
-
     def setUp(self):
         self._context_manager = ContextManager(dict_database.DictDatabase())
 
@@ -327,7 +326,6 @@ class TestSchedulers(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(scheduler_iter2)
 
-
     def test_serial_completion_on_finalize(self):
         """Tests that iteration will stop when finalized is called on an
         otherwise complete serial scheduler.
@@ -349,16 +347,18 @@ class TestSchedulers(unittest.TestCase):
         otherwise complete scheduler.
 
         Notes:
-            Adds one batch and transaction, then verifies the iterable returns
-            that transaction.  Sets the execution result and then calls finalize.
-            Since the the scheduler is complete (all transactions have had
-            results set, and it's been finalized), we should get a StopIteration.
-            This check is useful in making sure the finalize() can occur after
-            all set_transaction_execution_result()s have been performed, because
-            in a normal situation, finalize will probably occur prior to those
-            calls.
+            Adds one batch and transaction, then verifies the iterable
+            returns that transaction. Sets the execution result and
+            then calls finalize. Since the the scheduler is complete
+            (all transactions have had results set, and it's been
+            finalized), we should get a StopIteration. This check is
+            useful in making sure the finalize() can occur after all
+            set_transaction_execution_result()s have been performed,
+            because in a normal situation, finalize will probably
+            occur prior to those calls.
 
         This test should work for both a serial and parallel scheduler.
+
         """
 
         private_key = self._context.new_random_private_key()
@@ -412,12 +412,14 @@ class TestSchedulers(unittest.TestCase):
             that transaction.  Finalizes then sets the execution result. The
             schedule should not be marked as complete until after the
             execution result is set.
-            This check is useful in making sure the finalize() can occur after
-            all set_transaction_execution_result()s have been performed, because
-            in a normal situation, finalize will probably occur prior to those
-            calls.
+
+            This check is useful in making sure the finalize() can
+            occur after all set_transaction_execution_result()s have
+            been performed, because in a normal situation, finalize
+            will probably occur prior to those calls.
 
         This test should work for both a serial and parallel scheduler.
+
         """
         private_key = self._context.new_random_private_key()
         signer = self._crypto_factory.new_signer(private_key)
@@ -569,7 +571,6 @@ class TestSchedulers(unittest.TestCase):
         self._add_valid_batch_invalid_batch(scheduler, context_manager)
 
     def _add_valid_batch_invalid_batch(self, scheduler, context_manager):
-
         """Tests the squash function. That the correct state hash is found
         at the end of valid and invalid batches, similar to block publishing.
 
@@ -1198,6 +1199,7 @@ class TestParallelScheduler(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(iterable)
 
-        result = self.scheduler.get_batch_execution_result(batch.header_signature)
+        result = self.scheduler.get_batch_execution_result(
+            batch.header_signature)
         self.assertIsNotNone(result)
         self.assertTrue(result.is_valid)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=too-many-lines,invalid-name
+
 import unittest
 import hashlib
 import threading

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -234,7 +234,7 @@ class TestSchedulers(unittest.TestCase):
         invalid batch due to a prior transaction being invalid, won't run.
         """
 
-        context_manager, scheduler = self._setup_serial_scheduler()
+        _, scheduler = self._setup_serial_scheduler()
         self._fail_fast(scheduler)
 
     def _fail_fast(self, scheduler):
@@ -329,7 +329,7 @@ class TestSchedulers(unittest.TestCase):
         otherwise complete serial scheduler.
         """
 
-        context_manager, scheduler = self._setup_serial_scheduler()
+        _, scheduler = self._setup_serial_scheduler()
         self._completion_on_finalize(scheduler)
 
     def test_parallel_completion_on_finalize(self):
@@ -337,7 +337,7 @@ class TestSchedulers(unittest.TestCase):
         otherwise complete parallel scheduler.
         """
 
-        context_manager, scheduler = self._setup_parallel_scheduler()
+        _, scheduler = self._setup_parallel_scheduler()
         self._completion_on_finalize(scheduler)
 
     def _completion_on_finalize(self, scheduler):
@@ -390,7 +390,7 @@ class TestSchedulers(unittest.TestCase):
         has had finalize called and all txns have execution result set.
         """
 
-        context_manager, scheduler = self._setup_serial_scheduler()
+        _, scheduler = self._setup_serial_scheduler()
         self._completion_on_finalize_only_when_done(scheduler)
 
     def test_parallel_completion_on_finalize_only_when_done(self):
@@ -398,7 +398,7 @@ class TestSchedulers(unittest.TestCase):
         has had finalize called and all txns have execution result set.
         """
 
-        context_manager, scheduler = self._setup_parallel_scheduler()
+        _, scheduler = self._setup_parallel_scheduler()
         self._completion_on_finalize_only_when_done(scheduler)
 
     def _completion_on_finalize_only_when_done(self, scheduler):
@@ -451,7 +451,7 @@ class TestSchedulers(unittest.TestCase):
         as result of add_batch().
         """
 
-        context_manager, scheduler = self._setup_serial_scheduler()
+        _, scheduler = self._setup_serial_scheduler()
         self._add_batch_after_empty_iteration(scheduler)
 
     def test_parallel_add_batch_after_empty_iteration(self):
@@ -459,7 +459,7 @@ class TestSchedulers(unittest.TestCase):
         as result of add_batch().
         """
 
-        context_manager, scheduler = self._setup_parallel_scheduler()
+        _, scheduler = self._setup_parallel_scheduler()
         self._add_batch_after_empty_iteration(scheduler)
 
     def _add_batch_after_empty_iteration(self, scheduler):
@@ -637,7 +637,7 @@ class TestSchedulers(unittest.TestCase):
         txn_info_b = next(sched2)
         address_b = _get_address_from_txn(txn_info_b)
 
-        txn_infoInvalid = next(sched2)
+        next(sched2)
 
         txn_info_d = next(sched2)
         address_d = _get_address_from_txn(txn_info_d)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -14,8 +14,6 @@
 # ------------------------------------------------------------------------------
 
 import unittest
-from unittest.mock import Mock
-from collections import deque
 import hashlib
 import threading
 import time

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -108,15 +108,18 @@ class SchedulerTester(object):
             - string <address>
           valid: boolean. Optional. Defaults to True
           dependencies: list of string. Optional. Defaults to empty list.
-            - ..... string. No default. If a dependency is the
-                            same string as a 'name' for another txn, that txn's
-                            signature will be used for the actual Transaction's
-                            dependency. If the string is not an 'name' of another
-                            txn, if it is longer than 20 characters it will be
+            - ..... string. No default. If a dependency is the same
+                            string as a 'name' for another txn, that
+                            txn's signature will be used for the
+                            actual Transaction's dependency. If the
+                            string is not an 'name' of another txn, if
+                            it is longer than 20 characters it will be
                             used as if is is the actual
-                            Transaction.header_signature for the dependency.
-                            If not, it will be disregarded.
-          name: string. Optional. No default."""
+                            Transaction.header_signature for the
+                            dependency. If not, it will be
+                            disregarded.
+          name: string. Optional. No default.
+    """
 
     def __init__(self, file_name):
         """
@@ -175,7 +178,7 @@ class SchedulerTester(object):
 
         for i, batch in enumerate(self._batches):
             if i == len(self._batches) - 1 and \
-                            validation_state_hash is not None:
+                    validation_state_hash is not None:
                 s_h = validation_state_hash
             else:
                 s_h = self._batch_results[batch.header_signature].state_hash
@@ -428,11 +431,11 @@ class SchedulerTester(object):
                 t_id = txn.header_signature
                 is_valid, address_values, deletes = self._txn_execution[t_id]
                 partial_batch_transaction_contexts[t_id] = \
-                        TransactionExecutionContext(
-                            txn=txn,
-                            txn_num=txn_num + 1,
-                            batch_num=batch_num + 1,
-                            state=partial_batch_state_up_to_now.copy())
+                    TransactionExecutionContext(
+                        txn=txn,
+                        txn_num=txn_num + 1,
+                        batch_num=batch_num + 1,
+                        state=partial_batch_state_up_to_now.copy())
 
                 for item in address_values:
                     partial_batch_state_up_to_now.update(item)
@@ -443,8 +446,6 @@ class SchedulerTester(object):
                     break
             batch_id = batch.header_signature
             batch_is_valid = self._batch_results[batch_id].is_valid
-
-
 
             if batch_is_valid:
                 transaction_contexts.update(partial_batch_transaction_contexts)
@@ -563,12 +564,11 @@ class SchedulerTester(object):
             inputs_real = [self._address(a) for a in inputs]
             outputs_real = [self._address(a) for a in outputs]
             if self._contains_and_not_none('addresses_to_set', transaction):
-                addresses_to_set = [
-                    {self._address(a, require_full=True): self._bytes_if_none(
+                addresses_to_set = [{
+                    self._address(a, require_full=True): self._bytes_if_none(
                         d[a])
-                        for a in d}
-                    for d in transaction['addresses_to_set']
-                ]
+                    for a in d
+                } for d in transaction['addresses_to_set']]
             if self._contains_and_not_none('addresses_to_delete', transaction):
                 addresses_to_delete = [
                     self._address(a, require_full=True)
@@ -576,8 +576,10 @@ class SchedulerTester(object):
                 ]
 
             if self._contains_and_not_none('dependencies', transaction):
-                if any([a not in self._referenced_txns_in_other_batches and
-                        len(a) <= 20 for a in transaction['dependencies']]):
+                if any([
+                        a not in self._referenced_txns_in_other_batches
+                        and len(a) <= 20 for a in transaction['dependencies']
+                ]):
                     # This txn has a dependency with a txn signature that is
                     # not known about,
                     return None
@@ -585,7 +587,8 @@ class SchedulerTester(object):
                 dependencies = [
                     self._referenced_txns_in_other_batches[a]
                     if a in self._referenced_txns_in_other_batches else a
-                    for a in transaction['dependencies']]
+                    for a in transaction['dependencies']
+                ]
                 dependencies = [a for a in dependencies if len(a) > 20]
             else:
                 dependencies = []

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=invalid-name
+
 import binascii
 from collections import deque
 import hashlib

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -15,8 +15,6 @@
 
 import binascii
 from collections import deque
-from collections import namedtuple
-import copy
 import hashlib
 import itertools
 import logging

--- a/validator/tests/test_validation_rule_enforcer/mock.py
+++ b/validator/tests/test_validation_rule_enforcer/mock.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class MockSettingsViewFactory(object):
     def __init__(self):
         self.settings = {}

--- a/validator/tests/test_validation_rule_enforcer/test.py
+++ b/validator/tests/test_validation_rule_enforcer/test.py
@@ -16,7 +16,6 @@ import unittest
 
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.transaction_pb2 import Transaction
-from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.block_pb2 import Block

--- a/validator/tests/test_validation_rule_enforcer/test.py
+++ b/validator/tests/test_validation_rule_enforcer/test.py
@@ -25,14 +25,15 @@ from sawtooth_validator.journal.validation_rule_enforcer import \
     ValidationRuleEnforcer
 from test_validation_rule_enforcer.mock import MockSettingsViewFactory
 
-class ValidationRuleEnforcerTest(unittest.TestCase):
 
+class ValidationRuleEnforcerTest(unittest.TestCase):
     def setUp(self):
         self._settings_view_factory = MockSettingsViewFactory()
         self._validation_rule_enforcer = ValidationRuleEnforcer(
             self._settings_view_factory)
 
-    def _make_block(self, txns_family, signer_public_key, same_public_key=True):
+    def _make_block(self, txns_family, signer_public_key,
+                    same_public_key=True):
         transactions = []
         for family in txns_family:
             txn_header = TransactionHeader(
@@ -56,7 +57,6 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
         blkw = self._make_block(["intkey"], "pub_key")
         self.assertTrue(
             self._validation_rule_enforcer.validate(blkw, "state_root"))
-
 
     def test_n_of_x(self):
         """
@@ -87,7 +87,6 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
 
         self.assertTrue(
             self._validation_rule_enforcer.validate(blkw, "state_root"))
-
 
     def test_x_at_y(self):
         """


### PR DESCRIPTION
I recently discovered a typo in `run_lint` that was causing `pep8` to run incorrectly. Looking into it further, I learned that `pep8` had been renamed to `pycodestyle`. Fixing the problem revealed a bunch of lint errors that had been ignored for months. Since I was already fixing these, I decided that I might as well take the opportunity to lint the validator unit tests and integration tests.

The changes in this PR are mostly boring, but boy are there are a lot of them. Everyone should take a look at whatever sections interest them to make sure nothing important has been inadvertently affected.