### PR TITLE
Move TP list to own section; add missing TPs

### DIFF
--- a/docs/source/app_developers_guide.rst
+++ b/docs/source/app_developers_guide.rst
@@ -16,6 +16,7 @@ SDKs are provided in several languages: C++, Go, Java, Javascript, and Python.
    :maxdepth: 2
 
    app_developers_guide/installing_sawtooth
+   app_developers_guide/example_transaction_processors
    app_developers_guide/address_and_namespace
    app_developers_guide/intro_xo_transaction_family
    app_developers_guide/java_sdk

--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -307,29 +307,6 @@ Sawtooth provides a :doc:`Settings transaction family
 on-chain settings, along with a Settings family transaction processor written
 in Python.
 
-.. note::
-
-  Sawtooth supports multiple languages for transaction processor development and
-  includes additional transaction processors written in several languages.
-  The following lists the processors that are included:
-
-  * settings-tp - A Settings family transaction processor written in Python
-
-  * intkey-tp-go - An IntegerKey transaction processor written in Go
-
-  * intkey-tp-java - An IntegerKey transaction processor written in Java
-
-  * intkey-tp-javascript - An IntegerKey transaction processor written in JavaScript
-    (requires node.js)
-
-  * poet-validator-registry-tp - A transaction family used by the PoET consensus
-    algorithm implementation to keep track of other validators
-
-  * xo-tp-javascript - An XO transaction processor written in JavaScript
-    (requires node.js)
-
-  * xo-tp-python - An XO transaction processor written in Python
-
 One of the on-chain settings is the list of supported transaction families.
 The next step describes how to configure this setting with a single command.
 

--- a/docs/source/app_developers_guide/example_transaction_processors.rst
+++ b/docs/source/app_developers_guide/example_transaction_processors.rst
@@ -1,0 +1,40 @@
+******************************
+Example Transaction Processors
+******************************
+
+Sawtooth includes several transaction families as examples for developing a
+transaction processor. The following executables are available:
+
+* ``block-info-tp`` - BlockInfo transaction processor, written in Python
+
+* ``identity-tp`` - Identity transaction processor, written in Python
+
+* ``intkey-tp-go`` - IntegerKey transaction processor, written in Go
+
+* ``intkey-tp-java`` - IntegerKey transaction processor, written in Java
+
+* ``intkey-tp-javascript`` - IntegerKey transaction processor, written in
+  JavaScript (Node.js)
+
+* ``intkey-tp-python`` - IntegerKey transaction processor, written in Python
+
+* ``poet-validator-registry-tp`` - Validator Registry transaction processor,
+  which is used by the PoET consensus algorithm implementation to keep track of
+  other validators
+
+* ``settings-tp`` - Settings family transaction processor, written in Python
+
+  .. note::
+
+    In a production environment, you should always run a transaction processor
+    that supports the Settings transaction family.
+
+* ``smallbank-tp`` - Smallbank transaction processor, written in Go
+
+* ``xo-tp-javascript`` - XO transaction processor, written in JavaScript
+  (Node.js)
+
+* ``xo-tp-python`` - XO transaction processor, written in Python
+
+See :doc:`/transaction_family_specifications` for more information on each
+transaction processor.

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -200,37 +200,6 @@ transaction families.
 Transaction processors can be started either before or after the validator is
 started.
 
-Supported Transaction Families
-------------------------------
-
-Sawtooth supports multiple languages for transaction processor development and
-includes additional transaction processors written in several languages.
-Sawtooth includes following transaction processors:
-
-* settings-tp - A Settings family transaction processor written in Python
-
-* intkey-tp-go - An IntegerKey transaction processor written in Go
-
-* intkey-tp-java - An IntegerKey transaction processor written in Java
-
-* intkey-tp-javascript - An IntegerKey transaction processor written in
-  JavaScript (requires node.js)
-
-* intkey-tp-python - An IntegerKey transaction processor written in Python
-
-* poet-validator-registry-tp - A transaction family used by the PoET consensus
-  algorithm implementation to keep track of other validators
-
-* xo-tp-javascript - An XO transaction processor written in JavaScript
-  (requires node.js)
-
-* xo-tp-python - An XO transaction processor written in Python
-
-.. note::
-
-  In a production environment, you should always run a transaction processor
-  that supports the Settings transaction family.
-
 Starting the IntegerKey Transaction Processor
 ---------------------------------------------
 The IntegerKey transaction processor is provided as a simple example of a
@@ -258,7 +227,6 @@ The transaction processor produces the following output:
 .. code-block:: console
 
   [23:07:57 INFO    core] register attempt: OK
-
 
 Starting the Settings Family Transaction Processor
 --------------------------------------------------


### PR DESCRIPTION
This PR does two things to the list of transaction processor commands (aka executables) in the Application Developer's Guide:

Adds the missing TP commands:
- identity-tp
- block-info-tp
- smallbank-tp

Moves the list of transaction processor commands into a separate section so that the info appears only once (and is easier to find in the Contents). The list was in both the Ubuntu and AWS procedures, but the info isn't necessary for the steps in those procedures.

Signed-off-by: Anne Chenette <chenette@bitwise.io>