### PR TITLE
Fix typo in "sawtooth keygen" command

### DIFF
--- a/docs/source/sysadmin_guide/systemd.rst
+++ b/docs/source/sysadmin_guide/systemd.rst
@@ -43,7 +43,7 @@ the first validator can load:
 
 .. code-block:: console
 
-  $ sawtooth keygen --key-dir ~ sawtooth
+  $ sawtooth keygen --key-dir ~/sawtooth
   $ sawset genesis --key ~/sawtooth.priv
   $ sawadm genesis config-genesis.batch
 


### PR DESCRIPTION
Correct the --key-dir argument in the command to generate the sawtooth keys.

Signed-off-by: Anne Chenette <chenette@bitwise.io>