### PR TITLE
Edit REST API doc: Fix typos, punctuation, and wording issues

### DIFF
--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -4,7 +4,7 @@ Error Responses
 
 When the REST API encounters a problem, or receives notification that the
 validator has encountered a problem, it will notify clients with both an
-appropriate HTTP status code, and a more detailed JSON response.
+appropriate HTTP status code and a more detailed JSON response.
 
 
 HTTP Status Codes
@@ -24,14 +24,14 @@ HTTP Status Codes
        details.
    * - 404
      - Not Found
-     - The request was well formed, but an identifier specified did not
+     - The request was well formed, but the specified identifier did not
        correspond to any resource in the validator. Returned by endpoints which
        fetch a single resource. Endpoints which return lists of resources will
        simply return an empty list.
    * - 500
      - Internal Server Error
      - Something is broken internally in the REST API or the validator. This may
-       be a bug, and if reproducible, should be reported.
+       be a bug; if it is reproducible, the bug should be reported.
    * - 503
      - Service Unavailable
      - The REST API is unable to communicate with the validator. It may be down.
@@ -46,12 +46,13 @@ include a single *error* property with three values:
 
    * *code* (integer) - a machine readable error code
    * *title* (string) - a short headline for the error
-   * *message* (string) - a longer human readable description of what went wrong
+   * *message* (string) - a longer, human-readable description of what went wrong
 
 .. note::
 
-   While the title and message may change in the future, **the error code is
-   fixed**, and will always refer to this particular problem.
+   While the title and message may change in the future, the error code
+   will **not** change; it is fixed and will always refer to this particular
+   problem.
 
 
 Example JSON Response
@@ -63,7 +64,7 @@ Example JSON Response
      "error": {
        "code": 30,
        "title": "Submitted Batches Invalid",
-       "message": "The submitted BatchList is invalid. It was poorly formed, or has an invalid signature."
+       "message": "The submitted BatchList is invalid. It was poorly formed or has an invalid signature."
      }
    }
 
@@ -81,7 +82,8 @@ Error Codes and Descriptions
    * - 10
      - Unknown Validator Error
      - An unknown error occurred with the validator while processing the
-       request. This may be a bug, and if reproducible, should be reported.
+       request. This may be a bug; if it is reproducible, the bug should be
+       reported.
    * - 15
      - Validator Not Ready
      - The validator has no genesis block, and so cannot be queried. Wait for
@@ -90,8 +92,8 @@ Error Codes and Descriptions
    * - 17
      - Validator Timed Out
      - The request timed out while waiting for a response from the validator. It
-       may not be running, or have encountered an internal error. The request
-       may or may not have been processed.
+       may not be running, or may have encountered an internal error. The
+       request may not have been processed.
    * - 18
      - Validator Disconnected
      - The validator sent a disconnect signal while processing the response, and
@@ -113,15 +115,15 @@ Error Codes and Descriptions
    * - 30
      - Submitted Batches Invalid
      - The submitted BatchList failed initial validation by the validator. It
-       may have a bad signature, or be poorly formed.
+       may have a bad signature or be poorly formed.
    * - 31
      - Unable to Accept Batches
-     - The validator cannot currently accept more batches, due to a full queue.
+     - The validator cannot currently accept more batches due to a full queue.
        Please submit your request again.
    * - 34
      - No Batches Submitted
-     - The BatchList Protobuf submitted was empty and contained no Batches. All
-       submissions to the validator must include at least one Batch.
+     - The BatchList Protobuf submitted was empty and contained no batches. All
+       submissions to the validator must include at least one batch.
    * - 35
      - Protobuf Not Decodable
      - The REST API was unable to decode the submitted Protobuf binary. It is

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -495,7 +495,7 @@ parameters:
     in: path
     type: string
     required: true
-    description: Radix address of a leaf, or prefix for leaves
+    description: Radix address of a leaf
   block_id:
     name: block_id
     in: path

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -124,15 +124,15 @@ paths:
         `'COMMITTED'`, `'INVALID'`, `'PENDING'`, and `'UNKNOWN'`.
 
         The batch(es) you want to check can be specified using the `id` filter
-        parameter. If a `wait` time is specified in the url, the API will wait
+        parameter. If a `wait` time is specified in the URL, the API will wait
         to respond until all batches are committed, or the time in seconds has
-        elapsed. If the value of `wait` is not set (i.e. `?wait&id=...`), or
+        elapsed. If the value of `wait` is not set (i.e., `?wait&id=...`), or
         it is set to any non-integer value other than `false`, the wait time
-        will be just shy of the api's specified timeout (usually 300).
+        will be just under the API's specified timeout (usually 300).
 
-        Note that as this route does not return full resources, the response
-        will not be paginated, and there will be no `head` or `paging`
-        properties.
+        Note that because this route does not return full resources, the
+        response will not be paginated, and there will be no `head` or
+        `paging` properties.
       parameters:
         - name: id
           in: query
@@ -163,7 +163,7 @@ paths:
         formatted POST body rather than a query parameter. This allows for many
         more batches to be checked and should be used for more than 15 ids.
 
-        Note that since query information is not encoded in the URL, no `link`
+        Note that because query information is not encoded in the URL, no `link`
         will be returned with this query.
       consumes:
         - application/json
@@ -197,7 +197,7 @@ paths:
       summary: Fetches the data for the current state
       description: >
         Fetches a paginated list of entries for the current state, or relative
-        to a particular head block. Using the `address` filter parameter, will
+        to a particular head block. Using the `address` filter parameter will
         narrow the list to any entries that have an address beginning with the
         characters specified.
       parameters:
@@ -296,7 +296,7 @@ paths:
     parameters:
       - $ref: "#/parameters/block_id"
     get:
-      summary: Fetches a particlar block
+      summary: Fetches a particular block
       responses:
         200:
           description: Successfully retrieved block
@@ -414,7 +414,7 @@ paths:
         formatted POST body rather than a query parameter. This allows for many
         more receipts to be fetched and should be used with more than 15 ids.
 
-        Note that since query information is not encoded in the URL, no `link`
+        Note that because query information is not encoded in the URL, no `link`
         will be returned with this request.
       consumes:
         - application/json
@@ -513,7 +513,7 @@ parameters:
     in: path
     type: string
     required: true
-    description: Trainsaction id
+    description: Transaction id
   head:
     name: head
     in: query


### PR DESCRIPTION
Edited the RST doc and autogenerated content for the REST API documentation.

Note: This PR is a cherry-picked version of an earlier PR to fix typos in the REST API documentation.  This PR contains only the commit that changes the RST doc (docs/source/rest_api/error_codes.rst) and auto-generated content (rest_api/openapi.yaml).

I'll copy the relevant comments from #1222 , then close it.

Signed-off-by: Anne Chenette <chenette@bitwise.io>