### PR TITLE
Allow Publisher to Unschedule Incomplete Batches

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -24,7 +24,7 @@ class Scheduler(object, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def add_batch(self, batch, state_hash=None):
+    def add_batch(self, batch, state_hash=None, required=False):
         """Adds a batch to the scheduler.
 
         The batch, and thus its associated transactions, will be added to the
@@ -34,6 +34,9 @@ class Scheduler(object, metaclass=ABCMeta):
             batch: A batch_pb2.Batch instance.
             state_hash: The expected resulting state_hash after the
                 transactions have been applied.
+            required: The given batch must be included in the completed
+                schedule.  That is, it will not be removed when a call to
+                `unschedule_incomplete_batches` is made.  Defaults to `False`.
         """
         raise NotImplementedError()
 

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -107,6 +107,12 @@ class Scheduler(object, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
+    def unschedule_incomplete_batches(self):
+        """Remove any incomplete batches from the schedule.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def finalize(self):
         """Tell the scheduler that no more batches/transactions will be added.
 

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -324,7 +324,7 @@ class ParallelScheduler(Scheduler):
                 self._predecessor_tree.find_write_predecessors(address))
         return dependencies
 
-    def add_batch(self, batch, state_hash=None):
+    def add_batch(self, batch, state_hash=None, required=False):
         with self._condition:
             if self._final:
                 raise SchedulerError('Invalid attempt to add batch to '

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -831,6 +831,9 @@ class ParallelScheduler(Scheduler):
 
             return count
 
+    def unschedule_incomplete_batches(self):
+        pass
+
     def finalize(self):
         with self._condition:
             self._final = True

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -120,7 +120,7 @@ class SerialScheduler(Scheduler):
 
             self._condition.notify_all()
 
-    def add_batch(self, batch, state_hash=None):
+    def add_batch(self, batch, state_hash=None, required=False):
         with self._condition:
             if self._final:
                 raise SchedulerError("Scheduler is finalized. Cannot take"

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -241,6 +241,9 @@ class SerialScheduler(Scheduler):
             self._scheduled_transactions.append(txn_info)
             return txn_info
 
+    def unschedule_incomplete_batches(self):
+        pass
+
     def finalize(self):
         with self._condition:
             self._final = True

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -254,7 +254,8 @@ class _CandidateBlock(object):
                 self._pending_batches.append(b)
                 self._pending_batch_ids.add(b.header_signature)
                 try:
-                    self._scheduler.add_batch(b)
+                    injected = b.header_signature in self._injected_batch_ids
+                    self._scheduler.add_batch(b, required=injected)
                 except SchedulerError as err:
                     LOGGER.debug("Scheduler error processing batch: %s", err)
         else:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -291,6 +291,7 @@ class _CandidateBlock(object):
         In both cases the pending_batches will contain the list of batches
         that need to be added to the next Block that is built.
         """
+        self._scheduler.unschedule_incomplete_batches()
         self._scheduler.finalize()
         self._scheduler.complete(block=True)
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -118,6 +118,9 @@ class MockScheduler(Scheduler):
     def next_transaction(self):
         raise NotImplementedError()
 
+    def unschedule_incomplete_batches(self):
+        pass
+
     def finalize(self):
         pass
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -91,7 +91,7 @@ class MockScheduler(Scheduler):
         self.batches = {}
         self.batch_execution_result = batch_execution_result
 
-    def add_batch(self, batch, state_hash=None):
+    def add_batch(self, batch, state_hash=None, required=False):
         self.batches[batch.header_signature] = batch
 
     def get_batch_execution_result(self, batch_signature):

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -1251,3 +1251,51 @@ class TestParallelScheduler(unittest.TestCase):
             batch.header_signature)
         self.assertIsNotNone(result)
         self.assertTrue(result.is_valid)
+
+    def test_unschedule_incomplete_transactions(self):
+        """Tests that unschedule_incomplete_batches will remove
+        batches above the mimimum.
+
+        Given a schedule with two batches, ensure that a call to
+        unschedule_incomplete_batches will leave one batch in the schedule.
+        """
+        private_key = self._context.new_random_private_key()
+        signer = self._crypto_factory.new_signer(private_key)
+
+        txn_a, _ = create_transaction(
+            payload='A'.encode(),
+            signer=signer)
+
+        txn_b, _ = create_transaction(
+            payload='B'.encode(),
+            signer=signer)
+
+        batch_1 = create_batch(transactions=[txn_a],
+                               signer=signer)
+        batch_2 = create_batch(transactions=[txn_b],
+                               signer=signer)
+
+        self.scheduler.add_batch(batch_1)
+        self.scheduler.add_batch(batch_2)
+
+        self.scheduler.unschedule_incomplete_batches()
+        self.scheduler.finalize()
+        self.assertFalse(self.scheduler.complete(block=False))
+
+        scheduled_txn_info = self.scheduler.next_transaction()
+        self.assertIsNotNone(scheduled_txn_info)
+        self.assertEqual('A', scheduled_txn_info.txn.payload.decode())
+
+        c_id = self.context_manager.create_context(
+            self.first_state_root,
+            base_contexts=scheduled_txn_info.base_context_ids,
+            inputs=[],
+            outputs=[])
+
+        self.scheduler.set_transaction_execution_result(
+            scheduled_txn_info.txn.header_signature,
+            is_valid=True,
+            context_id=c_id)
+
+        scheduled_txn_info = self.scheduler.next_transaction()
+        self.assertIsNone(scheduled_txn_info)


### PR DESCRIPTION
Add unschedule_incomplete_batches to the Scheduler interface.  This method is called on finalize_block in the BlockPublisher.

This method is implemented on both Serial and Parallel Schedulers.  In both, they preserve the following:

* Any injected batch will always be run
* A minimum schedule of at least one batch, not including injected batches.