### PR TITLE
Introduce Adaptive Back Pressure to Pending Batches

### DIFF
--- a/docs/source/rest_api/error_codes.rst
+++ b/docs/source/rest_api/error_codes.rst
@@ -114,6 +114,10 @@ Error Codes and Descriptions
      - Submitted Batches Invalid
      - The submitted BatchList failed initial validation by the validator. It
        may have a bad signature, or be poorly formed.
+   * - 31
+     - Unable to Accept Batches
+     - The validator cannot currently accept more batches, due to a full queue.
+       Please submit your request again.
    * - 34
      - No Batches Submitted
      - The BatchList Protobuf submitted was empty and contained no Batches. All

--- a/protos/client_batch_submit.proto
+++ b/protos/client_batch_submit.proto
@@ -62,12 +62,15 @@ message ClientBatchSubmitRequest {
 //   * OK - everything with the request worked as expected
 //   * INTERNAL_ERROR - general error, such as protobuf failing to deserialize
 //   * INVALID_BATCH - the batch failed validation, likely due to a bad signature
+//   * QUEUE_FULL - the batch is unable to be queued for processing, due to
+//        a full processing queue.  The batch may be submitted again.
 message ClientBatchSubmitResponse {
     enum Status {
         STATUS_UNSET = 0;
         OK = 1;
         INTERNAL_ERROR = 2;
         INVALID_BATCH = 3;
+        QUEUE_FULL = 4;
     }
     Status status = 1;
 }

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -53,6 +53,8 @@ paths:
                 $ref: "#/definitions/Link"
         400:
           $ref: "#/responses/400BadRequest"
+        429:
+          $ref: "#/responses/429TooManyRequests"
         500:
           $ref: "#/responses/500ServerError"
         503:
@@ -472,6 +474,10 @@ responses:
       $ref: "#/definitions/Error"
   404NotFound:
     description: Address or id did not match any resource
+    schema:
+      $ref: "#/definitions/Error"
+  429TooManyRequests:
+    description: Too many requests have been made to process batches
     schema:
       $ref: "#/definitions/Error"
   500ServerError:

--- a/rest_api/sawtooth_rest_api/error_handlers.py
+++ b/rest_api/sawtooth_rest_api/error_handlers.py
@@ -68,6 +68,11 @@ class BatchInvalidTrap(_ErrorTrap):
     error = errors.SubmittedBatchesInvalid
 
 
+class BatchQueueFullTrap(_ErrorTrap):
+    trigger = client_batch_submit_pb2.ClientBatchSubmitResponse.QUEUE_FULL
+    error = errors.BatchQueueFull
+
+
 class InvalidAddressTrap(_ErrorTrap):
     trigger = client_state_pb2.ClientStateGetResponse.INVALID_ADDRESS
     error = errors.InvalidStateAddress

--- a/rest_api/sawtooth_rest_api/exceptions.py
+++ b/rest_api/sawtooth_rest_api/exceptions.py
@@ -129,6 +129,14 @@ class SubmittedBatchesInvalid(_ApiError):
                'poorly formed, or has an invalid signature.')
 
 
+class BatchQueueFull(_ApiError):
+    api_code = 31
+    status_code = 429
+    title = 'Unable to Accept Batches'
+    message = ('The validator cannot currently accept more batches, due to a '
+               'full queue.  Please submit your request again.')
+
+
 class NoBatchesSubmitted(_ApiError):
     api_code = 34
     status_code = 400

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -1024,4 +1024,7 @@ class RouteHandler(object):
 
     @staticmethod
     def _get_status_name(proto, status_enum):
-        return proto.Status.Name(status_enum)
+        try:
+            return proto.Status.Name(status_enum)
+        except ValueError:
+            return 'Unknown ({})'.format(status_enum)

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -156,7 +156,8 @@ class RouteHandler(object):
             raise errors.BadProtobufSubmitted()
 
         # Query validator
-        error_traps = [error_handlers.BatchInvalidTrap]
+        error_traps = [error_handlers.BatchInvalidTrap,
+                       error_handlers.BatchQueueFullTrap]
         validator_query = client_batch_submit_pb2.ClientBatchSubmitRequest(
             batches=batch_list.batches)
 

--- a/rest_api/tests/unit/test_submit_requests.py
+++ b/rest_api/tests/unit/test_submit_requests.py
@@ -166,6 +166,26 @@ class PostBatchTests(BaseApiTest):
         response = await request.json()
         self.assert_has_valid_error(response, 34)
 
+    @unittest_run_loop
+    async def test_post_rejected_due_to_full_queue(self):
+        """Verifies a POST /batches when the validator reports QUEUE_FULL
+        breaks properly.
+
+        It will receive a Protobuf response with:
+            - a status of QUEUE_FULL
+
+        It should send back a JSON response with:
+            - a response status of 429
+            - an error property with a code of 31
+        """
+        batches = Mocks.make_batches(ID_A)
+        self.connection.preset_response(self.status.QUEUE_FULL)
+
+        request = await self.post_batches(batches)
+        self.assertEqual(429, request.status)
+        response = await request.json()
+        self.assert_has_valid_error(response, 31)
+
 
 class ClientBatchStatusTests(BaseApiTest):
 

--- a/validator/sawtooth_validator/journal/back_pressure_handlers.py
+++ b/validator/sawtooth_validator/journal/back_pressure_handlers.py
@@ -1,0 +1,46 @@
+# Copyright 2016, 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+
+from sawtooth_validator.protobuf.client_batch_submit_pb2 \
+    import ClientBatchSubmitResponse
+from sawtooth_validator.protobuf.validator_pb2 import Message
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ClientBatchSubmitBackpressureHandler(Handler):
+    """This handler receives a batch list, and accepts it if the system is
+    able.  Otherwise it returns a QUEUE_FULL response.
+    """
+
+    def __init__(self, can_accept_fn):
+        self._can_accept = can_accept_fn
+
+    def handle(self, connection_id, message_content):
+        if not self._can_accept():
+            response = ClientBatchSubmitResponse(
+                status=ClientBatchSubmitResponse.QUEUE_FULL)
+            return HandlerResult(
+                status=HandlerStatus.RETURN,
+                message_out=response,
+                message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE
+            )
+        return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -507,10 +507,18 @@ class BlockPublisher(object):
             observer.notify_batch_pending(batch)
 
     def can_accept_batch(self):
+        return len(self._pending_batches) < self._get_current_queue_limit()
+
+    def _get_current_queue_limit(self):
         # Limit the number of batches to 2 times the publishing average.  This
         # allows the queue to grow geometrically, if the queue is drained.
-        return len(self._pending_batches) < \
-            (2 * self._publish_count_average.value)
+        return 2 * self._publish_count_average.value
+
+    def get_current_queue_info(self):
+        """Returns a tuple of the current size of the pending batch queue
+        and the current queue limit.
+        """
+        return (len(self._pending_batches), self._get_current_queue_limit())
 
     @property
     def chain_head_lock(self):

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -634,7 +634,14 @@ class BlockPublisher(object):
 
         num_committed_batches = len(committed_batches)
         if num_committed_batches > 0:
-            self._publish_count_average.update(num_committed_batches)
+            # Only update the average if either:
+            # a. Not drained below the current average
+            # b. Drained the queue, but the queue was not bigger than the
+            #    current running average
+            remainder = len(self._pending_batches) - num_committed_batches
+            if remainder > self._publish_count_average.value or \
+                    num_committed_batches > self._publish_count_average.value:
+                self._publish_count_average.update(num_committed_batches)
 
         # Uncommitted and pending disjoint sets
         # since batches can only be committed to a chain once.

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -506,6 +506,12 @@ class BlockPublisher(object):
         for observer in self._batch_observers:
             observer.notify_batch_pending(batch)
 
+    def can_accept_batch(self):
+        # Limit the number of batches to 2 times the publishing average.  This
+        # allows the queue to grow geometrically, if the queue is drained.
+        return len(self._pending_batches) < \
+            (2 * self._publish_count_average.value)
+
     @property
     def chain_head_lock(self):
         return self._lock

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -112,7 +112,10 @@ def add(
     # Submit
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
-        ClientBatchSubmitBackpressureHandler(block_publisher.can_accept_batch),
+        ClientBatchSubmitBackpressureHandler(
+            block_publisher.can_accept_batch,
+            block_publisher.get_current_queue_info
+        ),
         thread_pool)
 
     dispatcher.add_handler(

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -19,6 +19,8 @@ from sawtooth_validator.execution import tp_state_handlers
 
 from sawtooth_validator.journal.completer import \
     CompleterBatchListBroadcastHandler
+from sawtooth_validator.journal.back_pressure_handlers import \
+    ClientBatchSubmitBackpressureHandler
 
 from sawtooth_validator.gossip import structure_verifier
 
@@ -60,6 +62,7 @@ def add(
         permission_verifier,
         thread_pool,
         sig_pool,
+        block_publisher
 ):
 
     # -- Transaction Processor -- #
@@ -107,6 +110,11 @@ def add(
         sig_pool)
 
     # Submit
+    dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
+        ClientBatchSubmitBackpressureHandler(block_publisher.can_accept_batch),
+        thread_pool)
+
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
         signature_verifier.BatchListSignatureVerifier(),

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -300,14 +300,14 @@ class Validator(object):
             network_dispatcher, network_service, gossip, completer,
             responder, network_thread_pool, sig_pool,
             chain_controller.has_block, block_publisher.has_batch,
-            permission_verifier)
+            permission_verifier, block_publisher)
 
         component_handlers.add(
             component_dispatcher, gossip, context_manager, executor, completer,
             block_store, batch_tracker, global_state_db,
             self.get_chain_head_state_root_hash, receipt_store,
             event_broadcaster, permission_verifier, component_thread_pool,
-            sig_pool)
+            sig_pool, block_publisher)
 
         # -- Store Object References -- #
         self._component_dispatcher = component_dispatcher

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -74,6 +74,7 @@ def add(
         has_block,
         has_batch,
         permission_verifier,
+        block_publisher
 ):
 
     # -- Basic Networking -- #


### PR DESCRIPTION
Introduces adaptive back pressure on the pending batch queue.  

The amount of batches allowed in the pending queue at any point in time is predicted using a rolling average of batches committed per block.  This is initialized to 30 (the equivalent to 1 transaction per second, with a 30 second wait time), and updated on each block commit.

New batches are rejected before any processing can take place if the pending batch queue exceeds 2 * the average, giving it a geometric increase in batches if all are committed.

Supersedes #1221