### PR TITLE
Use queues to pass blocks between validator components

### DIFF
--- a/validator/sawtooth_validator/journal/block_pipeline.py
+++ b/validator/sawtooth_validator/journal/block_pipeline.py
@@ -1,0 +1,186 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import abc
+import logging
+import queue
+
+from sawtooth_validator.concurrent.thread import InstrumentedThread
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Sender:
+    def __init__(self, queue_to_wrap):
+        self._queue = queue_to_wrap
+
+    def send(self, item, timeout=None):
+        if timeout is None:
+            self._queue.put_nowait(item)
+        else:
+            self._queue.put(item, timeout=timeout)
+
+
+class Receiver:
+    def __init__(self, queue_to_wrap):
+        self._queue = queue_to_wrap
+
+    def receive(self, timeout=None):
+        if timeout is None:
+            return self._queue.get_nowait()
+        return self._queue.get(timeout=timeout)
+
+
+class SimpleReceiverThread(InstrumentedThread):
+    """Pull items off of the queue and submit them to an executor."""
+    def __init__(self, receiver, task, name='SimpleReceiverThread',
+                 executor=None, exit_poll_interval=1):
+        super().__init__(name=name)
+        self._receiver = receiver
+        self._task = task
+        self._executor = executor
+        self._exit_poll_interval = exit_poll_interval
+        self._exit = False
+
+    def run(self):
+        while True:
+            try:
+                # Set timeout so we can check if the thread has been stopped
+                item = self._receiver.receive(
+                    timeout=self._exit_poll_interval)
+                if self._executor is not None:
+                    self._executor.submit(self._task, item)
+                else:
+                    self._task(item)
+
+            except queue.Empty:
+                pass
+
+            if self._exit:
+                return
+
+    def stop(self):
+        self._exit = True
+
+
+class BlockPipelineStage:
+    @abc.abstractmethod
+    def start(self, receiver, sender):
+        """Start processing blocks from receiver and putting them onto
+        sender."""
+
+    @abc.abstractmethod
+    def stop(self):
+        """Stop processing blocks and cleanup."""
+
+    @abc.abstractmethod
+    def has_block(self, block_id):
+        """Return whether this stage has the given block."""
+
+
+class PipelineNotRunning(Exception):
+    def __init__(self):
+        super().__init__(
+            "Cannot perform the requested operation as the pipeline is not "
+            "running.")
+
+
+class PipelineRunning(Exception):
+    def __init__(self):
+        super().__init__(
+            "Cannot perform the requested operation as the pipeline is "
+            "already running.")
+
+
+class PipelineOutputEmpty(Exception):
+    def __init__(self):
+        super().__init__(
+            "The pipeline has nothing ready in the output queue.")
+
+
+class BlockPipeline:
+    def __init__(self):
+        self._incoming = None
+        self._outgoing = None
+        self._stages = []
+        self._running = False
+
+    def add_stage(self, stage):
+        if self._running:
+            raise PipelineRunning()
+        self._stages.append(stage)
+
+    def start(self):
+        """Create queues and wire up the stages."""
+        if self._running:
+            raise PipelineRunning()
+
+        receivers = []
+        senders = []
+
+        for stage in self._stages:
+            inter = queue.Queue()
+            receivers.append(Receiver(inter))
+            senders.append(Sender(inter))
+
+        last = queue.Queue()
+        senders.append(Sender(last))
+
+        for i, stage in enumerate(self._stages):
+            stage.start(receivers[i], senders[i + 1])
+
+        self._incoming = senders[0]
+        self._outgoing = Receiver(last)
+        self._running = True
+
+    def stop(self):
+        if not self._running:
+            raise PipelineNotRunning()
+
+        for stage in self._stages:
+            stage.stop()
+        self._running = False
+
+    def has_block(self, block):
+        if not self._running:
+            raise PipelineNotRunning()
+
+        return any(stage.has_block(block) for stage in self._stages)
+
+    def submit(self, item):
+        """Submit an item to be processed."""
+        if not self._running:
+            raise PipelineNotRunning()
+
+        self._incoming.send(item)
+
+    @property
+    def receiver(self):
+        return self._outgoing
+
+    def poll(self, timeout=None):
+        """Get the next finished item, if one is available.
+        Raises:
+            PipelineOutputEmpty: No items are ready.
+        """
+        if not self._running:
+            raise PipelineNotRunning()
+
+        try:
+            return self._outgoing.receive()
+
+        except queue.Empty:
+            raise PipelineOutputEmpty()

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -261,15 +261,15 @@ class BlockTreeManager(object):
         LOGGER.debug("Generated %s", dumps_block(block_wrapper))
         return block_wrapper
 
-    def generate_genesis_block(self):
+    def generate_genesis_block(self, valid=True):
         return self.create_block(
             payload='Genesis',
             previous_block_id=NULL_BLOCK_IDENTIFIER,
-            block_num=0)
+            block_num=0 if valid else 1)
 
     def _block_def(self,
                    add_to_store=False,
-                   add_to_cache=False,
+                   add_to_cache=True,
                    batch_count=1,
                    status=BlockStatus.Unknown,
                    invalid_consensus=False,

--- a/validator/tests/test_pipeline/__init__.py
+++ b/validator/tests/test_pipeline/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+__all__ = []

--- a/validator/tests/test_pipeline/tests.py
+++ b/validator/tests/test_pipeline/tests.py
@@ -1,0 +1,77 @@
+import logging
+import time
+import unittest
+
+from sawtooth_validator.concurrent.threadpool import \
+    InstrumentedThreadPoolExecutor
+from sawtooth_validator.concurrent.atomic import Counter
+from sawtooth_validator.journal.block_pipeline import BlockPipeline
+from sawtooth_validator.journal.block_pipeline import BlockPipelineStage
+from sawtooth_validator.journal.block_pipeline import PipelineOutputEmpty
+from sawtooth_validator.journal.block_pipeline import SimpleReceiverThread
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MockStage(BlockPipelineStage):
+    def __init__(self):
+        self._executor = InstrumentedThreadPoolExecutor(1)
+        self._receive_thread = None
+        self._sender = None
+        self._counter = Counter()
+
+    def start(self, receiver, sender):
+        if self._receive_thread is None:
+            self._sender = sender
+            self._receive_thread = SimpleReceiverThread(
+                receiver=receiver,
+                task=self.send_to_next,
+                executor=self._executor)
+            self._receive_thread.start()
+
+    def stop(self):
+        self._receive_thread.stop()
+        self._sender = None
+        self._receive_thread = None
+
+    def has_block(self, block_id):
+        return False
+
+    def send_to_next(self, block):
+        self._counter.inc()
+        self._sender.send(block)
+
+    def count(self):
+        return self._counter.get()
+
+
+class TestBlockPipeline(unittest.TestCase):
+    def test_dummy(self):
+        n_stages = 3
+        n_items = 3
+
+        stages = [
+            MockStage() for _ in range(n_stages)
+        ]
+
+        pipeline = BlockPipeline()
+        for stage in stages:
+            pipeline.add_stage(stage)
+
+        pipeline.start()
+        for i in range(n_items):
+            pipeline.submit(i)
+
+        out = 0
+        while out < n_items:
+            try:
+                item = pipeline.poll()
+                self.assertEqual(item, out)
+                out += 1
+            except PipelineOutputEmpty:
+                time.sleep(0.1)
+        pipeline.stop()
+
+        for stage in stages:
+            self.assertEqual(stage.count(), n_items)


### PR DESCRIPTION
This creates a pipeline with queues between each stage. The queues are used like channels. This replaces the use of callbacks for interactions between the completer, block validator, and chain controller.