### PR TITLE
Fix postinst rules for validator package

### DIFF
--- a/validator/packaging/ubuntu/postinst
+++ b/validator/packaging/ubuntu/postinst
@@ -25,7 +25,8 @@ directories="
 user="sawtooth"
 group="sawtooth"
 
-if [ "$1" = install ]; then
+# Run on install and not upgrade
+if [ "$1" = configure ] && [ -z "$2" ]; then
     if ! getent group $group > /dev/null; then
         addgroup --quiet --system $group
     fi


### PR DESCRIPTION
Add a check that "$2" is not set. On an upgrade "$2"
is the previous package version, on a new install it's
undefined.

Signed-off-by: Richard Berg <rberg@bitwise.io>