### PR TITLE
Improve logging around fork resolution

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_fork_resolver.py
@@ -125,9 +125,10 @@ class PoetForkResolver(ForkResolverInterface):
         if current_fork_wait_certificate is None:
             if new_fork_head.previous_block_id == cur_fork_head.identifier:
                 LOGGER.info(
-                    'Choose new fork %s: New fork head switches consensus to '
-                    'PoET',
-                    new_fork_head.identifier[:8])
+                    'Choose new fork %s over current fork %s: '
+                    'New fork head switches consensus to PoET',
+                    new_fork_head.header_signature[:8],
+                    cur_fork_head.header_signature[:8])
                 chosen_fork_head = new_fork_head
             else:
                 raise \
@@ -144,18 +145,22 @@ class PoetForkResolver(ForkResolverInterface):
             if current_fork_wait_certificate.duration < \
                     new_fork_wait_certificate.duration:
                 LOGGER.info(
-                    'Choose current fork %s: Current fork wait duration '
-                    '(%f) less than new fork wait duration (%f)',
+                    'Choose current fork %s over new fork %s: '
+                    'Current fork wait duration (%f) less than new fork wait '
+                    'duration (%f)',
                     cur_fork_head.header_signature[:8],
+                    new_fork_head.header_signature[:8],
                     current_fork_wait_certificate.duration,
                     new_fork_wait_certificate.duration)
                 chosen_fork_head = cur_fork_head
             elif new_fork_wait_certificate.duration < \
                     current_fork_wait_certificate.duration:
                 LOGGER.info(
-                    'Choose new fork %s: New fork wait duration (%f) '
-                    'less than current fork wait duration (%f)',
+                    'Choose new fork %s over current fork %s: '
+                    'New fork wait duration (%f) less than current fork wait '
+                    'duration (%f)',
                     new_fork_head.header_signature[:8],
+                    cur_fork_head.header_signature[:8],
                     new_fork_wait_certificate.duration,
                     current_fork_wait_certificate.duration)
                 chosen_fork_head = new_fork_head
@@ -191,20 +196,22 @@ class PoetForkResolver(ForkResolverInterface):
             if current_fork_consensus_state.aggregate_local_mean > \
                     new_fork_aggregate_local_mean:
                 LOGGER.info(
-                    'Choose current fork %s: Current fork aggregate '
-                    'local mean (%f) greater than new fork aggregate '
-                    'local mean (%f)',
+                    'Choose current fork %s over new fork %s: '
+                    'Current fork aggregate local mean (%f) greater than new '
+                    'fork aggregate local mean (%f)',
                     cur_fork_head.header_signature[:8],
+                    new_fork_head.header_signature[:8],
                     current_fork_consensus_state.aggregate_local_mean,
                     new_fork_aggregate_local_mean)
                 chosen_fork_head = cur_fork_head
             elif new_fork_aggregate_local_mean > \
                     current_fork_consensus_state.aggregate_local_mean:
                 LOGGER.info(
-                    'Choose new fork %s: New fork aggregate local mean '
-                    '(%f) greater than current fork aggregate local mean '
-                    '(%f)',
+                    'Choose new fork %s over current fork %s: '
+                    'New fork aggregate local mean (%f) greater than current '
+                    'fork aggregate local mean (%f)',
                     new_fork_head.header_signature[:8],
+                    cur_fork_head.header_signature[:8],
                     new_fork_aggregate_local_mean,
                     current_fork_consensus_state.aggregate_local_mean)
                 chosen_fork_head = new_fork_head
@@ -218,17 +225,21 @@ class PoetForkResolver(ForkResolverInterface):
             if cur_fork_head.header_signature > \
                     new_fork_head.header_signature:
                 LOGGER.info(
-                    'Choose current fork %s: Current fork header signature'
-                    '(%s) greater than new fork header signature (%s)',
+                    'Choose current fork %s over new fork %s: '
+                    'Current fork header signature (%s) greater than new fork '
+                    'header signature (%s)',
                     cur_fork_head.header_signature[:8],
+                    new_fork_head.header_signature[:8],
                     cur_fork_head.header_signature[:8],
                     new_fork_head.header_signature[:8])
                 chosen_fork_head = cur_fork_head
             else:
                 LOGGER.info(
-                    'Choose new fork %s: New fork header signature (%s) '
-                    'greater than current fork header signature (%s)',
+                    'Choose new fork %s over current fork %s: '
+                    'New fork header signature (%s) greater than current fork '
+                    'header signature (%s)',
                     new_fork_head.header_signature[:8],
+                    cur_fork_head.header_signature[:8],
                     new_fork_head.header_signature[:8],
                     cur_fork_head.header_signature[:8])
                 chosen_fork_head = new_fork_head

--- a/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_fork_resolver.py
@@ -478,23 +478,9 @@ class TestPoetForkResolver(TestCase):
              mock_new_fork_consensus_state]
 
         # check test
-        with mock.patch('sawtooth_poet.poet_consensus.poet_fork_resolver.'
-                        'LOGGER') as mock_logger:
-            self.assertFalse(fork_resolver.compare_forks(
-                cur_fork_head=mock_cur_fork_header,
-                new_fork_head=mock_new_fork_header))
-
-            # Could be a hack, but verify that the appropriate log message is
-            # generated - so we at least have some faith that the failure was
-            # because of what we are testing and not something else.  I know
-            # that this is fragile if the log message is changed, so would
-            # accept any suggestions on a better way to verify that the
-            # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('Current fork aggregate local mean (%f) '
-                            'greater than new fork aggregate local mean'
-                            in message)
+        self.assertFalse(fork_resolver.compare_forks(
+            cur_fork_head=mock_cur_fork_header,
+            new_fork_head=mock_new_fork_header))
 
         # Subtest 2: when the new fork head has
         # the higher aggregate local mean
@@ -511,23 +497,9 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_consensus_state.aggregate_local_mean = 1.0
 
         # check test
-        with mock.patch('sawtooth_poet.poet_consensus.poet_fork_resolver.'
-                        'LOGGER') as mock_logger:
-            self.assertTrue(fork_resolver.compare_forks(
-                cur_fork_head=mock_cur_fork_header,
-                new_fork_head=mock_new_fork_header))
-
-            # Could be a hack, but verify that the appropriate log message is
-            # generated - so we at least have some faith that the failure was
-            # because of what we are testing and not something else.  I know
-            # that this is fragile if the log message is changed, so would
-            # accept any suggestions on a better way to verify that the
-            # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('New fork aggregate local mean (%f) '
-                            'greater than current fork aggregate local mean '
-                            in message)
+        self.assertTrue(fork_resolver.compare_forks(
+            cur_fork_head=mock_cur_fork_header,
+            new_fork_head=mock_new_fork_header))
 
         # Subtest 3: when both the new & current fork heads have
         # the same aggregate local mean
@@ -544,23 +516,9 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_consensus_state.aggregate_local_mean = 1.0
 
         # check test
-        with mock.patch('sawtooth_poet.poet_consensus.poet_fork_resolver.'
-                        'LOGGER') as mock_logger:
-            self.assertTrue(fork_resolver.compare_forks(
-                cur_fork_head=mock_cur_fork_header,
-                new_fork_head=mock_new_fork_header))
-
-            # Could be a hack, but verify that the appropriate log message is
-            # generated - so we at least have some faith that the failure was
-            # because of what we are testing and not something else.  I know
-            # that this is fragile if the log message is changed, so would
-            # accept any suggestions on a better way to verify that the
-            # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('New fork header signature (%s) '
-                            'greater than current fork header signature (%s)'
-                            in message)
+        self.assertTrue(fork_resolver.compare_forks(
+            cur_fork_head=mock_cur_fork_header,
+            new_fork_head=mock_new_fork_header))
 
         # Subset 4: If we have gotten to this point and we have not chosen
         # a fork head yet, we are going to fall back
@@ -588,23 +546,9 @@ class TestPoetForkResolver(TestCase):
 
         # check test when Current fork header signature is greater than
         # the new fork header signature
-        with mock.patch('sawtooth_poet.poet_consensus.poet_fork_resolver.'
-                        'LOGGER') as mock_logger:
-            self.assertFalse(fork_resolver.compare_forks(
-                cur_fork_head=mock_cur_fork_header,
-                new_fork_head=mock_smaller_header_signature))
-
-            # Could be a hack, but verify that the appropriate log message is
-            # generated - so we at least have some faith that the failure was
-            # because of what we are testing and not something else.  I know
-            # that this is fragile if the log message is changed, so would
-            # accept any suggestions on a better way to verify that the
-            # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('Current fork header signature'
-                            '(%s) greater than new fork header signature (%s)'
-                            in message)
+        self.assertFalse(fork_resolver.compare_forks(
+            cur_fork_head=mock_cur_fork_header,
+            new_fork_head=mock_smaller_header_signature))
 
         # Subtest 5: Check when new header signature is greater than
         # the current fork header signature
@@ -619,20 +563,6 @@ class TestPoetForkResolver(TestCase):
         mock_new_fork_consensus_state.aggregate_local_mean = 0.0
 
         # check test
-        with mock.patch('sawtooth_poet.poet_consensus.poet_fork_resolver.'
-                        'LOGGER') as mock_logger:
-            self.assertTrue(fork_resolver.compare_forks(
-                cur_fork_head=mock_smaller_header_signature,
-                new_fork_head=mock_new_fork_header))
-
-            # Could be a hack, but verify that the appropriate log message is
-            # generated - so we at least have some faith that the failure was
-            # because of what we are testing and not something else.  I know
-            # that this is fragile if the log message is changed, so would
-            # accept any suggestions on a better way to verify that the
-            # function fails for the reason we expect.
-
-            (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('New fork header signature (%s) '
-                            'greater than current fork header signature (%s)'
-                            in message)
+        self.assertTrue(fork_resolver.compare_forks(
+            cur_fork_head=mock_smaller_header_signature,
+            new_fork_head=mock_new_fork_header))

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -484,6 +484,21 @@ class BlockValidator(object):
 
             # 4) Evaluate the 2 chains to see if the new chain should be
             # committed
+            LOGGER.info(
+                "Comparing current chain head '%s' against new block '%s'",
+                self._chain_head, self._new_block)
+            for i in range(max(len(new_chain), len(cur_chain))):
+                cur = new = num = "-"
+                if i < len(cur_chain):
+                    cur = cur_chain[i].header_signature[:8]
+                    num = cur_chain[i].block_num
+                if i < len(new_chain):
+                    new = new_chain[i].header_signature[:8]
+                    num = new_chain[i].block_num
+                LOGGER.info(
+                    "Fork comparison at height %s is between %s and %s",
+                    num, cur, new)
+
             commit_new_chain = self._test_commit_new_chain()
 
             # 5) Consensus to compute batch sets (only if we are switching).


### PR DESCRIPTION
Adds more INFO level log messages around fork resolution to the chain controller and poet fork resolver. Sample output:

```
[2017-12-19 22:26:45.391 INFO     chain] Comparing current chain head 'a89fbefe(47, S:99ef9592, P:0df858fd)' against new block '17d09efa(47, S:99ef9592, P:0df858fd)'
[2017-12-19 22:26:45.392 INFO     chain] Fork comparison at height 47 is between a89fbefe and 17d09efa
[2017-12-19 22:26:45.397 INFO     poet_fork_resolver] Choose current fork a89fbefe over new fork 17d09efa: Current fork wait duration (3.980731) less than new fork wait duration (4.144106)
[2017-12-19 22:26:45.400 INFO     chain] on_block_validated: 17d09efa(47, S:99ef9592, P:0df858fd)
[2017-12-19 22:26:45.402 INFO     chain] Rejected new chain head: 17d09efa(47, S:99ef9592, P:0df858fd)
[2017-12-19 22:26:45.404 INFO     chain] Finished block validation of: 17d09efa(47, S:99ef9592, P:0df858fd)
```