### PR TITLE
Remove noisy debug line in poet block publisher

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -543,7 +543,6 @@ class BlockPublisher(object):
             signer_public_key=public_key)
         block_builder = BlockBuilder(block_header)
         if not consensus.initialize_block(block_builder.block_header):
-            LOGGER.debug("Consensus not ready to build candidate block.")
             return None
 
         # create a new scheduler


### PR DESCRIPTION
If a validator is not yet registered block initialization will
repeatedly return false prompting a debug message that it's not
ready yet. That message hides the useful debug/info/warn messages
that indicate what the validator is waiting on for registration.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>