### PR TITLE
Add NewSecp256k1PrivateKey function to SDK go library

### DIFF
--- a/sdk/go/src/sawtooth_sdk/signing/secp256k1.go
+++ b/sdk/go/src/sawtooth_sdk/signing/secp256k1.go
@@ -35,6 +35,11 @@ type Secp256k1PrivateKey struct {
 	private_key []byte
 }
 
+// Creates a PrivateKey instance from private key bytes.
+func NewSecp256k1PrivateKey(private_key []byte) PrivateKey {
+	return &Secp256k1PrivateKey{private_key}
+}
+
 // WifToSecp256k1PrivateKey converts a WIF string to a private key.
 func WifToSecp256k1PrivateKey(wif string) (*Secp256k1PrivateKey, error) {
 	priv, err := wifToPriv(wif)


### PR DESCRIPTION
Adds a new `NewSecp256k1PrivateKey` function to the go SDK library that creates a `Secp256k1PrivateKey` instance from private key bytes.