### PR TITLE
Add block-info package installation to validator image

### DIFF
--- a/docker/sawtooth-int-validator
+++ b/docker/sawtooth-int-validator
@@ -45,6 +45,7 @@ RUN cd /debs \
 
 RUN apt-get install -y -q --allow-unauthenticated \
     python3-sawtooth-validator \
+    python3-sawtooth-block-info \
     python3-sawtooth-poet-cli \
     python3-sawtooth-cli
 


### PR DESCRIPTION
Required to add the block-info transaction injector that is configured in `sawtooth-seth` images and compose files