### PR TITLE
Set type of validator args for cli command

### DIFF
--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -97,15 +97,19 @@ def parse_args(args):
                              'validator network.')
     parser.add_argument('--opentsdb-url',
                         help='specify host and port for Open TSDB database \
-                        used for metrics')
+                        used for metrics',
+                        type=str)
     parser.add_argument('--opentsdb-db',
                         help='specify name of database used for storing \
-                        metrics')
+                        metrics',
+                        type=str)
     parser.add_argument('--minimum-peer-connectivity',
                         help='set the minimum number of peers required before \
-                        stopping peer search')
+                        stopping peer search',
+                        type=int)
     parser.add_argument('--maximum-peer-connectivity',
-                        help='set the maximum number of peers to accept')
+                        help='set the maximum number of peers to accept',
+                        type=int)
 
     try:
         version = pkg_resources.get_distribution(DISTRIBUTION_NAME).version


### PR DESCRIPTION
The default arg type is `str` causing the validator to crash if the min or max peer `--minimum-peer-connectivity` and `--maximum-peer-connectivity` arguments are set.