### PR TITLE
Handle None result correctly

### DIFF
--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -202,6 +202,11 @@ class Dispatcher(InstrumentedThread):
             LOGGER.exception("Dispatcher timeout waiting on handler result.")
             raise
 
+        if res is None:
+            LOGGER.debug('Ignoring None handler result, likely due to an '
+                         'unhandled error while executing the handler')
+            return
+
         if res.status == HandlerStatus.DROP:
             del self._message_information[message_id]
 


### PR DESCRIPTION
If previous handler had an exception, the future provided to `_determine_next` will return None, and therefore cause another error to occur.  This fixes the issue, and logs it accordingly.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>