### PR TITLE
Get rid of excessive logging

### DIFF
--- a/validator/sawtooth_validator/execution/tp_state_handlers.py
+++ b/validator/sawtooth_validator/execution/tp_state_handlers.py
@@ -45,7 +45,7 @@ class TpStateGetHandler(Handler):
                 validator_pb2.Message.TP_STATE_GET_RESPONSE)
 
         return_list = return_values if return_values is not None else []
-        LOGGER.debug("GET: %s", return_list)
+
         entry_list = [
             state_context_pb2.TpStateEntry(address=a, data=d)
             for a, d in return_list
@@ -90,7 +90,6 @@ class TpStateSetHandler(Handler):
             status=state_context_pb2.TpStateSetResponse.OK)
         if return_value is True:
             address_list = [e.address for e in set_request.entries]
-            LOGGER.debug("SET: %s", address_list)
             response.addresses.extend(address_list)
         else:
             LOGGER.debug("SET: No Values Set")
@@ -116,8 +115,9 @@ class TpStateDeleteHandler(Handler):
         delete_request = state_context_pb2.TpStateDeleteRequest()
         delete_request.ParseFromString(message_content)
         try:
-            return_values = self._context_manager.delete(
-                delete_request.context_id, list(delete_request.addresses))
+            self._context_manager.delete(
+                delete_request.context_id,
+                list(delete_request.addresses))
         except AuthorizationException:
             response = \
                 state_context_pb2.TpStateDeleteResponse(
@@ -128,7 +128,6 @@ class TpStateDeleteHandler(Handler):
                 response,
                 validator_pb2.Message.TP_STATE_DELETE_RESPONSE)
 
-        LOGGER.debug("DELETE: %s", return_values)
         response = state_context_pb2.TpStateDeleteResponse(
             addresses=delete_request.addresses,
             status=state_context_pb2.TpStateDeleteResponse.OK)

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -140,8 +140,6 @@ class GossipMessageSignatureVerifier(Handler):
                              block.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
-            LOGGER.debug("block passes signature verification %s",
-                         block.header_signature)
             self._seen_cache[block.header_signature] = None
             return HandlerResult(status=HandlerStatus.PASS)
 
@@ -158,8 +156,6 @@ class GossipMessageSignatureVerifier(Handler):
                              batch.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
-            LOGGER.debug("batch passes signature verification %s",
-                         batch.header_signature)
             self._seen_cache[batch.header_signature] = None
             return HandlerResult(status=HandlerStatus.PASS)
 
@@ -186,8 +182,6 @@ class GossipBlockResponseSignatureVerifier(Handler):
                          block.header_signature)
             return HandlerResult(status=HandlerStatus.DROP)
 
-        LOGGER.debug("requested block passes signature verification %s",
-                     block.header_signature)
         self._seen_cache = TimedCache()
         return HandlerResult(status=HandlerStatus.PASS)
 
@@ -212,8 +206,6 @@ class GossipBatchResponseSignatureVerifier(Handler):
                          batch.header_signature)
             return HandlerResult(status=HandlerStatus.DROP)
 
-        LOGGER.debug("requested batch passes signature verification %s",
-                     batch.header_signature)
         self._seen_cache[batch.header_signature] = None
         return HandlerResult(status=HandlerStatus.PASS)
 

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -95,8 +95,6 @@ class GossipHandlerStructureVerifier(Handler):
                              block.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
-            LOGGER.debug("block passes batch structure verification %s",
-                         block.header_signature)
             return HandlerResult(status=HandlerStatus.PASS)
         elif gossip_message.content_type == network_pb2.GossipMessage.BATCH:
             batch = Batch()
@@ -106,8 +104,6 @@ class GossipHandlerStructureVerifier(Handler):
                              batch.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
-            LOGGER.debug("batch passes structure verification %s",
-                         batch.header_signature)
             return HandlerResult(status=HandlerStatus.PASS)
 
         return HandlerResult(status=HandlerStatus.PASS)
@@ -125,8 +121,6 @@ class GossipBlockResponseStructureVerifier(Handler):
                          block.header_signature)
             return HandlerResult(status=HandlerStatus.DROP)
 
-        LOGGER.debug("requested block passes batch structure "
-                     "verification %s", block.header_signature)
         return HandlerResult(status=HandlerStatus.PASS)
 
 
@@ -142,8 +136,6 @@ class GossipBatchResponseStructureVerifier(Handler):
                          batch.header_signature)
             return HandlerResult(status=HandlerStatus.DROP)
 
-        LOGGER.debug("requested batch passes structure verification %s",
-                     batch.header_signature)
         return HandlerResult(status=HandlerStatus.PASS)
 
 

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -19,7 +19,6 @@ from functools import partial
 import hashlib
 import logging
 import queue
-import sys
 from threading import Event
 from threading import Lock
 import time
@@ -280,10 +279,6 @@ class _SendReceive(object):
                     yield from self._dispatcher_queue.get()
                 message = validator_pb2.Message()
                 message.ParseFromString(msg_bytes)
-                LOGGER.debug("%s receiving %s message: %s bytes",
-                             self._connection,
-                             get_enum_name(message.message_type),
-                             sys.getsizeof(msg_bytes))
 
                 tag = get_enum_name(message.message_type)
                 self._get_received_message_counter(tag).inc()
@@ -308,13 +303,7 @@ class _SendReceive(object):
                                               connection_id)
                 else:
                     my_future = self._futures.get(message.correlation_id)
-
-                    LOGGER.debug("message round "
-                                 "trip: %s %s",
-                                 get_enum_name(message.message_type),
-                                 my_future.get_duration())
                     my_future.timer_stop()
-
                     self._futures.remove(message.correlation_id)
 
             except CancelledError:
@@ -373,11 +362,6 @@ class _SendReceive(object):
                              connection_id)
 
         self._ready.wait()
-
-        LOGGER.debug("%s sending %s to %s",
-                     self._connection,
-                     get_enum_name(msg.message_type),
-                     zmq_identity if zmq_identity else self._address)
 
         if zmq_identity is None:
             message_bundle = [msg.SerializeToString()]


### PR DESCRIPTION
Following a suggestion of @jsmitchell in https://github.com/hyperledger/sawtooth-core/pull/1270, this PR gets rid of the following classes of frequently-logged messages:

* interconnect
```
validator-0_1                   | [2017-12-21 16:27:54.942 DEBUG    interconnect] message round trip: TP_PROCESS_RESPONSE 0.018114805221557617
validator-1_1                   | [2017-12-21 16:27:55.035 DEBUG    interconnect] ServerThread sending TP_STATE_GET_RESPONSE to b'a3b0e16d4aaf48b0'
validator-1_1                   | [2017-12-21 16:27:55.038 DEBUG    interconnect] ServerThread receiving TP_STATE_SET_REQUEST
```
* state handlers
```
validator-1_1                   | [2017-12-21 16:29:38.756 DEBUG    tp_state_handlers] GET: [('1cf126fc250d76798773a58316500893684ea4e2bce9ff07638b611bfecb145aa30bcd', b"\xa1fcornel\x19'\x87")]
validator-1_1                   | [2017-12-21 16:29:38.768 DEBUG    tp_state_handlers] SET: ['1cf126fc250d76798773a58316500893684ea4e2bce9ff07638b611bfecb145aa30bcd']
```
* verifiers
```
validator-1_1                   | [2017-12-21 16:45:44.051 DEBUG    signature_verifier] requested block passes signature verification c7ce6d4a0fe55002bf3fd2564fa0665b775fb0ac1ccd10e460892aa79c25719e60d07c853e54ee4f767378e39b36ea1ffa1da486ce00ba49bfbdc7bad422d45f
validator-1_1                   | [2017-12-21 16:45:44.056 DEBUG    structure_verifier] requested block passes batch structure verification c7ce6d4a0fe55002bf3fd2564fa0665b775fb0ac1ccd10e460892aa79c25719e60d07c853e54ee4f767378e39b36ea1ffa1da486ce00ba49bfbdc7bad422d45f
```
I'm assuming not everyone will agree with these changes, but that can be discussed here. I don't personally have an opinion one way or the other.