### PR TITLE
Add limit to block list

### DIFF
--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -46,12 +46,18 @@ def add_block_parser(subparsers, parent_parser):
         'blockchain, including the block id and number, public keys all '
         'of allsigners, and number of transactions and batches.')
 
-    grand_parsers.add_parser(
+    list_parser = grand_parsers.add_parser(
         'list',
         help='Displays information for all blocks on the current blockchain',
         description=description,
         parents=[base_http_parser(), base_list_parser()],
         formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    list_parser.add_argument(
+        '--limit',
+        type=int,
+        help='the number of blocks to list',
+    )
 
     description = (
         'Displays information about the specified block on '
@@ -78,7 +84,7 @@ def do_block(args):
     rest_client = RestClient(args.url, args.user)
 
     if args.subcommand == 'list':
-        blocks = rest_client.list_blocks()
+        blocks = rest_client.list_blocks(limit=args.limit)
         keys = ('num', 'block_id', 'batches', 'txns', 'signer')
         headers = tuple(k.upper() if k != 'batches' else 'BATS' for k in keys)
 

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -114,10 +114,16 @@ class RestClient(object):
 
     def _get_data(self, path, **queries):
         url = self._base_url + path
+        params = self._format_queries(queries)
+
+        limit = None
+        if "limit" in params:
+            limit = params["limit"]
+
         while url:
             code, json_result = self._submit_request(
                 url,
-                params=self._format_queries(queries),
+                params=params,
             )
 
             if code == 404:
@@ -130,6 +136,11 @@ class RestClient(object):
 
             for item in json_result.get('data', []):
                 yield item
+
+            if limit:
+                limit = limit - len(json_result.get('data', []))
+                if limit <= 0:
+                    break
 
             url = json_result['paging'].get('next', None)
 

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -146,10 +146,10 @@ sawtooth block list
 ===================
 
 The ``sawtooth block list`` subcommand queries the Sawtooth REST API
-(default: ``http://localhost:8008``) for a list of all blocks in the
-current chain. It returns the id and number of each block, the public
-key of each signer, and the number of transactions and batches in
-each.
+(default: ``http://localhost:8008``) for a list of blocks in the
+current chain. Using the ``--limit`` option, the number of blocks returned can
+be configured. It returns the id and number of each block, the public key of
+each signer, and the number of transactions and batches in each.
 
 By default, this information is displayed as a white-space delimited
 table intended for display, but other plain-text formats (CSV, JSON,


### PR DESCRIPTION
This makes the number of blocks returned from block list
configurable. Before, if a block list is run all, blocks would
be listed which pulls a lot of blocks from the database
which causes a Ram increase.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>