### PR TITLE
WIP sawnet peers {list,graph}

### DIFF
--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -81,6 +81,8 @@ save_usage sawadm genesis
 save_usage sawadm keygen
 
 save_usage sawnet
+save_usage sawnet peers
+save_usage sawnet peers list
 save_usage sawnet compare-chains
 
 save_usage sawtooth-validator

--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -83,6 +83,7 @@ save_usage sawadm keygen
 save_usage sawnet
 save_usage sawnet peers
 save_usage sawnet peers list
+save_usage sawnet peers graph
 save_usage sawnet compare-chains
 
 save_usage sawtooth-validator

--- a/cli/sawtooth_cli/network_command/peers.py
+++ b/cli/sawtooth_cli/network_command/peers.py
@@ -1,0 +1,83 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import json
+import shlex
+import subprocess
+
+from sawtooth_cli.exceptions import CliException
+
+
+def add_peers_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser(
+        'peers',
+        help='TODO',
+        description='TODO',
+    )
+
+    peers_parsers = parser.add_subparsers(
+        title='subcommands',
+        dest='peers_command')
+    peers_parsers.required = True
+
+    list_parser = peers_parsers.add_parser(
+        'list',
+        help='List peers for validators with given URLs',
+        description=(
+            'List peers for validators with given URLs separated by commas.'))
+
+    list_parser.add_argument(
+        'urls',
+        nargs=1,
+        help='the comma-separated URLs of the validators to be queried',
+        type=str)
+
+    list_parser.add_argument(
+        '--pretty', '-p',
+        action='store_true',
+        help='Pretty-print the results')
+
+
+def do_peers(args):
+    if args.peers_command == 'list':
+        do_peers_list(args)
+    else:
+        raise CliException('Invalid command: {}'.format(args.subcommand))
+
+
+def do_peers_list(args):
+    urls = args.urls[0].split(',')
+
+    peer_dict = {
+        url: _get_peers(url)
+        for url in urls
+    }
+
+    print(
+        json.dumps(
+            peer_dict,
+            sort_keys=True,
+            indent=(4 if args.pretty else 0)
+        )
+    )
+
+
+def _get_peers(url):
+    peers = subprocess.check_output(
+        shlex.split(
+            'sawtooth peer list --url {}'.format(url))
+    ).decode().strip().split(',')
+
+    return peers

--- a/cli/sawtooth_cli/peer.py
+++ b/cli/sawtooth_cli/peer.py
@@ -59,7 +59,7 @@ def do_peer(args):
 
 def do_peer_list(args):
     rest_client = RestClient(base_url=args.url)
-    peers = rest_client.list_peers()
+    peers = sorted(rest_client.list_peers())
 
     if args.format == 'csv' or args.format == 'default':
         print(','.join(peers))

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -201,7 +201,8 @@ class RestClient(object):
             return (e.response.status_code, e.response.reason)
         except RemoteDisconnected as e:
             raise CliException(e)
-        except requests.exceptions.MissingSchema as e:
+        except (requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidURL) as e:
             raise CliException(e)
         except requests.exceptions.ConnectionError as e:
             raise CliException(

--- a/cli/sawtooth_cli/sawnet.py
+++ b/cli/sawtooth_cli/sawnet.py
@@ -25,6 +25,8 @@ from colorlog import ColoredFormatter
 from sawtooth_cli.exceptions import CliException
 from sawtooth_cli.network_command.compare import add_compare_chains_parser
 from sawtooth_cli.network_command.compare import do_compare_chains
+from sawtooth_cli.network_command.peers import add_peers_parser
+from sawtooth_cli.network_command.peers import do_peers
 
 
 DISTRIBUTION_NAME = 'sawnet'
@@ -41,6 +43,7 @@ def create_parser(prog_name):
     subparsers.required = True
 
     add_compare_chains_parser(subparsers, parent_parser)
+    add_peers_parser(subparsers, parent_parser)
 
     return parser
 
@@ -61,6 +64,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None,
 
     if args.subcommand == 'compare-chains':
         do_compare_chains(args)
+    elif args.subcommand == 'peers':
+        do_peers(args)
     else:
         raise CliException('Invalid command: {}'.format(args.subcommand))
 

--- a/integration/sawtooth_integration/tests/test_peer_list.py
+++ b/integration/sawtooth_integration/tests/test_peer_list.py
@@ -26,20 +26,22 @@ LOGGER.setLevel(logging.DEBUG)
 
 
 EXPECTED = {
-    0: [1],
-    1: [0, 2, 3],
-    2: [1, 4],
-    3: [1, 4],
-    4: [2, 3],
+    0: {1},
+    1: {0, 2, 3},
+    2: {1, 4},
+    3: {1, 4},
+    4: {2, 3},
 }
 
 
 class TestPeerList(unittest.TestCase):
     def test_peer_list(self):
-        '''
-        Five validators are started, peered as described in EXPECTED (see
-        the test's associated yaml file for details). `sawtooth peer
-        list` is run against each of them and the output is verified.
+        '''Five validators are started, peered as described in EXPECTED (see
+        the test's associated yaml file for details). First `sawtooth
+        peer list` is run against each of them and the output is
+        verified, then `sawnet peers list` is run against the whole
+        network and the output is verified.
+
         '''
 
         # It would be preferable to use, as is normally done in
@@ -52,11 +54,12 @@ class TestPeerList(unittest.TestCase):
         # genesis node won't have any blocks.
         time.sleep(10)
 
+        # test `sawtooth peer list`
         for node_number, peer_numbers in EXPECTED.items():
             actual_peers = _get_peers(node_number)
 
             expected_peers = {
-                'tcp://validator-{}:8800'.format(peer_number)
+                _make_tcp_address(peer_number)
                 for peer_number in peer_numbers
             }
 
@@ -69,15 +72,40 @@ class TestPeerList(unittest.TestCase):
                 actual_peers,
                 expected_peers)
 
+        # test `sawnet peers list`
+        expected_network = {
+            _make_http_address(node_number): [
+                _make_tcp_address(peer_number)
+                for peer_number in peers
+            ]
+            for node_number, peers in EXPECTED.items()
+        }
+
+        http_addresses = ','.join([
+            _make_http_address(node_number)
+            for node_number in EXPECTED
+        ])
+
+        # make sure pretty-print option works
+        subprocess.run(shlex.split(
+            'sawnet peers list {} --pretty'.format(http_addresses)))
+
+        sawnet_peers_output = json.loads(
+            _run_peer_command(
+                'sawnet peers list {}'.format(http_addresses)
+            )
+        )
+
+        self.assertEqual(
+            sawnet_peers_output,
+            expected_network)
+
 
 def _get_peers(node_number, fmt='json'):
-    cmd_output = subprocess.check_output(
-        shlex.split(
-            'sawtooth peer list --url {} --format {}'.format(
-                'http://rest-api-{}:8008'.format(node_number),
-                fmt)
-        )
-    ).decode().replace("'", '"')
+    cmd_output = _run_peer_command(
+        'sawtooth peer list --url {} --format {}'.format(
+            _make_http_address(node_number),
+            fmt))
 
     LOGGER.debug('peer list output: %s', cmd_output)
 
@@ -88,3 +116,17 @@ def _get_peers(node_number, fmt='json'):
         parsed = cmd_output.split(',')
 
     return set(parsed)
+
+
+def _run_peer_command(command):
+    return subprocess.check_output(
+        shlex.split(command)
+    ).decode().strip().replace("'", '"')
+
+
+def _make_http_address(node_number):
+    return 'http://rest-api-{}:8008'.format(node_number)
+
+
+def _make_tcp_address(node_number):
+    return 'tcp://validator-{}:8800'.format(node_number)

--- a/integration/sawtooth_integration/tests/test_peer_list.py
+++ b/integration/sawtooth_integration/tests/test_peer_list.py
@@ -100,6 +100,10 @@ class TestPeerList(unittest.TestCase):
             sawnet_peers_output,
             expected_network)
 
+        # run `sawnet peers graph`, but don't verify output
+        subprocess.run(shlex.split(
+            'sawnet peers graph {}'.format(http_addresses)))
+
 
 def _get_peers(node_number, fmt='json'):
     cmd_output = _run_peer_command(


### PR DESCRIPTION
This is a WIP PR to solicit comments for the commands `sawnet peers {list,graph}`.

Currently `sawnet peers list` takes a CSV list of URLs and prints a JSON dict with each URL matched to its peers. The peers are the ones returned by `sawtooth peer list`, ie a list of the network endpoints of the validators. A `--pretty` flag can be passed to pretty-print the JSON. It has been suggested that the default should be to print columns and that a `--json` (or `--yaml` or whatever) flag should be passed if that format is desired.

`sawnet peers graph` takes a CSV list of URLs and writes a Graphviz graph to a file called `peers.dot` (overwriting an existing file if the `--force` flag is passed). If a `--png` flag is passed,  the Graphviz command `dot -Tpng peers.dot -o peers.png` will be executed, converting the graph file to a pretty picture. I assume more file formats can be supported; this particular command was copied from a shell script of @vaporos 's.

The problem with the graph command right now is that there's no general way to correlate a REST API's URL with the network endpoint of its associated validator, so the image produced actually shows two isomorphic but distinct graphs with different names for the nodes. It would be extremely helpful to be able to query for the validator endpoint. There are two options for this:

1) Add a `/status` endpoint that would return the validator's network endpoint, its public key, and maybe other stuff.

2) Change the `/peers` endpoint to include information about the validator being queried.