### PR TITLE
Properly destroy the PoET enclave in the case of SGX_ERROR_ENCLAVE_LOST

### DIFF
--- a/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/enclave.cpp
+++ b/consensus/poet/sgx/sawtooth_poet_sgx/libpoet_bridge/enclave.cpp
@@ -811,6 +811,7 @@ namespace sawtooth {
                 if (SGX_ERROR_ENCLAVE_LOST == ret) {
                     // Enclave lost, potentially due to power state change
                     // reload the enclave and try again
+                    this->Unload();
                     this->LoadEnclave();
                 } else if (SGX_ERROR_DEVICE_BUSY == ret) {
                     // Device is busy... wait and try again.


### PR DESCRIPTION
Signed-off-by: Cian Montgomery <cian.montgomery@intel.com>