### PR TITLE
Send blocks in increasing order during catchup

### DIFF
--- a/protos/network.proto
+++ b/protos/network.proto
@@ -76,6 +76,9 @@ message GossipBlockRequest {
     string nonce = 2;
     uint32 time_to_live = 3;
 
+    // TODO: Better name
+    uint64 and_n_parents = 4;
+
 }
 
 message GossipBlockResponse {

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -244,12 +244,13 @@ class Gossip(object):
         self.broadcast(
             gossip_message, validator_pb2.Message.GOSSIP_MESSAGE, exclude)
 
-    def broadcast_block_request(self, block_id):
+    def broadcast_block_request(self, block_id, and_n_parents=0):
         time_to_live = self.get_time_to_live()
         block_request = GossipBlockRequest(
             block_id=block_id,
             nonce=binascii.b2a_hex(os.urandom(16)),
-            time_to_live=time_to_live)
+            time_to_live=time_to_live,
+            and_n_parents=and_n_parents)
         self.broadcast(block_request,
                        validator_pb2.Message.GOSSIP_BLOCK_REQUEST)
 

--- a/validator/tests/test_completer/mock.py
+++ b/validator/tests/test_completer/mock.py
@@ -20,7 +20,7 @@ class MockGossip():
         self.requested_batches = []
         self.requested_batches_by_txn_id = []
 
-    def broadcast_block_request(self, block_id):
+    def broadcast_block_request(self, block_id, and_n_parents=0):
         self.requested_blocks.append(block_id)
 
     def broadcast_batch_by_batch_id_request(self, batch_id):


### PR DESCRIPTION
Rather than requesting and sending blocks in decreasing order when a new
validator joins a network, send blocks in increasing order so the
validator can start processing them immediately.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>