### PR TITLE
Remove non injected batches from block before broacasting

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -141,6 +141,10 @@ class _CandidateBlock(object):
             self._scheduler.cancel()
 
     @property
+    def injected_batch_ids(self):
+        return self._injected_batch_ids
+
+    @property
     def previous_block_id(self):
         return self._block_builder.previous_block_id
 
@@ -725,6 +729,8 @@ class BlockPublisher(object):
 
                     pending_batches = []  # will receive the list of batches
                     # that were not added to the block
+                    injected_batch_ids = \
+                        self._candidate_block.injected_batch_ids
                     last_batch = self._candidate_block.last_batch
                     block = self._candidate_block.finalize_block(
                         self._identity_signer,
@@ -743,7 +749,8 @@ class BlockPublisher(object):
                     if block:
                         blkw = BlockWrapper(block)
                         LOGGER.info("Claimed Block: %s", blkw)
-                        self._block_sender.send(blkw.block)
+                        self._block_sender.send(
+                            blkw.block, keep_batches=injected_batch_ids)
                         self._blocks_published_count.inc()
 
                         # We built our candidate, disable processing until

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -159,7 +159,7 @@ class MockBlockSender(BlockSender):
     def __init__(self):
         self.new_block = None
 
-    def send(self, block):
+    def send(self, block, keep_batches=None):
         self.new_block = block
 
 


### PR DESCRIPTION
This PR removes all batches (besides injected batches) from a block before it is broadcasted to the validator network. This will be an improvement for two main reasons:

1. Most nodes are already likely to have these batches in their pending batch queues from previous gossip messages, so sending these batches is likely to repeat work.
2. This will greatly reduce the message size of broadcasted blocks.

Injected batches will still be broadcasted. At the time of broadcast, only the injecting node will have these batches, and if they were omitted from the block all other nodes would request the batches at the same time.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>
  
  