### PR TITLE
Add package manager 'dep' to solve STL-237 (add usage of a Go package manager)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@
 /sdk/examples/xo_java/target/
 /sdk/java/target/
 /sdk/go/src/sawtooth_sdk/protobuf/
+/sdk/go/src/sawtooth_sdk/vendor/
+/sdk/go/src/sawtooth_sdk/Gopkg.lock
 /sdk/go/src/mocks/
 /sdk/go/src/github.com/
 /sdk/go/bin/

--- a/sdk/go/src/sawtooth_sdk/Gopkg.toml
+++ b/sdk/go/src/sawtooth_sdk/Gopkg.toml
@@ -1,0 +1,19 @@
+[[constraint]]
+  branch = "master"
+  name = "github.com/btcsuite/btcd"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/btcsuite/btcutil"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/golang/protobuf"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/pebbe/zmq4"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/satori/go.uuid"


### PR DESCRIPTION
Regarding https://jira.hyperledger.org/browse/STL-237 the [glide doc](https://github.com/Masterminds/glide) states 

> The Go community now has the dep project to manage dependencies. Please consider trying to migrate from Glide to dep.

That's why I used [dep](https://github.com/golang/dep)  to init the go sdk. Installing `dep` and running `dep ensure` will download the latest dependencies.

The .gitignore additions are here to leave out what's autogenerated by running `dep ensure`


Signed-off-by: asettouf <adonis.settouf@gmail.com>