### PR TITLE
Add docker files for Python debugging

### DIFF
--- a/docker/compose/sawtooth-debug.yaml
+++ b/docker/compose/sawtooth-debug.yaml
@@ -1,0 +1,112 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+  sawtooth-shell:
+    build:
+      context: ../..
+      dockerfile: docker/sawtooth-debug-python
+    volumes:
+      - ../../:/project/sawtooth-core
+    image: debug-sawtooth-python
+    container_name: debug-sawtooth-shell
+    cap_add:
+      - SYS_PTRACE
+    entrypoint: |
+      bash -c "
+        sed -i 's|#!/usr/bin/env python3|#!/usr/bin/env python3-dbg|' \
+          bin/sawtooth-validator &&
+        sed -i 's|#!/usr/bin/env python3|#!/usr/bin/env python3-dbg|' \
+          bin/sawtooth-rest-api &&
+        sed -i 's|#!/usr/bin/env python3|#!/usr/bin/env python3-dbg|' \
+          bin/sawtooth &&
+        tail -f /dev/null
+      "
+
+  validator:
+    build:
+      context: ../..
+      dockerfile: docker/sawtooth-debug-python
+    volumes:
+      - ../../:/project/sawtooth-core
+    image: debug-sawtooth-python
+    container_name: debug-validator
+    cap_add:
+      - SYS_PTRACE
+    expose:
+      - 4004
+      - 8800
+    ports:
+      - "4050:4004"
+    command: |
+      bash -c "
+        sleep 3 &&
+        if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
+        sawadm keygen &&
+        sawtooth keygen my_key &&
+        sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
+        sawadm genesis config-genesis.batch
+        fi;
+        sawtooth-validator -vv \
+          --endpoint tcp://validator:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://eth0:8800
+      "
+
+  settings-tp:
+    build:
+      context: ../..
+      dockerfile: docker/sawtooth-debug-python
+    volumes:
+      - ../../:/project/sawtooth-core
+    image: debug-sawtooth-python
+    container_name: debug-settings-tp
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - validator
+    command: settings-tp -vv -C tcp://validator:4004
+
+  intkey-tp-python:
+    build:
+      context: ../..
+      dockerfile: docker/sawtooth-debug-python
+    volumes:
+      - ../../:/project/sawtooth-core
+    image: debug-sawtooth-python
+    container_name: debug-intkey-tp-python
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - validator
+    command: settings-tp -vv -C tcp://validator:4004
+
+  rest-api:
+    build:
+      context: ../..
+      dockerfile: docker/sawtooth-debug-python
+    volumes:
+      - ../../:/project/sawtooth-core
+    image: debug-sawtooth-python
+    container_name: debug-rest-api
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - validator
+    ports:
+      - "8008:8008"
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008

--- a/docker/sawtooth-debug-python
+++ b/docker/sawtooth-debug-python
@@ -1,0 +1,108 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+FROM ubuntu:xenial
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb http://repo.sawtooth.me/ubuntu/debug/ xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+    --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
+ && apt-get update \
+ && apt-get install -y -q \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    inetutils-ping \
+    libffi-dev \
+    libssl-dev \
+    python3-aiodns=1.1.1-1 \
+    python3-aiohttp>=2.3.2-1 \
+    python3-aiopg \
+    python3-async-timeout=1.2.0-1 \
+    python3-bitcoin=1.1.42-1 \
+    python3-cbor \
+    python3-cchardet=2.0a3-1 \
+    python3-chardet=2.3.0-1 \
+    python3-colorlog \
+    python3-cov-core \
+    python3-cryptography-vectors=1.7.2-1 \
+    python3-cryptography=1.7.2-1 \
+    python3-dev \
+    python3-grpcio-tools=1.1.3-1 \
+    python3-grpcio=1.1.3-1 \
+    python3-lmdb=0.92-1 \
+    python3-multidict=2.1.4-1 \
+    python3-netifaces=0.10.4-0.1build2 \
+    python3-nose2 \
+    python3-pip \
+    python3-protobuf \
+    python3-psycopg2 \
+    python3-pycares=2.1.1-1 \
+    python3-pyformance \
+    python3-pytest-runner=2.6.2-1 \
+    python3-pytest=2.9.0-1 \
+    python3-pytz=2016.10-1 \
+    python3-requests \
+    python3-secp256k1=0.13.2-1 \
+    python3-setuptools-scm=1.15.0-1 \
+    python3-six=1.10.0-1 \
+    python3-toml \
+    python3-yaml \
+    python3-yarl=0.10.0-1 \
+    python3-zmq \
+    software-properties-common \
+    gdb \
+    python3-all-dbg \
+    python3-zmq-dbg \
+    python3-cffi-backend-dbg python3-apt-dbg \
+    python3-netifaces-dbg \
+    libzmq-dbg python3-cchardet-dbg \
+    python3-grpcio-dbg \
+    python3-lmdb-dbg python3-pycares-dbg \
+    python3-secp256k1-dbg \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && pip3 install \
+    pylint \
+    pycodestyle \
+    bandit \
+    coverage --upgrade
+
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+ && add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+      $(lsb_release -cs) \
+         stable"
+
+RUN apt-get update && apt-get install -y -q \
+    docker-ce \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# EXPOSE 4004/tcp
+# EXPOSE 8008
+
+RUN mkdir -p /project/sawtooth-core/ \
+ && mkdir -p /var/log/sawtooth \
+ && mkdir -p /var/lib/sawtooth \
+ && mkdir -p /etc/sawtooth \
+ && mkdir -p /etc/sawtooth/keys
+
+ENV PATH=$PATH:/project/sawtooth-core/bin
+
+WORKDIR /project/sawtooth-core
+CMD build_python


### PR DESCRIPTION
This PR adds two files:

1. A Dockerfile that can be used to build an image with all Sawtooth dependencies, and dependencies for debugging using GDB.

2. A docker-compose file that builds the `debug-sawtooth-python` image, runs a script to change the Python interpreter to `python3-dbg` in the validator, rest api, and sawtooth scripts, and creates containers based on `debug-sawtooth-python` based on local files that run a Validator, settings tp, intkey tp, REST API, and a sawtooth shell.

The purpose of this is to allow developers to use GDB to inspect Sawtooth components.

To test:

1. `$ docker-compose -f docker/compose/sawtooth-debug.yaml up`. No building is required prior to running this command as the docker-compose file automatically builds the required image if it does not exist.

2. `$ docker ps` to view running containers.

3. Exec into the desired container. For example: `$ docker exec -it debug-validator bash`.

4. `$ ps aux` to view the running processes once you're in the container, and find the process you want to debug (it should be the validator or the REST API). It will look something like this: 
```
PID TTY      STAT   TIME COMMAND
1   ?        Ssl    0:00 python3-dbg /project/sawtooth-core/bin/sawtooth-validator -vv --endpoint tcp://validator:8800 --bind component:tcp://eth0:4004 --bind network:tcp://eth0:8800
```
5. `$ gdb -p _PID_` to attach GDB to the process

You are now attached to the process. You can use use `(gdb) bt` to see the C Python stack trace, or do something like exec into the client shell, send an intkey workload, and step through its execution on the validator.

After you are done debugging, run the following script to reset your python interpreter:

```
#!/bin/bash

sed -i 's|#!/usr/bin/env python3-dbg|#!/usr/bin/env python3|' bin/sawtooth-validator
sed -i 's|#!/usr/bin/env python3-dbg|#!/usr/bin/env python3|' bin/sawtooth-rest-api
sed -i 's|#!/usr/bin/env python3-dbg|#!/usr/bin/env python3|' bin/sawtooth
```