### PR TITLE
Request Chain Head from Peers, if None

### DIFF
--- a/integration/sawtooth_integration/tests/test_peer_list.py
+++ b/integration/sawtooth_integration/tests/test_peer_list.py
@@ -14,12 +14,12 @@
 # ------------------------------------------------------------------------------
 
 import json
-import time
 import shlex
 import logging
 import unittest
 import subprocess
 
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
@@ -35,22 +35,18 @@ EXPECTED = {
 
 
 class TestPeerList(unittest.TestCase):
+    def setUp(self):
+        endpoints = ['rest-api-{}:8008'.format(i)
+                     for i in range(len(EXPECTED))]
+
+        wait_for_rest_apis(endpoints, tries=10)
+
     def test_peer_list(self):
         '''
         Five validators are started, peered as described in EXPECTED (see
         the test's associated yaml file for details). `sawtooth peer
         list` is run against each of them and the output is verified.
         '''
-
-        # It would be preferable to use, as is normally done in
-        # integration tests, `integration_tools.wait_for_rest_apis`
-        # instead of a sleep. However, `wait_for_rest_apis` relies on
-        # a call to `/blocks`, so if a validator doesn't have any
-        # blocks, it won't respond even if it is ready. As of 12/7/17,
-        # a network with no additional transactions won't properly
-        # pass around the genesis block, so nodes not peering with the
-        # genesis node won't have any blocks.
-        time.sleep(10)
 
         for node_number, peer_numbers in EXPECTED.items():
             actual_peers = _get_peers(node_number)

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -72,6 +72,7 @@ TIME_TO_LIVE = 3
 class Gossip(object):
     def __init__(self, network,
                  settings_cache,
+                 current_chain_head_func,
                  current_root_func,
                  endpoint=None,
                  peering_mode='static',
@@ -89,6 +90,7 @@ class Gossip(object):
                 outbound network connections.
             settings_cache (state.SettingsCache): A cache for on chain
                 settings.
+            current_chain_head_func (function): returns the current chain head.
             current_root_func (function): returns the current state root hash
                 for the current chain root.
             endpoint (str): The publically accessible zmq-style uri
@@ -132,6 +134,8 @@ class Gossip(object):
         self._maximum_peer_connectivity = maximum_peer_connectivity
         self._topology_check_frequency = topology_check_frequency
         self._settings_cache = settings_cache
+
+        self._current_chain_head_func = current_chain_head_func
         self._current_root_func = current_root_func
 
         self._topology = None
@@ -364,6 +368,7 @@ class Gossip(object):
             gossip=self,
             network=self._network,
             endpoint=self._endpoint,
+            current_chain_head_func=self._current_chain_head_func,
             initial_peer_endpoints=self._initial_peer_endpoints,
             initial_seed_endpoints=self._initial_seed_endpoints,
             peering_mode=self._peering_mode,
@@ -388,6 +393,7 @@ class Gossip(object):
 
 class ConnectionManager(InstrumentedThread):
     def __init__(self, gossip, network, endpoint,
+                 current_chain_head_func,
                  initial_peer_endpoints, initial_seed_endpoints,
                  peering_mode, min_peers=3, max_peers=10,
                  check_frequency=1):
@@ -398,6 +404,7 @@ class ConnectionManager(InstrumentedThread):
             network (network.Interconnect): The underlying network.
             endpoint (str): A zmq-style endpoint uri representing
                 this validator's publically reachable endpoint.
+            current_chain_head_func (function): Returns the current chain head.
             initial_peer_endpoints ([str]): A list of static peers
                 to attempt to connect and peer with.
             initial_seed_endpoints ([str]): A list of endpoints to
@@ -419,6 +426,7 @@ class ConnectionManager(InstrumentedThread):
         self._gossip = gossip
         self._network = network
         self._endpoint = endpoint
+        self._current_chain_head_func = current_chain_head_func
         self._initial_peer_endpoints = initial_peer_endpoints
         self._initial_seed_endpoints = initial_seed_endpoints
         self._peering_mode = peering_mode
@@ -445,12 +453,29 @@ class ConnectionManager(InstrumentedThread):
         super().start()
 
     def run(self):
+        has_chain_head = self._current_chain_head_func() is not None
         while not self._stopped:
             try:
                 if self._peering_mode == 'dynamic':
                     self.retry_dynamic_peering()
                 elif self._peering_mode == 'static':
                     self.retry_static_peering()
+
+                # This tests for a degenerate case where the node is connected
+                # to peers, but at first connection no peer had a valid chain
+                # head. Keep querying connected peers until a valid chain head
+                # is received.
+                has_chain_head = has_chain_head or \
+                    self._current_chain_head_func() is not None
+                if not has_chain_head:
+                    peered_connections = self._get_peered_connections()
+                    if peered_connections:
+                        LOGGER.debug(
+                            'Have not received a chain head from peers. '
+                            'Requesting from %s',
+                            peered_connections)
+
+                        self._request_chain_head(peered_connections)
 
                 time.sleep(self._check_frequency)
             except Exception:  # pylint: disable=broad-except
@@ -473,6 +498,22 @@ class ConnectionManager(InstrumentedThread):
             except ValueError:
                 # Connection has already been disconnected.
                 pass
+
+    def _get_peered_connections(self):
+        peers = self._gossip.get_peers()
+
+        return [conn_id for conn_id in peers
+                if self._connection_statuses[conn_id] == PeerStatus.PEER]
+
+    def _request_chain_head(self, peered_connections):
+        """Request chain head from the given peer ids.
+
+        Args:
+            peered_connecions (:list:str): a list of peer connection ids where
+                the requests will be sent.
+        """
+        for conn_id in peered_connections:
+            self._gossip.send_block_request("HEAD", conn_id)
 
     def retry_dynamic_peering(self):
         self._refresh_peer_list(self._gossip.get_peers())

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -87,6 +87,10 @@ class Gossip(object):
         Args:
             network (networking.Interconnect): Provides inbound and
                 outbound network connections.
+            settings_cache (state.SettingsCache): A cache for on chain
+                settings.
+            current_root_func (function): returns the current state root hash
+                for the current chain root.
             endpoint (str): The publically accessible zmq-style uri
                 endpoint for this validator.
             peering_mode (str): The type of peering approach. Either 'static'

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -208,6 +208,7 @@ class Validator(object):
         gossip = Gossip(
             network_service,
             settings_cache,
+            lambda: block_store.chain_head,
             block_store.chain_head_state_root,
             endpoint=endpoint,
             peering_mode=peering,


### PR DESCRIPTION
In the edge case where a node that joins a new network, where the only
block produced is the genesis block, and the network is larger than the
mimimum peering threashold, the a node can be left in a state where it
has no blocks, until new blocks are published.  This leaves the node in
a precarious state, whereby it cannot publish any blocks for the batches
it receives until its network is ready.

This change modifieds the peer search to include a check for an existing
chain.  If no chain exists, it will query its connected peers until it
receives a block.

Additionally:

- Update doc string with missing params
- separate dynamic peering retry to own function