### PR TITLE
DO NOT MERGE: Revert "Move lru_cache to get_setting"

### DIFF
--- a/validator/sawtooth_validator/state/settings_view.py
+++ b/validator/sawtooth_validator/state/settings_view.py
@@ -47,7 +47,6 @@ class SettingsView(object):
         """
         self._state_view = state_view
 
-    @lru_cache(maxsize=128)
     def get_setting(self, key, default_value=None, value_type=str):
         """Get the setting stored at the given key.
 
@@ -108,6 +107,7 @@ class SettingsView(object):
         return setting_list
 
     @staticmethod
+    @lru_cache(maxsize=128)
     def setting_address(key):
         """Computes the radix address for the given setting key.
 


### PR DESCRIPTION
This change inexplicably causes nodes to produce state variations that
cause a network to immediately fork.  Removing this should return
behavoiur to normal.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>