### PR TITLE
API Change remove WIF file decoding

### DIFF
--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -532,7 +532,7 @@ def _create_role_txn(signer, role_name, policy_name):
 
 
 def _read_signer(key_filename):
-    """Reads the given file as a hex, or (as a fallback) a WIF formatted key.
+    """Reads the given file as a hex key.
 
     Args:
         key_filename: The filename where the key is stored. If None,
@@ -560,10 +560,7 @@ def _read_signer(key_filename):
     try:
         private_key = Secp256k1PrivateKey.from_hex(signing_key)
     except ParseError as e:
-        try:
-            private_key = Secp256k1PrivateKey.from_wif(signing_key)
-        except ParseError:
-            raise CliException('Unable to read key in file: {}'.format(str(e)))
+        raise CliException('Unable to read key in file: {}'.format(str(e)))
 
     context = create_context('secp256k1')
     crypto_factory = CryptoFactory(context)

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -259,7 +259,7 @@ def _get_proposals(rest_client):
 
 
 def _read_signer(key_filename):
-    """Reads the given file as a hex, or (as a fallback) a WIF formatted key.
+    """Reads the given file as a hex key.
 
     Args:
         key_filename: The filename where the key is stored. If None,
@@ -286,11 +286,8 @@ def _read_signer(key_filename):
 
     try:
         private_key = Secp256k1PrivateKey.from_hex(signing_key)
-    except ParseError:
-        try:
-            private_key = Secp256k1PrivateKey.from_wif(signing_key)
-        except ParseError as e:
-            raise CliException('Unable to read key in file: {}'.format(str(e)))
+    except ParseError as e:
+        raise CliException('Unable to read key in file: {}'.format(str(e)))
 
     context = create_context('secp256k1')
     crypto_factory = CryptoFactory(context)

--- a/cli/tests/test_admin_keygen.py
+++ b/cli/tests/test_admin_keygen.py
@@ -100,7 +100,7 @@ class TestKeygen(unittest.TestCase):
 
 
 def _read_signing_keys(key_filename):
-    """Reads the given file as a WIF formatted key.
+    """Reads the given file as a HEX formatted key.
 
     Args:
         key_filename: The filename where the key is stored.

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -24,7 +24,8 @@ from sawtooth_cli.protobuf.batch_pb2 import BatchHeader
 from sawtooth_cli.protobuf.batch_pb2 import BatchList
 
 
-TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
+PRIV_HEX = \
+    '2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088'
 
 
 class TestConfigBatchlist(unittest.TestCase):
@@ -35,10 +36,10 @@ class TestConfigBatchlist(unittest.TestCase):
     def setUp(self):
         self._temp_dir = tempfile.mkdtemp()
 
-        # create a wif key for signing
-        self._wif_file = os.path.join(self._temp_dir, 'test.priv')
-        with open(self._wif_file, 'wb') as wif:
-            wif.write(TEST_WIF.encode())
+        # create a hex key for signing
+        self._priv_file = os.path.join(self._temp_dir, 'test.priv')
+        with open(self._priv_file, 'wb') as priv:
+            priv.write(PRIV_HEX.encode())
 
     def tearDown(self):
         shutil.rmtree(self._temp_dir)
@@ -54,7 +55,7 @@ class TestConfigBatchlist(unittest.TestCase):
     def test_set_value_creates_batch_list(self):
         subprocess.run(shlex.split(
             'sawset proposal create -k {} -o {} x=1 y=1'.format(
-                self._wif_file,
+                self._priv_file,
                 os.path.join(self._temp_dir, 'myconfig.batch'))))
 
         batch_list = self._read_target_file_as(BatchList)

--- a/consensus/poet/cli/sawtooth_poet_cli/registration.py
+++ b/consensus/poet/cli/sawtooth_poet_cli/registration.py
@@ -225,7 +225,7 @@ def _create_batch(signer, transactions):
 
 
 def _read_signer(key_filename):
-    """Reads the given file as a hex, or (as a fallback) a WIF formatted key.
+    """Reads the given file as a hex key.
 
     Args:
         key_filename: The filename where the key is stored. If None,
@@ -249,11 +249,8 @@ def _read_signer(key_filename):
 
     try:
         private_key = Secp256k1PrivateKey.from_hex(signing_key)
-    except ParseError:
-        try:
-            private_key = Secp256k1PrivateKey.from_wif(signing_key)
-        except ParseError as e:
-            raise CliException('Unable to read key in file: {}'.format(str(e)))
+    except ParseError as e:
+        raise CliException('Unable to read key in file: {}'.format(str(e)))
 
     context = create_context('secp256k1')
     crypto_factory = CryptoFactory(context)

--- a/consensus/poet/families/tests/test_tp_validator_registry.py
+++ b/consensus/poet/families/tests/test_tp_validator_registry.py
@@ -30,7 +30,7 @@ from sawtooth_signing import CryptoFactory
 from sawtooth_signing.secp256k1 import Secp256k1PrivateKey
 
 
-PRIVATE = '5HsjpyQzpeoGAAvNeG5PzQsn1Ght18GgSmDaEUCd1c1HpA2avzc'
+PRIVATE = '2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088'
 
 
 class TestValidatorRegistry(TransactionProcessorTestCase):
@@ -39,7 +39,7 @@ class TestValidatorRegistry(TransactionProcessorTestCase):
     def setUpClass(cls):
         super().setUpClass()
         context = create_context('secp256k1')
-        private_key = Secp256k1PrivateKey.from_wif(PRIVATE)
+        private_key = Secp256k1PrivateKey.from_hex(PRIVATE)
         signer = CryptoFactory(context).new_signer(private_key)
 
         cls.factory = ValidatorRegistryMessageFactory(

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -54,7 +54,6 @@ RUN go get -u \
     github.com/brianolson/cbor_go \
     github.com/satori/go.uuid \
     github.com/btcsuite/btcd/btcec \
-    github.com/btcsuite/btcutil/base58 \
     github.com/jessevdk/go-flags \
     github.com/pelletier/go-toml \
     github.com/golang/mock/gomock \

--- a/families/battleship/sawtooth_battleship/battleship_client.py
+++ b/families/battleship/sawtooth_battleship/battleship_client.py
@@ -62,12 +62,9 @@ class BattleshipClient:
 
         try:
             private_key = Secp256k1PrivateKey.from_hex(private_key_str)
-        except ParseError:
-            try:
-                private_key = Secp256k1PrivateKey.from_wif(private_key_str)
-            except ParseError as e:
-                raise BattleshipException(
-                    'Unable to load private key: {}'.format(str(e)))
+        except ParseError as e:
+            raise BattleshipException(
+                'Unable to load private key: {}'.format(str(e)))
 
         self._signer = CryptoFactory(
             create_context('secp256k1')).new_signer(private_key)

--- a/integration/sawtooth_integration/docker/test_config_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_config_smoke.yaml
@@ -36,7 +36,7 @@ services:
       - 4004
       - 8800
     command: "bash -c \"\
-        echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
+        echo 2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088 > test.priv && \
         sawadm keygen && \
         sawset genesis -k test.priv -o config-genesis.batch && \
         sawadm genesis config-genesis.batch  && \

--- a/integration/sawtooth_integration/docker/test_permission.yaml
+++ b/integration/sawtooth_integration/docker/test_permission.yaml
@@ -36,7 +36,7 @@ services:
       - 40000
       - 8800
     command: "bash -c \"\
-        echo 5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv > test.priv && \
+        echo 2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088 > test.priv && \
         sawadm keygen && \
         sawset genesis -k test.priv -o setting-genesis.batch && \
         sawadm genesis setting-genesis.batch  && \

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -29,9 +29,10 @@ LOGGER = logging.getLogger(__name__)
 LOGGER.addHandler(logging.StreamHandler())
 LOGGER.setLevel(logging.DEBUG)
 
-TEST_WIF = '5Jq6nhPbVjgi9vTUuK7e2W81VT5dpQR7qPweYJZPVJKNzSornyv'
+TEST_PRIVKEY = \
+    '2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088'
 TEST_PUBKEY = \
-    '033775c26a68a3872f03314ccd080b8d8ec828572469737c7d3aa467f853a069d5'
+    '026a2c795a9776f75464aa3bda3534c3154a6e91b357b1181d3f515110f84b67c5'
 
 
 class TestConfigSmoke(unittest.TestCase):
@@ -44,10 +45,10 @@ class TestConfigSmoke(unittest.TestCase):
         self._data_dir = os.path.join(self._temp_dir, 'data')
         os.makedirs(self._data_dir)
 
-        # create a wif key for signing
-        self._wif_file = os.path.join(self._temp_dir, 'test.priv')
-        with open(self._wif_file, 'wb') as wif:
-            wif.write(TEST_WIF.encode())
+        # create a private key for signing
+        self._priv_file = os.path.join(self._temp_dir, 'test.priv')
+        with open(self._priv_file, 'wb') as priv:
+            priv.write(TEST_PRIVKEY.encode())
 
     def _run(self, args):
         try:
@@ -85,7 +86,7 @@ class TestConfigSmoke(unittest.TestCase):
             '''
         # Submit transaction, then list it using subprocess
         cmds = [
-            ['sawset', 'proposal', 'create', '-k', self._wif_file,
+            ['sawset', 'proposal', 'create', '-k', self._priv_file,
              '--url', 'http://rest-api:8008', 'x=1', 'y=1'],
             ['sawtooth', 'settings', 'list', '--url',
              'http://rest-api:8008']

--- a/perf/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth_workload/src/main.rs
@@ -121,8 +121,7 @@ fn run_batch_command(args: &ArgMatches) -> Result<(), Box<Error>> {
     buf.pop(); // remove the new line
 
     let private_key = try!(
-        Secp256k1PrivateKey::from_hex(&buf).or(
-            Secp256k1PrivateKey::from_wif(&buf)));
+        Secp256k1PrivateKey::from_hex(&buf));
     let context = try!(signing::create_context("secp256k1"));
 
     if let Err(err) = generate_signed_batches(&mut in_file, &mut out_file,

--- a/perf/smallbank_workload/src/main.rs
+++ b/perf/smallbank_workload/src/main.rs
@@ -128,8 +128,7 @@ fn run_batch_command(args: &ArgMatches) -> Result<(), Box<Error>> {
     buf.pop(); // remove the new line
 
     let private_key = try!(
-        Secp256k1PrivateKey::from_hex(&buf).or(
-            Secp256k1PrivateKey::from_wif(&buf)));
+        Secp256k1PrivateKey::from_hex(&buf));
     let context = try!(signing::create_context("secp256k1"));
 
     if let Err(err) = generate_signed_batches(&mut in_file, &mut out_file,
@@ -335,8 +334,7 @@ fn run_playlist_process_command(args: &ArgMatches) -> Result<(), Box<Error>> {
 
     let context = try!(signing::create_context("secp256k1"));
     let private_key = try!(
-        Secp256k1PrivateKey::from_hex(&buf).or(
-            Secp256k1PrivateKey::from_wif(&buf)));
+        Secp256k1PrivateKey::from_hex(&buf));
 
     try!(process_smallbank_playlist(&mut output_writer, &mut in_file,
                                     context.as_ref(), &private_key));

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
@@ -53,12 +53,9 @@ class IntkeyClient:
 
             try:
                 private_key = Secp256k1PrivateKey.from_hex(private_key_str)
-            except ParseError:
-                try:
-                    private_key = Secp256k1PrivateKey.from_wif(private_key_str)
-                except ParseError as e:
-                    raise IntkeyClientException(
-                        'Unable to load private key: {}'.format(str(e)))
+            except ParseError as e:
+                raise IntkeyClientException(
+                    'Unable to load private key: {}'.format(str(e)))
 
             self._signer = CryptoFactory(
                 create_context('secp256k1')).new_signer(private_key)

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -57,12 +57,9 @@ class XoClient:
 
         try:
             private_key = Secp256k1PrivateKey.from_hex(private_key_str)
-        except ParseError:
-            try:
-                private_key = Secp256k1PrivateKey.from_wif(private_key_str)
-            except ParseError as e:
-                raise XoException(
-                    'Unable to load private key: {}'.format(str(e)))
+        except ParseError as e:
+            raise XoException(
+                'Unable to load private key: {}'.format(str(e)))
 
         self._signer = CryptoFactory(create_context('secp256k1')) \
             .new_signer(private_key)

--- a/sdk/go/src/sawtooth_sdk/signing/secp256k1.go
+++ b/sdk/go/src/sawtooth_sdk/signing/secp256k1.go
@@ -21,9 +21,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
-	"fmt"
 	ellcurv "github.com/btcsuite/btcd/btcec"
-	"github.com/btcsuite/btcutil/base58"
 	"math/big"
 )
 
@@ -38,16 +36,6 @@ type Secp256k1PrivateKey struct {
 // Creates a PrivateKey instance from private key bytes.
 func NewSecp256k1PrivateKey(private_key []byte) PrivateKey {
 	return &Secp256k1PrivateKey{private_key}
-}
-
-// WifToSecp256k1PrivateKey converts a WIF string to a private key.
-func WifToSecp256k1PrivateKey(wif string) (*Secp256k1PrivateKey, error) {
-	priv, err := wifToPriv(wif)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Secp256k1PrivateKey{priv}, nil
 }
 
 // PemToSecp256k1PrivateKey converts a PEM string to a private key.
@@ -73,14 +61,6 @@ func (self *Secp256k1PrivateKey) AsHex() string {
 // Returns the bytes of the private key.
 func (self *Secp256k1PrivateKey) AsBytes() []byte {
 	return self.private_key
-}
-
-// Returns the private key as a WIF-encoded string.
-func (self *Secp256k1PrivateKey) AsWif() string {
-	extended := append([]byte{0x80}, self.AsBytes()...)
-	checksum := doSHA256(doSHA256(extended))[:4]
-	extcheck := append(extended, checksum...)
-	return base58.Encode(extcheck)
 }
 
 // -- Public Key --
@@ -190,18 +170,6 @@ func doSHA256(input []byte) []byte {
 	hash := sha256.New()
 	hash.Write(input)
 	return hash.Sum(nil)
-}
-
-// -- WIF --
-
-func wifToPriv(wif string) (key []byte, err error) {
-	defer func() {
-		if recover() != nil {
-			err = fmt.Errorf("Failed to load WIF key")
-		}
-	}()
-	extcheck := base58.Decode(wif)
-	return extcheck[1 : len(extcheck)-4], nil
 }
 
 func pemToPriv(pem string, password string) ([]byte, error) {

--- a/sdk/go/tests/secp256k1_test.go
+++ b/sdk/go/tests/secp256k1_test.go
@@ -18,7 +18,6 @@
 package tests
 
 import (
-	"encoding/hex"
 	. "sawtooth_sdk/signing"
 	"testing"
 )
@@ -44,7 +43,6 @@ L/8e9mXvEQPAmBC0NMiltnk4/26iN7hB1QxSQQwy/Zc=
 	ENCPEMPRIV = "2cc32bc33935a5dbad8118abc63dfb627bb91a98d5e6310f5d60f5d65f6adb2f"
 	PEMPUBSTR  = "03582e93c8cd63a58bb77ff18622e92d0e4e27335ab239ff4f10f1e446437cccad"
 	ENCPEMPUB  = "0257510b4718fd79b21dee3173ffb48ab9a668a35a377be7b7dc432243a940c510"
-	WIFSTR     = "5J7bEeWs14sKkz7yVHfVc2FXKfBe6Hb5oNZxxTKqKZCgjbDTuUj"
 	PUBSTR     = "035e1de3048a62f9f478440a22fd7655b80f0aac997be963b119ac54b3bfdea3b7"
 	SIGSTR     = "0062bc154dca72472e66062c4539c8befb2680d79d59b3cc539dd182ff36072b199adc1118db5fc1884d50cdec9d31a2356af03175439ccb841c7b0e3ae83297"
 )
@@ -84,30 +82,6 @@ func TestSigning(t *testing.T) {
 func assertSecp256k1(name string, t *testing.T) {
 	if name != "secp256k1" {
 		t.Error("Wrong name", name)
-	}
-}
-
-func TestEncoding(t *testing.T) {
-	priv, err := WifToSecp256k1PrivateKey(WIFSTR)
-	if err != nil {
-		t.Error("Failed to load WIF key")
-	}
-
-	if priv.AsWif() != WIFSTR {
-		t.Error("Private key is different after encoding/decoding")
-	}
-
-	context := NewSecp256k1Context()
-
-	pubhex := context.GetPublicKey(priv).AsHex()
-
-	if pubhex != PUBSTR {
-		t.Error("Public key doesn't match expected. Got", pubhex, PUBSTR)
-	}
-
-	sigstr := hex.EncodeToString(context.Sign(data, priv))
-	if sigstr != SIGSTR {
-		t.Error("Signature doesn't match expected. Got", sigstr)
 	}
 }
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -22,7 +22,6 @@ authors = ["sawtooth"]
 protobuf="1.4.1"
 secp256k1 = "0.7.1"
 rust-crypto = "0.2.36"
-rust-base58 = "0.0.4"
 zmq = "0.8"
 uuid = { version = "0.5", features = ["v4"] }
 log = "0.3"

--- a/signing/sawtooth_signing/secp256k1.py
+++ b/signing/sawtooth_signing/secp256k1.py
@@ -17,7 +17,6 @@ import binascii
 import warnings
 
 import secp256k1
-import bitcoin as pybitcointools
 
 from sawtooth_signing.core import SigningError
 from sawtooth_signing.core import ParseError
@@ -47,18 +46,6 @@ class Secp256k1PrivateKey(PrivateKey):
     @property
     def secp256k1_private_key(self):
         return self._private_key
-
-    @staticmethod
-    def from_wif(wif):
-        """Decodes a PrivateKey from a wif-encoded string
-        """
-        try:
-            priv = pybitcointools.encode_privkey(wif, 'hex')
-            priv = binascii.unhexlify(priv)
-            return Secp256k1PrivateKey(
-                secp256k1.PrivateKey(priv, ctx=__CTX__))
-        except Exception as e:
-            raise ParseError('Unable to parse wif key: {}'.format(e))
 
     @staticmethod
     def from_hex(hex_str):

--- a/signing/setup.py
+++ b/signing/setup.py
@@ -27,7 +27,6 @@ setup(
     url='https://github.com/hyperledger/sawtooth-core',
     packages=find_packages(),
     install_requires=[
-        "bitcoin",
         "secp256k1",
     ],
     data_files=[],

--- a/signing/tests/test_secp256k1_signer.py
+++ b/signing/tests/test_secp256k1_signer.py
@@ -22,13 +22,11 @@ from sawtooth_signing.secp256k1 import Secp256k1PrivateKey
 from sawtooth_signing.secp256k1 import Secp256k1PublicKey
 
 
-KEY1_PRIV_WIF = "5JB3B6o5cbtYfgabgNKDwyYjs58jgUwCLDopNuS5QQdaGv1EHt2"
 KEY1_PRIV_HEX = \
     "2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088"
 KEY1_PUB_HEX = \
     "026a2c795a9776f75464aa3bda3534c3154a6e91b357b1181d3f515110f84b67c5"
 
-KEY2_PRIV_WIF = "5JSH1DMki8kDYeApoXYDJ6DcAyf9JpZhoQQVMBbNw9zpSEqM1QB"
 KEY2_PRIV_HEX = \
     "51b845c2cdde22fe646148f0b51eaf5feec8c82ee921d5e0cbe7619f3bb9c62d"
 KEY2_PUB_HEX = \
@@ -54,15 +52,6 @@ class Secp256k1SigningTest(unittest.TestCase):
         pub_key = Secp256k1PublicKey.from_hex(KEY1_PUB_HEX)
         self.assertEqual(pub_key.get_algorithm_name(), "secp256k1")
         self.assertEqual(pub_key.as_hex(), KEY1_PUB_HEX)
-
-    def test_wif_key(self):
-        priv_key1 = Secp256k1PrivateKey.from_wif(KEY1_PRIV_WIF)
-        self.assertEqual(priv_key1.get_algorithm_name(), "secp256k1")
-        self.assertEqual(priv_key1.as_hex(), KEY1_PRIV_HEX)
-
-        priv_key2 = Secp256k1PrivateKey.from_wif(KEY2_PRIV_WIF)
-        self.assertEqual(priv_key2.get_algorithm_name(), "secp256k1")
-        self.assertEqual(priv_key2.as_hex(), KEY2_PRIV_HEX)
 
     def test_priv_to_public_key(self):
         context = create_context("secp256k1")

--- a/validator/sawtooth_validator/server/keys.py
+++ b/validator/sawtooth_validator/server/keys.py
@@ -54,12 +54,9 @@ def load_identity_signer(key_dir, key_name):
 
     try:
         private_key = Secp256k1PrivateKey.from_hex(private_key_str)
-    except signing.ParseError:
-        try:
-            private_key = Secp256k1PrivateKey.from_wif(private_key_str)
-        except signing.ParseError as e:
-            raise LocalConfigurationError(
-                "Invalid key in file {}: {}".format(key_path, str(e)))
+    except signing.ParseError as e:
+        raise LocalConfigurationError(
+            "Invalid key in file {}: {}".format(key_path, str(e)))
 
     context = signing.create_context('secp256k1')
     crypto_factory = CryptoFactory(context)


### PR DESCRIPTION
Remove WIF as an option in CLI's and libraries.
Remove supporting libraries incl. pybitcointools and base58
WIF was originally used in Sawtooth because of some ease of using
bitcoin signing libraries. It's since been deprecated in Sawtooth.
Finally, there were concerns raised about some of the requisite libraries
including end of life of pybitcointools.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>