### PR TITLE
Make Settings View LRU Cache per Instance

### DIFF
--- a/validator/sawtooth_validator/state/settings_view.py
+++ b/validator/sawtooth_validator/state/settings_view.py
@@ -47,8 +47,13 @@ class SettingsView(object):
         """
         self._state_view = state_view
 
-    @lru_cache(maxsize=128)
-    def get_setting(self, key, default_value=None, value_type=str):
+        # The public method for get_settings should have its results memoized
+        # via an lru_cache.  Typical use of the decorator results in the
+        # cache being global, which can cause views to return incorrect
+        # values across state root hash boundaries.
+        self.get_setting = lru_cache(maxsize=128)(self._get_setting)
+
+    def _get_setting(self, key, default_value=None, value_type=str):
         """Get the setting stored at the given key.
 
         Args:
@@ -108,6 +113,7 @@ class SettingsView(object):
         return setting_list
 
     @staticmethod
+    @lru_cache(maxsize=128)
     def setting_address(key):
         """Computes the radix address for the given setting key.
 


### PR DESCRIPTION
Use of lru_cache on SettingsView.get_setting created a global setting
cache, which cuased the networks to fork for a significant amount of
time, early in their runs.  Changing this to a per-instance cache, which
was the original intention, fixes the issue.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>