### PR TITLE
Add a from_state option to identity cache

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -273,7 +273,7 @@ class BlockValidator(object):
 
             for batch in blkw.batches:
                 if not self._permission_verifier.is_batch_signer_authorized(
-                        batch, state_root):
+                        batch, state_root, from_state=True):
                     return False
         return True
 

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -268,7 +268,8 @@ def CreateSetting(key, value):
 
 
 class MockPermissionVerifier(object):
-    def is_batch_signer_authorized(self, batch, state_root=None):
+    def is_batch_signer_authorized(self, batch, state_root=None,
+                                   from_state=False):
         return True
 
 


### PR DESCRIPTION
This will remove the case where a value in the cache could
be replaced by an outdated value while validating an old
block. Instead the value will be checked from state and it
will not be added to the cache.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>