### PR TITLE
Create new sawadm blockstore command (in rust)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@
 /consensus/poet/sgx/sawtooth_poet_sgx/libpoet_enclave/cmake_install.cmake
 
 # Everything else
+/adm/Cargo.lock
+/adm/target/
+
 /build/
 
 /cli/build/

--- a/adm/Cargo.toml
+++ b/adm/Cargo.toml
@@ -20,6 +20,7 @@ authors = ["sawtooth"]
 
 [dependencies]
 clap = ">=2.29.0"
+libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
 protobuf = "1.4.1"
 sawtooth_sdk = { path = "../sdk/rust" }

--- a/adm/Cargo.toml
+++ b/adm/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+[package]
+name = "sawadm"
+version = "0.1.0"
+authors = ["sawtooth"]
+
+[dependencies]
+clap = ">=2.29.0"
+lmdb-zero = ">=0.4.1"
+protobuf = "1.4.1"
+sawtooth_sdk = { path = "../sdk/rust" }
+serde = "1.0"
+serde_derive = "1.0"
+serde_yaml = "0.7"

--- a/adm/packaging/ubuntu/changelog
+++ b/adm/packaging/ubuntu/changelog
@@ -1,0 +1,5 @@
+sawadm (@VERSION@) unstable; urgency=low
+
+  * change data here
+
+  -- Hyperledger Sawtooth <HyperledgerSawtooth@gmail.com>

--- a/adm/packaging/ubuntu/control
+++ b/adm/packaging/ubuntu/control
@@ -1,0 +1,11 @@
+Source: sawadm
+Maintainer: Hyperledger Sawtooth <unknown@unknown>
+Section: rust
+Priority: optional
+Standards-Version: 3.9.6
+Homepage: https://github.com/hyperledger/sawtooth-core
+Package: sawtooth-admin-tools
+Architecture: all
+Depends: libssl-dev, libzmq3-dev
+Description: Sawtooth Admin Tools
+Version: @VERSION@

--- a/adm/packaging/ubuntu/postinst
+++ b/adm/packaging/ubuntu/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
-#
-# Copyright 2017 Intel Corporation
+
+# Copyright 2018 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,18 +17,13 @@
 
 set -e
 
-top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+user="sawtooth"
+group="sawtooth"
 
-echo -e "\033[0;32m--- Building Rust SDK ---\n\033[0m"
-cd $top_dir/sdk/rust/
-cargo build
+if ! getent group $group > /dev/null; then
+    addgroup --quiet --system $group
+fi
 
-echo -e "\033[0;32m--- Building sawadm ---\n\033[0m"
-cd $top_dir/adm
-cargo build
-
-# echo -e "\033[0;32m--- Building intkey-tp-rust ---\n\033[0m"
-
-# echo -e "\033[0;32m--- Building xo-tp-rust ---\n\033[0m"
-
-# echo -e "\033[0;32m--- Building noop-tp-rust ---\n\033[0m"
+if ! getent passwd $user > /dev/null; then
+    adduser --quiet --system --ingroup $group $user
+fi

--- a/adm/src/blockstore.rs
+++ b/adm/src/blockstore.rs
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use protobuf;
+use protobuf::Message;
+use sawtooth_sdk::messages::block::{Block, BlockHeader};
+
+use database::database::DatabaseError;
+use database::lmdb::LmdbDatabase;
+
+pub struct Blockstore<'a> {
+    db: LmdbDatabase<'a>,
+}
+
+impl<'a> Blockstore<'a> {
+    pub fn new(db: LmdbDatabase<'a>) -> Self {
+        Blockstore{
+            db: db,
+        }
+    }
+
+    pub fn get(&self, block_id: &str) -> Result<Block, DatabaseError> {
+        let reader = self.db.reader()?;
+        let packed = reader.get(&block_id.as_bytes())
+            .ok_or(DatabaseError::NotFoundError(format!("Block not found: {}", block_id)))?;
+        let block: Block = protobuf::parse_from_bytes(&packed)
+            .map_err(|err|
+                DatabaseError::CorruptionError(
+                    format!("Could not interpret stored data as a block: {}", err)))?;
+        Ok(block)
+    }
+
+    pub fn put(&self, block: Block) -> Result<(), DatabaseError> {
+        let block_header: BlockHeader = protobuf::parse_from_bytes(&block.header).map_err(|err|
+            DatabaseError::CorruptionError(format!("Invalid block header: {}", err)))?;
+        let mut writer = self.db.writer()?;
+        // Add block to main db
+        let packed = block.write_to_bytes().map_err(|err|
+            DatabaseError::WriterError(format!("Failed to serialize block: {}", err)))?;
+        writer.put(&block.header_signature.as_bytes(), &packed)?;
+
+        // Add block to block num index
+        let block_num_index = format!("0x{:0>16x}", block_header.block_num);
+        writer.index_put("index_block_num", &block_num_index.as_bytes(), &block.header_signature.as_bytes())?;
+
+        for batch in block.batches.iter() {
+            for txn in batch.transactions.iter() {
+                writer.index_put(
+                    "index_transaction",
+                    &txn.header_signature.as_bytes(),
+                    &block.header_signature.as_bytes())?;
+            }
+        }
+
+        // Add block to batch index
+        for batch in block.batches.iter() {
+            writer.index_put(
+                "index_batch",
+                &batch.header_signature.as_bytes(),
+                &block.header_signature.as_bytes())?;
+        }
+
+        writer.commit()
+    }
+
+    pub fn delete(&self, block_id: &str) -> Result<(), DatabaseError> {
+        let block = self.get(block_id)?;
+        let block_id = &block.header_signature;
+        let block_header: BlockHeader = protobuf::parse_from_bytes(&block.header).map_err(|err|
+            DatabaseError::CorruptionError(format!("Invalid block header: {}", err)))?;
+        // Delete block from main db
+        let mut writer = self.db.writer()?;
+        writer.delete(&block_id.as_bytes())?;
+
+        // Delete block from block_num index
+        let block_num_index = format!("0x{:0>16x}", block_header.block_num);
+        writer.index_delete("index_block_num", &block_num_index.as_bytes())?;
+
+        // Delete block from transaction index
+        for batch in block.batches.iter() {
+            for txn in batch.transactions.iter() {
+                writer.index_delete("index_transaction", &txn.header_signature.as_bytes())?;
+            }
+        }
+
+        // Delete block from batch index
+        for batch in block.batches.iter() {
+            writer.index_delete("index_batch", &batch.header_signature.as_bytes())?;
+        }
+        writer.commit()
+    }
+
+    /// Get the header signature of the highest block in the blockstore.
+    pub fn get_chain_head(&self) -> Result<String, DatabaseError> {
+        let reader = self.db.reader()?;
+        let mut cursor = reader.index_cursor("index_block_num")?;
+        let (_, val) = cursor.last().ok_or(
+            DatabaseError::NotFoundError("No chain head".into()))?;
+        String::from_utf8(val.into()).map_err(|err|
+            DatabaseError::CorruptionError(format!("Chain head block id is corrupt: {}", err)))
+    }
+}

--- a/adm/src/commands/blockstore.rs
+++ b/adm/src/commands/blockstore.rs
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::io::{self, Write};
+use std::fs::File;
+use std::io::prelude::*;
+
+use clap::ArgMatches;
+use protobuf;
+use protobuf::Message;
+use serde_yaml;
+
+use sawtooth_sdk::messages::block::{Block, BlockHeader};
+
+use blockstore::Blockstore;
+use database::lmdb;
+use database::database::DatabaseError;
+use err::{CliError};
+use config;
+use wrappers::Block as BlockWrapper;
+
+pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    match args.subcommand() {
+        ("list", Some(args)) => run_list_command(args),
+        ("show", Some(args)) => run_show_command(args),
+        ("prune", Some(args)) => run_prune_command(args),
+        ("export", Some(args)) => run_export_command(args),
+        ("import", Some(args)) => run_import_command(args),
+        _ => { println!("Invalid subcommand; Pass --help for usage."); Ok(()) },
+    }
+}
+
+fn run_list_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let ctx = create_context()?;
+    let blockstore = open_blockstore(&ctx)?;
+
+    let mut count = u64::from_str_radix(args.value_of("count").unwrap_or("100"), 10).unwrap();
+
+    // Get the chain head
+    let head_sig = match args.value_of("start") {
+        None => blockstore.get_chain_head().map_err(|err|
+            CliError::EnvironmentError(format!("{}", err))),
+        Some(sig) => Ok(sig.into()),
+    }?;
+
+    // Walk back from the chain head
+    let mut block_id = head_sig;
+    print_block_store_list_header();
+
+    while block_id != "0000000000000000" && count > 0 {
+        let block = blockstore.get(&block_id).map_err(|err|
+            CliError::EnvironmentError(format!("{}", err)))?;
+        let block_header: BlockHeader = protobuf::parse_from_bytes(&block.header)
+            .map_err(|err| CliError::ParseError(format!("{}", err)))?;
+        let batches = block.batches.len();
+        let txns = block.batches.iter().fold(0, |acc, batch| acc + batch.transactions.len());
+        print_block_store_list_row(
+            block_header.block_num,
+            &block.header_signature,
+            batches, txns,
+            &block_header.signer_public_key);
+        block_id = block_header.previous_block_id;
+        count -= 1;
+    }
+    Ok(())
+}
+
+fn print_block_store_list_header() {
+    println!(
+        "{:<5} {:<128} {:<5} {:<5} {}",
+        "NUM", "BLOCK_ID", "BATS", "TXNS", "SIGNER");
+}
+
+fn print_block_store_list_row(block_num: u64, block_id: &str, batches: usize, txns: usize, signer: &str) {
+    println!(
+        "{:<5} {:<128} {:<5} {:<5} {}...",
+        block_num, block_id, batches, txns, &signer[..6]);
+}
+
+fn run_show_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let ctx = create_context()?;
+    let blockstore = open_blockstore(&ctx)?;
+
+    let block_id = args.value_of("block").ok_or(CliError::ArgumentError("No block id".into()))?;
+
+    let block = blockstore.get(block_id).map_err(|_|
+        CliError::ArgumentError(format!("Block not found: {}", block_id)))?;
+
+    let block_wrapper = BlockWrapper::try_from(block).map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
+    let block_yaml = serde_yaml::to_string(&block_wrapper).map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
+    println!("{}", block_yaml);
+    Ok(())
+}
+
+fn run_prune_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let ctx = create_context()?;
+    let blockstore = open_blockstore(&ctx)?;
+
+    let block_id = args.value_of("block").ok_or(CliError::ArgumentError("No block id".into()))?;
+
+    blockstore.get(block_id).map_err(|_|
+        CliError::ArgumentError(format!("Block not found: {}", block_id)))?;
+
+    // Get the chain head
+    let chain_head = blockstore.get_chain_head()
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+    let mut current = blockstore.get(&chain_head)
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+    loop {
+        blockstore.delete(&current.header_signature)
+            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+        if current.header_signature == block_id {
+            break;
+        }
+        let header: BlockHeader = protobuf::parse_from_bytes(&current.header)
+            .map_err(|err| CliError::ParseError(format!("{}", err)))?;
+
+        current = blockstore.get(&header.previous_block_id)
+            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+    }
+    Ok(())
+}
+
+fn run_export_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let ctx = create_context()?;
+    let blockstore = open_blockstore(&ctx)?;
+
+    let block_id = args.value_of("block").ok_or(CliError::ArgumentError("No block id".into()))?;
+
+    let block = blockstore.get(block_id).map_err(|_|
+        CliError::ArgumentError(format!("Block not found: {}", block_id)))?;
+
+    let packed = block.write_to_bytes().map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    handle.write(&packed)
+        .map(|_| ())
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
+}
+
+fn run_import_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let ctx = create_context()?;
+    let blockstore = open_blockstore(&ctx)?;
+
+    let filepath = args.value_of("blockfile").ok_or(CliError::ArgumentError("No file".into()))?;
+    let mut file = File::open(filepath).map_err(|err|
+        CliError::EnvironmentError(format!("Failed to open file: {}", err)))?;
+    let mut packed = Vec::new();
+    file.read_to_end(&mut packed).map_err(|err|
+        CliError::EnvironmentError(format!("Failed to read file: {}", err)))?;
+
+    let block: Block = protobuf::parse_from_bytes(&packed)
+        .map_err(|err| CliError::ParseError(format!("{}", err)))?;
+    let block_header: BlockHeader = protobuf::parse_from_bytes(&block.header)
+        .map_err(|err| CliError::ParseError(format!("{}", err)))?;
+    let block_id = block.header_signature.clone();
+
+    // Ensure this block is an immediate child of the current chain head
+    match blockstore.get_chain_head() {
+        Ok(chain_head) => {
+            if block_header.previous_block_id != chain_head {
+                return Err(CliError::ArgumentError(format!(
+                    "New block must be an immediate child of the current chain head: {}",
+                    chain_head)))
+            }
+        },
+        Err(DatabaseError::NotFoundError(_)) => (),
+        Err(err) => {
+            return Err(CliError::EnvironmentError(format!("{}", err)));
+        },
+    }
+
+    blockstore.put(block).map_err(|err|
+        CliError::ArgumentError(format!("Failed to put block into database: {}", err)))?;
+
+    println!("Block {} added", block_id);
+    Ok(())
+}
+
+fn create_context() -> Result<lmdb::LmdbContext, CliError> {
+    let path_config = config::get_path_config();
+    let blockstore_path = &path_config.data_dir.join(config::get_blockstore_filename());
+
+    lmdb::LmdbContext::new(blockstore_path, 3, None)
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
+}
+
+fn open_blockstore<'a>(ctx: &'a lmdb::LmdbContext) -> Result<Blockstore<'a>, CliError> {
+    let blockstore_db = lmdb::LmdbDatabase::new(ctx, &["index_batch", "index_transaction", "index_block_num"])
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+    Ok(Blockstore::new(blockstore_db))
+}

--- a/adm/src/commands/genesis.rs
+++ b/adm/src/commands/genesis.rs
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path};
+
+use clap::ArgMatches;
+use protobuf;
+use protobuf::Message;
+
+use sawtooth_sdk::messages::batch::{Batch, BatchList};
+use sawtooth_sdk::messages::genesis::{GenesisData};
+use sawtooth_sdk::messages::transaction::{TransactionHeader};
+
+use config;
+use err::{CliError};
+
+pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let genesis_file_path = if args.is_present("output") {
+        args.value_of("output")
+            .ok_or(CliError::ArgumentError(format!("Failed to read `output` arg")))
+            .map(|pathstr| Path::new(pathstr).to_path_buf())
+    } else {
+        Ok(config::get_path_config().data_dir.join("genesis.batch"))
+    }?;
+
+    if genesis_file_path.exists() {
+        return Err(CliError::EnvironmentError(format!("File already exists: {:?}", genesis_file_path)));
+    }
+
+    let input_files = args.values_of("input_file")
+        .ok_or(CliError::ArgumentError("No input files passed".into()))?;
+
+    let batch_lists = input_files.map(|filepath| {
+            let mut file = File::open(filepath).map_err(|err|
+                CliError::EnvironmentError(format!("Failed to open file: {}", err)))?;
+            let mut packed = Vec::new();
+            file.read_to_end(&mut packed).map_err(|err|
+                CliError::EnvironmentError(format!("Failed to read file: {}", err)))?;
+            let batch_list: BatchList = protobuf::parse_from_bytes(&packed).map_err(|err|
+                CliError::ArgumentError(format!("Unable to read {}: {}", filepath, err)))?;
+            Ok(batch_list)})
+        .collect::<Result<Vec<BatchList>, CliError>>()?;
+
+    let batches = batch_lists.into_iter().fold(Vec::new(), |mut batches, batch_list| {
+        batches.extend(batch_list.batches.into_iter());
+        batches
+    });
+
+    validate_depedencies(&batches)?;
+
+    let mut genesis_data = GenesisData::new();
+    genesis_data.set_batches(protobuf::RepeatedField::from_vec(batches));
+
+    let buf = genesis_data.write_to_bytes().map_err(|err|
+        CliError::ArgumentError(format!("Failed to convert BatchLists to GenesisData: {}", err)))?;
+
+    let mut genesis_data_file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .mode(0o640)
+        .open(genesis_file_path.as_path())
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+    genesis_data_file.write(&buf)
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+    Ok(())
+}
+
+fn validate_depedencies(batches: &[Batch]) -> Result<(), CliError> {
+    let mut txn_ids: Vec<String> = Vec::new();
+    for batch in batches.iter() {
+        for txn in batch.transactions.iter() {
+            let header: TransactionHeader = protobuf::parse_from_bytes(&txn.header).map_err(|err|
+                CliError::ArgumentError(format!(
+                    "Invalid transaction header for txn {}: {}", &txn.header_signature, err)))?;
+            for dep in header.dependencies.iter() {
+                if !txn_ids.contains(dep) {
+                    return Err(CliError::ArgumentError(format!(
+                        "Unsatisfied dependency in given transaction {}: {}",
+                        &txn.header_signature, dep)));
+                }
+                txn_ids.push(dep.clone())
+            }
+        }
+    }
+    Ok(())
+}

--- a/adm/src/commands/keygen.rs
+++ b/adm/src/commands/keygen.rs
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::ffi::CString;
+use std::fs::{metadata, OpenOptions};
+use std::io::prelude::*;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+use clap::ArgMatches;
+use libc;
+
+use sawtooth_sdk::signing;
+
+use config;
+use err::{CliError};
+
+pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
+    let path_config = config::get_path_config();
+    let key_dir = &path_config.key_dir;
+    if !key_dir.exists() {
+        return Err(CliError::EnvironmentError(
+            format!("Key directory does not exist: {:?}", key_dir)));
+    }
+
+    let key_name = args.value_of("key_name").unwrap_or("validator");
+    let private_key_path = key_dir.join(key_name).with_extension("priv");
+    let public_key_path = key_dir.join(key_name).with_extension("pub");
+
+
+    if !args.is_present("force") {
+        if private_key_path.exists() {
+            return Err(CliError::EnvironmentError(
+                format!("file exists: {:?}", private_key_path)));
+        }
+        if public_key_path.exists() {
+            return Err(CliError::EnvironmentError(
+                format!("file exists: {:?}", public_key_path)));
+        }
+    }
+
+    let context = signing::create_context("secp256k1").map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
+    let private_key = context.new_random_private_key().map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+    let public_key = context.get_public_key(&*private_key).map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
+    let key_dir_info = metadata(key_dir).map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+    let key_dir_uid = key_dir_info.st_uid();
+    let key_dir_gid = key_dir_info.st_gid();
+
+    {
+        if private_key_path.exists() {
+            println!("overwriting file: {:?}", private_key_path);
+        } else {
+            println!("writing file: {:?}", private_key_path);
+        }
+        let mut private_key_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .mode(0o640)
+            .open(private_key_path.as_path())
+            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+        private_key_file.write(private_key.as_hex().as_bytes()).map_err(|err|
+            CliError::EnvironmentError(format!("{}", err)))?;
+    }
+
+    {
+        if public_key_path.exists() {
+            println!("overwriting file: {:?}", public_key_path);
+        } else {
+            println!("writing file: {:?}", public_key_path);
+        }
+        let mut public_key_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .mode(0o640)
+            .open(public_key_path.as_path())
+            .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
+
+        public_key_file.write(public_key.as_hex().as_bytes()).map_err(|err|
+            CliError::EnvironmentError(format!("{}", err)))?;
+    }
+
+    chown(private_key_path.as_path(), key_dir_uid, key_dir_gid)?;
+    chown(public_key_path.as_path(), key_dir_uid, key_dir_gid)?;
+    Ok(())
+}
+
+fn chown(path: &Path, uid: u32, gid: u32) -> Result<(), CliError> {
+    let pathstr = path.to_str().ok_or(
+        CliError::EnvironmentError(format!("Invalid path: {:?}", path)))?;
+    let cpath = CString::new(pathstr).map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+    let result = unsafe {
+        libc::chown(cpath.as_ptr(), uid, gid)
+    };
+    match result {
+        0 => Ok(()),
+        code =>
+            Err(CliError::EnvironmentError(format!("Error chowning file {}: {}", pathstr, code))),
+    }
+}

--- a/adm/src/commands/mod.rs
+++ b/adm/src/commands/mod.rs
@@ -16,3 +16,5 @@
  */
 
 pub mod blockstore;
+pub mod keygen;
+pub mod genesis;

--- a/adm/src/commands/mod.rs
+++ b/adm/src/commands/mod.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+pub mod blockstore;

--- a/adm/src/config.rs
+++ b/adm/src/config.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::env;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_CONFIG_DIR: &'static str = "/etc/sawtooth";
+const DEFAULT_LOG_DIR: &'static str = "/var/log/sawtooth";
+const DEFAULT_DATA_DIR: &'static str = "/var/lib/sawtooth";
+const DEFAULT_KEY_DIR: &'static str = "/etc/sawtooth/keys";
+const DEFAULT_POLICY_DIR: &'static str = "/etc/sawtooth/policy";
+
+const DEFAULT_BLOCKSTORE_FILENAME: &'static str = "block-00.lmdb";
+
+pub struct PathConfig {
+    pub config_dir: PathBuf,
+    pub log_dir: PathBuf,
+    pub data_dir: PathBuf,
+    pub key_dir: PathBuf,
+    pub policy_dir: PathBuf,
+}
+
+pub fn get_path_config() -> PathConfig {
+    match env::var("SAWTOOTH_HOME") {
+        Ok(prefix) => PathConfig{
+            config_dir: Path::new(&prefix).join("etc").to_path_buf(),
+            log_dir: Path::new(&prefix).join("logs").to_path_buf(),
+            data_dir: Path::new(&prefix).join("data").to_path_buf(),
+            key_dir: Path::new(&prefix).join("keys").to_path_buf(),
+            policy_dir: Path::new(&prefix).join("policy").to_path_buf(),
+        },
+        Err(_) => PathConfig{
+            config_dir: Path::new(DEFAULT_CONFIG_DIR).to_path_buf(),
+            log_dir: Path::new(DEFAULT_LOG_DIR).to_path_buf(),
+            data_dir: Path::new(DEFAULT_DATA_DIR).to_path_buf(),
+            key_dir: Path::new(DEFAULT_KEY_DIR).to_path_buf(),
+            policy_dir: Path::new(DEFAULT_POLICY_DIR).to_path_buf(),
+        },
+    }
+}
+
+pub fn get_blockstore_filename() -> String {
+    String::from(DEFAULT_BLOCKSTORE_FILENAME)
+}

--- a/adm/src/database/database.rs
+++ b/adm/src/database/database.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std;
+
+#[derive(Debug)]
+pub enum DatabaseError {
+    InitError(String),
+    ReaderError(String),
+    WriterError(String),
+    CorruptionError(String),
+    NotFoundError(String),
+}
+
+impl std::fmt::Display for DatabaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DatabaseError::InitError(ref msg) => write!(f, "InitError: {}",  msg),
+            DatabaseError::ReaderError(ref msg) => write!(f, "ReaderError: {}",  msg),
+            DatabaseError::WriterError(ref msg) => write!(f, "WriterError: {}",  msg),
+            DatabaseError::CorruptionError(ref msg) => write!(f, "CorruptionError: {}",  msg),
+            DatabaseError::NotFoundError(ref msg) => write!(f, "NotFoundError: {}",  msg),
+        }
+    }
+}
+
+impl std::error::Error for DatabaseError {
+    fn description(&self) -> &str {
+        match *self {
+            DatabaseError::InitError(ref msg) => msg,
+            DatabaseError::ReaderError(ref msg) => msg,
+            DatabaseError::WriterError(ref msg) => msg,
+            DatabaseError::CorruptionError(ref msg) => msg,
+            DatabaseError::NotFoundError(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+        match * self {
+            DatabaseError::InitError(_) => None,
+            DatabaseError::ReaderError(_) => None,
+            DatabaseError::WriterError(_) => None,
+            DatabaseError::CorruptionError(_) => None,
+            DatabaseError::NotFoundError(_) => None,
+        }
+    }
+}

--- a/adm/src/database/lmdb.rs
+++ b/adm/src/database/lmdb.rs
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use lmdb_zero as lmdb;
+
+use database::database::DatabaseError;
+
+const DEFAULT_SIZE: usize = 1 << 40; // 1024 ** 4
+
+pub struct LmdbContext {
+    pub env: lmdb::Environment,
+}
+
+impl LmdbContext {
+    pub fn new(filepath: &Path, indexes: u32, size: Option<usize>) -> Result<Self, DatabaseError> {
+        let flags = lmdb::open::MAPASYNC | lmdb::open::WRITEMAP | lmdb::open::NOSUBDIR;
+
+        let filepath_str = filepath.to_str()
+            .ok_or(DatabaseError::InitError(format!("Invalid filepath: {:?}", filepath)))?;
+
+        let mut builder = lmdb::EnvBuilder::new().map_err(|err|
+            DatabaseError::InitError(format!("Failed to initialize environment: {}", err)))?;
+        builder.set_maxdbs(indexes + 1).map_err(|err|
+            DatabaseError::InitError(format!("Failed to set MAX_DBS: {}", err)))?;
+        builder.set_mapsize(size.unwrap_or(DEFAULT_SIZE)).map_err(|err|
+            DatabaseError::InitError(format!("Failed to set MAP_SIZE: {}", err)))?;
+
+        let env = unsafe {
+                builder.open(filepath_str, flags, 0o600)
+                    .map_err(|err|
+                        DatabaseError::InitError(format!("Database not found: {}", err)))
+        }?;
+        Ok(LmdbContext{
+            env: env
+        })
+    }
+}
+
+pub struct LmdbDatabase<'e> {
+    ctx:     &'e LmdbContext,
+    main:    lmdb::Database<'e>,
+    indexes: HashMap<String, lmdb::Database<'e>>,
+}
+
+impl<'e> LmdbDatabase<'e> {
+    pub fn new(ctx: &'e LmdbContext, indexes: &[&str]) -> Result<Self, DatabaseError> {
+        let main = lmdb::Database::open(
+            &ctx.env, Some("main"), &lmdb::DatabaseOptions::new(lmdb::db::CREATE)
+        ).map_err(|err|
+            DatabaseError::InitError(format!("Failed to open database: {:?}", err)))?;
+
+        let mut index_dbs = HashMap::with_capacity(indexes.len());
+        for name in indexes {
+            let db = lmdb::Database::open(
+                &ctx.env, Some(name), &lmdb::DatabaseOptions::new(lmdb::db::CREATE)
+            ).map_err(|err|
+                DatabaseError::InitError(
+                    format!("Failed to open database: {:?}", err)))?;
+            index_dbs.insert(String::from(*name), db);
+        }
+        Ok(LmdbDatabase{
+            ctx: ctx,
+            main: main,
+            indexes: index_dbs,
+        })
+    }
+
+    pub fn reader(&self) -> Result<LmdbDatabaseReader, DatabaseError> {
+        let txn = lmdb::ReadTransaction::new(&self.ctx.env).map_err(|err|
+            DatabaseError::ReaderError(format!("Failed to create reader: {}", err)))?;
+        Ok(LmdbDatabaseReader{
+            db: self,
+            txn: txn,
+        })
+    }
+
+    pub fn writer(&self) -> Result<LmdbDatabaseWriter, DatabaseError> {
+        let txn = lmdb::WriteTransaction::new(&self.ctx.env).map_err(|err|
+            DatabaseError::WriterError(format!("Failed to create writer: {}", err)))?;
+        Ok(LmdbDatabaseWriter{
+            db: self,
+            txn: txn,
+        })
+    }
+}
+
+pub struct LmdbDatabaseReader<'a> {
+    db:     &'a LmdbDatabase<'a>,
+    txn:    lmdb::ReadTransaction<'a>,
+}
+
+impl<'a> LmdbDatabaseReader<'a> {
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        let access = self.txn.access();
+        let val: Result<&[u8], _> = access.get(&self.db.main, key);
+        val.ok().map(|v| Vec::from(v))
+    }
+
+    pub fn index_get(&self, index: &str, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let index = self.db.indexes.get(index).ok_or(
+            DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        let access = self.txn.access();
+        let val: Result<&[u8], _> = access.get(index, key);
+        Ok(val.ok().map(|v| Vec::from(v)))
+    }
+
+    pub fn cursor(&self) -> Result<LmdbDatabaseReaderCursor, DatabaseError> {
+        let cursor = self.txn.cursor(&self.db.main).map_err(|err|
+            DatabaseError::ReaderError(format!("{}", err)))?;
+        let access = self.txn.access();
+        Ok(LmdbDatabaseReaderCursor{
+            access: access,
+            cursor: cursor,
+        })
+    }
+
+    pub fn index_cursor(&self, index: &str) -> Result<LmdbDatabaseReaderCursor, DatabaseError> {
+        let index = self.db.indexes.get(index).ok_or(
+            DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        let cursor = self.txn.cursor(index).map_err(|err|
+            DatabaseError::ReaderError(format!("{}", err)))?;
+        let access = self.txn.access();
+        Ok(LmdbDatabaseReaderCursor{
+            access: access,
+            cursor: cursor,
+        })
+    }
+}
+
+pub struct LmdbDatabaseReaderCursor<'a> {
+    access: lmdb::ConstAccessor<'a>,
+    cursor: lmdb::Cursor<'a, 'a>,
+}
+
+impl<'a> LmdbDatabaseReaderCursor<'a> {
+    pub fn first(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.cursor
+            .first(&self.access)
+            .ok()
+            .map(|(key, value): (&[u8], &[u8])| (Vec::from(key), Vec::from(value)))
+    }
+
+    pub fn last(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.cursor
+            .last(&self.access)
+            .ok()
+            .map(|(key, value): (&[u8], &[u8])| (Vec::from(key), Vec::from(value)))
+    }
+}
+
+pub struct LmdbDatabaseWriter<'a> {
+    db:     &'a LmdbDatabase<'a>,
+    txn:    lmdb::WriteTransaction<'a>,
+}
+
+impl<'a> LmdbDatabaseWriter<'a> {
+    pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        self.txn.access().put(&self.db.main, key, value, lmdb::put::Flags::empty()).map_err(|err|
+            DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn delete(&mut self, key: &[u8]) -> Result<(), DatabaseError>{
+        self.txn.access().del_key(&self.db.main, key).map_err(|err|
+            DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn index_put(&mut self, index: &str, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        let index = self.db.indexes.get(index).ok_or(
+            DatabaseError::WriterError(format!("Not an index: {}", index)))?;
+        self.txn.access().put(index, key, value, lmdb::put::Flags::empty()).map_err(|err|
+            DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn index_delete(&mut self, index: &str, key: &[u8]) -> Result<(), DatabaseError>{
+        let index = self.db.indexes.get(index).ok_or(
+            DatabaseError::WriterError(format!("Not an index: {}", index)))?;
+        self.txn.access().del_key(index, key).map_err(|err|
+            DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn commit(self) -> Result<(), DatabaseError> {
+        self.txn.commit().map_err(|err|
+            DatabaseError::WriterError(format!("{}", err)))
+    }
+}

--- a/adm/src/database/mod.rs
+++ b/adm/src/database/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+pub mod database;
+pub mod lmdb;

--- a/adm/src/err.rs
+++ b/adm/src/err.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std;
+
+#[derive(Debug)]
+pub enum CliError {
+    ArgumentError(String),
+    EnvironmentError(String),
+    ParseError(String),
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            CliError::ArgumentError(ref msg) => write!(f, "ArgumentError: {}",  msg),
+            CliError::EnvironmentError(ref msg) => write!(f, "EnvironmentError: {}",  msg),
+            CliError::ParseError(ref msg) => write!(f, "ParseError: {}",  msg),
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn description(&self) -> &str {
+        match *self {
+            CliError::ArgumentError(ref msg) => msg,
+            CliError::EnvironmentError(ref msg) => msg,
+            CliError::ParseError(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+        match * self {
+            CliError::ArgumentError(_) => None,
+            CliError::EnvironmentError(_) => None,
+            CliError::ParseError(_) => None,
+        }
+    }
+}

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+#[macro_use]
+extern crate clap;
+extern crate lmdb_zero;
+extern crate protobuf;
+extern crate sawtooth_sdk;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_yaml;
+
+mod blockstore;
+mod commands;
+mod config;
+mod database;
+mod err;
+mod wrappers;
+
+use clap::ArgMatches;
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    let args = parse_args();
+
+    let result = match args.subcommand() {
+        ("blockstore", Some(args)) => commands::blockstore::run(args),
+        ("keygen", Some(args)) => commands::keygen::run(args),
+        ("genesis", Some(args)) => commands::genesis::run(args),
+        _ => { println!("Invalid subcommand; Pass --help for usage."); Ok(()) },
+    };
+
+    std::process::exit(match result {
+        Ok(_) => 0,
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            1
+        }
+    });
+}
+
+fn parse_args<'a>() -> ArgMatches<'a> {
+    let app = clap_app!(sawadm =>
+        (version: VERSION)
+        (about: "Manage a local validator keys and data files")
+        (@subcommand blockstore =>
+            (about: "manage the blockstore database directly")
+            (@subcommand list =>
+                (about: "list blocks from the block store")
+                (@arg count: --count +takes_value "the number of blocks to list")
+                (@arg start: --start +takes_value "the first block to list"))
+            (@subcommand show =>
+                (about: "inspect a block in the blockstore")
+                (@arg block: +required "the block to show"))
+            (@subcommand prune =>
+                (about: "remove a block and all children blocks from the blockstore")
+                (@arg block: +required "the block to remove"))
+            (@subcommand export =>
+                (about: "write a block's packed representation to stdout")
+                (@arg block: +required "the block to export"))
+            (@subcommand import =>
+                (about: "add a block to the blockstore; new block's parent must be the current chain head")
+                (@arg blockfile: +required "a protobuf file containing the block to add")))
+        (@arg verbose: -v... "increase the logging level.")
+    );
+    app.get_matches()
+}

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -17,6 +17,7 @@
 
 #[macro_use]
 extern crate clap;
+extern crate libc;
 extern crate lmdb_zero;
 extern crate protobuf;
 extern crate sawtooth_sdk;
@@ -77,6 +78,15 @@ fn parse_args<'a>() -> ArgMatches<'a> {
             (@subcommand import =>
                 (about: "add a block to the blockstore; new block's parent must be the current chain head")
                 (@arg blockfile: +required "a protobuf file containing the block to add")))
+        (@subcommand keygen =>
+            (about: "generates keys for the validator to use when signing blocks")
+            (@arg key_name: +takes_value "name of the key to create")
+            (@arg force: --force "overwrite files if they exist")
+            (@arg quiet: -q --quiet "do not display output"))
+        (@subcommand genesis =>
+            (about: "creates the genesis.batch file for initializing the validator")
+            (@arg input_file: +takes_value ... "file or files containing batches to add to the resulting")
+            (@arg output: -o --output "choose the output file for GenesisData"))
         (@arg verbose: -v... "increase the logging level.")
     );
     app.get_matches()

--- a/adm/src/wrappers.rs
+++ b/adm/src/wrappers.rs
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use std;
+
+use protobuf;
+
+use sawtooth_sdk::messages;
+
+#[derive(Debug)]
+pub enum Error {
+    ParseError(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Error::ParseError(ref msg) => write!(f, "ParseError: {}",  msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::ParseError(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+        match * self {
+            Error::ParseError(_) => None,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct Block {
+    pub batches: Vec<Batch>,
+    pub block_num: u64,
+    #[serde(skip)]
+    pub consensus: Vec<u8>,
+    pub header_signature: String,
+    pub previous_block_id: String,
+    pub state_root_hash: String,
+}
+
+impl Block {
+    pub fn try_from(block: messages::block::Block) -> Result<Self, Error> {
+        protobuf::parse_from_bytes(&block.header)
+            .map_err(|err|
+                Error::ParseError(format!(
+                    "Invalid BlockHeader {}: {}", block.header_signature, err)))
+            .and_then(|block_header: messages::block::BlockHeader|
+                block.get_batches()
+                    .iter()
+                    .map(|batch|
+                        Batch::try_from(batch.clone()))
+                    .collect::<Result<Vec<Batch>, Error>>()
+                    .map(move |batches|
+                        Block{
+                            batches: batches,
+                            block_num: block_header.get_block_num(),
+                            consensus: Vec::from(block_header.get_consensus()),
+                            header_signature: String::from(block.get_header_signature()),
+                            previous_block_id: String::from(block_header.get_previous_block_id()),
+                            state_root_hash: String::from(block_header.get_state_root_hash()),
+                    })
+            )
+    }
+}
+
+#[derive(Serialize)]
+pub struct Batch {
+    pub header_signature: String,
+    pub signer_public_key: String,
+    pub transactions: Vec<Transaction>,
+}
+
+impl Batch {
+    pub fn try_from(batch: messages::batch::Batch) -> Result<Self, Error> {
+        protobuf::parse_from_bytes(&batch.header)
+            .map_err(|err|
+                Error::ParseError(format!(
+                    "Invalid BatchHeader {}: {}", batch.header_signature, err)))
+            .and_then(|batch_header: messages::batch::BatchHeader|
+                batch.get_transactions()
+                    .iter()
+                    .map(|transaction|
+                        Transaction::try_from(transaction.clone()))
+                    .collect::<Result<Vec<Transaction>, Error>>()
+                    .map(move |transactions|
+                        Batch{
+                            header_signature: String::from(batch.get_header_signature()),
+                            signer_public_key: String::from(batch_header.get_signer_public_key()),
+                            transactions: transactions,
+                    })
+            )
+    }
+}
+
+#[derive(Serialize)]
+pub struct Transaction {
+    pub batcher_public_key: String,
+    pub dependencies: Vec<String>,
+    pub family_name: String,
+    pub family_version: String,
+    pub header_signature: String,
+    pub inputs: Vec<String>,
+    pub nonce: String,
+    pub outputs: Vec<String>,
+    #[serde(skip)]
+    pub payload: Vec<u8>,
+    pub payload_sha512: String,
+    pub signer_public_key: String,
+}
+
+impl Transaction {
+    pub fn try_from(transaction: messages::transaction::Transaction) -> Result<Self, Error> {
+        protobuf::parse_from_bytes(&transaction.header)
+            .map_err(|err|
+                Error::ParseError(format!(
+                    "Invalid TransactionHeader {}: {}", transaction.header_signature, err)))
+            .map(|transaction_header: messages::transaction::TransactionHeader|
+                Transaction{
+                    batcher_public_key: String::from(transaction_header.get_batcher_public_key()),
+                    dependencies: transaction_header.get_dependencies()
+                        .iter().map(|dependency| dependency.clone()).collect(),
+                    family_name: String::from(transaction_header.get_family_name()),
+                    family_version: String::from(transaction_header.get_family_version()),
+                    header_signature: String::from(transaction.get_header_signature()),
+                    inputs: transaction_header.get_inputs()
+                        .iter().map(|input| input.clone()).collect(),
+                    nonce: String::from(transaction_header.get_nonce()),
+                    outputs: transaction_header.get_outputs()
+                        .iter().map(|output| output.clone()).collect(),
+                    payload: Vec::from(transaction.get_payload()),
+                    payload_sha512: String::from(transaction_header.get_payload_sha512()),
+                    signer_public_key: String::from(transaction_header.get_signer_public_key()),
+            })
+    }
+}

--- a/bin/build_debs
+++ b/bin/build_debs
@@ -53,10 +53,15 @@ main() {
             echo "Building go packages"
             build_go
             ;;
+        rust)
+            echo "Building rust packages"
+            build_rust
+            ;;
         *)
-            echo "Building python and go packages"
+            echo "Building all packages"
             build_python
             build_go
+            build_rust
             ;;
     esac
 
@@ -195,6 +200,23 @@ build_go() {
 
 }
 
+build_rust() {
+
+    output_dir=$top_dir/build/debs/rust
+    mkdir -p $output_dir
+    rm -f $output_dir/*.deb
+
+    info "sawadm"
+    build_rust_pkg sawadm $top_dir/adm $output_dir
+
+    for pkg in $output_dir/*.deb
+    do
+        echo
+        info "Package $pkg"
+        dpkg -I $pkg
+    done
+}
+
 build_go_pkg(){
 
     pkg_dir=$top_dir/build/debs/go
@@ -244,6 +266,49 @@ build_go_pkg(){
     mv debian.deb $pkg_dir/"${PACKAGENAME}_${PACKAGEVERSION}_${PACKAGEARCH}.deb"
 }
 
+build_rust_pkg(){
+    pkg=$1
+    pkg_dir=$2
+    output_dir=$3
+
+    # GO_TP_DASH=$(echo $pkg | sed s/_/-/)
+    CHANGELOG_DIR="debian/usr/share/doc/sawadm"
+    ST_VERSION=$($top_dir/bin/get_version)
+
+    cd $pkg_dir
+
+    if [ -d "debian" ]
+    then
+        rm -rf debian
+    fi
+
+    mkdir -p debian/DEBIAN
+
+    mkdir -p $CHANGELOG_DIR
+    cp packaging/ubuntu/* debian
+    sed -i -e"s/@VERSION@/$ST_VERSION/" debian/control
+    sed -i -e"s/@VERSION@/$ST_VERSION/" debian/changelog
+    cp debian/changelog $CHANGELOG_DIR
+    mv debian/changelog $CHANGELOG_DIR/changelog.Debian
+    gzip --best $CHANGELOG_DIR/changelog
+    gzip --best $CHANGELOG_DIR/changelog.Debian
+    mv debian/control debian/DEBIAN
+    mv debian/postinst debian/DEBIAN
+
+    PACKAGENAME=$(awk '/^Package:/ { print $2 }' debian/DEBIAN/control)
+    PACKAGEVERSION=$(dpkg-parsechangelog -S version -l $CHANGELOG_DIR/changelog.gz)
+    PACKAGEARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
+
+    mkdir debian/usr/bin
+    cp -R bin/ debian/usr/
+    cp -R packaging/systemd/* debian/
+
+    fakeroot dpkg-deb --build debian
+    echo --
+    echo "${PACKAGENAME}_${PACKAGEVERSION}_${PACKAGEARCH}.deb"
+    echo --
+    mv debian.deb $output_dir/"${PACKAGENAME}_${PACKAGEVERSION}_${PACKAGEARCH}.deb"
+}
 
 build_python_pkg() {
     pkg=$1

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -21,6 +21,7 @@ authors = ["sawtooth"]
 [dependencies]
 protobuf="1.4.1"
 secp256k1 = "0.7.1"
+rand = "0.4.2"
 rust-crypto = "0.2.36"
 zmq = "0.8"
 uuid = { version = "0.5", features = ["v4"] }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -20,6 +20,7 @@ extern crate libc;
 #[macro_use]
 extern crate log;
 extern crate protobuf;
+extern crate rand;
 extern crate secp256k1;
 extern crate uuid;
 extern crate zmq;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -15,9 +15,14 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate protobuf;
+extern crate crypto;
+extern crate libc;
 #[macro_use]
 extern crate log;
+extern crate protobuf;
+extern crate secp256k1;
+extern crate uuid;
+extern crate zmq;
 
 pub mod messages;
 pub mod messaging;

--- a/sdk/rust/src/messaging/zmq_stream.rs
+++ b/sdk/rust/src/messaging/zmq_stream.rs
@@ -14,9 +14,8 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
-
-extern crate zmq;
-extern crate uuid;
+use uuid;
+use zmq;
 
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{Receiver, SyncSender, Sender,
@@ -30,7 +29,7 @@ use protobuf;
 use messages::validator::Message;
 use messages::validator::Message_MessageType;
 
-use super::stream::*;
+use messaging::stream::*;
 
 /// A MessageConnection over ZMQ sockets
 pub struct ZmqMessageConnection {

--- a/sdk/rust/src/signing/mod.rs
+++ b/sdk/rust/src/signing/mod.rs
@@ -26,7 +26,8 @@ use std::borrow::Borrow;
 pub enum Error {
     NoSuchAlgorithm(String),
     ParseError(String),
-    SigningError(Box<StdError>)
+    SigningError(Box<StdError>),
+    KeyGenError(String),
 }
 
 impl StdError for Error {
@@ -34,7 +35,8 @@ impl StdError for Error {
         match *self {
             Error::NoSuchAlgorithm(ref msg) => msg,
             Error::ParseError(ref msg) => msg,
-            Error::SigningError(ref err) => err.description()
+            Error::SigningError(ref err) => err.description(),
+            Error::KeyGenError(ref msg) => msg,
         }
     }
 
@@ -42,7 +44,8 @@ impl StdError for Error {
         match *self {
             Error::NoSuchAlgorithm(_) => None,
             Error::ParseError(_) => None,
-            Error::SigningError(ref err) => Some(err.borrow())
+            Error::SigningError(ref err) => Some(err.borrow()),
+            Error::KeyGenError(_) => None,
         }
     }
 }
@@ -55,7 +58,9 @@ impl std::fmt::Display for Error {
             Error::ParseError(ref s) =>
                 write!(f, "ParseError: {}", s),
             Error::SigningError(ref err) =>
-                write!(f, "SigningError: {}", err.description())
+                write!(f, "SigningError: {}", err.description()),
+            Error::KeyGenError(ref s) =>
+                write!(f, "KeyGenError: {}", s),
         }
     }
 }
@@ -77,6 +82,7 @@ pub trait Context {
     fn sign(&self, message: &[u8], key: &PrivateKey) -> Result<String, Error>;
     fn verify(&self, signature: &str, message: &[u8], key: &PublicKey) -> Result<bool, Error>;
     fn get_public_key(&self, private_key: &PrivateKey) -> Result<Box<PublicKey>, Error>;
+    fn new_random_private_key(&self) -> Result<Box<PrivateKey>, Error>;
 }
 
 pub fn create_context(algorithm_name: &str) -> Result<Box<Context>, Error> {

--- a/sdk/rust/src/signing/pem_loader.rs
+++ b/sdk/rust/src/signing/pem_loader.rs
@@ -26,7 +26,6 @@ mod ffi {
     }
 
 }
-extern crate libc;
 use std::ffi::CString;
 use super::Error;
 

--- a/sdk/rust/src/signing/secp256k1.rs
+++ b/sdk/rust/src/signing/secp256k1.rs
@@ -14,18 +14,16 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+use crypto::digest::Digest;
+use crypto::sha2::Sha256;
 
-extern crate secp256k1;
-extern crate crypto;
+use secp256k1;
 
-use self::crypto::digest::Digest;
-use self::crypto::sha2::Sha256;
-
-use super::PrivateKey;
-use super::PublicKey;
-use super::Context;
-use super::Error;
-use super::pem_loader::load_pem_key;
+use signing::PrivateKey;
+use signing::PublicKey;
+use signing::Context;
+use signing::Error;
+use signing::pem_loader::load_pem_key;
 
 impl From<secp256k1::Error> for Error {
     fn from(e: secp256k1::Error) -> Self {

--- a/sdk/rust/src/signing/secp256k1.rs
+++ b/sdk/rust/src/signing/secp256k1.rs
@@ -17,6 +17,8 @@
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;
 
+use rand::Rng;
+use rand::os::OsRng;
 use secp256k1;
 
 use signing::PrivateKey;
@@ -148,6 +150,13 @@ impl Context for Secp256k1Context {
             Err(err) => Err(err),
             Ok(pk) => Ok(Box::new(pk))
         }
+    }
+
+    fn new_random_private_key(&self) -> Result<Box<PrivateKey>, Error> {
+        let mut rng = OsRng::new().map_err(|err| Error::KeyGenError(format!("{}", err)))?;
+        let mut key = [0u8; secp256k1::constants::SECRET_KEY_SIZE];
+        rng.fill_bytes(&mut key);
+        Ok(Box::new(Secp256k1PrivateKey { private: Vec::from(&key[..]) }))
     }
 }
 


### PR DESCRIPTION
This creates a new subcommand for the `sawadm` command called `blockstore` which allows users to directly inspect and modify the blockstore database. The `blockstore` subcommand names and arguments should be treated as unstable as additional work is being done on this command.

The new command was written in rust and so the old command has been removed.