### PR TITLE
Improve block validator logging

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -45,16 +45,10 @@ from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 LOGGER = logging.getLogger(__name__)
 
 
-class BlockValidationAborted(Exception):
-    """
-    Indication that the validation of this fork has terminated for an
-    expected(handled) case and that the processing should exit.
-    """
-    pass
-
-
 class BlockValidationError(Exception):
-    pass
+    """
+    Indication that some step in the block validation process has failed.
+    """
 
 
 class ChainHeadUpdated(Exception):
@@ -371,7 +365,7 @@ class BlockValidator(object):
                 except KeyError:
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
-                    raise BlockValidationAborted(
+                    raise BlockValidationError(
                         'Block {} missing predecessor {}'.format(
                             new_blkw,
                             new_blkw.previous_block_id))
@@ -396,7 +390,7 @@ class BlockValidator(object):
                 # We are at a genesis block and the blocks are not the same
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted(
+                raise BlockValidationError(
                     'Block {} has wrong genesis: {}'.format(
                         cur_blkw,
                         new_blkw))
@@ -408,7 +402,7 @@ class BlockValidator(object):
             except KeyError:
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted(
+                raise BlockValidationError(
                     'Block {} missing predecessor {}'.format(
                         new_blkw,
                         new_blkw.previous_block_id))
@@ -476,7 +470,7 @@ class BlockValidator(object):
                     new_blkw, cur_blkw,
                     new_chain, cur_chain)
 
-            except BlockValidationAborted as err:
+            except BlockValidationError as err:
                 LOGGER.warning('Could not find common ancestor: %s', err)
                 self._done_cb(False, self._result)
                 return

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -266,9 +266,6 @@ class BlockValidator(object):
         roles stored in state as of the previous block. If a transactor is
         found to not be permitted, the block is invalid.
         """
-        if blkw.block_num == 0:
-            return True
-
         try:
             state_root = self._get_previous_block_root_state_hash(blkw)
         except KeyError:
@@ -289,9 +286,6 @@ class BlockValidator(object):
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        if blkw.block_num == 0:
-            return True
-
         try:
             state_root = self._get_previous_block_root_state_hash(blkw)
         except KeyError:
@@ -310,8 +304,12 @@ class BlockValidator(object):
             if blkw.status == BlockStatus.Invalid:
                 return False
 
-            if not self._validate_permissions(blkw):
-                return False
+            if blkw.block_num != 0:
+                if not self._validate_permissions(blkw):
+                    return False
+
+                if not self._validate_on_chain_rules(blkw):
+                    return False
 
             public_key = \
                 self._identity_signer.get_public_key().as_hex()
@@ -322,9 +320,6 @@ class BlockValidator(object):
                 config_dir=self._config_dir,
                 validator_id=public_key)
             if not consensus.verify_block(blkw):
-                return False
-
-            if not self._validate_on_chain_rules(blkw):
                 return False
 
             if not self._verify_block_batches(blkw):

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -189,9 +189,8 @@ class BlockValidator(object):
             txn_hdr = self._txn_header(txn)
             if self._chain_commit_state.has_transaction(txn.header_signature):
                 LOGGER.debug(
-                    "Block rejected due to duplicate"
-                    " transaction, transaction: %s",
-                    txn.header_signature[:8])
+                    'Block rejected due to duplicate transaction: %s',
+                    txn.header_signature)
                 raise InvalidBatch()
             for dep in txn_hdr.dependencies:
                 if not self._chain_commit_state.has_transaction(dep):
@@ -199,8 +198,8 @@ class BlockValidator(object):
                         "Block rejected due to missing "
                         "transaction dependency, transaction %s "
                         "depends on %s",
-                        txn.header_signature[:8],
-                        dep[:8])
+                        txn.header_signature,
+                        dep)
                     raise InvalidBatch()
             self._chain_commit_state.add_txn(txn.header_signature)
 
@@ -215,9 +214,10 @@ class BlockValidator(object):
             for batch, has_more in look_ahead(blkw.block.batches):
                 if self._chain_commit_state.has_batch(
                         batch.header_signature):
-                    LOGGER.debug("Block(%s) rejected due to duplicate "
-                                 "batch, batch: %s", blkw,
-                                 batch.header_signature[:8])
+                    LOGGER.debug(
+                        'Block %s rejected due to duplicate batch: %s',
+                        blkw,
+                        batch.header_signature)
                     raise InvalidBatch()
 
                 self._verify_batch_transactions(batch)
@@ -228,10 +228,10 @@ class BlockValidator(object):
                 else:
                     scheduler.add_batch(batch, blkw.state_root_hash)
         except InvalidBatch:
-            LOGGER.debug("Invalid batch %s encountered during "
-                         "verification of block %s",
-                         batch.header_signature[:8],
-                         blkw)
+            LOGGER.debug(
+                'Invalid batch %s encountered during verification of block %s',
+                batch.header_signature,
+                blkw)
             scheduler.cancel()
             return False
         except Exception:
@@ -965,7 +965,7 @@ class ChainController(object):
         if chain_id is not None and chain_id != block.identifier:
             LOGGER.warning("Block id does not match block chain id %s. "
                            "Cannot set initial chain head.: %s",
-                           chain_id[:8], block.identifier[:8])
+                           chain_id, block.identifier)
             return
 
         state_view = self._state_view_factory.create_view()

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -200,11 +200,10 @@ class BlockValidator(object):
                     raise InvalidBatch()
             self._chain_commit_state.add_txn(txn.header_signature)
 
-    def _verify_block_batches(self, blkw):
+    def _verify_block_batches(self, blkw, prev_state):
         if not blkw.block.batches:
             return True
 
-        prev_state = self._get_previous_block_root_state_hash(blkw)
         scheduler = self._executor.create_scheduler(
             self._squash_handler, prev_state)
         self._executor.execute(scheduler)
@@ -259,20 +258,13 @@ class BlockValidator(object):
 
         return True
 
-    def _validate_permissions(self, blkw):
+    def _validate_permissions(self, blkw, state_root):
         """
         Validate that all of the batch signers and transaction signer for the
         batches in the block are permitted by the transactor permissioning
         roles stored in state as of the previous block. If a transactor is
         found to not be permitted, the block is invalid.
         """
-        try:
-            state_root = self._get_previous_block_root_state_hash(blkw)
-        except KeyError:
-            LOGGER.info(
-                "Block rejected due to missing predecessor: %s", blkw)
-            return False
-
         for batch in blkw.batches:
             if not self._permission_verifier.is_batch_signer_authorized(
                     batch, state_root, from_state=True):
@@ -280,19 +272,12 @@ class BlockValidator(object):
 
         return True
 
-    def _validate_on_chain_rules(self, blkw):
+    def _validate_on_chain_rules(self, blkw, state_root):
         """
         Validate that the block conforms to all validation rules stored in
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        try:
-            state_root = self._get_previous_block_root_state_hash(blkw)
-        except KeyError:
-            LOGGER.debug(
-                "Block rejected due to missing" + " predecessor: %s", blkw)
-            return False
-
         return self._validation_rule_enforcer.validate(blkw, state_root)
 
     def validate_block(self, blkw):
@@ -304,11 +289,18 @@ class BlockValidator(object):
             if blkw.status == BlockStatus.Invalid:
                 return False
 
+            try:
+                state_root = self._get_previous_block_root_state_hash(blkw)
+            except KeyError:
+                LOGGER.debug(
+                    "Block rejected due to missing predecessor: %s", blkw)
+                return False
+
             if blkw.block_num != 0:
-                if not self._validate_permissions(blkw):
+                if not self._validate_permissions(blkw, state_root):
                     return False
 
-                if not self._validate_on_chain_rules(blkw):
+                if not self._validate_on_chain_rules(blkw, state_root):
                     return False
 
             public_key = \
@@ -322,7 +314,7 @@ class BlockValidator(object):
             if not consensus.verify_block(blkw):
                 return False
 
-            if not self._verify_block_batches(blkw):
+            if not self._verify_block_batches(blkw, state_root):
                 return False
 
             # since changes to the chain-head can change the state of the

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -363,19 +363,19 @@ class BlockValidator(object):
             # new chain is longer
             # walk the current chain back until we find the block that is the
             # same height as the current chain.
-            while new_blkw.block_num > cur_blkw.block_num and \
-                    new_blkw.previous_block_id != NULL_BLOCK_IDENTIFIER:
+            while (new_blkw.block_num > cur_blkw.block_num
+                   and new_blkw.previous_block_id != NULL_BLOCK_IDENTIFIER):
                 new_chain.append(new_blkw)
                 try:
                     new_blkw = self._block_cache[new_blkw.previous_block_id]
                 except KeyError:
-                    LOGGER.info(
-                        "Block %s rejected due to missing predecessor %s",
-                        new_blkw,
-                        new_blkw.previous_block_id)
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
-                    raise BlockValidationAborted()
+                    raise BlockValidationAborted(
+                        'Block {} missing predecessor {}'.format(
+                            new_blkw,
+                            new_blkw.previous_block_id))
+
         elif new_blkw.block_num < cur_blkw.block_num:
             # current chain is longer
             # walk the current chain back until we find the block that is the
@@ -384,7 +384,8 @@ class BlockValidator(object):
                    and new_blkw.previous_block_id != NULL_BLOCK_IDENTIFIER):
                 cur_chain.append(cur_blkw)
                 cur_blkw = self._block_cache[cur_blkw.previous_block_id]
-        return (new_blkw, cur_blkw)
+
+        return new_blkw, cur_blkw
 
     def _find_common_ancestor(self, new_blkw, cur_blkw, new_chain, cur_chain):
         """ Finds a common ancestor of the two chains.
@@ -393,23 +394,24 @@ class BlockValidator(object):
             if (cur_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER
                     or new_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER):
                 # We are at a genesis block and the blocks are not the same
-                LOGGER.info(
-                    "Block rejected due to wrong genesis: %s %s",
-                    cur_blkw, new_blkw)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted()
+                raise BlockValidationAborted(
+                    'Block {} has wrong genesis: {}'.format(
+                        cur_blkw,
+                        new_blkw))
+
             new_chain.append(new_blkw)
+
             try:
                 new_blkw = self._block_cache[new_blkw.previous_block_id]
             except KeyError:
-                LOGGER.info(
-                    "Block %s rejected due to missing predecessor %s",
-                    new_blkw,
-                    new_blkw.previous_block_id)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted()
+                raise BlockValidationAborted(
+                    'Block {} missing predecessor {}'.format(
+                        new_blkw,
+                        new_blkw.previous_block_id))
 
             cur_chain.append(cur_blkw)
             cur_blkw = self._block_cache[cur_blkw.previous_block_id]
@@ -453,27 +455,35 @@ class BlockValidator(object):
         """
         try:
             LOGGER.info("Starting block validation of : %s", self._new_block)
-            cur_chain = self._result["cur_chain"]  # ordered list of the
-            # current chain blocks
-            new_chain = self._result["new_chain"]  # ordered list of the new
-            # chain blocks
+
+            # ordered list of the current chain blocks
+            cur_chain = self._result["cur_chain"]
+            # ordered list of the new chain blocks
+            new_chain = self._result["new_chain"]
 
             # get the current chain_head.
             self._chain_head = self._block_cache.block_store.chain_head
             self._result['chain_head'] = self._chain_head
 
-            # 1) Find the common ancestor block, the root of the fork.
-            # walk back till both chains are the same height
-            (new_blkw, cur_blkw) = self._find_common_height(new_chain,
-                                                            cur_chain)
+            try:
+                # 1) Find the common ancestor block, the root of the
+                # fork. Walk back till both chains are the same height.
+                new_blkw, cur_blkw = \
+                    self._find_common_height(new_chain, cur_chain)
 
-            # 2) Walk back until we find the common ancestor
-            self._find_common_ancestor(new_blkw, cur_blkw,
-                                       new_chain, cur_chain)
+                # 2) Walk back until we find the common ancestor.
+                self._find_common_ancestor(
+                    new_blkw, cur_blkw,
+                    new_chain, cur_chain)
 
-            # 3) Determine the validity of the new fork
-            # build the transaction cache to simulate the state of the
-            # chain at the common root.
+            except BlockValidationAborted as err:
+                LOGGER.warning('Could not find common ancestor: %s', err)
+                self._done_cb(False, self._result)
+                return
+
+            # 3) Determine the validity of the new fork build the
+            # transaction cache to simulate the state of the chain at
+            # the common root.
             self._chain_commit_state = ChainCommitState(
                 self._block_cache.block_store, cur_chain)
 
@@ -489,6 +499,13 @@ class BlockValidator(object):
                             block,
                             err)
                         valid = False
+                    except ChainHeadUpdated:
+                        LOGGER.warning(
+                            'Chain head updated during validation of %s',
+                            block)
+                        self._done_cb(False, self._result)
+                        return
+
                     block.status = BlockStatus.Valid
                     self._result["num_transactions"] += block.num_transactions
                 else:
@@ -534,18 +551,14 @@ class BlockValidator(object):
             self._done_cb(commit_new_chain, self._result)
 
             LOGGER.info(
-                "Finished block validation of: %s",
+                'Finished validation of block %s',
                 self._new_block)
-        except BlockValidationAborted:
-            self._done_cb(False, self._result)
-            return
-        except ChainHeadUpdated:
-            self._done_cb(False, self._result)
-            return
-        except Exception:  # pylint: disable=broad-except
+
+        except Exception as err:  # pylint: disable=broad-except
             LOGGER.exception(
-                "Block validation failed with unexpected error: %s",
-                self._new_block)
+                'Validation of block %s failed with unexpected error: %s',
+                self._new_block,
+                err)
             # callback to clean up the block out of the processing list.
             self._done_cb(False, self._result)
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -30,6 +30,8 @@ from sawtooth_validator.journal.consensus.consensus_factory import \
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.validation_rule_enforcer import \
     ValidationRuleEnforcer
+from sawtooth_validator.journal.validation_rule_enforcer import \
+    ValidationRuleError
 from sawtooth_validator.state.settings_view import SettingsViewFactory
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
@@ -186,54 +188,52 @@ class BlockValidator(object):
         are unique.
         """
         for txn in batch.transactions:
-            txn_hdr = self._txn_header(txn)
             if self._chain_commit_state.has_transaction(txn.header_signature):
-                LOGGER.debug(
-                    'Block rejected due to duplicate transaction: %s',
-                    txn.header_signature)
-                raise InvalidBatch()
+                raise InvalidBatch(
+                    'Duplicate transaction {}'.format(
+                        txn.header_signature))
+
+            txn_hdr = self._txn_header(txn)
+
             for dep in txn_hdr.dependencies:
                 if not self._chain_commit_state.has_transaction(dep):
-                    LOGGER.debug(
-                        "Block rejected due to missing "
-                        "transaction dependency, transaction %s "
-                        "depends on %s",
-                        txn.header_signature,
-                        dep)
-                    raise InvalidBatch()
+                    raise InvalidBatch(
+                        'Transaction {} missing dependency {}'.format(
+                            txn.header_signature,
+                            dep))
+
             self._chain_commit_state.add_txn(txn.header_signature)
 
     def _verify_block_batches(self, blkw, prev_state):
         if not blkw.block.batches:
-            return True
+            return
 
         scheduler = self._executor.create_scheduler(
             self._squash_handler, prev_state)
+
         self._executor.execute(scheduler)
+
         try:
             for batch, has_more in look_ahead(blkw.block.batches):
                 if self._chain_commit_state.has_batch(
                         batch.header_signature):
-                    LOGGER.debug(
-                        'Block %s rejected due to duplicate batch: %s',
-                        blkw,
-                        batch.header_signature)
-                    raise InvalidBatch()
+                    raise InvalidBatch(
+                        'Duplicate batch {}'.format(
+                            batch.header_signature))
 
                 self._verify_batch_transactions(batch)
+
                 self._chain_commit_state.add_batch(
                     batch, add_transactions=False)
+
                 if has_more:
                     scheduler.add_batch(batch)
                 else:
                     scheduler.add_batch(batch, blkw.state_root_hash)
-        except InvalidBatch:
-            LOGGER.debug(
-                'Invalid batch %s encountered during verification of block %s',
-                batch.header_signature,
-                blkw)
+
+        except InvalidBatch as err:
             scheduler.cancel()
-            return False
+            raise err
         except Exception:
             scheduler.cancel()
             raise
@@ -245,22 +245,29 @@ class BlockValidator(object):
         for batch in blkw.batches:
             batch_result = scheduler.get_batch_execution_result(
                 batch.header_signature)
-            if batch_result is not None and batch_result.is_valid:
-                txn_results = \
-                    scheduler.get_transaction_execution_results(
-                        batch.header_signature)
-                blkw.execution_results.extend(txn_results)
-                state_hash = batch_result.state_hash
-                blkw.num_transactions += len(batch.transactions)
-            else:
-                return False
-        if blkw.state_root_hash != state_hash:
-            LOGGER.debug("Block(%s) rejected due to state root hash "
-                         "mismatch: %s != %s", blkw, blkw.state_root_hash,
-                         state_hash)
-            return False
 
-        return True
+            try:
+                if not batch_result.is_valid:
+                    raise BlockValidationError(
+                        'Invalid execution result for batch {}'.format(
+                            batch.header_signature))
+            except AttributeError:
+                raise BlockValidationError(
+                    'Invalid execution result for batch {}'.format(
+                        batch.header_signature))
+
+            txn_results = \
+                scheduler.get_transaction_execution_results(
+                    batch.header_signature)
+            blkw.execution_results.extend(txn_results)
+            state_hash = batch_result.state_hash
+            blkw.num_transactions += len(batch.transactions)
+
+        if not blkw.state_root_hash == state_hash:
+            raise BlockValidationError(
+                'State root hash mismatch: {} != {}'.format(
+                    blkw.state_root_hash,
+                    state_hash))
 
     def _validate_permissions(self, blkw, state_root):
         """
@@ -272,9 +279,9 @@ class BlockValidator(object):
         for batch in blkw.batches:
             if not self._permission_verifier.is_batch_signer_authorized(
                     batch, state_root, from_state=True):
-                return False
-
-        return True
+                raise BlockValidationError(
+                    'Signer for batch {} is not authorized'.format(
+                        batch.header_signature))
 
     def _validate_on_chain_rules(self, blkw, state_root):
         """
@@ -282,7 +289,10 @@ class BlockValidator(object):
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        return self._validation_rule_enforcer.validate(blkw, state_root)
+        try:
+            self._validation_rule_enforcer.validate(blkw, state_root)
+        except ValidationRuleError as err:
+            raise BlockValidationError(str(err))
 
     def validate_block(self, blkw):
         '''Verifies that blkw has certain properties, raising
@@ -304,13 +314,8 @@ class BlockValidator(object):
                     'Block has missing predecessor')
 
             if blkw.block_num != 0:
-                if not self._validate_permissions(blkw, state_root):
-                    raise BlockValidationError(
-                        'Failed permissions')
-
-                if not self._validate_on_chain_rules(blkw, state_root):
-                    raise BlockValidationError(
-                        'Failed on-chain validation rules')
+                self._validate_permissions(blkw, state_root)
+                self._validate_on_chain_rules(blkw, state_root)
 
             public_key = \
                 self._identity_signer.get_public_key().as_hex()
@@ -325,17 +330,15 @@ class BlockValidator(object):
                     'Failed {} consensus verification'.format(
                         self._consensus_module))
 
-            if not self._verify_block_batches(blkw, state_root):
-                raise BlockValidationError(
-                    'Failed batch verification')
+            self._verify_block_batches(blkw, state_root)
 
             # since changes to the chain-head can change the state of the
             # blocks in BlockStore we have to revalidate this block.
-            block_store = self._block_cache.block_store
-            if (self._chain_head is not None
-                    and self._chain_head.identifier !=
-                    block_store.chain_head.identifier):
-                raise ChainHeadUpdated()
+            if self._chain_head is not None:
+                chain_head = self._block_cache.block_store.chain_head
+
+                if not self._chain_head.identifier == chain_head.identifier
+                    raise ChainHeadUpdated()
 
         except Exception as exp:
             raise BlockValidationError(

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -201,59 +201,62 @@ class BlockValidator(object):
             self._chain_commit_state.add_txn(txn.header_signature)
 
     def _verify_block_batches(self, blkw):
-        if blkw.block.batches:
-            prev_state = self._get_previous_block_root_state_hash(blkw)
-            scheduler = self._executor.create_scheduler(
-                self._squash_handler, prev_state)
-            self._executor.execute(scheduler)
-            try:
-                for batch, has_more in look_ahead(blkw.block.batches):
-                    if self._chain_commit_state.has_batch(
-                            batch.header_signature):
-                        LOGGER.debug("Block(%s) rejected due to duplicate "
-                                     "batch, batch: %s", blkw,
-                                     batch.header_signature[:8])
-                        raise InvalidBatch()
+        if not blkw.block.batches:
+            return True
 
-                    self._verify_batch_transactions(batch)
-                    self._chain_commit_state.add_batch(
-                        batch, add_transactions=False)
-                    if has_more:
-                        scheduler.add_batch(batch)
-                    else:
-                        scheduler.add_batch(batch, blkw.state_root_hash)
-            except InvalidBatch:
-                LOGGER.debug("Invalid batch %s encountered during "
-                             "verification of block %s",
-                             batch.header_signature[:8],
-                             blkw)
-                scheduler.cancel()
-                return False
-            except Exception:
-                scheduler.cancel()
-                raise
+        prev_state = self._get_previous_block_root_state_hash(blkw)
+        scheduler = self._executor.create_scheduler(
+            self._squash_handler, prev_state)
+        self._executor.execute(scheduler)
+        try:
+            for batch, has_more in look_ahead(blkw.block.batches):
+                if self._chain_commit_state.has_batch(
+                        batch.header_signature):
+                    LOGGER.debug("Block(%s) rejected due to duplicate "
+                                 "batch, batch: %s", blkw,
+                                 batch.header_signature[:8])
+                    raise InvalidBatch()
 
-            scheduler.finalize()
-            scheduler.complete(block=True)
-            state_hash = None
-
-            for batch in blkw.batches:
-                batch_result = scheduler.get_batch_execution_result(
-                    batch.header_signature)
-                if batch_result is not None and batch_result.is_valid:
-                    txn_results = \
-                        scheduler.get_transaction_execution_results(
-                            batch.header_signature)
-                    blkw.execution_results.extend(txn_results)
-                    state_hash = batch_result.state_hash
-                    blkw.num_transactions += len(batch.transactions)
+                self._verify_batch_transactions(batch)
+                self._chain_commit_state.add_batch(
+                    batch, add_transactions=False)
+                if has_more:
+                    scheduler.add_batch(batch)
                 else:
-                    return False
-            if blkw.state_root_hash != state_hash:
-                LOGGER.debug("Block(%s) rejected due to state root hash "
-                             "mismatch: %s != %s", blkw, blkw.state_root_hash,
-                             state_hash)
+                    scheduler.add_batch(batch, blkw.state_root_hash)
+        except InvalidBatch:
+            LOGGER.debug("Invalid batch %s encountered during "
+                         "verification of block %s",
+                         batch.header_signature[:8],
+                         blkw)
+            scheduler.cancel()
+            return False
+        except Exception:
+            scheduler.cancel()
+            raise
+
+        scheduler.finalize()
+        scheduler.complete(block=True)
+        state_hash = None
+
+        for batch in blkw.batches:
+            batch_result = scheduler.get_batch_execution_result(
+                batch.header_signature)
+            if batch_result is not None and batch_result.is_valid:
+                txn_results = \
+                    scheduler.get_transaction_execution_results(
+                        batch.header_signature)
+                blkw.execution_results.extend(txn_results)
+                state_hash = batch_result.state_hash
+                blkw.num_transactions += len(batch.transactions)
+            else:
                 return False
+        if blkw.state_root_hash != state_hash:
+            LOGGER.debug("Block(%s) rejected due to state root hash "
+                         "mismatch: %s != %s", blkw, blkw.state_root_hash,
+                         state_hash)
+            return False
+
         return True
 
     def _validate_permissions(self, blkw):
@@ -263,18 +266,21 @@ class BlockValidator(object):
         roles stored in state as of the previous block. If a transactor is
         found to not be permitted, the block is invalid.
         """
-        if blkw.block_num != 0:
-            try:
-                state_root = self._get_previous_block_root_state_hash(blkw)
-            except KeyError:
-                LOGGER.info(
-                    "Block rejected due to missing predecessor: %s", blkw)
+        if blkw.block_num == 0:
+            return True
+
+        try:
+            state_root = self._get_previous_block_root_state_hash(blkw)
+        except KeyError:
+            LOGGER.info(
+                "Block rejected due to missing predecessor: %s", blkw)
+            return False
+
+        for batch in blkw.batches:
+            if not self._permission_verifier.is_batch_signer_authorized(
+                    batch, state_root, from_state=True):
                 return False
 
-            for batch in blkw.batches:
-                if not self._permission_verifier.is_batch_signer_authorized(
-                        batch, state_root, from_state=True):
-                    return False
         return True
 
     def _validate_on_chain_rules(self, blkw):
@@ -283,62 +289,63 @@ class BlockValidator(object):
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        if blkw.block_num != 0:
-            try:
-                state_root = self._get_previous_block_root_state_hash(blkw)
-            except KeyError:
-                LOGGER.debug(
-                    "Block rejected due to missing" + " predecessor: %s", blkw)
-                return False
-            return self._validation_rule_enforcer.validate(blkw, state_root)
-        return True
+        if blkw.block_num == 0:
+            return True
+
+        try:
+            state_root = self._get_previous_block_root_state_hash(blkw)
+        except KeyError:
+            LOGGER.debug(
+                "Block rejected due to missing" + " predecessor: %s", blkw)
+            return False
+
+        return self._validation_rule_enforcer.validate(blkw, state_root)
 
     def validate_block(self, blkw):
         # pylint: disable=broad-except
         try:
             if blkw.status == BlockStatus.Valid:
                 return True
-            elif blkw.status == BlockStatus.Invalid:
+
+            if blkw.status == BlockStatus.Invalid:
                 return False
-            else:
-                valid = True
 
-                valid = self._validate_permissions(blkw)
+            valid = True
 
-                if valid:
-                    public_key = \
-                        self._identity_signer.get_public_key().as_hex()
-                    consensus = self._consensus_module.BlockVerifier(
-                        block_cache=self._block_cache,
-                        state_view_factory=self._state_view_factory,
-                        data_dir=self._data_dir,
-                        config_dir=self._config_dir,
-                        validator_id=public_key)
-                    valid = consensus.verify_block(blkw)
+            valid = self._validate_permissions(blkw)
 
-                if valid:
-                    valid = self._validate_on_chain_rules(blkw)
+            if valid:
+                public_key = \
+                    self._identity_signer.get_public_key().as_hex()
+                consensus = self._consensus_module.BlockVerifier(
+                    block_cache=self._block_cache,
+                    state_view_factory=self._state_view_factory,
+                    data_dir=self._data_dir,
+                    config_dir=self._config_dir,
+                    validator_id=public_key)
+                valid = consensus.verify_block(blkw)
 
-                if valid:
-                    valid = self._verify_block_batches(blkw)
+            if valid:
+                valid = self._validate_on_chain_rules(blkw)
 
-                # since changes to the chain-head can change the state of the
-                # blocks in BlockStore we have to revalidate this block.
-                block_store = self._block_cache.block_store
-                if (self._chain_head is not None
-                        and self._chain_head.identifier !=
-                        block_store.chain_head.identifier):
-                    raise ChainHeadUpdated()
+            if valid:
+                valid = self._verify_block_batches(blkw)
 
-                blkw.status = \
-                    BlockStatus.Valid if valid else BlockStatus.Invalid
+            # since changes to the chain-head can change the state of the
+            # blocks in BlockStore we have to revalidate this block.
+            block_store = self._block_cache.block_store
+            if (self._chain_head is not None
+                    and self._chain_head.identifier !=
+                    block_store.chain_head.identifier):
+                raise ChainHeadUpdated()
 
-                return valid
-        except ChainHeadUpdated as chu:
-            raise chu
+            blkw.status = \
+                BlockStatus.Valid if valid else BlockStatus.Invalid
+
+            return valid
         except Exception:
             LOGGER.exception(
-                "Unhandled exception BlockPublisher.validate_block()")
+                "Unhandled exception BlockPublisher")
             return False
 
     def _find_common_height(self, new_chain, cur_chain):
@@ -948,48 +955,51 @@ class ChainController(object):
     def _set_genesis(self, block):
         # This is used by a non-genesis journal when it has received the
         # genesis block from the genesis validator
-        if block.previous_block_id == NULL_BLOCK_IDENTIFIER:
-            chain_id = self._chain_id_manager.get_block_chain_id()
-            if chain_id is not None and chain_id != block.identifier:
-                LOGGER.warning("Block id does not match block chain id %s. "
-                               "Cannot set initial chain head.: %s",
-                               chain_id[:8], block.identifier[:8])
-            else:
-                state_view = self._state_view_factory.create_view()
-                consensus_module = \
-                    ConsensusFactory.get_configured_consensus_module(
-                        NULL_BLOCK_IDENTIFIER,
-                        state_view)
-
-                validator = BlockValidator(
-                    consensus_module=consensus_module,
-                    new_block=block,
-                    block_cache=self._block_cache,
-                    state_view_factory=self._state_view_factory,
-                    done_cb=self.on_block_validated,
-                    executor=self._transaction_executor,
-                    squash_handler=self._squash_handler,
-                    identity_signer=self._identity_signer,
-                    data_dir=self._data_dir,
-                    config_dir=self._config_dir,
-                    permission_verifier=self._permission_verifier,
-                    metrics_registry=self._metrics_registry)
-
-                valid = validator.validate_block(block)
-                if valid:
-                    if chain_id is None:
-                        self._chain_id_manager.save_block_chain_id(
-                            block.identifier)
-                    self._block_store.update_chain([block])
-                    self._chain_head = block
-                    self._notify_on_chain_updated(self._chain_head)
-                else:
-                    LOGGER.warning("The genesis block is not valid. Cannot "
-                                   "set chain head: %s", block)
-
-        else:
+        if block.previous_block_id != NULL_BLOCK_IDENTIFIER:
             LOGGER.warning("Cannot set initial chain head, this is not a "
                            "genesis block: %s", block)
+            return
+
+        chain_id = self._chain_id_manager.get_block_chain_id()
+        if chain_id is not None and chain_id != block.identifier:
+            LOGGER.warning("Block id does not match block chain id %s. "
+                           "Cannot set initial chain head.: %s",
+                           chain_id[:8], block.identifier[:8])
+            return
+
+        state_view = self._state_view_factory.create_view()
+        consensus_module = \
+            ConsensusFactory.get_configured_consensus_module(
+                NULL_BLOCK_IDENTIFIER,
+                state_view)
+
+        validator = BlockValidator(
+            consensus_module=consensus_module,
+            new_block=block,
+            block_cache=self._block_cache,
+            state_view_factory=self._state_view_factory,
+            done_cb=self.on_block_validated,
+            executor=self._transaction_executor,
+            squash_handler=self._squash_handler,
+            identity_signer=self._identity_signer,
+            data_dir=self._data_dir,
+            config_dir=self._config_dir,
+            permission_verifier=self._permission_verifier,
+            metrics_registry=self._metrics_registry)
+
+        valid = validator.validate_block(block)
+
+        if not valid:
+            LOGGER.warning("The genesis block is not valid. Cannot "
+                           "set chain head: %s", block)
+            return
+
+        if chain_id is None:
+            self._chain_id_manager.save_block_chain_id(block.identifier)
+
+        self._block_store.update_chain([block])
+        self._chain_head = block
+        self._notify_on_chain_updated(self._chain_head)
 
     def _make_receipts(self, results):
         receipts = []

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -32,6 +32,7 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.chain import BlockValidator
 from sawtooth_validator.journal.chain import ChainController
+from sawtooth_validator.journal.chain import BlockValidationError
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.publisher import BlockPublisher
 from sawtooth_validator.journal.timed_cache import TimedCache
@@ -1230,7 +1231,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          return_value=False):
+                          side_effect=BlockValidationError):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)

--- a/validator/tests/test_validation_rule_enforcer/test.py
+++ b/validator/tests/test_validation_rule_enforcer/test.py
@@ -22,6 +22,8 @@ from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.validation_rule_enforcer import \
     ValidationRuleEnforcer
+from sawtooth_validator.journal.validation_rule_enforcer import \
+    ValidationRuleError
 from test_validation_rule_enforcer.mock import MockSettingsViewFactory
 
 
@@ -54,8 +56,7 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
         Test that if no validation rules are set, the block is valid.
         """
         blkw = self._make_block(["intkey"], "pub_key")
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_n_of_x(self):
         """
@@ -70,22 +71,20 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "NofX:1,intkey")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "NofX:0,intkey")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "NofX:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_x_at_y(self):
         """
@@ -100,22 +99,20 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "XatY:blockinfo,0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "XatY:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_local(self):
         """
@@ -132,23 +129,21 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "local:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         blkw = self._make_block(["intkey"], "pub_key", False)
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "local:test")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once(self):
         """
@@ -160,8 +155,7 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:intkey,0;local:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_bad_number_of_intkey(self):
         """
@@ -173,8 +167,8 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "NofX:0,intkey;XatY:intkey,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_bad_family_at_index(self):
         """
@@ -187,8 +181,8 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:blockinfo,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_signer_key(self):
         """
@@ -201,5 +195,5 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:intkey,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")


### PR DESCRIPTION
Currently when a block fails validation, the reason it failed is logged separately from the message saying that it failed. This makes it hard to track down what happened. This PR rearranges things in the block validator so that the messages are logged together.

Unrelated to that, there is also a commit to remove some noisy and expensive route handler logging statements.