### PR TITLE
Improve block validator logging

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -266,9 +266,6 @@ class BlockValidator(object):
         roles stored in state as of the previous block. If a transactor is
         found to not be permitted, the block is invalid.
         """
-        if blkw.block_num == 0:
-            return True
-
         try:
             state_root = self._get_previous_block_root_state_hash(blkw)
         except KeyError:
@@ -289,9 +286,6 @@ class BlockValidator(object):
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        if blkw.block_num == 0:
-            return True
-
         try:
             state_root = self._get_previous_block_root_state_hash(blkw)
         except KeyError:
@@ -310,8 +304,12 @@ class BlockValidator(object):
             if blkw.status == BlockStatus.Invalid:
                 return False
 
-            if not self._validate_permissions(blkw):
-                return False
+            if blkw.block_num != 0:
+                if not self._validate_permissions(blkw):
+                    return False
+
+                if not self._validate_on_chain_rules(blkw):
+                    return False
 
             public_key = \
                 self._identity_signer.get_public_key().as_hex()
@@ -322,9 +320,6 @@ class BlockValidator(object):
                 config_dir=self._config_dir,
                 validator_id=public_key)
             if not consensus.verify_block(blkw):
-                return False
-
-            if not self._validate_on_chain_rules(blkw):
                 return False
 
             if not self._verify_block_batches(blkw):

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -45,16 +45,10 @@ from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 LOGGER = logging.getLogger(__name__)
 
 
-class BlockValidationAborted(Exception):
-    """
-    Indication that the validation of this fork has terminated for an
-    expected(handled) case and that the processing should exit.
-    """
-    pass
-
-
 class BlockValidationError(Exception):
-    pass
+    """
+    Indication that some step in the block validation process has failed.
+    """
 
 
 class ChainHeadUpdated(Exception):
@@ -371,7 +365,7 @@ class BlockValidator(object):
                 except KeyError:
                     for b in new_chain:
                         b.status = BlockStatus.Invalid
-                    raise BlockValidationAborted(
+                    raise BlockValidationError(
                         'Block {} missing predecessor {}'.format(
                             new_blkw,
                             new_blkw.previous_block_id))
@@ -395,7 +389,7 @@ class BlockValidator(object):
                 # We are at a genesis block and the blocks are not the same
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted(
+                raise BlockValidationError(
                     'Block {} has wrong genesis: {}'.format(
                         cur_blkw,
                         new_blkw))
@@ -407,7 +401,7 @@ class BlockValidator(object):
             except KeyError:
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted(
+                raise BlockValidationError(
                     'Block {} missing predecessor {}'.format(
                         new_blkw,
                         new_blkw.previous_block_id))
@@ -475,7 +469,7 @@ class BlockValidator(object):
                     new_blkw, cur_blkw,
                     new_chain, cur_chain)
 
-            except BlockValidationAborted as err:
+            except BlockValidationError as err:
                 LOGGER.warning('Could not find common ancestor: %s', err)
                 self._done_cb(False, self._result)
                 return

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -310,26 +310,25 @@ class BlockValidator(object):
             if blkw.status == BlockStatus.Invalid:
                 return False
 
-            valid = True
+            if not self._validate_permissions(blkw):
+                return False
 
-            valid = self._validate_permissions(blkw)
+            public_key = \
+                self._identity_signer.get_public_key().as_hex()
+            consensus = self._consensus_module.BlockVerifier(
+                block_cache=self._block_cache,
+                state_view_factory=self._state_view_factory,
+                data_dir=self._data_dir,
+                config_dir=self._config_dir,
+                validator_id=public_key)
+            if not consensus.verify_block(blkw):
+                return False
 
-            if valid:
-                public_key = \
-                    self._identity_signer.get_public_key().as_hex()
-                consensus = self._consensus_module.BlockVerifier(
-                    block_cache=self._block_cache,
-                    state_view_factory=self._state_view_factory,
-                    data_dir=self._data_dir,
-                    config_dir=self._config_dir,
-                    validator_id=public_key)
-                valid = consensus.verify_block(blkw)
+            if not self._validate_on_chain_rules(blkw):
+                return False
 
-            if valid:
-                valid = self._validate_on_chain_rules(blkw)
-
-            if valid:
-                valid = self._verify_block_batches(blkw)
+            if not self._verify_block_batches(blkw):
+                return False
 
             # since changes to the chain-head can change the state of the
             # blocks in BlockStore we have to revalidate this block.
@@ -339,7 +338,8 @@ class BlockValidator(object):
                     block_store.chain_head.identifier):
                 raise ChainHeadUpdated()
 
-            return valid
+            return True
+
         except Exception:
             LOGGER.exception(
                 "Unhandled exception BlockPublisher.validate_block()")

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -189,9 +189,8 @@ class BlockValidator(object):
             txn_hdr = self._txn_header(txn)
             if self._chain_commit_state.has_transaction(txn.header_signature):
                 LOGGER.debug(
-                    "Block rejected due to duplicate"
-                    " transaction, transaction: %s",
-                    txn.header_signature[:8])
+                    'Block rejected due to duplicate transaction: %s',
+                    txn.header_signature)
                 raise InvalidBatch()
             for dep in txn_hdr.dependencies:
                 if not self._chain_commit_state.has_transaction(dep):
@@ -199,8 +198,8 @@ class BlockValidator(object):
                         "Block rejected due to missing "
                         "transaction dependency, transaction %s "
                         "depends on %s",
-                        txn.header_signature[:8],
-                        dep[:8])
+                        txn.header_signature,
+                        dep)
                     raise InvalidBatch()
             self._chain_commit_state.add_txn(txn.header_signature)
 
@@ -215,9 +214,10 @@ class BlockValidator(object):
             for batch, has_more in look_ahead(blkw.block.batches):
                 if self._chain_commit_state.has_batch(
                         batch.header_signature):
-                    LOGGER.debug("Block(%s) rejected due to duplicate "
-                                 "batch, batch: %s", blkw,
-                                 batch.header_signature[:8])
+                    LOGGER.debug(
+                        'Block %s rejected due to duplicate batch: %s',
+                        blkw,
+                        batch.header_signature)
                     raise InvalidBatch()
 
                 self._verify_batch_transactions(batch)
@@ -228,10 +228,10 @@ class BlockValidator(object):
                 else:
                     scheduler.add_batch(batch, blkw.state_root_hash)
         except InvalidBatch:
-            LOGGER.debug("Invalid batch %s encountered during "
-                         "verification of block %s",
-                         batch.header_signature[:8],
-                         blkw)
+            LOGGER.debug(
+                'Invalid batch %s encountered during verification of block %s',
+                batch.header_signature,
+                blkw)
             scheduler.cancel()
             return False
         except Exception:
@@ -965,7 +965,7 @@ class ChainController(object):
         if chain_id is not None and chain_id != block.identifier:
             LOGGER.warning("Block id does not match block chain id %s. "
                            "Cannot set initial chain head.: %s",
-                           chain_id[:8], block.identifier[:8])
+                           chain_id, block.identifier)
             return
 
         state_view = self._state_view_factory.create_view()

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -51,6 +51,10 @@ class BlockValidationAborted(Exception):
     pass
 
 
+class BlockValidationError(Exception):
+    pass
+
+
 class ChainHeadUpdated(Exception):
     """ Raised when a chain head changed event is detected and we need to abort
     processing and restart processing with the new chain head.
@@ -281,27 +285,32 @@ class BlockValidator(object):
         return self._validation_rule_enforcer.validate(blkw, state_root)
 
     def validate_block(self, blkw):
+        '''Verifies that blkw has certain properties, raising
+        BlockValidationError if any of the checks fail.
+        '''
         # pylint: disable=broad-except
         try:
             if blkw.status == BlockStatus.Valid:
-                return True
+                return
 
             if blkw.status == BlockStatus.Invalid:
-                return False
+                raise BlockValidationError(
+                    'Block is already invalid')
 
             try:
                 state_root = self._get_previous_block_root_state_hash(blkw)
             except KeyError:
-                LOGGER.debug(
-                    "Block rejected due to missing predecessor: %s", blkw)
-                return False
+                raise BlockValidationError(
+                    'Block has missing predecessor')
 
             if blkw.block_num != 0:
                 if not self._validate_permissions(blkw, state_root):
-                    return False
+                    raise BlockValidationError(
+                        'Failed permissions')
 
                 if not self._validate_on_chain_rules(blkw, state_root):
-                    return False
+                    raise BlockValidationError(
+                        'Failed on-chain validation rules')
 
             public_key = \
                 self._identity_signer.get_public_key().as_hex()
@@ -312,10 +321,13 @@ class BlockValidator(object):
                 config_dir=self._config_dir,
                 validator_id=public_key)
             if not consensus.verify_block(blkw):
-                return False
+                raise BlockValidationError(
+                    'Failed {} consensus verification'.format(
+                        self._consensus_module))
 
             if not self._verify_block_batches(blkw, state_root):
-                return False
+                raise BlockValidationError(
+                    'Failed batch verification')
 
             # since changes to the chain-head can change the state of the
             # blocks in BlockStore we have to revalidate this block.
@@ -325,12 +337,10 @@ class BlockValidator(object):
                     block_store.chain_head.identifier):
                 raise ChainHeadUpdated()
 
-            return True
-
-        except Exception:
-            LOGGER.exception(
-                "Unhandled exception BlockPublisher.validate_block()")
-            return False
+        except Exception as exp:
+            raise BlockValidationError(
+                'Unhandled block validation error: {}'.format(
+                    exp))
 
     def _find_common_height(self, new_chain, cur_chain):
         """
@@ -467,9 +477,14 @@ class BlockValidator(object):
             valid = True
             for block in reversed(new_chain):
                 if valid:
-                    if not self.validate_block(block):
+                    try:
+                        self.validate_block(block)
+                    except BlockValidationError as err:
                         block.status = BlockStatus.Invalid
-                        LOGGER.info("Block validation failed: %s", block)
+                        LOGGER.warning(
+                            'Block %s failed validation: %s',
+                            block,
+                            err)
                         valid = False
                     block.status = BlockStatus.Valid
                     self._result["num_transactions"] += block.num_transactions
@@ -973,12 +988,14 @@ class ChainController(object):
             permission_verifier=self._permission_verifier,
             metrics_registry=self._metrics_registry)
 
-        valid = validator.validate_block(block)
-
-        if not valid:
+        try:
+            validator.validate_block(block)
+        except BlockValidationError as err:
             block.status = BlockStatus.Invalid
-            LOGGER.warning("The genesis block is not valid. Cannot "
-                           "set chain head: %s", block)
+            LOGGER.warning(
+                'Cannot set chain head; genesis block %s is not valid: %s',
+                block,
+                err)
             return
 
         block.status = BlockStatus.Valid

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -32,6 +32,7 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.chain import BlockValidator
 from sawtooth_validator.journal.chain import ChainController
+from sawtooth_validator.journal.chain import BlockValidationError
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.publisher import BlockPublisher
 from sawtooth_validator.journal.timed_cache import TimedCache
@@ -1230,7 +1231,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          return_value=False):
+                          side_effect=BlockValidationError):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)

--- a/validator/tests/test_validation_rule_enforcer/test.py
+++ b/validator/tests/test_validation_rule_enforcer/test.py
@@ -22,6 +22,8 @@ from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.validation_rule_enforcer import \
     ValidationRuleEnforcer
+from sawtooth_validator.journal.validation_rule_enforcer import \
+    ValidationRuleError
 from test_validation_rule_enforcer.mock import MockSettingsViewFactory
 
 
@@ -54,8 +56,7 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
         Test that if no validation rules are set, the block is valid.
         """
         blkw = self._make_block(["intkey"], "pub_key")
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_n_of_x(self):
         """
@@ -70,22 +71,20 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "NofX:1,intkey")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "NofX:0,intkey")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "NofX:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_x_at_y(self):
         """
@@ -100,22 +99,20 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "XatY:blockinfo,0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "XatY:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_local(self):
         """
@@ -132,23 +129,21 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "local:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
         blkw = self._make_block(["intkey"], "pub_key", False)
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
         self._settings_view_factory.add_setting(
             "sawtooth.validator.block_validation_rules",
             "local:test")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once(self):
         """
@@ -160,8 +155,7 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:intkey,0;local:0")
 
-        self.assertTrue(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_bad_number_of_intkey(self):
         """
@@ -173,8 +167,8 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "NofX:0,intkey;XatY:intkey,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_bad_family_at_index(self):
         """
@@ -187,8 +181,8 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:blockinfo,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")
 
     def test_all_at_once_signer_key(self):
         """
@@ -201,5 +195,5 @@ class ValidationRuleEnforcerTest(unittest.TestCase):
             "sawtooth.validator.block_validation_rules",
             "XatY:intkey,0;XatY:intkey,0;local:0")
 
-        self.assertFalse(
-            self._validation_rule_enforcer.validate(blkw, "state_root"))
+        with self.assertRaises(ValidationRuleError):
+            self._validation_rule_enforcer.validate(blkw, "state_root")


### PR DESCRIPTION
Currently when a block fails validation, the reason it failed is logged separately from the message saying that it failed. This makes it hard to track down what happened. This PR rearranges things in the block validator so that the messages are logged together.