### PR TITLE
Centralize block validation logging

### DIFF
--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -31,6 +31,7 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.chain import BlockValidator
+from sawtooth_validator.journal.chain import BlockValidationAborted
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.publisher import BlockPublisher
@@ -1230,7 +1231,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          return_value=False):
+                          side_effect=BlockValidationAborted):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)


### PR DESCRIPTION
Currently when a block fails validation, the reason it failed is logged separately from the message saying that it failed. This makes it hard to track down what happened. This PR rearranges things in the block validator so that the messages are logged together.