### PR TITLE
1.0: Avoid db write via StateViewFactory.create_view

### DIFF
--- a/validator/sawtooth_validator/state/state_view.py
+++ b/validator/sawtooth_validator/state/state_view.py
@@ -14,6 +14,7 @@
 # ------------------------------------------------------------------------------
 
 from sawtooth_validator.state.merkle import MerkleDatabase
+from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 
 
 class StateViewFactory(object):
@@ -43,9 +44,11 @@ class StateViewFactory(object):
         """
         # Create a default Merkle database and if we have a state root hash,
         # update the Merkle database's root to that
-        merkle_db = MerkleDatabase(self._database)
-        if state_root_hash is not None:
-            merkle_db.set_merkle_root(state_root_hash)
+        if state_root_hash is None:
+            state_root_hash = INIT_ROOT_KEY
+
+        merkle_db = MerkleDatabase(self._database,
+                                   merkle_root=state_root_hash)
 
         return StateView(merkle_db)
 


### PR DESCRIPTION
This fixes an issue where the call to create_view separates the
construciton and a call to set_merkle_root, in the case where no
root is provided.  However, the constructor also calls set_merkle_root,
which does a db put when the INIT_ROOT_KEY is the root. Therefore,
every instance of StateView is incurring the cost of a db write, after
block 0.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>