### PR TITLE
backport: Add 5 min. delay before systemd restarts services

### DIFF
--- a/validator/packaging/systemd/sawtooth-validator.service
+++ b/validator/packaging/systemd/sawtooth-validator.service
@@ -23,6 +23,7 @@ Group=sawtooth
 EnvironmentFile=-/etc/default/sawtooth-validator
 ExecStart=/usr/bin/sawtooth-validator $SAWTOOTH_VALIDATOR_ARGS
 Restart=on-failure
+RestartSec=300
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Systemd was restarting sawtooth services so fast the network was
unaware a node had dropped off. This change should also help the
core dump issue by reducing IO contention while the core gets written
to disk.

Signed-off-by: Richard Berg <rberg@bitwise.io>