### PR TITLE
Fix typo in sawtooth-debug compose file

### DIFF
--- a/docker/compose/sawtooth-debug.yaml
+++ b/docker/compose/sawtooth-debug.yaml
@@ -93,7 +93,7 @@ services:
       - SYS_PTRACE
     depends_on:
       - validator
-    command: settings-tp -vv -C tcp://validator:4004
+    command: intkey-tp-python -vv -C tcp://validator:4004
 
   rest-api:
     build:


### PR DESCRIPTION
The compose file was creating two settings TPs instead of a settings TP and an intkey TP.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>