### PR TITLE
Add new peer reporting CLI commands

### DIFF
--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -66,6 +66,9 @@ save_usage sawtooth state list
 save_usage sawtooth state show
 save_usage sawtooth transaction
 
+save_usage sawtooth status
+save_usage sawtooth status show
+
 save_usage sawtooth transaction list
 save_usage sawtooth transaction show
 

--- a/bin/generate_cli_output
+++ b/bin/generate_cli_output
@@ -84,6 +84,9 @@ save_usage sawadm genesis
 save_usage sawadm keygen
 
 save_usage sawnet
+save_usage sawnet peers
+save_usage sawnet peers list
+save_usage sawnet peers graph
 save_usage sawnet compare-chains
 
 save_usage sawtooth-validator

--- a/cli/sawtooth_cli/main.py
+++ b/cli/sawtooth_cli/main.py
@@ -42,6 +42,8 @@ from sawtooth_cli.settings import add_settings_parser
 from sawtooth_cli.settings import do_settings
 from sawtooth_cli.peer import add_peer_parser
 from sawtooth_cli.peer import do_peer
+from sawtooth_cli.status import add_status_parser
+from sawtooth_cli.status import do_status
 
 from sawtooth_cli.cli_config import load_cli_config
 
@@ -120,6 +122,7 @@ def create_parser(prog_name):
     add_identity_parser(subparsers, parent_parser)
     add_keygen_parser(subparsers, parent_parser)
     add_peer_parser(subparsers, parent_parser)
+    add_status_parser(subparsers, parent_parser)
     add_settings_parser(subparsers, parent_parser)
     add_state_parser(subparsers, parent_parser)
     add_transaction_parser(subparsers, parent_parser)
@@ -159,6 +162,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None,
         do_settings(args)
     elif args.command == 'peer':
         do_peer(args)
+    elif args.command == 'status':
+        do_status(args)
     else:
         raise CliException("invalid command: {}".format(args.command))
 

--- a/cli/sawtooth_cli/network_command/peers.py
+++ b/cli/sawtooth_cli/network_command/peers.py
@@ -1,0 +1,142 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import os
+import json
+
+from sawtooth_cli.network_command.parent_parsers import base_multinode_parser
+from sawtooth_cli.network_command.parent_parsers import split_comma_append_args
+from sawtooth_cli.network_command.parent_parsers import make_rest_apis
+
+from sawtooth_cli.exceptions import CliException
+
+
+DOT_FILE = 'peers.dot'
+
+
+def add_peers_parser(subparsers, parent_parser):
+    help_text = 'Shows the peering arrangment of a network'
+
+    parser = subparsers.add_parser(
+        'peers',
+        help=help_text,
+        description='{}.'.format(help_text))
+
+    peers_parsers = parser.add_subparsers(
+        title='subcommands',
+        dest='peers_command')
+    peers_parsers.required = True
+
+    _add_list_parser(peers_parsers, parent_parser)
+    _add_graph_parser(peers_parsers, parent_parser)
+
+
+def _add_list_parser(parser, parent_parser):
+    help_text = 'Lists peers for validators with given URLs'
+
+    list_parser = parser.add_parser(
+        'list',
+        help=help_text,
+        description='{}.'.format(help_text),
+        parents=[parent_parser, base_multinode_parser()])
+
+    list_parser.add_argument(
+        '--pretty', '-p',
+        action='store_true',
+        help='Pretty-print the results')
+
+
+def do_peers(args):
+    if args.peers_command == 'list':
+        _do_peers_list(args)
+    elif args.peers_command == 'graph':
+        _do_peers_graph(args)
+    else:
+        raise CliException('Invalid command: {}'.format(args.subcommand))
+
+
+def _do_peers_list(args):
+    urls = split_comma_append_args(args.urls)
+    users = split_comma_append_args(args.users)
+    clients = make_rest_apis(urls, users)
+
+    print(
+        json.dumps(
+            _get_peer_endpoints(clients),
+            sort_keys=True,
+            indent=(4 if args.pretty else 0)
+        )
+    )
+
+
+def _get_peer_endpoints(clients):
+    statuses = [client.get_status() for client in clients]
+
+    return {
+        status['endpoint']: [
+            peer['endpoint']
+            for peer in status['peers']
+        ]
+        for status in statuses
+    }
+
+
+def _add_graph_parser(parser, parent_parser):
+    help_text = "Generates a file to graph a network's peering arrangement"
+
+    graph_parser = parser.add_parser(
+        'graph',
+        help=help_text,
+        description='{}.'.format(help_text),
+        parents=[parent_parser, base_multinode_parser()])
+
+    graph_parser.add_argument(
+        '-o', '--output',
+        help='The path of the dot file to be produced (defaults to peers.dot)')
+
+    graph_parser.add_argument(
+        '--force',
+        action='store_true',
+        help='TODO')
+
+
+def _do_peers_graph(args):
+    urls = split_comma_append_args(args.urls)
+    users = split_comma_append_args(args.users)
+    clients = make_rest_apis(urls, users)
+
+    status_dict = _get_peer_endpoints(clients)
+
+    path = args.output if args.output else DOT_FILE
+
+    if not args.force and os.path.isfile(path):
+        raise CliException(
+            '{} already exists; '
+            'rerun with `--force` to overwrite'.format(path))
+
+    with open(path, 'w') as dot:
+        print(
+            'strict graph peers {',
+            file=dot)
+
+        for node, peers in status_dict.items():
+            for peer in peers:
+                print(
+                    '    "{}" -- "{}"'.format(node, peer),
+                    file=dot)
+
+        print(
+            '}',
+            file=dot)

--- a/cli/sawtooth_cli/peer.py
+++ b/cli/sawtooth_cli/peer.py
@@ -59,7 +59,7 @@ def do_peer(args):
 
 def do_peer_list(args):
     rest_client = RestClient(base_url=args.url)
-    peers = rest_client.list_peers()
+    peers = sorted(rest_client.list_peers())
 
     if args.format == 'csv' or args.format == 'default':
         print(','.join(peers))

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -54,6 +54,9 @@ class RestClient(object):
     def list_peers(self):
         return self._get('/peers')['data']
 
+    def get_status(self):
+        return self._get('/status')['data']
+
     def list_transactions(self):
         return self._get_data('/transactions')
 

--- a/cli/sawtooth_cli/rest_client.py
+++ b/cli/sawtooth_cli/rest_client.py
@@ -197,7 +197,8 @@ class RestClient(object):
             return (e.response.status_code, e.response.reason)
         except RemoteDisconnected as e:
             raise CliException(e)
-        except requests.exceptions.MissingSchema as e:
+        except (requests.exceptions.MissingSchema,
+                requests.exceptions.InvalidURL) as e:
             raise CliException(e)
         except requests.exceptions.ConnectionError as e:
             raise CliException(

--- a/cli/sawtooth_cli/sawnet.py
+++ b/cli/sawtooth_cli/sawnet.py
@@ -27,6 +27,8 @@ from sawtooth_cli.network_command.compare import add_compare_chains_parser
 from sawtooth_cli.network_command.compare import do_compare_chains
 from sawtooth_cli.network_command.list_blocks import add_list_blocks_parser
 from sawtooth_cli.network_command.list_blocks import do_list_blocks
+from sawtooth_cli.network_command.peers import add_peers_parser
+from sawtooth_cli.network_command.peers import do_peers
 
 
 DISTRIBUTION_NAME = 'sawnet'
@@ -44,6 +46,7 @@ def create_parser(prog_name):
 
     add_compare_chains_parser(subparsers, parent_parser)
     add_list_blocks_parser(subparsers, parent_parser)
+    add_peers_parser(subparsers, parent_parser)
 
     return parser
 
@@ -66,6 +69,8 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None,
         do_compare_chains(args)
     elif args.subcommand == 'list-blocks':
         do_list_blocks(args)
+    elif args.subcommand == 'peers':
+        do_peers(args)
     else:
         raise CliException('Invalid command: {}'.format(args.subcommand))
 

--- a/cli/sawtooth_cli/status.py
+++ b/cli/sawtooth_cli/status.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_cli import format_utils as fmt
+from sawtooth_cli.rest_client import RestClient
+from sawtooth_cli.exceptions import CliException
+from sawtooth_cli.parent_parsers import base_http_parser
+from sawtooth_cli.parent_parsers import base_list_parser
+
+
+def add_status_parser(subparsers, parent_parser):
+    """Adds argument parser for the status command
+
+        Args:
+            subparsers: Add parsers to this subparser object
+            parent_parser: The parent argparse.ArgumentParser object
+    """
+    parser = subparsers.add_parser(
+        'status',
+        help='Displays information about validator status',
+        description="Provides a subcommand to show a validator\'s status")
+
+    grand_parsers = parser.add_subparsers(title='subcommands',
+                                          dest='subcommand')
+    grand_parsers.required = True
+    add_status_show_parser(grand_parsers, parent_parser)
+
+
+def add_status_show_parser(subparsers, parent_parser):
+    description = ('Displays information about the status of a validator.')
+
+    subparsers.add_parser(
+        'show',
+        description=description,
+        parents=[base_http_parser(), base_list_parser()])
+
+
+def do_status(args):
+    if args.subcommand == 'show':
+        do_status_show(args)
+    else:
+        raise CliException('Invalid command: {}'.format(args.subcommand))
+
+
+def do_status_show(args):
+    rest_client = RestClient(base_url=args.url)
+    status = rest_client.get_status()
+
+    if args.format == 'csv' or args.format == 'default':
+        print(status)
+
+    elif args.format == 'json':
+        fmt.print_json(status)
+
+    elif args.format == 'yaml':
+        fmt.print_yaml(status)

--- a/docs/source/cli/sawnet.rst
+++ b/docs/source/cli/sawnet.rst
@@ -39,3 +39,30 @@ The ``sawnet compare-chains`` compares chains across the nodes given.
 .. literalinclude:: output/sawnet_compare-chains_usage.out
    :language: console
    :linenos:
+
+sawnet peers
+============
+
+.. literalinclude:: output/sawnet_peers_usage.out
+   :language: console
+   :linenos:
+
+sawnet peers list
+=================
+
+The ``sawnet peers list`` command displays the peers of the nodes
+given.
+
+.. literalinclude:: output/sawnet_peers_list_usage.out
+   :language: console
+   :linenos:
+
+sawnet peers graph
+==================
+
+The ``sawnet peers graph`` command outputs a file called ``peers.dot``
+describing the peering arrangement of the nodes given.
+
+.. literalinclude:: output/sawnet_peers_graph_usage.out
+   :language: console
+   :linenos:

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -394,6 +394,31 @@ into a file for further processing.
    :language: console
    :linenos:
 
+sawtooth status
+===============
+
+The ``sawtooth status`` subcommands display information related to a
+validator's status.
+
+.. literalinclude:: output/sawtooth_status_usage.out
+   :language: console
+   :linenos:
+
+sawtooth status show
+====================
+
+The ``sawtooth status`` subcommand displays information related to a
+validator's current status, including its public network endpoint and
+its peers.
+
+This subcommand requires the URL of the REST API (default:
+``http://localhost:8008``), and can specify a `username`:`password`
+combination when the REST API is behind a Basic Auth proxy.
+
+.. literalinclude:: output/sawtooth_status_show_usage.out
+   :language: console
+   :linenos:
+
 sawtooth transaction
 ====================
 

--- a/protos/client_status.proto
+++ b/protos/client_status.proto
@@ -31,7 +31,6 @@ message ClientStatusGetResponse {
     ERROR = 2;
   }
 
-  enum Peer {
   // Information about the validator's peers
   message Peer {
     // The peer's public network endpoint

--- a/protos/client_status.proto
+++ b/protos/client_status.proto
@@ -1,0 +1,45 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "client_status";
+
+// A request to get miscellaneous information about the validator
+message ClientStatusGetRequest{
+}
+
+message ClientStatusGetResponse {
+  // The status of the response message, not the validator's status
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    ERROR = 2;
+  }
+
+  enum Peer {
+  // Information about the validator's peers
+  message Peer {
+    // The peer's public network endpoint
+    string endpoint = 1;
+  }
+
+  Status status = 1;
+  repeated Peer peers = 2;
+  // The validator's public network endpoint
+  string endpoint = 3;
+}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -111,6 +111,10 @@ message Message {
         CLIENT_PEERS_GET_RESPONSE = 126;
         CLIENT_BLOCK_GET_BY_TRANSACTION_ID_REQUEST = 127;
         CLIENT_BLOCK_GET_BY_BATCH_ID_REQUEST = 128;
+        // A request for a validator's status
+        CLIENT_STATUS_GET_REQUEST = 129;
+        // A response with the validator's status
+        CLIENT_STATUS_GET_RESPONSE = 130;
 
         // Message types for events
         CLIENT_EVENTS_SUBSCRIBE_REQUEST = 500;

--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -467,6 +467,37 @@ paths:
         503:
           $ref: "#/responses/503ServiceUnavailable"
 
+  /status:
+    get:
+      summary: Fetches information pertaining to the status of the validator
+      responses:
+        200:
+          description: Successfully retrieved status
+          schema:
+            properties:
+              data:
+                type: object
+                properties:
+                  endpoint:
+                    type: string
+                    example: tcp://12.345.67.890:8800
+                  peers:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        endpoint:
+                          type: string
+                          example: tcp://12.345.67.890:8800
+              link:
+                $ref: "#/definitions/Link"
+        400:
+          $ref: "#/responses/400BadRequest"
+        500:
+          $ref: "#/responses/500ServerError"
+        503:
+          $ref: "#/responses/503ServiceUnavailable"
+
 responses:
   400BadRequest:
     description: Request was malformed

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -122,6 +122,7 @@ def start_rest_api(host, port, connection, timeout, registry):
     app.router.add_post('/receipts', handler.list_receipts)
 
     app.router.add_get('/peers', handler.fetch_peers)
+    app.router.add_get('/status', handler.fetch_status)
 
     subscriber_handler = StateDeltaSubscriberHandler(connection)
     app.router.add_get('/subscriptions', subscriber_handler.subscriptions)

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -38,6 +38,7 @@ from sawtooth_rest_api.protobuf import client_block_pb2
 from sawtooth_rest_api.protobuf import client_batch_pb2
 from sawtooth_rest_api.protobuf import client_receipt_pb2
 from sawtooth_rest_api.protobuf import client_peers_pb2
+from sawtooth_rest_api.protobuf import client_status_pb2
 from sawtooth_rest_api.protobuf.block_pb2 import BlockHeader
 from sawtooth_rest_api.protobuf.batch_pb2 import BatchList
 from sawtooth_rest_api.protobuf.batch_pb2 import BatchHeader
@@ -574,6 +575,22 @@ class RouteHandler(object):
         return self._wrap_response(
             request,
             data=response['peers'],
+            metadata=self._get_metadata(request, response))
+
+    async def fetch_status(self, request):
+        '''Fetches information pertaining to the valiator's status.'''
+
+        response = await self._query_validator(
+            Message.CLIENT_STATUS_GET_REQUEST,
+            client_status_pb2.ClientStatusGetResponse,
+            client_status_pb2.ClientStatusGetRequest())
+
+        return self._wrap_response(
+            request,
+            data={
+                'peers': response['peers'],
+                'endpoint': response['endpoint']
+            },
             metadata=self._get_metadata(request, response))
 
     async def _query_validator(self, request_type, response_proto,

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -187,6 +187,12 @@ class Gossip(object):
         with self._lock:
             return copy.copy(self._peers)
 
+    @property
+    def endpoint(self):
+        """Returns the validator's public endpoint.
+        """
+        return self._endpoint
+
     def register_peer(self, connection_id, endpoint):
         """Registers a connected connection_id.
 

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -228,7 +228,16 @@ def add(
         ClientEventsGetRequestHandler(event_broadcaster),
         thread_pool)
 
+    # Peers
+
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_PEERS_GET_REQUEST,
         client_handlers.PeersGetRequest(gossip),
+        thread_pool)
+
+    # Status
+
+    dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_STATUS_GET_REQUEST,
+        client_handlers.StatusGetRequest(gossip),
         thread_pool)

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -41,6 +41,7 @@ from sawtooth_validator.protobuf import client_transaction_pb2
 from sawtooth_validator.protobuf import client_batch_submit_pb2
 from sawtooth_validator.protobuf import client_list_control_pb2
 from sawtooth_validator.protobuf import client_peers_pb2
+from sawtooth_validator.protobuf import client_status_pb2
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf import validator_pb2
 
@@ -1072,3 +1073,23 @@ class PeersGetRequest(_ClientRequestHandler):
         peers = self._gossip.get_peers()
         endpoints = [peers[connection_id] for connection_id in peers]
         return self._wrap_response(peers=endpoints)
+
+
+class StatusGetRequest(_ClientRequestHandler):
+    def __init__(self, gossip):
+        super().__init__(
+            client_status_pb2.ClientStatusGetRequest,
+            client_status_pb2.ClientStatusGetResponse,
+            validator_pb2.Message.CLIENT_STATUS_GET_RESPONSE
+        )
+        self._gossip = gossip
+
+    def _respond(self, request):
+        peers = [
+            {'endpoint': endpoint}
+            for endpoint in self._gossip.get_peers().values()
+        ]
+
+        return self._wrap_response(
+            endpoint=self._gossip.endpoint,
+            peers=sorted(peers, key=lambda peer: peer['endpoint']))

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -1086,10 +1086,11 @@ class StatusGetRequest(_ClientRequestHandler):
 
     def _respond(self, request):
         peers = [
-            {'endpoint': endpoint}
+            self._response_proto.Peer(endpoint=endpoint)
+            # {'endpoint': endpoint}
             for endpoint in self._gossip.get_peers().values()
         ]
 
         return self._wrap_response(
             endpoint=self._gossip.endpoint,
-            peers=sorted(peers, key=lambda peer: peer['endpoint']))
+            peers=sorted(peers, key=lambda peer: peer.endpoint))


### PR DESCRIPTION
This PR adds `sawtooth status show`, which currently reports a node's public network endpoint and peers, and `sawnet peers {list,graph}`, which display the peering arrangement of a network of nodes.