### PR TITLE
Fix failure to Re-Request

### DIFF
--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -106,6 +106,11 @@ class Completer(object):
             LOGGER.debug("Drop duplicate block: %s", block)
             return None
 
+        if block.header_signature in self._requested:
+            # We asked for the batch, and now we got it, so let's remove it
+            # from our our requested set
+            del self._requested[block.header_signature]
+
         if block.previous_block_id not in self.block_cache:
             if not self._has_block(block.previous_block_id):
                 if block.previous_block_id not in self._incomplete_blocks:
@@ -163,16 +168,12 @@ class Completer(object):
             del block.batches[:]
             # reset batches with full list batches
             block.batches.extend(batches)
-            if block.header_signature in self._requested:
-                del self._requested[block.header_signature]
             return block
 
         else:
             batch_id_list = [x.header_signature for x in block.batches]
             # Check to see if batchs are in the correct order.
             if batch_id_list == list(block.header.batch_ids):
-                if block.header_signature in self._requested:
-                    del self._requested[block.header_signature]
                 return block
             # Check to see if the block has all batch_ids and they can be put
             # in the correct order
@@ -185,9 +186,6 @@ class Completer(object):
                     block.batches.extend(batches)
                 else:
                     return None
-
-                if block.header_signature in self._requested:
-                    del self._requested[block.header_signature]
 
                 return block
             else:


### PR DESCRIPTION
This fixes an issue where a gap occurs between the 'incomplete_blocks'
cache and the 'requested' cache.  On a long chain, the incomplete_blocks
cache will purge out items that have been received at the beginning,
while the requested cache has a longer lifespan.  When new block appear,
they are touching the entry for predecessors, but only walking back far
enough until they hit an already requested block.

On a chain where we're starting from block N, and need to catch up to M
(where M >> N), block M will be requested first, and be put in the
incomplete_blocks cache.  As we collect it's predecessors, it will
eventually be purged from the cache.  Incomming blocks will proceed to
request their predecessors, until they reach a block that has been
requested (starting with M-1).  Since touching the entry in the cache
resets its cache lifetime, it won't be purged, nor will it purge items,
since that only occurs on a __setitem__ call.  This requested cache entry
is only removed under certain branch conditions, therefore, the gap that
has been created in the incomplete_batches will widen, but never be
refilled.

By removing any block from the requested cache, we can avoid this
situation.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>