### PR TITLE
Move work done by completer to separate thread

### DIFF
--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -15,8 +15,11 @@
 
 import logging
 from threading import RLock
+import queue
 from collections import deque
+from enum import Enum
 
+from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.journal.block_cache import BlockCache
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
@@ -32,6 +35,40 @@ from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
 
 LOGGER = logging.getLogger(__name__)
+
+
+class _ItemType(Enum):
+    BLOCK = 0
+    BATCH = 1
+
+
+class _CompleterThread(InstrumentedThread):
+    def __init__(self, completer, item_queue):
+        super().__init__(name='_ChainThread')
+        self._completer = completer
+        self._queue = item_queue
+        self._exit = False
+
+    def run(self):
+        try:
+            while True:
+                try:
+                    (item_type, item) = self._queue.get(timeout=1)
+                    if item_type == _ItemType.BLOCK:
+                        self._completer.add_block(item)
+                    elif item_type == _ItemType.BATCH:
+                        self._completer.add_batch(item)
+                except queue.Empty:
+                    pass
+
+                if self._exit:
+                    return
+        # pylint: disable=broad-except
+        except Exception:
+            LOGGER.exception("_CompleterThread exited with error")
+
+    def stop(self):
+        self._exit = True
 
 
 class Completer(object):
@@ -76,10 +113,25 @@ class Completer(object):
                                              cache_purge_frequency)
         self._requested = TimedCache(requested_keep_time,
                                      cache_purge_frequency)
+
+        self._completer_thread = None
+        self._queue = queue.Queue()
+
         self._on_block_received = None
         self._on_batch_received = None
         self._has_block = None
         self.lock = RLock()
+
+    def start(self):
+        self._completer_thread = _CompleterThread(
+            completer=self,
+            item_queue=self._queue)
+        self._completer_thread.start()
+
+    def stop(self):
+        if self._completer_thread is not None:
+            self._completer_thread.stop()
+            self._completer_thread = None
 
     def _complete_block(self, block):
         """ Check the block to see if it is complete and if it can be passed to
@@ -279,6 +331,9 @@ class Completer(object):
     def set_chain_has_block(self, set_chain_has_block):
         self._has_block = set_chain_has_block
 
+    def queue_block(self, block):
+        self._queue.put((_ItemType.BLOCK, block))
+
     def add_block(self, block):
         with self.lock:
             blkw = BlockWrapper(block)
@@ -287,6 +342,9 @@ class Completer(object):
                 self.block_cache[block.header_signature] = blkw
                 self._on_block_received(blkw)
                 self._process_incomplete_blocks(block.header_signature)
+
+    def queue_batch(self, batch):
+        self._queue.put((_ItemType.BATCH, batch))
 
     def add_batch(self, batch):
         with self.lock:
@@ -360,7 +418,7 @@ class CompleterBatchListBroadcastHandler(Handler):
             if batch.trace:
                 LOGGER.debug("TRACE %s: %s", batch.header_signature,
                              self.__class__.__name__)
-            self._completer.add_batch(batch)
+            self._completer.queue_batch(batch)
             self._gossip.broadcast_batch(batch)
         return HandlerResult(status=HandlerStatus.PASS)
 
@@ -375,11 +433,11 @@ class CompleterGossipHandler(Handler):
         if gossip_message.content_type == network_pb2.GossipMessage.BLOCK:
             block = Block()
             block.ParseFromString(gossip_message.content)
-            self._completer.add_block(block)
+            self._completer.queue_block(block)
         elif gossip_message.content_type == network_pb2.GossipMessage.BATCH:
             batch = Batch()
             batch.ParseFromString(gossip_message.content)
-            self._completer.add_batch(batch)
+            self._completer.queue_batch(batch)
         return HandlerResult(status=HandlerStatus.PASS)
 
 
@@ -393,7 +451,7 @@ class CompleterGossipBlockResponseHandler(Handler):
 
         block = Block()
         block.ParseFromString(block_response_message.content)
-        self._completer.add_block(block)
+        self._completer.queue_block(block)
 
         return HandlerResult(status=HandlerStatus.PASS)
 
@@ -408,6 +466,6 @@ class CompleterGossipBatchResponseHandler(Handler):
 
         batch = Batch()
         batch.ParseFromString(batch_response_message.content)
-        self._completer.add_batch(batch)
+        self._completer.queue_batch(batch)
 
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -338,6 +338,7 @@ class Validator(object):
         self._genesis_controller = genesis_controller
         self._gossip = gossip
 
+        self._completer = completer
         self._block_publisher = block_publisher
         self._chain_controller = chain_controller
 
@@ -354,6 +355,7 @@ class Validator(object):
         self._network_service.start()
 
         self._gossip.start()
+        self._completer.start()
         self._block_publisher.start()
         self._chain_controller.start()
 
@@ -383,6 +385,7 @@ class Validator(object):
 
         self._block_publisher.stop()
         self._chain_controller.stop()
+        self._completer.stop()
 
         threads = threading.enumerate()
 


### PR DESCRIPTION
Previously the work being done by the completer was being done on the
network dispatcher's thread pool. It was observed that this work can be
expensive, which in turn slows down the validator's ability to process
new messages. Moving this work to a separate thread should allow the
validator to continue processing new messages while the completer does
its work.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>