### PR TITLE
Add protocol_version to  PeerRegisterRequest

### DIFF
--- a/protos/network.proto
+++ b/protos/network.proto
@@ -25,6 +25,9 @@ message DisconnectMessage {
 // The registration request from a peer to the validator
 message PeerRegisterRequest {
     string endpoint = 1;
+    // The current version of the network protocol that is being used by the
+    // sender.  This version is an increasing value.
+    uint32 protocol_version = 2;
 }
 
 // The unregistration request from a peer to the validator

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -68,6 +68,11 @@ MAXIMUM_STATIC_RETRIES = 24
 
 TIME_TO_LIVE = 3
 
+# This is the protocol version number.  It should only be incremented when
+# there are changes to the network protocols, as well as only once per
+# release.
+NETWORK_PROTOCOL_VERSION = 1
+
 
 class Gossip(object):
     def __init__(self, network,
@@ -776,7 +781,8 @@ class ConnectionManager(InstrumentedThread):
                     endpoint)
 
             register_request = PeerRegisterRequest(
-                endpoint=self._endpoint)
+                endpoint=self._endpoint,
+                protocol_version=NETWORK_PROTOCOL_VERSION)
 
             self._network.send(
                 validator_pb2.Message.GOSSIP_REGISTER,
@@ -884,7 +890,8 @@ class ConnectionManager(InstrumentedThread):
         LOGGER.debug("Connection to %s succeeded", connection_id)
 
         register_request = PeerRegisterRequest(
-            endpoint=self._endpoint)
+            endpoint=self._endpoint,
+            protocol_version=NETWORK_PROTOCOL_VERSION)
         self._connection_statuses[connection_id] = PeerStatus.TEMP
         try:
             self._network.send(

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -80,7 +80,8 @@ class PeerRegisterHandler(Handler):
         request = PeerRegisterRequest()
         request.ParseFromString(message_content)
 
-        LOGGER.debug("Got peer register message from %s", connection_id)
+        LOGGER.debug("Got peer register message from %s (%s, protocol v%s)",
+                     connection_id, request.endpoint, request.protocol_version)
 
         ack = NetworkAcknowledgement()
         try:


### PR DESCRIPTION
Add `protocol_version` to `PeerRegisterRequest`, to create a future avenue for dealing with network protocol changes.
