### PR TITLE
Add lock around get_connection_id_by_endpoint

### DIFF
--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -1046,11 +1046,12 @@ class Interconnect(object):
             endpoint (str): A zmq-style uri which identifies a publically
                 reachable endpoint.
         """
-        for connection_id in self._connections:
-            connection_info = self._connections[connection_id]
-            if connection_info.uri == endpoint:
-                return connection_id
-        raise KeyError()
+        with self._connections_lock:
+            for connection_id in self._connections:
+                connection_info = self._connections[connection_id]
+                if connection_info.uri == endpoint:
+                    return connection_id
+            raise KeyError()
 
     def update_connection_endpoint(self, connection_id, endpoint):
         """Adds the endpoint to the connection definition. When the


### PR DESCRIPTION
A recent traceback showed `RuntimeError: dictionary changed size
during iteration` getting raised from this function. This may be
related to occasional bad repeering behavior.