### PR TITLE
Add shutdown on CTL-C to rust transaction processor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,8 @@
 /sdk/go/bin/
 /sdk/examples/intkey_go/bin/
 /sdk/examples/intkey_rust/target/
-/sdk/examples/intkey_rust/Cargo.lock/
+/sdk/examples/intkey_rust/Cargo.lock
+/sdk/examples/intkey_rust/bin/
 /sdk/examples/xo_go/bin/
 /sdk/examples/noop_go/bin/
 /sdk/go/pkg/

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -28,6 +28,7 @@ zmq = { git = "https://github.com/erickt/rust-zmq", branch = "release/v0.8" }
 uuid = { version = "0.5", features = ["v4"] }
 log = "0.3"
 libc = "0.2"
+ctrlc = { version = "3.0", features = ["termination"] }
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/sdk/rust/src/messaging/stream.rs
+++ b/sdk/rust/src/messaging/stream.rs
@@ -20,6 +20,7 @@ use messages::validator::Message_MessageType;
 use std::error::Error;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::RecvError;
+use std::time::Duration;
 
 /// A Message Sender
 ///
@@ -152,6 +153,20 @@ impl MessageFuture {
                 result
             }
             Err(err) => Err(ReceiveError::ChannelError(err))
+        }
+    }
+
+    pub fn get_timeout(&mut self, timeout: Duration) -> MessageResult {
+        if let Some(ref result) = self.result {
+            return result.clone();
+        }
+
+        match self.inner.recv_timeout(timeout) {
+            Ok(result) => {
+                self.result = Some(result.clone());
+                result
+            }
+            Err(_) => Err(ReceiveError::TimeoutError)
         }
     }
 }


### PR DESCRIPTION
Looking for suggestions on ways to improve this. Currently, I needed to add timeouts to 3 places we were blocking on  (using arbitrary timeouts for now). I originally tried adding unregister directly as the handler for ctl-c but the handler can only be set once but we need to be able to update the sender used in case of reconnection. 