### PR TITLE
Fix doc and comment for minimum wait time

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -63,8 +63,7 @@ class ConsensusState(object):
             claimed by all validators
     """
 
-    # MINIMUM_WAIT_TIME should be same as the value
-    # at ecall_CreateWaitTimer
+    # MINIMUM_WAIT_TIME must match the constants in the enclaves
     MINIMUM_WAIT_TIME = 1.0
 
     _BlockInfo = \

--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -425,7 +425,6 @@ and specifies the appropriate settings:
           sawtooth.consensus.algorithm=poet \
           sawtooth.poet.initial_wait_timer=x \
           sawtooth.poet.target_wait_time=x \
-          sawtooth.poet.minimum_wait_time=x \
           sawtooth.poet.population_estimate_sample_size=x \
 	  sawadm genesis \
           sawset.batch


### PR DESCRIPTION
Remove reference in docs to now unsupported minimum_wait_time
and improve the code comment on the now hard-coded value.

Signed-off-by: Dan Middleton <dan.middleton@intel.com>

See also #1367 