### PR TITLE
Fix for two errors dealing with unscheduling.

### DIFF
--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -299,9 +299,15 @@ class ContextManager(object):
             # the context.
             for address in addresses_not_in_ctx:
                 context.validate_read(address)
-            address_values, reads = self._find_address_values_in_chain(
-                base_contexts=[context_id],
-                addresses_to_find=addresses_not_in_ctx)
+            try:
+                address_values, reads = self._find_address_values_in_chain(
+                    base_contexts=[context_id],
+                    addresses_to_find=addresses_not_in_ctx)
+            except KeyError:
+                # This is in the exceptional case when a txn is in flight
+                # and so the context may not exist but the tp is asking
+                # about it.
+                return []
 
             values_list.extend(address_values)
 

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -871,6 +871,7 @@ class ParallelScheduler(Scheduler):
     def unschedule_incomplete_batches(self):
         incomplete_batches = set()
         with self._condition:
+            # These transactions have never been scheduled.
             for txn in self._unscheduled_transactions():
                 batch = self._batches_by_txn_id[txn.header_signature]
                 batch_id = batch.header_signature
@@ -879,7 +880,11 @@ class ParallelScheduler(Scheduler):
                 if not annotated_batch.preserve:
                     incomplete_batches.add(batch_id)
 
-            for txn_id in self._outstanding:
+            # These transactions were in flight.
+            in_flight = set(self._transactions.keys()).difference(
+                self._txn_results.keys())
+
+            for txn_id in in_flight:
                 batch = self._batches_by_txn_id[txn_id]
                 batch_id = batch.header_signature
 


### PR DESCRIPTION
One error is a scheduler - context manager - wildcarded addresses interaction where a transaction is in flight when unscheduling occurs. This would raise a KeyError in the context manager when the transaction processor performed a Get using the context id for the in-flight transaction. This was apparent during manual testing of Smallbank and SupplyChain, and in the unit test in this PR.

The other error is in the parallel-scheduler unscheduling mechanism. This was found by the unit test in this PR. This caused the parallel-scheduler to hang on calling complete with block=True.