### PR TITLE
Explicitly Cancel Discarded Candidate Blocks

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -136,9 +136,10 @@ class _CandidateBlock(object):
         self._batch_injectors = batch_injectors
 
     def __del__(self):
-        # Cancel the scheduler if it is not complete
-        if not self._scheduler.complete(block=False):
-            self._scheduler.cancel()
+        self.cancel()
+
+    def cancel(self):
+        self._scheduler.cancel()
 
     @property
     def injected_batch_ids(self):
@@ -692,6 +693,9 @@ class BlockPublisher(object):
                                 'chain head arrives.')
 
                 self._chain_head = chain_head
+
+                if self._candidate_block:
+                    self._candidate_block.cancel()
 
                 self._candidate_block = None  # we need to make a new
                 # _CandidateBlock (if we can) since the block chain has updated


### PR DESCRIPTION
Currently, when the chain is updated and a candidate block is in progress,
it is set to None - i.e. discarded. Its schedule is cancelled when the
garbage collector reclaims the object's memory. This can happen at
unpredictable times, which results blocks being published which should
have been abandoned.

By converting this to an explicit cancel, the candidate block is
abandoned and its schedule cancelled immediately.  This reduces the need
for the network to evaluate blocks that should never have been produced
in the first place.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>