### PR TITLE
1-0 Backport Swap completer cache keep times

### DIFF
--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -49,9 +49,9 @@ class Completer(object):
     def __init__(self,
                  block_store,
                  gossip,
-                 cache_keep_time=300,
+                 cache_keep_time=1200,
                  cache_purge_frequency=30,
-                 requested_keep_time=1200):
+                 requested_keep_time=300):
         """
         :param block_store (dictionary) The block store shared with the journal
         :param gossip (gossip.Gossip) Broadcasts block and batch request to
@@ -60,6 +60,11 @@ class Completer(object):
             TimedCaches.
         :param cache_purge_frequency (float) Time between purging the
             TimedCaches.
+        :param requested_keep_time (float) Time in seconds to keep the ids
+            of requested objects. WARNING this time should always be less than
+            cache_keep_time or the validator can get into a state where it
+            fails to make progress because it thinks it has already requested
+            something that it is missing.
         """
         self.gossip = gossip
         self.batch_cache = TimedCache(cache_keep_time, cache_purge_frequency)


### PR DESCRIPTION
Setting the requested keep time higher than the cache keep time can
cause the validator to get into a state where it stops processing blocks
all together because it thinks it has already requested the blocks that
it needs to request.

Swapping these keep times should eliminate this bug and allow a
validator to catchup successfully, provided it does not run out of
memory (a different bug).

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>