### PR TITLE
Correct settings-tp name in doc and command's help text

### DIFF
--- a/docs/source/cli/sawset.rst
+++ b/docs/source/cli/sawset.rst
@@ -44,7 +44,7 @@ during genesis block construction.
 sawset proposal
 ===============
 
-The Settings transaction processor (``sawtooth-settings``) supports a
+The Settings transaction family supports a
 simple voting mechanism for applying changes to on-change settings.
 The ``sawset proposal`` subcommands provide tools to view,
 create and vote on proposed settings.

--- a/families/settings/sawtooth_settings/processor/main.py
+++ b/families/settings/sawtooth_settings/processor/main.py
@@ -90,7 +90,7 @@ def setup_loggers(verbose_level, processor):
 def create_parser(prog_name):
     parser = argparse.ArgumentParser(
         prog=prog_name,
-        description='Starts a sawtooth-settings transaction processor.',
+        description='Starts a Settings transaction processor (settings-tp).',
         epilog='This process is required to apply any changes to on-chain '
                'settings used by the Sawtooth platform.',
         formatter_class=argparse.RawDescriptionHelpFormatter)


### PR DESCRIPTION
Bug fix to change the incorrect command name, "sawtooth-settings", to the right one: "settings-tp". 

This PR has two commits: one to fix the documentation, and one to fix the code comment.

    
    