### PR TITLE
Fix titles and content in Sawtooth documentation

### DIFF
--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -487,10 +487,7 @@ sophisticated, `BSON <http://bsonspec.org/>`_.
 Implementing Game Play
 ======================
 
-This tutorial does not include example code for playing tic-tac-toe. The details are fairly
-straightforward, and the functionality could certainly be implemented in
-different ways.
-
+Game-play functionality can be implemented in different ways.
 For our implementation, see
 {% if language == 'JavaScript' %}
 `sawtooth-core/sdk/examples/xo_javascript/xo_handler.js

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -487,7 +487,7 @@ sophisticated, `BSON <http://bsonspec.org/>`_.
 Implementing Game Play
 ======================
 
-Next, describe how to play tic-tac-toe. The details here are fairly
+This tutorial does not include example code for playing tic-tac-toe. The details are fairly
 straightforward, and the functionality could certainly be implemented in
 different ways.
 

--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -16,7 +16,7 @@ the following tasks:
 * Launching and connecting to an EC2 instance running Sawtooth
 * Starting a Sawtooth validator and related components
 * Submitting transactions to the REST API
-* Viewing blocks, transactions, and state with the sawtooth CLI tool
+* Viewing blocks, transactions, and state with Sawtooth commands
 
 Upon completion of this section, you will be prepared for subsequent sections
 that describe application development topics, such as implementing business
@@ -73,13 +73,13 @@ to log in to the instance you just launched. Use the username
 
 Once you've successfully logged in, continue to the next section.
 
-Using Sawtooth with the CLI Commands
-====================================
+Using Sawtooth Commands
+=======================
 
 Creating and Submitting Transactions with intkey
 ------------------------------------------------
 
-The ``intkey`` CLI command is provided to create sample transactions of the
+The ``intkey`` command is provided to create sample transactions of the
 intkey (IntegerKey) transaction type for testing purposes. Using it you will
 be able to prepare batches of intkey transactions that *set* a few keys to
 random values, then randomly *inc* (increment) and *dec* (decrement) those
@@ -157,8 +157,8 @@ command.
 
 .. note::
 
-  The sawtooth CLI provides help for all subcommands. For example, to get help
-  for the ``block`` subcommand, enter the command ``sawtooth block -h``.
+  The ``sawtooth`` command provides help for all subcommands. For example, to
+  get help for the ``block`` subcommand, enter the command ``sawtooth block -h``.
 
 Viewing the List of Blocks
 ++++++++++++++++++++++++++

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -9,7 +9,7 @@ Sawtooth concepts necessary for application development, and walks through
 performing the following tasks:
 
 * Submit transactions to the REST API
-* View blocks, transactions, and state with the sawtooth CLI tool
+* View blocks, transactions, and state with Sawtooth commands
 * Start and stop validators and transaction processors
 
 
@@ -83,7 +83,7 @@ containers:
 * A single validator using dev-mode consensus
 * A REST API connected to the validator
 * The Settings, IntegerKey, and XO transaction processors
-* A client container for running the CLI commands
+* A client container for running Sawtooth commands
 
 The Docker Compose file also specifies the container images to download from
 Docker Hub and the network settings needed for all the containers to communicate
@@ -190,7 +190,7 @@ After shutdown has completed, run this command:
 Logging Into The Client Container
 =================================
 
-The client container is used to run sawtooth CLI commands, which is the usual
+The client container is used to run Sawtooth commands, which is the usual
 way to interact with validators or validator networks.
 
 Log into the client container by opening a new terminal window and
@@ -264,13 +264,13 @@ If the validator process or the validator container is not running, the ``curl``
 command will time out or return nothing.
 
 
-Using Sawtooth with CLI Commands
-================================
+Using Sawtooth Commands
+=======================
 
 Creating and Submitting Transactions with intkey
 ------------------------------------------------
 
-The ``intkey`` CLI command is provided to create sample transactions of the
+The ``intkey`` command is provided to create sample transactions of the
 intkey (IntegerKey) transaction type for testing purposes. This step uses
 ``intkey`` to prepare batches of intkey transactions which set a few keys
 to random values, then randomly increment and decrement those values. These
@@ -325,8 +325,8 @@ You can view the blocks stored in the blockchain using the
 
 .. note::
 
-  The sawtooth CLI provides help for all subcommands. For example, to get help
-  for the ``block`` subcommand, enter the command ``sawtooth block -h``.
+  The ``sawtooth`` command provides help for all subcommands. For example, to
+  get help for the ``block`` subcommand, enter the command ``sawtooth block -h``.
 
 Viewing the List of Blocks
 ++++++++++++++++++++++++++
@@ -482,7 +482,7 @@ The Client Container
 --------------------
 
 * Submits transactions
-* Runs ``sawtooth`` CLI commands
+* Runs Sawtooth commands
 * Container name: ``sawtooth-shell-default``
 
 No Sawtooth components are automatically started in this container.
@@ -664,7 +664,7 @@ commands.
   The config command needs to use a key generated in the validator container.
   Thus, you must open a terminal window running in the validator container,
   rather than the client container (for the following command only).
-  Run the following command from your host machine's CLI.
+  Run the following command on your host machine:
 
 .. code-block:: console
 

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -357,8 +357,8 @@ Merkle-Radix tree (global state) by using the ``sawtooth block`` command.
 
 .. note::
 
-  The ``sawtooth`` CLI provides help for all subcommands. For example, to get
-  help for the ``block`` subcommand, enter the command ``sawtooth block -h``.
+  The ``sawtooth`` command provides help for all subcommands. For example, to
+  get help for the ``block`` subcommand, enter the command ``sawtooth block -h``.
 
 Viewing the List of Blocks
 --------------------------

--- a/docs/source/architecture/transactions_and_batches.rst
+++ b/docs/source/architecture/transactions_and_batches.rst
@@ -1,6 +1,6 @@
-*************************
-Transactions and Batches!
-*************************
+************************
+Transactions and Batches
+************************
 
 Modifications to state are performed by creating and applying transactions.  A
 client creates a transaction and submits it to the validator.  The validator

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -196,8 +196,8 @@ Real-world Application Examples
 
   * XO: Demonstrates how to construct basic transactions by playing
     `Tic-tac-toe <https://en.wikipedia.org/wiki/Tic-tac-toe>`_. The
-    XO transaction family includes create and take transactions, with an XO
-    command-line interface (CLI) that allows two participants to play the game.
+    XO transaction family includes create and take transactions, with an ``xo``
+    command that allows two participants to play the game.
     For more information, see
     :doc:`/app_developers_guide/intro_xo_transaction_family`.
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -48,7 +48,7 @@ provide "adversarial trust" among all participants in a blockchain network.
 Distinctive Features of Sawtooth
 ================================
 
-Separation between the application level and the core system
+Separation Between the Application Level and the Core System
 ------------------------------------------------------------
 
 Sawtooth makes it easy to develop and deploy an application by providing a
@@ -75,7 +75,7 @@ creation of new contract languages, including Python, JavaScript, Go, C++,
 Java, and Rust. A provided REST API simplifies client development by
 adapting :term:`validator<Validator>` communication to standard HTTP/JSON.
 
-Private networks with the Sawtooth permissioning features
+Private Networks with the Sawtooth Permissioning Features
 ---------------------------------------------------------
 
 Sawtooth is built to solve the challenges of permissioned (private) networks.
@@ -87,9 +87,7 @@ The blockchain stores the settings that specify the permissions, such as roles
 and identities, so that all participants in the network can access this
 information.
 
-.. _parallel-execution-label:
-
-Parallel transaction execution
+Parallel Transaction Execution
 ------------------------------
 
 Most blockchains require serial transaction execution in order to guarantee
@@ -104,7 +102,7 @@ double-spending even with multiple modifications to the same state. Parallel
 scheduling provides a substantial potential increase in performance over
 serial execution.
 
-Event system
+Event System
 ------------
 
 Hyperledger Sawtooth supports creating and broadcasting events. This allows
@@ -120,7 +118,7 @@ applications to:
 
 Subscriptions are submitted and serviced over a ZMQ Socket.
 
-Ethereum contract compatibility with Seth
+Ethereum Contract Compatibility with Seth
 -----------------------------------------
 
 The Sawtooth-Ethereum integration project, Seth, extends the interoperability
@@ -163,7 +161,7 @@ Sawtooth currently supports these consensus implementations:
 
 .. _sample-transaction-families-label:
 
-Sample transaction families
+Sample Transaction Families
 ---------------------------
 
 In Sawtooth, the data model and transaction language are implemented

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -93,8 +93,8 @@ roles and policies.
 
   $ sawset proposal create sawtooth.identity.allowed_keys=02b2be336a6ada8f96881cd55fd848c10386d99d0a05e1778d2fc1c60c2783c2f4
 
-Once your signer key is stored in the setting, the ``identity`` CLI can be used
-to set and update roles and policies. Make sure that the identity transaction
+Once your signer key is stored in the setting, the ``identity-tp`` command can be used
+to set and update roles and policies. Make sure that the Identity transaction
 processor and the REST API are running.
 
 .. literalinclude:: ../cli/output/sawtooth_identity_policy_create_usage.out

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -188,7 +188,7 @@ The ``validator.toml`` configuration file has the following options:
   .. Note::
 
     The ``default`` role cannot be set in the configuration file. Use the
-    ``sawtooth identity`` CLI to change this on-chain-only setting.
+    ``sawtooth identity`` command to change this on-chain-only setting.
 
   See :doc:`../configuring_permissions` for more information on roles and
   permissions.

--- a/docs/source/transaction_family_specifications/settings_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/settings_transaction_family.rst
@@ -5,7 +5,7 @@ Settings Transaction Family
 Overview
 =========
 
-The settings transaction family provides a methodology for storing on-chain
+The Settings transaction family provides a methodology for storing on-chain
 configuration settings.
 
 The settings stored in state as a result of this transaction family play a
@@ -40,7 +40,7 @@ State
 =====
 
 This section describes in detail how settings are stored and addressed using
-the settings transaction family.
+the Settings transaction family.
 
 The setting data consists of setting/value pairs. A setting is the name for the
 item of configuration data. The value is the data in the form of a string.
@@ -58,7 +58,7 @@ sawtooth.validator.max_transactions_per_block 1000
 ============================================= ============
 
 
-The settings transaction family uses the following settings for its own configuration:
+The Settings transaction family uses the following settings for its own configuration:
 
 +-------------------------------------------+------------------------------------------------------------------------------+
 | Setting (Settings)                        | Value Description                                                            |


### PR DESCRIPTION
- Fix wording and capitalization for several titles (and remove ! from "Transactions and Batches")
- Correct a few wording problems, such as capitalization for the Identity and Settings transaction family 
- Change "CLI" to "command" throughout

