### PR TITLE
Edit Community section and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,5 @@
 # Contributing to Hyperledger Sawtooth
 
-This document covers how to report issues and contribute code
-to the Hyperledger Sawtooth project.
-
-## Topics
-
-* [Reporting Issues](#reporting-issues)
-* [Contributing Code](#contributing-code)
-
-# Reporting Issues
-
-Please refer to [Issue Tracking](https://sawtooth.hyperledger.org/docs/core/releases/latest/community/issue_tracking.html)
-in the Sawtooth documentation.
-
-# Contributing Code
-
 Hyperledger Sawtooth is Apache 2.0 licensed and accepts contributions via
 [GitHub](https://github.com/hyperledger/sawtooth-core) pull requests.
 

--- a/docs/source/community/contributing.rst
+++ b/docs/source/community/contributing.rst
@@ -14,8 +14,6 @@ Ways you can contribute:
 
 * Bugs or issues: Report problems or defects found when working with Sawtooth
 * Core features and enhancements: Provide expanded capabilities or optimizations
-* Arcade features: Add games that demonstrate Sawtooth; see the existing
-  games XO (tic-tac-toe) and Battleship
 * Documentation: Improve existing documentation or create new information
 * Tests for events and results: Add functional, performance, or scalability
   tests
@@ -38,7 +36,6 @@ pull requests. When contributing code, please follow these guidelines:
 * Ensure that the unit and integration tests run successfully. Run both
   of these tests with ``./bin/run_tests``
 * Check that the lint tests pass by running ``./bin/run_lint -s master``.
-  Note that this command does not produce output on success
 
 **Pull Request Guidelines**
 
@@ -72,6 +69,12 @@ These rules are well documented in `Chris Beam's blog post
 Each commit must include a "Signed-off-by" line in the commit message
 (``git commit -s``). This sign-off indicates that you agree the commit satisfies
 the `Developer Certificate of Origin (DCO) <http://developercertificate.org/>`_.
+
+**Commit Email Address**
+
+Your commit email address must match your GitHub email address. For more
+information, see
+https://help.github.com/articles/setting-your-commit-email-address-in-git/
 
 **Important GitHub Requirements**
 

--- a/docs/source/community/contributing.rst
+++ b/docs/source/community/contributing.rst
@@ -2,100 +2,95 @@
 Contributing
 ------------
 
+==========================================
+Ways to Contribute to Hyperledger Sawtooth
+==========================================
+
+Contributions from the development community help improve the capabilities of
+Hyperledger Sawtooth. These contributions are the most effective way to
+make a positive impact on the project.
+
+Ways you can contribute:
+
+* Bugs or issues: Report problems or defects found when working with Sawtooth
+* Core features and enhancements: Provide expanded capabilities or optimizations
+* Arcade features: Add games that demonstrate Sawtooth; see the existing
+  games XO (tic-tac-toe) and Battleship
+* Documentation: Improve existing documentation or create new information
+* Tests for events and results: Add functional, performance, or scalability
+  tests
+
+Hyperledger Sawtooth issues can be found in :ref:`jira`.  Any unassigned items
+are probably still open. When in doubt, ask on RocketChat about
+a specific JIRA issue (see :doc:`join_the_discussion`).
+
 ==================
-Ways to Contribute
+The Commit Process
 ==================
-
-Contributions by the community help grow and optimize the capabilities of
-Hyperledger Sawtooth, and are the most effective method of having a positive
-impact on the project.
-
-**Different ways you can contribute**
-
-* Bugs or Issues (issues or defects found when working with Sawtooth)
-* Core Features & Enhancements (expanded capabilities or optimization)
-* Arcade Features (games that demonstrate Sawtooth such as Tic-Tac-Toe
-  and Battleship)
-* New or Enhanced Documentation (improve existing documentation or create new)
-* Testing Events and Results (functional, performance or scalability)
-
-**Unassigned JIRA Issues**
-
-More specific items can be found in :ref:`jira`.  Any JIRA items which are
-unassigned are probably still open.  If in doubt, ask on :ref:`chat` about
-the particular JIRA issue.
-
-==============
-Commit Process
-==============
 
 Hyperledger Sawtooth is Apache 2.0 licensed and accepts contributions
 via `GitHub <https://github.com/hyperledger/sawtooth-core>`_
-pull requests. When contributing code please do the following:
+pull requests. When contributing code, please follow these guidelines:
 
-* Fork the repository and make your changes in a feature branch.
-* Please include unit and integration tests for any new features and updates
-  to existing tests.
-* Please ensure the unit and integration tests run successfully. Both are run
-  with `./bin/run_tests`.
-* Please ensure that lint passes by running './bin/run_lint -s master'.
-  On success, the command produces no output.
+* Fork the repository and make your changes in a feature branch
+* Include unit and integration tests for any new features and updates
+  to existing tests
+* Ensure that the unit and integration tests run successfully. Run both
+  of these tests with ``./bin/run_tests``
+* Check that the lint tests pass by running ``./bin/run_lint -s master``.
+  Note that this command does not produce output on success
 
 **Pull Request Guidelines**
 
-Pull requests can contain a single commit or multiple commits. The most
-important part is that **a single commit maps to a single fix or enhancement**.
+A pull request can contain a single commit or multiple commits. The most
+important guideline is that a single commit should map to a single fix or
+enhancement. Here are some example scenarios:
 
-Here are a few scenarios:
+* If a pull request adds a feature but also fixes two bugs, the pull
+  request should have three commits: one commit for the feature change and
+  two commits for the bug fixes.
+* If a PR is opened with five commits that contain changes to fix a single
+  issue, the PR should be rebased to a single commit.
+* If a PR is opened with several commits, where the first commit fixes one issue
+  and the rest fix a separate issue, the PR should be rebased to two
+  commits (one for each issue).
 
-* If a pull request adds a feature but also fixes two bugs, then the pull
-  request should have three commits, one commit each for the feature and two
-  bug fixes
-* If a PR is opened with 5 commits that was work involved to fix a single issue,
-  it should be rebased to a single commit
-* If a PR is opened with 5 commits, with the first three to fix one issue and
-  the second two to fix a separate issue, then it should be rebased to two
-  commits, one for each issue
-
-Your pull request should be rebased against the current master branch. Please do
-not merge the current master branch in with your topic branch, nor use the
-Update Branch button provided by GitHub on the pull request page.
+**Important:**
+  Your pull request should be rebased against the current master branch. Do
+  not merge the current master branch in with your topic branch. Do not use the
+  Update Branch button provided by GitHub on the pull request page.
 
 **Commit Messages**
 
-Commit messages should follow common Git conventions, such as the imperative
-mood, separate subject lines, and a line-length of 72 characters. These rules
-are well documented by Chris Beam in
-`his blog post <https://chris.beams.io/posts/git-commit/#seven-rules>`_ on the
-subject.
+Commit messages should follow common Git conventions, such as using the
+imperative mood, separate subject lines, and a line length of 72 characters.
+These rules are well documented in `Chris Beam's blog post
+<https://chris.beams.io/posts/git-commit/#seven-rules>`_.
 
 **Signed-off-by**
 
-Commits must include Signed-off-by in the commit message (``git commit -s``).
-This indicates that you agree the commit satisfies the
-`Developer Certificate of Origin (DCO) <http://developercertificate.org/>`_.
+Each commit must include a "Signed-off-by" line in the commit message
+(``git commit -s``). This sign-off indicates that you agree the commit satisfies
+the `Developer Certificate of Origin (DCO) <http://developercertificate.org/>`_.
 
 **Important GitHub Requirements**
 
-PLEASE NOTE: Pull requests can only be merged after they have passed all
-status checks.
-
-These checks are:
+A pull request cannot merged until it has passed these status checks:
 
 * The build must pass on Jenkins
-* The PR must be approved by at least two reviewers and there cannot be
-  outstanding changes requested
+* The PR must be approved by at least two reviewers without any
+  outstanding requests for changes
 
 **Integrating GitHub Commits with JIRA**
 
-You can link JIRA issues to your Hyperledger Sawtooth GitHub commits to integrate
-the developer's activity with the associated issue. JIRA uses the issue key to
-associate the commit with the issue, so the commit can be summarized in the
+You can link JIRA issues to your commits, which  will integrate
+developer activity with the associated issue. JIRA uses the issue key to
+associate the commit with the issue, so that the commit can be summarized in the
 development panel for the JIRA issue.
 
-When you make a commit, add the JIRA issue key to the end of the commit message.
-Alternatively, you can add the JIRA issue key to the branch name. Either method
-should integrate your commit with the JIRA issue it references.
+When you make a commit, add the JIRA issue key to the end of the commit message
+or to the branch name. Either method should integrate your commit with the JIRA
+issue that it references.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/community/issue_tracking.rst
+++ b/docs/source/community/issue_tracking.rst
@@ -1,53 +1,50 @@
-**************
-Issue Tracking
-**************
+***************
+Tracking Issues
+***************
+
+A great way to contribute is by reporting issues. Before reporting an issue,
+please review the current open issues to see if someone has already reported
+the issue.
 
 .. _jira:
 
-Reporting Issues
-================
+Using JIRA
+==========
 
-This is a great way to contribute. Before reporting an issue, please review current
-open issues to see if there are any matches.
+Hyperledger Sawtooth uses JIRA as our issue tracking system:
+
+https://jira.hyperledger.org/projects/STL
+
+If you want to contribute to Hyperledger Sawtooth quickly, we have a list of
+issues that will help you get involved right away. See the open Sawtooth issues:
+
+https://jira.hyperledger.org/issues/?filter=10612
+
 
 How to Report an Issue
 ======================
 
-Issues should be created in JIRA under the Hyperledger Sawtooth project
-(which uses the *STL* JIRA key).
+To report issues, log into `jira.hyperledger.org
+<https://jira.hyperledger.org>`_, which requires a
+`Linux Foundation Account <https://identity.linuxfoundation.org/>`_.
+
+Create issues in JIRA under the Hyperledger Sawtooth project,
+which uses the ``STL`` JIRA key.
 
 When reporting an issue, please provide as much detail as possible about how
-to reproduce it.  If possible, provide instructions for how to reproduce the
-issue.
-
-Details are key. Please include the following:
+to reproduce it. If possible, explain how to reproduce the issue.
+Details are very helpful. Please include the following information:
 
 * OS version
 * Sawtooth version
 * Environment details (virtual, physical, etc.)
-* Steps to reproduce
+* Steps to reproduce the issue
 * Actual results
 * Expected results
 
-If you would like, you could also bring up the issue on :ref:`chat`
+If you would like, you could also describe the issue on RocketChat
+(see :doc:`join_the_discussion`)
 for initial feedback before submitting the issue in JIRA.
-
-JIRA
-====
-
-Hyperledger Sawtooth uses JIRA as our issue tracking system, found using this
-`Link <https://jira.hyperledger.org/secure/RapidBoard.
-jspa?rapidView=3&projectKey=STL&view=planning.nodetail>`_
-
-If you want to contribute to Hyperledger Sawtooth quickly, we have a list of
-issues which will help you get involved right away. This can be found
-`here <https://jira.hyperledger.org/issues/
-?filter=10612>`_
-
-To report issues, you will need to log into Hyperledger Sawtooth JIRA, which requires a
-`Linux Foundation Account <https://identity.linuxfoundation.org/>`_
-
-
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/community/join_the_discussion.rst
+++ b/docs/source/community/join_the_discussion.rst
@@ -1,22 +1,20 @@
-*******************
-Join the Discussion
-*******************
-
-.. _chat:
+**********************
+Joining the Discussion
+**********************
 
 Chat
 ====
 
-Hyperledger Sawtooth RocketChat is the place to go for real-time chat about everything from quick help to
-involved discussion.
+Hyperledger Sawtooth RocketChat is the place to go for real-time chat about
+everything from quick help to involved discussions.
 
-Hyperledger Sawtooth discussions are located at:
+For general Hyperledger Sawtooth discussions:
 
-	`#sawtooth <https://chat.hyperledger.org/channel/sawtooth>`_
+  `#sawtooth <https://chat.hyperledger.org/channel/sawtooth>`_
 
-Hyperledger Sawtooth Consensus discussions are located at:
-	
-	`#sawtooth-consensus <https://chat.hyperledger.org/channel/sawtooth-consensus>`_
+For Hyperledger Sawtooth Consensus discussions:
+
+  `#sawtooth-consensus <https://chat.hyperledger.org/channel/sawtooth-consensus>`_
 
 
 Mailing Lists
@@ -24,7 +22,7 @@ Mailing Lists
 
 The Hyperledger Sawtooth mailing list is hosted by the Hyperledger Project:
 
-   `hyperledger-stl Mailing List <http://lists.hyperledger.org/mailman/listinfo/hyperledger-stl>`_
+  `hyperledger-stl Mailing List <http://lists.hyperledger.org/mailman/listinfo/hyperledger-stl>`_
 
 
 .. Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
In Community chapter:
   - Lightly edit to fix titles, reduce wordiness, wrap lines at 80,
      and conform to Sawtooth doc standards (first pass)
   - Add JIRA links and cross references to helpful info in the
      Sawtooth documentation

In CONTRIBUTING.md:
   - Change content in CONTRIBUTING.md to point to the Sawtooth documentation.

Plus a second commit with changes to address review comments: 
  - Delete "Arcade features" bullet from "Ways to contribute" (outdated info)
  - Correct lint test info (lint DOES produce output on success)
  - Add new "Commit email address" section (must match GitHub account)
Signed-off-by: Anne Chenette <chenette@bitwise.io>