### PR TITLE
More parallel scheduler optimizations

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -774,8 +774,11 @@ class ParallelScheduler(Scheduler):
         for prior in self._batches[:index_of_batch_in_schedule]:
             number_of_txns_in_prior_batches += len(prior.transactions) - 1
 
-        txn_ids_in_order = [t.header_signature for t in batch.transactions]
-        txn_index = txn_ids_in_order.index(txn_id)
+        txn_index, _ = next(
+            (i, t)
+            for i, t in enumerate(batch.transactions)
+            if t.header_signature == txn_id)
+
         return number_of_txns_in_prior_batches + txn_index
 
     def _can_fail_fast(self, txn_id):


### PR DESCRIPTION
This PR makes two changes to the parallel scheduler.

The first change affects the function `_index_of_txn_in_schedule`. This function was taking around .7% of total CPU time, with most of that being taking up by a list comprehension. It's in the upper left corner of the graph below.

![index-before-2](https://user-images.githubusercontent.com/25748894/35534074-0176bae8-0505-11e8-9390-8792aa6dd963.png)

It turns out that the function, which is called frequently, was taking a list of transactions and then building out a new list of transaction ids every time just to get the index of one id. Switching from list comprehension / index to an enumeration causes the function to drop off the graph entirely, indicating that it no longer takes a significant amount of time.

![index-after-1](https://user-images.githubusercontent.com/25748894/35534434-222f00f0-0506-11e8-9470-3df53ae7e457.png)

The second change has to do with a function called `_txn_is_in_valid_batch`. This function takes around 5% of total CPU time. About 2/5 of that time (2% of total CPU time) is spent in a little function called `_txn_result_is_invalid`, which checks that a signature is in a dictionary called `_txn_results` and, if it is, whether its result is valid. My thought was that this "look before you leap" approach in such a tight loop was not efficient, and that it would be faster to construct the set of ids with results beforehand and then check whether they are all valid.

The results in the `yappi` graph are a little strange:

![valid-after-1](https://user-images.githubusercontent.com/25748894/35535020-e6040ec0-0507-11e8-901f-1b4fffa19744.png)

If you look where those functions should be (under `next_transaction`), you'll see that they aren't there at all, and that `next_transaction` has gone from 8-9% to less than 4%. Pretty great, right? Well, if you look in the upper left corner, you'll see two new nodes labeled only `<genexpr>`, representing the generators used in the rewritten function. Together they add up to around 4%, which is a savings of 1% of total CPU time.

I don't quite understand why the nodes are floating off in the corner rather than being attached to their calling chain. Is that computation being executed in another thread? If so, is that good?