### PR TITLE
Centralize block validator logging (master)

### DIFF
--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -419,7 +419,9 @@ class BlockValidator(object):
                 # as invalid.
                 for blk in fork_diff:
                     blk.status = BlockStatus.Invalid
-                raise BlockValidationError()
+                raise BlockValidationError(
+                    'Failed to build fork diff: block {} missing predecessor'
+                    .format(blk))
 
         return blk, fork_diff
 
@@ -433,24 +435,21 @@ class BlockValidator(object):
             if (cur_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER
                     or new_blkw.previous_block_id == NULL_BLOCK_IDENTIFIER):
                 # We are at a genesis block and the blocks are not the same
-                LOGGER.info(
-                    "Block rejected due to wrong genesis: %s %s",
-                    cur_blkw, new_blkw)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationError()
+                raise BlockValidationError(
+                    'Block {} rejected due to wrong genesis {}'.format(
+                        cur_blkw, new_blkw))
 
             new_chain.append(new_blkw)
             try:
                 new_blkw = self._block_cache[new_blkw.previous_block_id]
             except KeyError:
-                LOGGER.info(
-                    "Block %s rejected due to missing predecessor %s",
-                    new_blkw,
-                    new_blkw.previous_block_id)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationError()
+                raise BlockValidationError(
+                    'Block {} rejected due to missing predecessor {}'.format(
+                        new_blkw, new_blkw.previous_block_id))
 
             cur_chain.append(cur_blkw)
             cur_blkw = self._block_cache[cur_blkw.previous_block_id]
@@ -514,22 +513,27 @@ class BlockValidator(object):
             current_block = chain_head
             new_block = block
 
-            # Get all the blocks since the greatest common height from the
-            # longer chain.
-            if self._compare_chain_height(current_block, new_block):
-                current_block, result.current_chain =\
-                    self._build_fork_diff_to_common_height(
-                        current_block, new_block)
-            else:
-                new_block, result.new_chain =\
-                    self._build_fork_diff_to_common_height(
-                        new_block, current_block)
+            try:
+                # Get all the blocks since the greatest common height from the
+                # longer chain.
+                if self._compare_chain_height(current_block, new_block):
+                    current_block, result.current_chain =\
+                        self._build_fork_diff_to_common_height(
+                            current_block, new_block)
+                else:
+                    new_block, result.new_chain =\
+                        self._build_fork_diff_to_common_height(
+                            new_block, current_block)
 
-            # Add blocks to the two chains until a common ancestor is found
-            # or raise an exception if no common ancestor is found
-            self._extend_fork_diff_to_common_ancestor(
-                new_block, current_block,
-                result.new_chain, result.current_chain)
+                # Add blocks to the two chains until a common ancestor is found
+                # or raise an exception if no common ancestor is found
+                self._extend_fork_diff_to_common_ancestor(
+                    new_block, current_block,
+                    result.new_chain, result.current_chain)
+            except BlockValidationError as err:
+                LOGGER.warning('%s', err)
+                callback(False, result)
+                return
 
             valid = True
             for blk in reversed(result.new_chain):
@@ -592,9 +596,6 @@ class BlockValidator(object):
             callback(commit_new_chain, result)
             LOGGER.info("Finished block validation of: %s", block)
 
-        except BlockValidationError:
-            callback(False, result)
-            return
         except ChainHeadUpdated:
             callback(False, result)
             return

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -32,12 +32,10 @@ from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 LOGGER = logging.getLogger(__name__)
 
 
-class BlockValidationAborted(Exception):
+class BlockValidationError(Exception):
     """
-    Indication that the validation of this fork has terminated for an
-    expected(handled) case and that the processing should exit.
+    Indication that an error has occurred during block validation.
     """
-    pass
 
 
 class ChainHeadUpdated(Exception):
@@ -387,7 +385,7 @@ class BlockValidator(object):
             last block in the shorter chain. Ordered newest to oldest.
 
         Raises:
-            BlockValidationAborted
+            BlockValidationError
                 The block is missing a predecessor. Note that normally this
                 shouldn't happen because of the completer."""
         fork_diff = []
@@ -411,7 +409,7 @@ class BlockValidator(object):
                 # as invalid.
                 for blk in fork_diff:
                     blk.status = BlockStatus.Invalid
-                raise BlockValidationAborted()
+                raise BlockValidationError()
 
         return blk, fork_diff
 
@@ -430,7 +428,7 @@ class BlockValidator(object):
                     cur_blkw, new_blkw)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted()
+                raise BlockValidationError()
 
             new_chain.append(new_blkw)
             try:
@@ -442,7 +440,7 @@ class BlockValidator(object):
                     new_blkw.previous_block_id)
                 for b in new_chain:
                     b.status = BlockStatus.Invalid
-                raise BlockValidationAborted()
+                raise BlockValidationError()
 
             cur_chain.append(cur_blkw)
             cur_blkw = self._block_cache[cur_blkw.previous_block_id]
@@ -582,7 +580,7 @@ class BlockValidator(object):
             callback(commit_new_chain, result)
             LOGGER.info("Finished block validation of: %s", block)
 
-        except BlockValidationAborted:
+        except BlockValidationError:
             callback(False, result)
             return
         except ChainHeadUpdated:

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -23,6 +23,7 @@ from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+from sawtooth_validator.journal.block_validator import BlockValidationError
 from sawtooth_validator.journal.consensus.consensus_factory import \
     ConsensusFactory
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
@@ -428,18 +429,22 @@ class ChainController(object):
                         NULL_BLOCK_IDENTIFIER,
                         state_view)
 
-                valid = self._block_validator.validate_block(
-                    block, consensus_module)
-                if valid:
-                    if chain_id is None:
-                        self._chain_id_manager.save_block_chain_id(
-                            block.identifier)
-                    self._block_store.update_chain([block])
-                    self._chain_head = block
-                    self._notify_on_chain_updated(self._chain_head)
-                else:
-                    LOGGER.warning("The genesis block is not valid. Cannot "
-                                   "set chain head: %s", block)
+                try:
+                    self._block_validator.validate_block(
+                        block, consensus_module)
+                except BlockValidationError as err:
+                    LOGGER.warning(
+                        'Cannot set chain head; '
+                        'genesis block %s is not valid: %s',
+                        block, err)
+                    return
+
+                if chain_id is None:
+                    self._chain_id_manager.save_block_chain_id(
+                        block.identifier)
+                self._block_store.update_chain([block])
+                self._chain_head = block
+                self._notify_on_chain_updated(self._chain_head)
 
         else:
             LOGGER.warning("Cannot set initial chain head, this is not a "

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -31,6 +31,7 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_validator import BlockValidator
+from sawtooth_validator.journal.block_validator import BlockValidationError
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.publisher import BlockPublisher
@@ -1246,7 +1247,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          return_value=False):
+                          side_effect=BlockValidationError):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)


### PR DESCRIPTION
This PR changes the block validator to log the reason for failed validation. The idea is to ensure that we have the block validation process logged in a clear, ordered way: "Starting block validation...Block validation failed because blah blah blah...Finished block validation". Currently the error message only gets logged by helper functions, and we might end up with the messages out of order.

This PR does not change the helper functions the throw exceptions rather than log, so there will be some duplicate logging. A longer-term goal is to convert everything to exception-throwing style, but the various components (permission validation, block validation, etc) can be changed independently and in separate PRs.

This is basically the same change as https://github.com/hyperledger/sawtooth-core/commit/a3c7096caa8785e6d8109d7bf4efa04010d0b033 in the 1-0 branch, but with more liberties taken .