### PR TITLE
Ignore unscheduled transaction results

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -651,8 +651,6 @@ class ParallelScheduler(Scheduler):
                     "transaction not scheduled: {}".format(txn_signature))
 
             if txn_signature not in self._batches_by_txn_id:
-                LOGGER.debug('Received result for %s, but was unscheduled',
-                             txn_signature)
                 return
 
             self._set_least_batch_id(txn_signature=txn_signature)

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -649,6 +649,12 @@ class ParallelScheduler(Scheduler):
             if txn_signature not in self._scheduled:
                 raise SchedulerError(
                     "transaction not scheduled: {}".format(txn_signature))
+
+            if txn_signature not in self._batches_by_txn_id:
+                LOGGER.debug('Received result for %s, but was unscheduled',
+                             txn_signature)
+                return
+
             self._set_least_batch_id(txn_signature=txn_signature)
             if not is_valid:
                 self._remove_subsequent_result_because_of_batch_failure(

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -82,8 +82,6 @@ class SerialScheduler(Scheduler):
         with self._condition:
             if (self._in_progress_transaction is None or
                     self._in_progress_transaction != txn_signature):
-                LOGGER.debug('Received result for %s, but was unscheduled',
-                             txn_signature)
                 return
 
             self._in_progress_transaction = None


### PR DESCRIPTION
When an transaction has been removed from the schedule, but was being
processed by a transaction processor, the scheduler will ignore any
results provided.

Includes a pair of unit tests for both schedulers to verify this
behavior.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>