### PR TITLE
Executor and interconnect metrics

### DIFF
--- a/validator/sawtooth_validator/metrics/__init__.py
+++ b/validator/sawtooth_validator/metrics/__init__.py
@@ -12,3 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+
+from sawtooth_validator.metrics.wrappers import CounterWrapper
+from sawtooth_validator.metrics.wrappers import GaugeWrapper
+from sawtooth_validator.metrics.wrappers import TimerWrapper
+
+
+def make_counter(name, metrics_registry=None):
+    if metrics_registry is None:
+        return CounterWrapper()
+
+    return CounterWrapper(
+        metrics_registry.counter(name))
+
+
+def make_gauge(name, metrics_registry=None):
+    if metrics_registry is None:
+        return GaugeWrapper()
+
+    return GaugeWrapper(
+        metrics_registry.gauge(name))
+
+
+def make_timer(name, metrics_registry=None):
+    if metrics_registry is None:
+        return TimerWrapper()
+
+    return TimerWrapper(
+        metrics_registry.timer(name))

--- a/validator/sawtooth_validator/metrics/wrappers.py
+++ b/validator/sawtooth_validator/metrics/wrappers.py
@@ -46,6 +46,10 @@ class CounterWrapper():
         if self._counter:
             self._counter.inc(val)
 
+    def dec(self, val=1):
+        if self._counter:
+            self._counter.dec(val)
+
 
 class GaugeWrapper():
     def __init__(self, gauge=None):


### PR DESCRIPTION
This PR adds two metrics: a dispatcher queue size gauge (replacing a log message) and an in-process transaction counter in the executor.

Our current pattern for metrics has a lot of inconvenient boilerplate, so I've also included an idea for a simplified pattern. I'm sure other ideas like this have been considered, so I'm not too attached to this one. In any case, however, I do think we should settle on something more convenient than the way we're doing it now.