### PR TITLE
Add VERSION env var to dev-cxx dockerfile

### DIFF
--- a/docker/sawtooth-dev-cxx
+++ b/docker/sawtooth-dev-cxx
@@ -70,5 +70,6 @@ RUN mkdir -p /project/sawtooth-core/ \
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 
+ENV VERSION=AUTO_STRICT
 WORKDIR /project/sawtooth-core
 CMD build_cxx


### PR DESCRIPTION
When this is not set, the cxx deb packages build without an incremented
.dev version. This is causing problems with package publishing.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>