### PR TITLE
Relocate metrics dockerfiles and improve dashboard

### DIFF
--- a/bin/build_all
+++ b/bin/build_all
@@ -237,10 +237,10 @@ docker_build() {
 build_external() {
     docker_build docker/apache-basic_auth_proxy docker/ apache-basic_auth_proxy
     docker_build docker/grafana/sawtooth-stats-grafana \
-        docker/grafana \
+        docker/ \
         sawtooth-stats-grafana
     docker_build docker/influxdb/sawtooth-stats-influxdb \
-        docker/influxdb \
+        docker/ \
         sawtooth-stats-influxdb
 }
 

--- a/docker/compose/sawtooth-local-poet.yaml
+++ b/docker/compose/sawtooth-local-poet.yaml
@@ -1,0 +1,465 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  validator-0:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-poet-validator-0
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawset genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm=poet \
+          sawtooth.poet.report_public_key_pem=\
+          \\\"$$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)\\\" \
+          sawtooth.poet.valid_enclave_measurements=$$(poet enclave measurement) \
+          sawtooth.poet.valid_enclave_basenames=$$(poet enclave basename) \
+          -o config.batch && \
+        poet registration create -k /etc/sawtooth/keys/validator.priv -o poet.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          $$(/project/sawtooth-core/docker/poet-settings.sh) \
+          -o poet-settings.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch poet.batch poet-settings.batch && \
+        sawtooth-validator -vv \
+          --bind network:tcp://eth0:8800 \
+          --bind component:tcp://eth0:4004 \
+          --peering dynamic \
+          --endpoint tcp://validator-0:8800 \
+          --scheduler serial \
+          --network trust \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+    \""
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-1:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-poet-validator-1
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: |
+      bash -c "
+        sawadm keygen --force && \
+        sawtooth-validator -v \
+            --bind network:tcp://eth0:8800 \
+            --bind component:tcp://eth0:4004 \
+            --peering dynamic \
+            --endpoint tcp://validator-1:8800 \
+            --seeds tcp://validator-0:8800 \
+            --scheduler serial \
+            --network trust \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics
+      "
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-2:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-poet-validator-2
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: |
+      bash -c "
+        sawadm keygen --force && \
+        sawtooth-validator -v \
+            --bind network:tcp://eth0:8800 \
+            --bind component:tcp://eth0:4004 \
+            --peering dynamic \
+            --endpoint tcp://validator-2:8800 \
+            --seeds tcp://validator-0:8800 \
+            --scheduler serial \
+            --network trust \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics
+      "
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-3:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-poet-validator-3
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: |
+      bash -c "
+        sawadm keygen --force && \
+        sawtooth-validator -v \
+            --bind network:tcp://eth0:8800 \
+            --bind component:tcp://eth0:4004 \
+            --peering dynamic \
+            --endpoint tcp://validator-3:8800 \
+            --seeds tcp://validator-0:8800 \
+            --scheduler serial \
+            --network trust \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics
+      "
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  validator-4:
+    image: sawtooth-validator:latest
+    container_name: sawtooth-poet-validator-4
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: |
+      bash -c "
+        sawadm keygen --force && \
+        sawtooth-validator -v \
+            --bind network:tcp://eth0:8800 \
+            --bind component:tcp://eth0:4004 \
+            --peering dynamic \
+            --endpoint tcp://validator-4:8800 \
+            --seeds tcp://validator-0:8800 \
+            --scheduler serial \
+            --network trust \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics
+      "
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
+        /project/sawtooth-core/consensus/poet/simulator:\
+        /project/sawtooth-core/consensus/poet/core"
+    stop_signal: SIGKILL
+
+  rest-api-0:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-poet-rest-api-0
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: |
+      bash -c "
+        sawtooth-rest-api \
+          --connect tcp://validator-0:4004 \
+          --bind rest-api-0:8008 \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+      "
+    stop_signal: SIGKILL
+
+  rest-api-1:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-poet-rest-api-1
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: |
+      bash -c "
+        sawtooth-rest-api \
+          --connect tcp://validator-1:4004 \
+          --bind rest-api-1:8008 \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+      "
+    stop_signal: SIGKILL
+
+  rest-api-2:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-poet-rest-api-2
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: |
+      bash -c "
+        sawtooth-rest-api \
+          --connect tcp://validator-2:4004 \
+          --bind rest-api-2:8008 \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+      "
+    stop_signal: SIGKILL
+
+  rest-api-3:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-poet-rest-api-3
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: |
+      bash -c "
+        sawtooth-rest-api \
+          --connect tcp://validator-3:4004 \
+          --bind rest-api-3:8008 \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+      "
+    stop_signal: SIGKILL
+
+  rest-api-4:
+    image: sawtooth-rest-api:latest
+    container_name: sawtooth-poet-rest-api-4
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: |
+      bash -c "
+        sawtooth-rest-api \
+          --connect tcp://validator-4:4004 \
+          --bind rest-api-4:8008 \
+          --opentsdb-url http://influxdb:8086 \
+          --opentsdb-db metrics
+      "
+    stop_signal: SIGKILL
+
+  intkey-tp-0:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-poet-intkey-tp-0
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-0:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-1:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-poet-intkey-tp-1
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-1:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-2:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-poet-intkey-tp-2
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-2:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-3:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-poet-intkey-tp-3
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-3:4004
+    stop_signal: SIGKILL
+
+  intkey-tp-4:
+    image: sawtooth-intkey-tp-python:latest
+    container_name: sawtooth-poet-intkey-tp-4
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: intkey-tp-python -C tcp://validator-4:4004
+    stop_signal: SIGKILL
+
+  settings-tp-0:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-poet-settings-tp-0
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-0:4004
+    stop_signal: SIGKILL
+
+  settings-tp-1:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-poet-settings-tp-1
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-1:4004
+    stop_signal: SIGKILL
+
+  settings-tp-2:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-poet-settings-tp-2
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-2:4004
+    stop_signal: SIGKILL
+
+  settings-tp-3:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-poet-settings-tp-3
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-3:4004
+    stop_signal: SIGKILL
+
+  settings-tp-4:
+    image: sawtooth-settings-tp:latest
+    container_name: sawtooth-poet-settings-tp-4
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -C tcp://validator-4:4004
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-0:
+    image: sawtooth-poet-validator-registry-tp:latest
+    container_name: sawtooth-poet-validator-registry-tp-0
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-0:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-1:
+    image: sawtooth-poet-validator-registry-tp:latest
+    container_name: sawtooth-poet-validator-registry-tp-1
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-1:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-2:
+    image: sawtooth-poet-validator-registry-tp:latest
+    container_name: sawtooth-poet-validator-registry-tp-2
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-2:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-3:
+    image: sawtooth-poet-validator-registry-tp:latest
+    container_name: sawtooth-poet-validator-registry-tp-3
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-3:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  poet-validator-registry-tp-4:
+    image: sawtooth-poet-validator-registry-tp:latest
+    container_name: sawtooth-poet-validator-registry-tp-4
+    volumes:
+      - ../../:/project/sawtooth-core
+    expose:
+      - 4004
+    command: poet-validator-registry-tp -C tcp://validator-4:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  client:
+    image: sawtooth-dev-python:latest
+    container_name: sawtooth-poet-client
+    volumes:
+      - ../../:/project/sawtooth-core
+    entrypoint: |
+      bash -c "
+        sawtooth keygen && \
+        tail -f /dev/null \
+      "
+    expose:
+      - 8008
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/sdk/examples/intkey_python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/signing:\
+        /project/sawtooth-core/cli"
+
+  influxdb:
+    build:
+      context: ..
+      dockerfile: influxdb/sawtooth-stats-influxdb
+    image: sawtooth-stats-influxdb:latest
+    container_name: sawtooth-poet-influxdb
+    ports:
+      - "8086:8086"
+    stop_signal: SIGKILL
+
+  grafana:
+    build:
+      context: ..
+      dockerfile: grafana/sawtooth-stats-grafana
+    image: sawtooth-stats-grafana:latest
+    container_name: sawtooth-poet-grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ../../:/project/sawtooth-core
+    stop_signal: SIGKILL

--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -1,40 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_METRICS_NETWORK",
-      "label": "metrics_network",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "influxdb",
-      "pluginName": "InfluxDB"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "4.6.3"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "influxdb",
-      "name": "InfluxDB",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -52,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "hideControls": false,
-  "id": null,
+  "id": 1,
   "links": [],
   "refresh": false,
   "rows": [
@@ -62,7 +26,7 @@
       "panels": [
         {
           "columns": [],
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fontSize": "100%",
           "id": 1,
           "interval": ">10s",
@@ -164,7 +128,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 2,
           "legend": {
@@ -276,7 +240,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 3,
           "legend": {
@@ -400,7 +364,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 22,
           "legend": {
@@ -458,7 +422,7 @@
                 [
                   {
                     "params": [
-                      "value"
+                      "count"
                     ],
                     "type": "field"
                   },
@@ -512,7 +476,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "description": "The number of blocks that go through the validation process",
           "fill": 0,
           "id": 23,
@@ -571,7 +535,7 @@
                 [
                   {
                     "params": [
-                      "value"
+                      "count"
                     ],
                     "type": "field"
                   },
@@ -625,7 +589,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 25,
           "legend": {
@@ -674,7 +638,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "sawtooth_validator.chain_head",
+              "measurement": "sawtooth_validator.chain_head_moved_to_fork_count",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -742,138 +706,14 @@
     },
     {
       "collapse": false,
-      "height": 250,
+      "height": "250",
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
-          "fill": 0,
-          "id": 4,
-          "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 4,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "alias": "[[tag_host]]",
-              "dsType": "influxdb",
-              "groupBy": [
-                {
-                  "params": [
-                    "$__interval"
-                  ],
-                  "type": "time"
-                },
-                {
-                  "params": [
-                    "host"
-                  ],
-                  "type": "tag"
-                },
-                {
-                  "params": [
-                    "none"
-                  ],
-                  "type": "fill"
-                }
-              ],
-              "measurement": "sawtooth_rest_api.post_batches_count",
-              "orderByTime": "ASC",
-              "policy": "default",
-              "refId": "A",
-              "resultFormat": "time_series",
-              "select": [
-                [
-                  {
-                    "params": [
-                      "count"
-                    ],
-                    "type": "field"
-                  },
-                  {
-                    "params": [],
-                    "type": "mean"
-                  },
-                  {
-                    "params": [],
-                    "type": "difference"
-                  },
-                  {
-                    "params": [
-                      " / 10"
-                    ],
-                    "type": "math"
-                  }
-                ]
-              ],
-              "tags": []
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Rest API Batch Submission Rate",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": "batches per second",
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ]
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 5,
           "legend": {
@@ -895,7 +735,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -985,7 +825,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 24,
           "legend": {
@@ -1007,7 +847,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1102,14 +942,14 @@
     },
     {
       "collapse": false,
-      "height": 250,
+      "height": "250",
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 6,
           "legend": {
@@ -1233,7 +1073,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 21,
           "legend": {
@@ -1255,7 +1095,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 4,
+          "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1351,7 +1191,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 7,
           "legend": {
@@ -1457,6 +1297,166 @@
               "show": true
             }
           ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 4,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "measurement": "sawtooth_rest_api.post_batches_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "total",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "10s"
+                  ],
+                  "type": "time"
+                }
+              ],
+              "hide": false,
+              "measurement": "sawtooth_rest_api.post_batches_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "B",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "sum"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Rest API Batch Submission Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "batches per second",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
         }
       ],
       "repeat": null,
@@ -1475,7 +1475,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 8,
           "legend": {
@@ -1593,7 +1593,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 9,
           "legend": {
@@ -1717,7 +1717,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 10,
           "legend": {
@@ -1860,7 +1860,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 12,
           "legend": {
@@ -2036,7 +2036,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 13,
           "legend": {
@@ -2224,7 +2224,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 11,
           "legend": {
@@ -2436,7 +2436,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 14,
           "legend": {
@@ -2606,7 +2606,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 15,
           "legend": {
@@ -2774,7 +2774,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 16,
           "legend": {
@@ -2904,7 +2904,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 17,
           "legend": {
@@ -3016,7 +3016,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 18,
           "legend": {
@@ -3144,7 +3144,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 19,
           "legend": {
@@ -3273,7 +3273,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 20,
           "legend": {
@@ -3390,7 +3390,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "${DS_METRICS_NETWORK}",
+          "datasource": "$DATASOURCE",
           "fill": 0,
           "id": 21,
           "legend": {
@@ -3509,17 +3509,1109 @@
       "showTitle": false,
       "title": "Dashboard Row",
       "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 243,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 26,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.Network-threadpool.task_run_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Network Threadpool Task Run Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 27,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "limit": "",
+              "measurement": "sawtooth_validator.Network-threadpool.task_time_in_queue",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT non_negative_derivative(last(\"count\"), 1s) FROM \"sawtooth_validator.Network-threadpool.task_time_in_queue\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(null)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Network Threadpool Task Time in Queue",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 28,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.Network-threadpool.task_run_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"sawtooth_validator.Network-threadpool.workers_already_in_use\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": false,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Network Threadpool Workers Already in Use",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 29,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.Network-threadpool.task_run_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT non_negative_derivative(last(\"count\"), 1s) FROM \"sawtooth_validator.Component-threadpool.task_run_time\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Component Threadpool Task Run Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 30,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.Network-threadpool.task_run_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT non_negative_derivative(last(\"count\"), 1s) FROM \"sawtooth_validator.Component-threadpool.task_time_in_queue\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Component Threadpool Task Time in Queue",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 31,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.Network-threadpool.task_run_time",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"sawtooth_validator.Component-threadpool.workers_already_in_use\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Component Threadpool Workers Already in Use",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 32,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT non_negative_derivative(last(\"count\"), 1s) FROM \"sawtooth_validator.Signature-threadpool.task_run_time\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Signature Threadpool Task Run Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 33,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT non_negative_derivative(last(\"count\"), 1s) FROM \"sawtooth_validator.Signature-threadpool.task_time_in_queue\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Signature Threadpool Task Time in Queue",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 1,
+          "id": 34,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"value\") FROM \"sawtooth_validator.Signature-threadpool.workers_already_in_use\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Component Threadpool Workers Already in Use",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
     }
   ],
   "schemaVersion": 14,
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "text": "metrics",
+          "value": "metrics"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "DATASOURCE",
+        "options": [],
+        "query": "influxdb",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
-    "from": "2017-11-16T11:22:03.417Z",
-    "to": "2018-01-11T21:30:37.743Z"
+    "from": "now-5m",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [
@@ -3547,6 +4639,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "NETWORK_ID",
-  "version": 4
+  "title": "dashboard",
+  "version": 1
 }

--- a/docker/grafana/grafana_entrypoint.sh
+++ b/docker/grafana/grafana_entrypoint.sh
@@ -34,7 +34,7 @@ if [ ! -f "/var/lib/grafana/.init" ]; then
     done
 
     for dashboard in /etc/grafana/dashboards/*; do
-        post "$(cat $dashboard)" "/api/dashboards/db"
+        post "$(cat $dashboard)" "/api/dashboards/import"
     done
 
     touch "/var/lib/grafana/.init"

--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -20,12 +20,12 @@ RUN apt-get update && \
         curl && \
     rm -rf /var/lib/apt/lists/*
 
-COPY dashboards /etc/grafana/dashboards
-COPY datasources /etc/grafana/datasources
-COPY grafana.ini /etc/grafana
+COPY grafana/dashboards /etc/grafana/dashboards
+COPY grafana/datasources /etc/grafana/datasources
+COPY grafana/grafana.ini /etc/grafana
 
-WORKDIR /app  
-COPY grafana_entrypoint.sh ./  
+WORKDIR /app
+COPY grafana/grafana_entrypoint.sh ./
 RUN chmod u+x grafana_entrypoint.sh
 
 ENTRYPOINT ["/app/grafana_entrypoint.sh"]

--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM grafana/grafana:latest
+FROM grafana/grafana:4.6.3
 
 RUN apt-get update && \
     apt-get install -y \

--- a/docker/poet-settings.sh
+++ b/docker/poet-settings.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +14,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM influxdb:alpine
+settings=""
+settings="$settings sawtooth.poet.target_wait_time=5"
+settings="$settings sawtooth.poet.initial_wait_time=25"
+settings="$settings sawtooth.publisher.max_batches_per_block=100"
 
-RUN apk add --update curl && \
-    rm -rf /var/cache/apk/*
-
-WORKDIR /app
-COPY influxdb/influxdb_entrypoint.sh ./
-RUN chmod u+x influxdb_entrypoint.sh
-
-ENTRYPOINT ["/app/influxdb_entrypoint.sh"]
+echo "$settings"


### PR DESCRIPTION
- The influxdb and grafana dockerfiles do not follow the same format as the rest of our Docker stuff. This moves the dockerfiles into the docker directory, and moves the scripts and json files to their own directory.

- This PR adds some new metrics to the grafana dashboard. It also utilizes a different json structure for the dashboard that allows us to use a template variable for the metrics datasource. This means we will not have to create a new dashboard for each LR network that show the same graphs. It will also allow us to create new dashboards for specialized metrics without having to edit the main dashboard.

- The sawtooth-metrics.yaml docker-compose file starts up a network that is connected to influxdb and grafana. This allows us to easily test new metrics or conduct other experiments using Docker. The containers are built from mounted files. The grafana and influxdb images will automatically be built if they are not already.

[Creating and Editing Dashboards](https://docs.google.com/document/d/1yAOzW_Ez7zXPSAzakY1o4gYUFbnKmr95Xwmc9BWUgE4/edit#)