### PR TITLE
Split off predecessor tree's tree

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -70,7 +70,7 @@ class PredecessorTree:
             for i in range(0, len(address), self._token_size)
         ]
 
-    def _get(self, address, create=False):
+    def insert(self, address):
         tokens = self._tokenize_address(address)
 
         node = self._root
@@ -78,8 +78,6 @@ class PredecessorTree:
             if token in node.children:
                 node = node.children[token]
             else:
-                if not create:
-                    return None
                 child = PredecessorTreeNode()
                 node.children[token] = child
                 node = child
@@ -87,14 +85,23 @@ class PredecessorTree:
         return node
 
     def get(self, address):
-        return self._get(address)
+        tokens = self._tokenize_address(address)
+
+        node = self._root
+        for token in tokens:
+            if token in node.children:
+                node = node.children[token]
+            else:
+                return None
+
+        return node
 
     def add_reader(self, address, reader):
-        node = self._get(address, create=True)
+        node = self.insert(address)
         node.readers.append(reader)
 
     def set_writer(self, address, writer):
-        node = self._get(address, create=True)
+        node = self.insert(address)
         node.readers = []
         node.writer = writer
         node.children = {}

--- a/validator/tests/test_scheduler/test_predecessor_tree.py
+++ b/validator/tests/test_scheduler/test_predecessor_tree.py
@@ -943,15 +943,16 @@ class TestPredecessorTree(unittest.TestCase):
 
             self.assertIsNotNone(node)
 
-            self.assertEqual(
-                readers,
-                node.readers,
-                error_msg.format('readers'))
+            if node.data is not None:
+                self.assertEqual(
+                    readers,
+                    node.data.readers,
+                    error_msg.format('readers'))
 
-            self.assertEqual(
-                writer,
-                node.writer,
-                error_msg.format('writer'))
+                self.assertEqual(
+                    writer,
+                    node.data.writer,
+                    error_msg.format('writer'))
 
             self.assertEqual(
                 set(children),
@@ -973,7 +974,10 @@ class TestPredecessorTree(unittest.TestCase):
         def count_readers(node=None):
             if node is None:
                 node = self.get_node('')  # root node
-            count = len(node.readers)
+            if node.data is not None:
+                count = len(node.data.readers)
+            else:
+                count = 0
             for child in node.children:
                 next_node = node.children[child]
                 count += count_readers(next_node)
@@ -982,7 +986,13 @@ class TestPredecessorTree(unittest.TestCase):
         def count_writers(node=None):
             if node is None:
                 node = self.get_node('')  # root node
-            count = 1 if node.writer is not None else 0
+            if node.data is not None:
+                if node.data.writer is not None:
+                    count = 1
+                else:
+                    count = 0
+            else:
+                count = 0
             for child in node.children:
                 next_node = node.children[child]
                 count += count_writers(next_node)
@@ -1050,7 +1060,7 @@ class TestPredecessorTree(unittest.TestCase):
         self.tree.set_writer(address, txn)
 
     def get_node(self, address):
-        return self.tree.get(address)
+        return self.tree._tree.get(address)
 
     # display
 
@@ -1061,19 +1071,20 @@ class TestPredecessorTree(unittest.TestCase):
 
 
 def tree_to_string(tree):
-    return node_to_string(tree._root)
+    return node_to_string(tree._tree._root)
 
 
 def node_to_string(node, indent=2):
     string = '\nROOT:' if indent == 2 else ''
 
-    writer = node.writer
-    if writer is not None:
-        string += ' Writer: {}'.format(writer)
+    if node.data is not None:
+        writer = node.data.writer
+        if writer is not None:
+            string += ' Writer: {}'.format(writer)
 
-    readers = node.readers
-    if readers:
-        string += ' Readers: {}'.format(readers)
+        readers = node.data.readers
+        if readers:
+            string += ' Readers: {}'.format(readers)
 
     for child_address in node.children:
         string += '\n' + ' ' * indent


### PR DESCRIPTION
Currently the predecessor tree's data structure is not particularly efficient. Separating the data structure for the predecessor tree itself will make it easier to improve.