### PR TITLE
Add generating proto files to smallbank_workload

### DIFF
--- a/perf/sawtooth_perf/src/workload.rs
+++ b/perf/sawtooth_perf/src/workload.rs
@@ -396,8 +396,7 @@ fn handle_future_post_response(counter: Rc<HTTPRequestCounter>,
             let link = serde_json::from_str::<Link>(&s);
             match link {
                 Ok(link) => {
-                    let mut l = link.link;
-                    l.push_str("&wait=100");
+                    let l = link.link;
                     let uri = Uri::from_str(l.as_ref())?;
                     Ok(uri)
                 },

--- a/perf/smallbank_workload/Cargo.toml
+++ b/perf/smallbank_workload/Cargo.toml
@@ -15,6 +15,7 @@
 [package]
 name = "smallbank_workload"
 version = "0.1.0"
+build = "build.rs"
 
 [dependencies]
 sawtooth_sdk = { path = "../../sdk/rust" }
@@ -29,3 +30,7 @@ env_logger = "0.5.3"
 [[bin]]
 name = "smallbank-workload"
 path = "./src/main.rs"
+
+[build-dependencies]
+protoc-rust = "1.4"
+glob = "0.2"

--- a/perf/smallbank_workload/build.rs
+++ b/perf/smallbank_workload/build.rs
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+ extern crate glob;
+ extern crate protoc_rust;
+
+ fn main() {
+
+     let proto_src_files = glob_simple("../../families/smallbank/protos/*.proto");
+     println!("{:?}", proto_src_files);
+
+     protoc_rust::run(protoc_rust::Args {
+         out_dir: "./src",
+         input: &proto_src_files.iter().map(|a| a.as_ref()).collect::<Vec<&str>>(),
+         includes: &["../../families/smallbank/protos"],
+     }).expect("Error generating rust files from smallbank protos");
+ }
+
+ fn glob_simple(pattern: &str) -> Vec<String> {
+    glob::glob(pattern)
+        .expect("glob")
+        .map(|g| {
+            g.expect("item")
+                .as_path()
+                .to_str()
+                .expect("utf-8")
+                .to_owned()
+        }).collect()
+ }

--- a/perf/smallbank_workload/src/main.rs
+++ b/perf/smallbank_workload/src/main.rs
@@ -109,7 +109,7 @@ fn create_load_subcommand_args<'a, 'b>() -> App<'a, 'b> {
               .short("n")
               .long("max-batch-size")
               .value_name("NUMBER")
-              .help("The number of transaction in a batch. Defaults to 100."))
+              .help("The number of transaction in a batch. Defaults to 1."))
         .arg(Arg::with_name("num-accounts")
               .short("a")
               .long("accounts")
@@ -147,7 +147,7 @@ fn create_load_subcommand_args<'a, 'b>() -> App<'a, 'b> {
 
 fn run_load_command(args: &ArgMatches) -> Result<(), Box<Error>> {
     let max_txns: usize = match args.value_of("max-batch-size")
-        .unwrap_or("100")
+        .unwrap_or("1")
         .parse() {
             Ok(n) => n,
             Err(_) => 0,


### PR DESCRIPTION
This PR has three main fixes:
  - #1325 took out generating rust files from protogen script and handled it by using a build.rs file. This PR adds it back in for smallbank_workload.
 - Removing the wait from the sawtooth_perf long running batch submitter. This is only a short-term fix and will be handled better by work done in STL-1052. 
- ~Adding the Cargo.lock to version control since smallbank_workload is a bin. https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html This cargo documentation explains.~
- Changing the default transactions per batch to 1.