### PR TITLE
Reject Batches That Will Violate Block Validation Rules

### DIFF
--- a/families/block_info/sawtooth_block_info/processor/handler.py
+++ b/families/block_info/sawtooth_block_info/processor/handler.py
@@ -46,7 +46,7 @@ def validate_hex(string, length):
 
 def validate_timestamp(timestamp, tolerance):
     now = time.time()
-    if abs(now - timestamp) > tolerance:
+    if (timestamp - now) > tolerance:
         raise InvalidTransaction(
             "Timestamp must be less than local time."
             " Expected {0} in ({1}-{2}, {1}+{2})".format(

--- a/integration/sawtooth_integration/docker/test_poet_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_poet_liveness.yaml
@@ -74,6 +74,8 @@ services:
           \\\"$$(cat /project/sawtooth-core/consensus/poet/simulator/packaging/simulator_rk_pub.pem)\\\" \
           sawtooth.poet.valid_enclave_measurements=$$(poet enclave measurement) \
           sawtooth.poet.valid_enclave_basenames=$$(poet enclave basename) \
+          sawtooth.validator.batch_injectors=block_info \
+          'sawtooth.validator.block_validation_rules=NofX:1,block_info;XatY:block_info,0;local:0' \
           -o config.batch && \
         poet registration create -k /etc/sawtooth/keys/validator.priv -o poet.batch && \
         sawset proposal create \
@@ -87,7 +89,8 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
         /project/sawtooth-core/consensus/poet/simulator:\
-        /project/sawtooth-core/consensus/poet/core"
+        /project/sawtooth-core/consensus/poet/core:\
+        /project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   validator-1:
@@ -105,7 +108,8 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
         /project/sawtooth-core/consensus/poet/simulator:\
-        /project/sawtooth-core/consensus/poet/core"
+        /project/sawtooth-core/consensus/poet/core:\
+        /project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   validator-2:
@@ -123,7 +127,8 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
         /project/sawtooth-core/consensus/poet/simulator:\
-        /project/sawtooth-core/consensus/poet/core"
+        /project/sawtooth-core/consensus/poet/core:\
+        /project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   validator-3:
@@ -141,7 +146,8 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
         /project/sawtooth-core/consensus/poet/simulator:\
-        /project/sawtooth-core/consensus/poet/core"
+        /project/sawtooth-core/consensus/poet/core:\
+        /project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   validator-4:
@@ -159,7 +165,8 @@ services:
     environment:
       PYTHONPATH: "/project/sawtooth-core/consensus/poet/common:\
         /project/sawtooth-core/consensus/poet/simulator:\
-        /project/sawtooth-core/consensus/poet/core"
+        /project/sawtooth-core/consensus/poet/core:\
+        /project/sawtooth-core/families/block_info"
     stop_signal: SIGKILL
 
   rest-api-0:
@@ -355,4 +362,59 @@ services:
     command: poet-validator-registry-tp -C tcp://validator-4:4004
     environment:
       PYTHONPATH: /project/sawtooth-core/consensus/poet/common
+    stop_signal: SIGKILL
+
+  block-info-tp-0:
+    image: sawtooth-block-info-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: block-info-tp -C tcp://validator-0:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/families/block_info
+    stop_signal: SIGKILL
+
+  block-info-tp-1:
+    image: sawtooth-block-info-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: block-info-tp -C tcp://validator-1:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/families/block_info
+    stop_signal: SIGKILL
+
+  block-info-tp-2:
+    image: sawtooth-block-info-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: block-info-tp -C tcp://validator-2:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/families/block_info
+    stop_signal: SIGKILL
+
+  block-info-tp-3:
+    image: sawtooth-block-info-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: block-info-tp -C tcp://validator-3:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/families/block_info
+    stop_signal: SIGKILL
+
+  block-info-tp-4:
+    image: sawtooth-block-info-tp:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: block-info-tp -C tcp://validator-4:4004
+    environment:
+      PYTHONPATH: /project/sawtooth-core/families/block_info
     stop_signal: SIGKILL

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -21,7 +21,7 @@ from sawtooth_validator.journal.block_wrapper import BlockStatus
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.validation_rule_enforcer import \
-    ValidationRuleEnforcer
+    enforce_validation_rules
 from sawtooth_validator.state.settings_view import SettingsViewFactory
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.metrics.wrappers import CounterWrapper
@@ -151,8 +151,7 @@ class BlockValidator(object):
         self._config_dir = config_dir
         self._permission_verifier = permission_verifier
 
-        self._validation_rule_enforcer = ValidationRuleEnforcer(
-            SettingsViewFactory(state_view_factory))
+        self._settings_view_factory = SettingsViewFactory(state_view_factory)
 
         self._thread_pool = InstrumentedThreadPoolExecutor(1) \
             if thread_pool is None else thread_pool
@@ -287,8 +286,11 @@ class BlockValidator(object):
         invalid.
         """
         if blkw.block_num != 0:
-            return self._validation_rule_enforcer.validate(
-                blkw, prev_state_root)
+            return enforce_validation_rules(
+                self._settings_view_factory.create_settings_view(
+                    prev_state_root),
+                blkw.header.signer_public_key,
+                blkw.batches)
         return True
 
     def validate_block(self, blkw, consensus, chain_head=None, chain=None):

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -31,6 +31,8 @@ from sawtooth_validator.journal.consensus.batch_publisher import \
     BatchPublisher
 from sawtooth_validator.journal.consensus.consensus_factory import \
     ConsensusFactory
+from sawtooth_validator.journal.validation_rule_enforcer import \
+    enforce_validation_rules
 
 from sawtooth_validator.journal.chain_commit_state import \
     TransactionCommitCache
@@ -40,6 +42,8 @@ from sawtooth_validator.metrics.wrappers import GaugeWrapper
 
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
+
+from sawtooth_validator.state.settings_view import SettingsView
 
 LOGGER = logging.getLogger(__name__)
 
@@ -120,6 +124,8 @@ class _CandidateBlock(object):
                  block_builder,
                  max_batches,
                  batch_injectors,
+                 settings_view,
+                 signer_public_key,
                  ):
         self._pending_batches = []
         self._pending_batch_ids = set()
@@ -134,6 +140,9 @@ class _CandidateBlock(object):
         self._block_builder = block_builder
         self._max_batches = max_batches
         self._batch_injectors = batch_injectors
+
+        self._settings_view = settings_view
+        self._signer_public_key = signer_public_key
 
     def __del__(self):
         self.cancel()
@@ -268,6 +277,12 @@ class _CandidateBlock(object):
                     self._block_builder.previous_block_id), batches_to_add)
 
             batches_to_add.append(batch)
+
+            if not enforce_validation_rules(
+                    self._settings_view,
+                    self._signer_public_key,
+                    self._pending_batches + batches_to_add):
+                return
 
             for b in batches_to_add:
                 self._pending_batches.append(b)
@@ -616,7 +631,9 @@ class BlockPublisher(object):
             committed_txn_cache,
             block_builder,
             max_batches,
-            batch_injectors)
+            batch_injectors,
+            SettingsView(state_view),
+            public_key)
 
         for batch in self._pending_batches:
             if self._candidate_block.can_add_batch:

--- a/validator/sawtooth_validator/journal/validation_rule_enforcer.py
+++ b/validator/sawtooth_validator/journal/validation_rule_enforcer.py
@@ -18,162 +18,164 @@ from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 LOGGER = logging.getLogger(__name__)
 
 
-class ValidationRuleEnforcer(object):
-    def __init__(self, setting_view_factory):
-        self._settings_view_factory = setting_view_factory
+def enforce_validation_rules(settings_view, expected_signer, batches):
+    """
+    Retrieve the validation rules stored in state and check that the
+    given batches do not violate any of those rules. These rules include:
 
-    def validate(self, block, state_root):
-        """
-        Retrieve the validation rules stored in state and check that the
-        block does not violate any of those rules. These rules include:
+        NofX: Only N of transaction type X may be included in a block.
+        XatY: A transaction of type X must be in the list at position Y.
+        local: A transaction must be signed by the given public key
 
-            NofX: Only N of transaction type X may be included in a block.
-            XatY: A transaction of type X must be in the block at position Y.
-            local: A transaction must be signed by the same key as the block.
+    If any setting stored in state does not match the required format for
+    that rule, the rule will be ignored.
 
-        If any setting stored in state does not match the required format for
-        that rule, the rule will be ignored.
+    Args:
+        settings_view (:obj:SettingsView): the settings view to find the
+            current rule values
+        expected_signer (str): the public key used to use for local signing
+        batches (:list:Batch): the list of batches to validate
 
-        """
-        settings_view = self._settings_view_factory.create_settings_view(
-            state_root)
-        rules = settings_view.get_setting(
-            "sawtooth.validator.block_validation_rules")
-        if rules is None:
-            return True
+    """
+    rules = settings_view.get_setting(
+        "sawtooth.validator.block_validation_rules")
 
-        transactions = []
-        for batch in block.batches:
-            transactions += batch.transactions
-
-        expected_signer = block.header.signer_public_key
-
-        rules = rules.split(";")
-        valid = True
-        for rule in rules:
-            try:
-                rule_type, arguments = rule.split(":")
-            except ValueError:
-                LOGGER.warning("Validation Rule Ignored, not in the correct "
-                               "format: %s",
-                               rule)
-                continue
-
-            rule_type = rule_type.strip()
-            # NofX: Only N of transaction type X may be included in a block.
-            if rule_type == "NofX":
-                valid = self._do_nofx(transactions, arguments)
-
-            # XatY: A transaction of type X must be in the block at position Y.
-            elif rule_type == "XatY":
-                valid = self._do_xaty(transactions, arguments)
-
-            # local: A transaction must be signed by the same key as the block.
-            elif rule_type == "local":
-                valid = self._do_local(
-                    transactions, expected_signer, arguments)
-
-            if not valid:
-                return False
-
-        return valid
-
-    def _do_nofx(self, transactions, arguments):
-        """
-        Only N of transaction type X may be included in a block. The first
-        argument must be interpretable as an integer. The second argument is
-        interpreted as the name of a transaction family. For example, the
-        string "NofX:2,intkey" means only allow 2 intkey transactions per
-        block.
-        """
-        try:
-            num, family = arguments.split(',')
-            limit = int(num.strip())
-        except ValueError:
-            LOGGER.warning("Ignore, NofX requires arguments in the format "
-                           "int,family not %s", arguments)
-            return True
-        count = 0
-        family = family.strip()
-        for txn in transactions:
-            header = TransactionHeader()
-            header.ParseFromString(txn.header)
-            if header.family_name == family:
-                count += 1
-
-            if count > limit:
-                LOGGER.debug("Too many transactions of type %s", family)
-                return False
-
+    if rules is None:
         return True
 
-    def _do_xaty(self, transactions, arguments):
-        """
-        A transaction of type X must be in the block at position Y. The
-        first argument is interpreted as the name of a transaction family.
-        The second argument must be interpretable as an integer and defines
-        the index of the transaction in the block that must be checked.
-        Negative numbers can be used and count backwards from the last
-        transaction in the block. The first transaction in the block has
-        index 0. The last transaction in the block has index -1. If abs(Y)
-        is larger than the number of transactions per block, then there
-        would not be a transaction of type X at Y and the block would be
-        invalid. For example, the string "XatY:intkey,0" means the first
-        transaction in the block must be an intkey transaction.
-        """
+    transactions = []
+    for batch in batches:
+        transactions += batch.transactions
+
+    rules = rules.split(";")
+    valid = True
+    for rule in rules:
         try:
-            family, num = arguments.split(',')
-            position = int(num.strip())
+            rule_type, arguments = rule.split(":")
         except ValueError:
-            LOGGER.warning("Ignore, XatY requires arguments in the format "
-                           "family,position not %s", arguments)
-            return True
+            LOGGER.warning("Validation Rule Ignored, not in the correct "
+                           "format: %s",
+                           rule)
+            continue
 
-        family = family.strip()
-        if abs(position) >= len(transactions):
-            LOGGER.debug("Block does not have enough transactions to "
-                         "validate this rule XatY:%s", arguments)
+        rule_type = rule_type.strip()
+        # NofX: Only N of transaction type X may be included in a block.
+        if rule_type == "NofX":
+            valid = _do_nofx(transactions, arguments)
+
+        # XatY: A transaction of type X must be in the block at position Y.
+        elif rule_type == "XatY":
+            valid = _do_xaty(transactions, arguments)
+
+        # local: A transaction must be signed by the same key as the block.
+        elif rule_type == "local":
+            valid = _do_local(
+                transactions, expected_signer, arguments)
+
+        if not valid:
             return False
-        txn = transactions[position]
 
+    return valid
+
+
+def _do_nofx(transactions, arguments):
+    """
+    Only N of transaction type X may be included in a block. The first
+    argument must be interpretable as an integer. The second argument is
+    interpreted as the name of a transaction family. For example, the
+    string "NofX:2,intkey" means only allow 2 intkey transactions per
+    block.
+    """
+    try:
+        num, family = arguments.split(',')
+        limit = int(num.strip())
+    except ValueError:
+        LOGGER.warning("Ignore, NofX requires arguments in the format "
+                       "int,family not %s", arguments)
+        return True
+    count = 0
+    family = family.strip()
+    for txn in transactions:
         header = TransactionHeader()
         header.ParseFromString(txn.header)
-        if header.family_name != family:
-            LOGGER.debug("Transaction at postion %s is not of type %s",
-                         position, family)
+        if header.family_name == family:
+            count += 1
+
+        if count > limit:
+            LOGGER.debug("Too many transactions of type %s", family)
             return False
+
+    return True
+
+
+def _do_xaty(transactions, arguments):
+    """
+    A transaction of type X must be in the block at position Y. The
+    first argument is interpreted as the name of a transaction family.
+    The second argument must be interpretable as an integer and defines
+    the index of the transaction in the block that must be checked.
+    Negative numbers can be used and count backwards from the last
+    transaction in the block. The first transaction in the block has
+    index 0. The last transaction in the block has index -1. If abs(Y)
+    is larger than the number of transactions per block, then there
+    would not be a transaction of type X at Y and the block would be
+    invalid. For example, the string "XatY:intkey,0" means the first
+    transaction in the block must be an intkey transaction.
+    """
+    try:
+        family, num = arguments.split(',')
+        position = int(num.strip())
+    except ValueError:
+        LOGGER.warning("Ignore, XatY requires arguments in the format "
+                       "family,position not %s", arguments)
         return True
 
-    def _do_local(self, transactions, expected_signer, arguments):
-        """
-        A transaction must be signed by the same key as the block. This
-        rule takes a list of transaction indices in the block and enforces the
-        rule on each. This rule is useful in combination with the other rules
-        to ensure a client is not submitting transactions that should only be
-        injected by the winning validator.
-        """
-        indices = arguments.split(",")
-        txns_len = len(transactions)
-        for index in indices:
-            try:
-                index = int(index.strip())
-            except ValueError:
-                LOGGER.warning("Ignore, local requries one or more comma "
-                               "seperated integers that represent indices, not"
-                               " %s", arguments)
-                return True
+    family = family.strip()
+    if abs(position) >= len(transactions):
+        LOGGER.debug("Block does not have enough transactions to "
+                     "validate this rule XatY:%s", arguments)
+        return False
+    txn = transactions[position]
 
-            if abs(index) >= txns_len:
-                LOGGER.debug("Ignore, Block does not have enough "
-                             "transactions to validate this rule local:%s",
-                             index)
-                continue
-            txn = transactions[index]
-            header = TransactionHeader()
-            header.ParseFromString(txn.header)
+    header = TransactionHeader()
+    header.ParseFromString(txn.header)
+    if header.family_name != family:
+        LOGGER.debug("Transaction at postion %s is not of type %s",
+                     position, family)
+        return False
+    return True
 
-            if header.signer_public_key != expected_signer:
-                LOGGER.debug("Transaction at postion %s was not signed by the"
-                             " same key as the block.", index)
-                return False
-        return True
+
+def _do_local(transactions, expected_signer, arguments):
+    """
+    A transaction must be signed by the same key as the block. This
+    rule takes a list of transaction indices in the block and enforces the
+    rule on each. This rule is useful in combination with the other rules
+    to ensure a client is not submitting transactions that should only be
+    injected by the winning validator.
+    """
+    indices = arguments.split(",")
+    txns_len = len(transactions)
+    for index in indices:
+        try:
+            index = int(index.strip())
+        except ValueError:
+            LOGGER.warning("Ignore, local requries one or more comma "
+                           "seperated integers that represent indices, not"
+                           " %s", arguments)
+            return True
+
+        if abs(index) >= txns_len:
+            LOGGER.debug("Ignore, Block does not have enough "
+                         "transactions to validate this rule local:%s",
+                         index)
+            continue
+        txn = transactions[index]
+        header = TransactionHeader()
+        header.ParseFromString(txn.header)
+
+        if header.signer_public_key != expected_signer:
+            LOGGER.debug("Transaction at postion %s was not signed by the"
+                         " same key as the block.", index)
+            return False
+    return True

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -263,7 +263,7 @@ def CreateSetting(key, value):
     addr = SettingsView.setting_address(key)
 
     setting = Setting()
-    setting.entries.add(key=key, value=repr(value))
+    setting.entries.add(key=key, value=str(value))
     return addr, setting.SerializeToString()
 
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -409,6 +409,52 @@ class TestBlockPublisher(unittest.TestCase):
 
         self.assert_batch_in_block(injected_batch)
 
+    def test_validation_rules_reject_batches(self):
+        """Test that a batch is not added to the block if it will violate the
+        block validation rules.
+
+        It does the following:
+
+        - Sets the block_validation_rules to limit the number of 'test'
+          transactions to 1
+        - creates two batches, limited to 1 transaction each, and receives
+          them
+        - verifies that only the first batch was committed to the block
+        """
+        addr, value = CreateSetting(
+            'sawtooth.validator.block_validation_rules', 'NofX:1,test')
+        self.state_view_factory = MockStateViewFactory(
+            {addr: value})
+
+        batch1 = self.make_batch(txn_count=1)
+        batch2 = self.make_batch(txn_count=1)
+
+        self.publisher = BlockPublisher(
+            transaction_executor=MockTransactionExecutor(),
+            block_cache=self.block_tree_manager.block_cache,
+            state_view_factory=self.state_view_factory,
+            settings_cache=SettingsCache(
+                SettingsViewFactory(
+                    self.state_view_factory),
+            ),
+            block_sender=self.block_sender,
+            batch_sender=self.batch_sender,
+            squash_handler=None,
+            chain_head=self.block_tree_manager.chain_head,
+            identity_signer=self.block_tree_manager.identity_signer,
+            data_dir=None,
+            config_dir=None,
+            check_publish_block_frequency=0.1,
+            batch_observers=[],
+            permission_verifier=self.permission_verifier)
+
+        self.receive_batches(batches=[batch1, batch2])
+
+        self.publish_block()
+
+        self.assert_block_batch_count(1)
+        self.assert_batch_in_block(batch1)
+
     # assertions
     def assert_block_published(self):
         self.assertIsNotNone(
@@ -480,8 +526,9 @@ class TestBlockPublisher(unittest.TestCase):
             uncommitted_batches=uncommitted)
 
     # batches
-    def make_batch(self, missing_deps=False):
+    def make_batch(self, missing_deps=False, txn_count=2):
         return self.block_tree_manager.generate_batch(
+            txn_count=txn_count,
             missing_deps=missing_deps)
 
     def make_batches(self, batch_count=None, missing_deps=False):


### PR DESCRIPTION
Validate that a batch added to a candidate block does not violate the block validation rules specified in the settings.  Before this change, batches that violated these rules were only verified before the block was committed, but this left open the possibility of rule-violating transactions being processed, which could affect downstream state in a given schedule.

Additionally:

* Adds block-info-tp to PoET Liveness test