### PR TITLE
Implement blockstore stats command

### DIFF
--- a/adm/src/blockstore.rs
+++ b/adm/src/blockstore.rs
@@ -159,4 +159,20 @@ impl<'a> Blockstore<'a> {
         String::from_utf8(val.into()).map_err(|err|
             DatabaseError::CorruptionError(format!("Chain head block id is corrupt: {}", err)))
     }
+
+    // Get the number of blocks
+    pub fn get_current_height(&self) -> Result<usize, DatabaseError> {
+        let reader = self.db.reader()?;
+        reader.count()
+    }
+
+    pub fn get_transaction_count(&self) -> Result<usize, DatabaseError> {
+        let reader = self.db.reader()?;
+        reader.index_count("index_transaction")
+    }
+
+    pub fn get_batch_count(&self) -> Result<usize, DatabaseError> {
+        let reader = self.db.reader()?;
+        reader.index_count("index_batch")
+    }
 }

--- a/adm/src/database/lmdb.rs
+++ b/adm/src/database/lmdb.rs
@@ -142,6 +142,23 @@ impl<'a> LmdbDatabaseReader<'a> {
             cursor: cursor,
         })
     }
+
+
+    pub fn count(&self) -> Result<usize, DatabaseError> {
+        self.txn.db_stat(&self.db.main)
+            .map_err(|err|
+                DatabaseError::CorruptionError(format!("Failed to get database stats: {}", err)))
+            .map(|stat| stat.entries)
+    }
+
+    pub fn index_count(&self, index: &str) -> Result<usize, DatabaseError> {
+        let index = self.db.indexes.get(index).ok_or(
+            DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        self.txn.db_stat(index)
+            .map_err(|err|
+                DatabaseError::CorruptionError(format!("Failed to get database stats: {}", err)))
+            .map(|stat| stat.entries)
+    }
 }
 
 pub struct LmdbDatabaseReaderCursor<'a> {

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -90,7 +90,10 @@ fn parse_args<'a>() -> ArgMatches<'a> {
                 (@arg block: +required "the block to export"))
             (@subcommand import =>
                 (about: "add a block to the blockstore; new block's parent must be the current chain head")
-                (@arg blockfile: +required "a protobuf file containing the block to add")))
+                (@arg blockfile: +required "a protobuf file containing the block to add"))
+            (@subcommand stats =>
+                (about: "print out database stats")
+                (@arg extended: -x --extended "show extended stats about the blockstore")))
         (@subcommand keygen =>
             (about: "generates keys for the validator to use when signing blocks")
             (@arg key_name: +takes_value "name of the key to create")


### PR DESCRIPTION
This adds a subcommand to compute some basic summary stats for the
blockstore database. More detailed stats can be added later.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>