### PR TITLE
Make TransactionContext cloneable

### DIFF
--- a/sdk/rust/src/processor/handler.rs
+++ b/sdk/rust/src/processor/handler.rs
@@ -161,6 +161,7 @@ impl From<ReceiveError> for ContextError {
     }
 }
 
+#[derive(Clone)]
 pub struct TransactionContext {
     context_id: String,
     sender: ZmqMessageSender


### PR DESCRIPTION
Give the cloneable trait to TransactionContext.
Signed-off-by: Ryan Banks <rbanks@bitwise.io>