### PR TITLE
Log TP internal error on validator

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -132,6 +132,13 @@ class TransactionExecutorThread(object):
                 data=data)
 
         elif response.status == processor_pb2.TpProcessResponse.INTERNAL_ERROR:
+            LOGGER.error(
+                "Transaction processor internal error: %s "
+                "(transaction: %s, name: %s, version: %s)",
+                response.message,
+                req.signature,
+                req.header.family_name,
+                req.header.family_version)
 
             processor_type = processor_iterator.ProcessorType(
                 req.header.family_name,


### PR DESCRIPTION
This commit logs any transaction processor internal errors at the error
level on the validator. It also includes information about the
transaction that was being executed when the error ocurred.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>