### PR TITLE
Update metadata address typo in blockinfo docs

### DIFF
--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -59,7 +59,7 @@ For example, in Python the address could be constructed with:
 
 .. code-block:: pycon
 
-  >>> '00b10c01' + hex(block_num)[2:].zfill(62))
+  >>> '00b10c00' + hex(block_num)[2:].zfill(62))
 
 BlockInfo
 ---------


### PR DESCRIPTION
Signed-off-by: Al Hulaton <al.hulaton@gmail.com>