### PR TITLE
Add logging implementation to Java sdk tests

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -23,6 +23,10 @@
     <artifactId>sdk</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <extensions>
             <extension>
@@ -108,6 +112,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This cleans up some warnings that are printed during `mvn package`.