### PR TITLE
Add transactions in process metric

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -971,7 +971,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [
@@ -1075,6 +1075,118 @@
           "dashes": false,
           "datasource": "$DATASOURCE",
           "fill": 0,
+          "id": 35,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.in_process_transactions_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "last"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Transactions in Process",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": "transactions",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
           "id": 21,
           "legend": {
             "avg": false,
@@ -1095,7 +1207,7 @@
           "renderer": "flot",
           "seriesOverrides": [],
           "spaceLength": 10,
-          "span": 6,
+          "span": 4,
           "stack": false,
           "steppedLine": false,
           "targets": [

--- a/validator/sawtooth_validator/metrics/wrappers.py
+++ b/validator/sawtooth_validator/metrics/wrappers.py
@@ -46,6 +46,10 @@ class CounterWrapper():
         if self._counter:
             self._counter.inc(val)
 
+    def dec(self, val=1):
+        if self._counter:
+            self._counter.dec(val)
+
 
 class GaugeWrapper():
     def __init__(self, gauge=None):


### PR DESCRIPTION
This PR adds a new metric to track the transactions that are currently in process for each node. In order to do this, the metrics counter wrapper had to be extended to allow the `dec()` method. This PR also adds the metric to the dashboard.

In order to test this metric, run the `sawtooth-local-poet.yaml` docker-compose file, and set a workload. Since the validators in this compose file use the serial scheduler, we see on the graph that each node has between 0 and 2 transactions in process at a time. Next, edit the validators in `sawtooth-local-poet.yaml` to use the parallel scheduler. We see that many more transactions can be processed in parallel with this scheduler.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>