### PR TITLE
Export blocks as regular protobuf messages

### DIFF
--- a/adm/src/commands/blockstore.rs
+++ b/adm/src/commands/blockstore.rs
@@ -223,15 +223,20 @@ fn run_export_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
     let block = blockstore.get(block_id).map_err(|_|
         CliError::ArgumentError(format!("Block not found: {}", block_id)))?;
 
-    let packed = block.write_to_bytes().map_err(|err|
-        CliError::EnvironmentError(format!("{}", err)))?;
-
-    let stdout = io::stdout();
-    let mut handle = stdout.lock();
-
-    handle.write(&packed)
-        .map(|_| ())
-        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
+    match args.value_of("output") {
+        Some(filepath) => {
+            let mut file = File::create(filepath).map_err(|err|
+                CliError::EnvironmentError(format!("Failed to create file: {}", err)))?;
+            block.write_to_writer(&mut file)
+                .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
+        },
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            block.write_to_writer(&mut handle)
+                .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
+        }
+    }
 }
 
 fn run_import_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {

--- a/adm/src/commands/blockstore.rs
+++ b/adm/src/commands/blockstore.rs
@@ -223,10 +223,15 @@ fn run_export_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
     let block = blockstore.get(block_id).map_err(|_|
         CliError::ArgumentError(format!("Block not found: {}", block_id)))?;
 
+    let packed = block.write_to_bytes().map_err(|err|
+        CliError::EnvironmentError(format!("{}", err)))?;
+
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    backup_block(&block, &mut handle)
+    handle.write(&packed)
+        .map(|_| ())
+        .map_err(|err| CliError::EnvironmentError(format!("{}", err)))
 }
 
 fn run_import_command<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -86,8 +86,9 @@ fn parse_args<'a>() -> ArgMatches<'a> {
                 (about: "remove a block and all children blocks from the blockstore")
                 (@arg block: +required "the block to remove"))
             (@subcommand export =>
-                (about: "write a block's packed representation to stdout")
-                (@arg block: +required "the block to export"))
+                (about: "write a block's packed representation to file or stdout")
+                (@arg block: +required "the block to export")
+                (@arg output: -o --output +takes_value "the file to export the block to"))
             (@subcommand import =>
                 (about: "add a block to the blockstore; new block's parent must be the current chain head")
                 (@arg blockfile: +required "a protobuf file containing the block to add"))


### PR DESCRIPTION
Previously, this was including a length delimiter byte, which makes
reading exported blocks more difficult. The length delimiter is only
needed when exporting multiple blocks to one file, such as with the
backup command.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>