### PR TITLE
make deb packages depend on cryptography >=1.7.1

### DIFF
--- a/consensus/poet/families/stdeb.cfg
+++ b/consensus/poet/families/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+Depends3: python3-cryptography (>=1.7.1)

--- a/consensus/poet/simulator/stdeb.cfg
+++ b/consensus/poet/simulator/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+Depends3: python3-cryptography (>=1.7.1)


### PR DESCRIPTION
Make the poet-families and poet-simulator deb packages depend on our
build or greater of python3-cryptography. This resolves STL-988 where
python3-cryptography is not upgraded to the correct version if the
Ubuntu package was already installed.

Signed-off-by: Richard Berg <rberg@bitwise.io>