### PR TITLE
Create block-info docker - Backport

### DIFF
--- a/ci/sawtooth-block-info-tp
+++ b/ci/sawtooth-block-info-tp
@@ -1,0 +1,42 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth block-info package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci
+#   $ docker build . -f sawtooth-block-info-tp -t sawtooth-block-info-tp
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-block-info-tp
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-block-info \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["block-info-tp", "-C", "tcp://validator:4004"]

--- a/ci/sawtooth-validator
+++ b/ci/sawtooth-validator
@@ -33,6 +33,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \
+    python3-sawtooth-block-info \
     python3-sawtooth-cli \
     python3-sawtooth-validator \
     python3-sawtooth-poet-cli \


### PR DESCRIPTION
This is merged to master in PR #1440 . This was not tested in LR because we don't run docker containers there. This was tested locally.