### PR TITLE
Fix issue Unscheduled InternalError Results

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -148,8 +148,10 @@ class TransactionExecutorThread(object):
                 req.header.family_name,
                 req.header.family_version)
 
-            self._execute_or_wait_for_processor_type(
-                processor_type, request, req.signature)
+            # Make sure that the transaction wasn't unscheduled in the interim
+            if self._scheduler.is_transaction_in_schedule(req.signature):
+                self._execute_or_wait_for_processor_type(
+                    processor_type, request, req.signature)
 
         else:
             self._context_manager.delete_contexts(

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -116,6 +116,17 @@ class Scheduler(object, metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
+    def is_transaction_in_schedule(self, txn_signature):
+        """Returns True if a transaction is in this schedule.
+
+        Args:
+            txn_signature (str): The signature of the transaction, which
+                must match the header_signature field of the Transaction
+                object which was part of the added Batch.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def finalize(self):
         """Tell the scheduler that no more batches/transactions will be added.
 

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -922,6 +922,10 @@ class ParallelScheduler(Scheduler):
             LOGGER.debug('Removed %s incomplete batches from the schedule',
                          len(incomplete_batches))
 
+    def is_transaction_in_schedule(self, txn_signature):
+        with self._condition:
+            return txn_signature in self._batches_by_txn_id
+
     def finalize(self):
         with self._condition:
             self._final = True

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -312,6 +312,10 @@ class SerialScheduler(Scheduler):
             LOGGER.debug('Removed %s incomplete batches from the schedule',
                          len(incomplete_batches))
 
+    def is_transaction_in_schedule(self, txn_signature):
+        with self._condition:
+            return txn_signature in self._txn_to_batch
+
     def finalize(self):
         with self._condition:
             self._final = True

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -121,6 +121,9 @@ class MockScheduler(Scheduler):
     def unschedule_incomplete_batches(self):
         pass
 
+    def is_transaction_in_schedule(self, txn_id):
+        raise NotImplementedError()
+
     def finalize(self):
         pass
 


### PR DESCRIPTION
Transaction that return INTERNAL_ERROR on their result will immediately be resent to a transaction processor.  This can trigger a death spiral of transaction executions, over and over again.  We can mitigate this problem by not resending the transaction once its containing batch has been unscheduled.

This requires the addition of a `is_transaction_in_schedule` method to the Scheduler interface.