### PR TITLE
Implement parallelism hint and handling

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -1583,6 +1583,390 @@
           "dashes": false,
           "datasource": "$DATASOURCE",
           "fill": 0,
+          "id": 43,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.executor.TransactionExecutorThread.tp_process_response_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "response_type",
+                  "operator": "=",
+                  "value": "OK"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Valid Transaction Response Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 44,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.executor.TransactionExecutorThread.tp_process_response_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "response_type",
+                  "operator": "=",
+                  "value": "INVALID_TRANSACTION"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Invalid Transaction Response Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 45,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "host"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "sawtooth_validator.executor.TransactionExecutorThread.tp_process_response_count",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "count"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  },
+                  {
+                    "params": [
+                      "1s"
+                    ],
+                    "type": "non_negative_derivative"
+                  }
+                ]
+              ],
+              "tags": [
+                {
+                  "key": "response_type",
+                  "operator": "=",
+                  "value": "INTERNAL_ERROR"
+                }
+              ]
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Internal Error Response Rate",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
           "id": 8,
           "legend": {
             "avg": false,
@@ -3689,7 +4073,7 @@
               "measurement": "sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_run_time",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "",
+              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.Component-threadpool.task_run_time\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -4064,7 +4448,7 @@
               "measurement": "sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_run_time",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.Component-threadpool.task_run_time\" WHERE $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "query": "",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -4433,10 +4817,11 @@
                   "type": "fill"
                 }
               ],
+              "hide": false,
               "measurement": "sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_run_time",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "",
+              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_run_time\" WHERE (\"name\" = 'Signature') AND $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -4556,7 +4941,7 @@
               "measurement": "sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_time_in_queue",
               "orderByTime": "ASC",
               "policy": "default",
-              "query": "",
+              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_time_in_queue\" WHERE (\"name\" = 'Signature') AND $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
               "rawQuery": false,
               "refId": "A",
               "resultFormat": "time_series",
@@ -4707,6 +5092,340 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "Signature Threadpool Workers in Use",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 40,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "hide": false,
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_run_time\" WHERE (\"name\" = 'Executing') AND $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Executing Threadpool Task Run Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 41,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"99_percentile\") FROM \"sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.task_time_in_queue\" WHERE (\"name\" = 'Executing') AND $timeFilter GROUP BY time($__interval), \"host\" fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Executing Threadpool Task Run Time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "$DATASOURCE",
+          "fill": 0,
+          "id": 42,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": false,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 4,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "[[tag_host]]",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT last(\"count\") FROM \"sawtooth_validator.threadpool.InstrumentedThreadPoolExecutor.workers_in_use\" WHERE (\"name\" = 'Executing') AND $timeFilter GROUP BY time($__interval), \"host\" fill(previous)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Executing Threadpool Workers in Use",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -38,6 +38,10 @@ message TpRegisterRequest {
     // when processing transactions matching this specification; will be
     // enforced by the state API on the validator.
     repeated string namespaces = 4;
+
+    // The maximum number of transactions that this transaction processor can
+    // handle at once.
+    uint32 max_occupancy = 5;
 }
 
 // A response sent from the validator to the transaction processor

--- a/sdk/go/src/sawtooth_sdk/processor/processor.go
+++ b/sdk/go/src/sawtooth_sdk/processor/processor.go
@@ -143,7 +143,7 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 	// Register all handlers with the validator
 	for _, handler := range self.handlers {
 		for _, version := range handler.FamilyVersions() {
-			err := register(validator, handler, version, queue)
+			err := register(validator, handler, version, queue, uint32(self.maxQueue))
 			if err != nil {
 				return restart, fmt.Errorf(
 					"Error registering handler (%v, %v, %v): %v",
@@ -346,11 +346,12 @@ func receiveWorkers(ids map[string]string, validator, workers messaging.Connecti
 }
 
 // Register a handler with the validator
-func register(validator messaging.Connection, handler TransactionHandler, version string, queue chan *validator_pb2.Message) error {
+func register(validator messaging.Connection, handler TransactionHandler, version string, queue chan *validator_pb2.Message, maxOccupancy uint32) error {
 	regRequest := &processor_pb2.TpRegisterRequest{
-		Family:     handler.FamilyName(),
-		Version:    version,
-		Namespaces: handler.Namespaces(),
+		Family:       handler.FamilyName(),
+		Version:      version,
+		Namespaces:   handler.Namespaces(),
+		MaxOccupancy: maxOccupancy,
 	}
 
 	regRequestData, err := proto.Marshal(regRequest)

--- a/validator/sawtooth_validator/exceptions.py
+++ b/validator/sawtooth_validator/exceptions.py
@@ -72,3 +72,15 @@ class PossibleForkDetectedError(Exception):
     through the block store.
     """
     pass
+
+
+class NoProcessorVacancyError(Exception):
+    """Error thrown when no processor has occupancy to handle a transaction
+    """
+    pass
+
+
+class WaitCancelledException(Exception):
+    """Exception thrown when a wait function has detected a cancellation event
+    """
+    pass

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -94,6 +94,14 @@ class TransactionExecutorThread(object):
         response = processor_pb2.TpProcessResponse()
         response.ParseFromString(result.content)
 
+        processor_type = processor_iterator.ProcessorType(
+            req.header.family_name,
+            req.header.family_version)
+
+        self._processors[processor_type].get_processor(
+            result.connection_id).dec_occupancy()
+        self._processors.notify()
+
         if result.connection_id in self._open_futures and \
                 req.signature in self._open_futures[result.connection_id]:
             del self._open_futures[result.connection_id][req.signature]
@@ -129,10 +137,6 @@ class TransactionExecutorThread(object):
                 "(transaction: %s, name: %s, version: %s)",
                 response.message,
                 req.signature,
-                req.header.family_name,
-                req.header.family_version)
-
-            processor_type = processor_iterator.ProcessorType(
                 req.header.family_name,
                 req.header.family_version)
 

--- a/validator/sawtooth_validator/execution/processor_handlers.py
+++ b/validator/sawtooth_validator/execution/processor_handlers.py
@@ -15,7 +15,7 @@
 
 import logging
 
-from sawtooth_validator.execution import processor_iterator
+from sawtooth_validator.execution import processor_manager
 
 from sawtooth_validator.protobuf import processor_pb2
 from sawtooth_validator.protobuf import validator_pb2
@@ -53,11 +53,11 @@ class ProcessorRegisterHandler(Handler):
             list(request.namespaces),
             max_occupancy)
 
-        processor_type = processor_iterator.ProcessorType(
+        processor_type = processor_manager.ProcessorType(
             request.family,
             request.version)
 
-        processor = processor_iterator.Processor(
+        processor = processor_manager.Processor(
             connection_id,
             request.namespaces,
             max_occupancy)

--- a/validator/sawtooth_validator/execution/processor_iterator.py
+++ b/validator/sawtooth_validator/execution/processor_iterator.py
@@ -153,9 +153,11 @@ class ProcessorIteratorCollection(object):
 
 
 class Processor(object):
-    def __init__(self, connection_id, namespaces):
+    def __init__(self, connection_id, namespaces, max_occupancy):
         self.connection_id = connection_id
         self.namespaces = namespaces
+        self._max_occupancy = max_occupancy
+        self._current_occupancy = 0
 
     def __repr__(self):
         return "{}: {}".format(self.connection_id,

--- a/validator/sawtooth_validator/execution/processor_manager.py
+++ b/validator/sawtooth_validator/execution/processor_manager.py
@@ -28,7 +28,7 @@ from sawtooth_validator.exceptions import WaitCancelledException
 LOGGER = logging.getLogger(__name__)
 
 
-class ProcessorIteratorCollection(object):
+class ProcessorManager(object):
     """Contains all of the registered (added via __setitem__)
     transaction processors in a _processors (dict) where the keys
     are ProcessorTypes and the values are ProcessorIterators.

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -94,12 +94,14 @@ def add(
 
     dispatcher.add_handler(
         validator_pb2.Message.TP_REGISTER_REQUEST,
-        processor_handlers.ProcessorRegisterHandler(executor.processors),
+        processor_handlers.ProcessorRegisterHandler(
+            executor.processor_manager),
         thread_pool)
 
     dispatcher.add_handler(
         validator_pb2.Message.TP_UNREGISTER_REQUEST,
-        processor_handlers.ProcessorUnRegisterHandler(executor.processors),
+        processor_handlers.ProcessorUnRegisterHandler(
+            executor.processor_manager),
         thread_pool)
 
     # -- Client -- #


### PR DESCRIPTION
Adds a maxOccupancy field to the TpRegisterRequest proto. This will act as a limit to the number of in-flight transactions a validator can have with a given TP

Tracks the number of current in-flight transactions a validator has with a TP

Removes the _execute_or_wait_for_processor_type() method and the waiting threadpool from the executor, and shifts all wait functionality to the ProcessorManager (previously ProcessorIteratorCollection). Execution will now happen as follows:

- The executor will attempt to grab a processor from the processor iterator collection.
- The processor iterator collection will check to make sure that aprocessor of the requested type is registered. If not, the thread will wait until a suitable processor registers.
- The processor iterator collection will attempt to get the next processor out of the processor iterator of the requested type.
- The processor iterator will cycle through its processors to find a processor that has occupancy to handle another transaction. If all processors are at max occupancy it will throw an exception.
- If the processor iterator encounters an exception, it will wait for a processor to become available and return the processor. If not, it  will just return the processor.