### PR TITLE
Convert predecessor tree's trie to a prefix tree

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -188,9 +188,9 @@ class PredecessorTree:
     def add_reader(self, address, reader):
         def updater(data):
             if data is None:
-                return Predecessors(readers=[reader], writer=None)
+                return Predecessors(readers={reader}, writer=None)
 
-            data.readers.append(reader)
+            data.readers.add(reader)
 
             return data
 
@@ -199,7 +199,7 @@ class PredecessorTree:
     def set_writer(self, address, writer):
         def updater(data):
             if data is None:
-                return Predecessors(readers=[], writer=writer)
+                return Predecessors(readers=set(), writer=writer)
 
             data.writer = writer
             data.readers.clear()

--- a/validator/tests/test_scheduler/test_predecessor_tree.py
+++ b/validator/tests/test_scheduler/test_predecessor_tree.py
@@ -44,12 +44,10 @@ class TestPredecessorTree(unittest.TestCase):
         4) Assert the read and write predecessors for various addresses
            (using assert_rw_preds_at_addresses).
 
-    Although the default token size for the predecessor tree is 2,
-    1 is used for most tests because it makes for more natural examples.
     '''
 
     def setUp(self):
-        self.tree = PredecessorTree(token_size=1)
+        self.tree = PredecessorTree()
 
     def tearDown(self):
         self.tree = None
@@ -627,10 +625,10 @@ class TestPredecessorTree(unittest.TestCase):
         })
 
     def test_long_addresses(self):
-        """Tests predecessor tree with len-64 addresses and token size 2
+        """Tests predecessor tree with len-64 addresses
         """
 
-        self.tree = PredecessorTree(token_size=2)
+        self.tree = PredecessorTree()
 
         address_a = \
             'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'


### PR DESCRIPTION
This PR changes the data structure of the parallel scheduler's predecessor tree from a trie to a prefix tree (there's a lot of confusing and overlapping terminology for this family of data structures; these are the names I've settled on). For a nice comparison of these data structures, see https://medium.com/basecs/compressing-radix-trees-without-too-many-tears-a2e658adb9a0. The tl;dr is that the new one should use a lot less memory than the old one. How much less, you ask? I ran the dynamic network test before and after this change with the following logging statement added:

```
class Node:
    def __init__(self, address, data=None):
        LOGGER.error('NEW NODE')  # <--
        self.address = address
        self.children = set()
        self.data = data
```

Then I counted all the occurrences of that statement. Before this change, the message logged 24140 times. With this change, the message was logged 959 times.