### PR TITLE
Adds missing handler for GetBlockByTransaction

### DIFF
--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -178,6 +178,11 @@ def add(
         client_handlers.BlockGetByNumRequest(block_store),
         client_thread_pool)
 
+    dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_BLOCK_GET_BY_TRANSACTION_REQUEST,
+        client_handlers.BlockGetByTransactionRequest(block_store),
+        thread_pool)
+
     # Batches
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_LIST_REQUEST,


### PR DESCRIPTION
The message `CLIENT_BLOCK_GET_BY_TRANSACTION_REQUEST` is now properly handled by the validator code.