### PR TITLE
Adds missing handlers for GetBlock client messages

### DIFF
--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -178,6 +178,16 @@ def add(
         client_handlers.BlockGetByNumRequest(block_store),
         client_thread_pool)
 
+    dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_BLOCK_GET_BY_BATCH_ID_REQUEST,
+        client_handlers.BlockGetByBatchRequest(block_store),
+        client_thread_pool)
+
+    dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_BLOCK_GET_BY_TRANSACTION_ID_REQUEST,
+        client_handlers.BlockGetByTransactionRequest(block_store),
+        client_thread_pool)
+
     # Batches
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_LIST_REQUEST,


### PR DESCRIPTION
The messages `CLIENT_BLOCK_GET_BY_TRANSACTION_ID_REQUEST` and `CLIENT_BLOCK_GET_BY_BATCH_ID` are now properly handled by the validator code.