### PR TITLE
Export client_peers protobuf messages

### DIFF
--- a/sdk/rust/src/messages/mod.rs
+++ b/sdk/rust/src/messages/mod.rs
@@ -29,6 +29,7 @@ pub mod client_state;
 pub mod client_transaction;
 pub mod client_batch_submit;
 pub mod client_list_control;
+pub mod client_peers;
 pub mod network;
 pub mod events;
 pub mod client_event;


### PR DESCRIPTION
Needed for implementing `net_peerCount` in https://github.com/hyperledger/sawtooth-seth/pull/11