### PR TITLE
Purge blocks from chain controller that depend on a missing predecessor

### DIFF
--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -542,9 +542,8 @@ class BlockValidator(object):
     def _wrap_callback(self, block, callback):
         # Internal cleanup after verification
         def wrapper(commit_new_block, result):
-            LOGGER.debug(
-                "Removing block from processing %s",
-                block.identifier[:6])
+            block = result.block
+            LOGGER.debug("Removing block from processing %s", block.identifier)
             try:
                 self._blocks_processing.remove(block.identifier)
             except KeyError:
@@ -595,7 +594,6 @@ class BlockValidator(object):
                     # Get descendants of the descendant
                     blocks_to_remove.extend(
                         self._blocks_pending.pop(block.identifier, []))
-
 
             callback(commit_new_block, result)
 

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -636,7 +636,7 @@ class BlockValidator(object):
                     result.transaction_count += block.num_transactions
                 else:
                     LOGGER.info(
-                        "Block marked invalid(invalid predecessor): %s", blk)
+                        "Block marked invalid (invalid predecessor): %s", blk)
                     blk.status = BlockStatus.Invalid
 
             if not valid:

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -322,7 +322,7 @@ class BlockValidator(object):
             try:
                 prev_state_root = self._get_previous_block_state_root(blkw)
             except KeyError:
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Block {} rejected due to missing predecessor'.format(
                         blkw))
 
@@ -405,7 +405,7 @@ class BlockValidator(object):
             last block in the shorter chain. Ordered newest to oldest.
 
         Raises:
-            BlockValidationFailure
+            BlockValidationError
                 The block is missing a predecessor. Note that normally this
                 shouldn't happen because of the completer."""
         fork_diff = []
@@ -421,15 +421,7 @@ class BlockValidator(object):
             try:
                 blk = self._block_cache[blk.previous_block_id]
             except KeyError:
-                LOGGER.debug(
-                    "Failed to build fork diff due to missing predecessor: %s",
-                    blk)
-
-                # Mark all blocks in the longer chain since the invalid block
-                # as invalid.
-                for blk in fork_diff:
-                    blk.status = BlockStatus.Invalid
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Failed to build fork diff: block {} missing predecessor'
                     .format(blk))
 
@@ -455,9 +447,7 @@ class BlockValidator(object):
             try:
                 new_blkw = self._block_cache[new_blkw.previous_block_id]
             except KeyError:
-                for b in new_chain:
-                    b.status = BlockStatus.Invalid
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Block {} rejected due to missing predecessor {}'.format(
                         new_blkw, new_blkw.previous_block_id))
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -21,7 +21,7 @@ from threading import RLock
 
 from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
-from sawtooth_validator.journal.block_validator import BlockValidationError
+from sawtooth_validator.journal.block_validator import BlockValidationFailure
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
     TransactionReceipt
 from sawtooth_validator.metrics.wrappers import CounterWrapper
@@ -325,7 +325,7 @@ class ChainController(object):
             else:
                 try:
                     self._block_validator.validate_block(block)
-                except BlockValidationError as err:
+                except BlockValidationFailure as err:
                     LOGGER.warning(
                         'Cannot set chain head; '
                         'genesis block %s is not valid: %s',

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -213,7 +213,8 @@ class BlockTreeManager(object):
         LOGGER.debug("Generated %s", dumps_block(block_wrapper))
         return block_wrapper
 
-    def generate_chain(self, root_block, blocks, params=None):
+    def generate_chain(self, root_block, blocks, params=None,
+                       exclude_head=True):
         """
         Generate a new chain based on the root block and place it in the
         block cache.
@@ -229,7 +230,8 @@ class BlockTreeManager(object):
 
         try:
             block_defs = [self._block_def(**params) for _ in range(blocks)]
-            block_defs[-1] = self._block_def()
+            if exclude_head:
+                block_defs[-1] = self._block_def()
         except TypeError:
             block_defs = blocks
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -648,7 +648,7 @@ class TestBlockValidator(unittest.TestCase):
 
         self.validate_block(head)
 
-        self.assert_invalid_block(head)
+        self.assert_unknown_block(head)
         self.assert_new_block_not_committed()
 
     def test_fork_invalid_predecessor(self):
@@ -827,6 +827,11 @@ class TestBlockValidator(unittest.TestCase):
         self.assertEqual(
             block.status, BlockStatus.Invalid,
             "Block should be invalid")
+
+    def assert_unknown_block(self, block):
+        self.assertEqual(
+            block.status, BlockStatus.Unknown,
+            "Block should be unknown")
 
     def assert_new_block_committed(self):
         self.assert_handler_has_result()

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -672,7 +672,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a bad batch
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         new_block = self.block_tree_manager.generate_block(
             previous_block=head,
@@ -689,7 +689,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a bad batch
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         new_block = self.block_tree_manager.generate_block(
             previous_block=head,
@@ -707,7 +707,7 @@ class TestBlockValidator(unittest.TestCase):
         dependency.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction(deps=["missing"])
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -728,7 +728,7 @@ class TestBlockValidator(unittest.TestCase):
         the chain.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         batch = self.block_tree_manager.generate_batch()
         new_block = self.block_tree_manager.generate_block(
@@ -753,7 +753,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a duplicate batches.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         batch = self.block_tree_manager.generate_batch()
 
@@ -773,7 +773,7 @@ class TestBlockValidator(unittest.TestCase):
         committed.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -802,7 +802,7 @@ class TestBlockValidator(unittest.TestCase):
         transactions.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn, txn])
@@ -879,9 +879,10 @@ class TestBlockValidator(unittest.TestCase):
 
     # block tree manager interface
 
-    def generate_chain_with_head(self, root_block, num_blocks, params=None):
+    def generate_chain_with_head(self, root_block, num_blocks, params=None,
+                                 exclude_head=True):
         chain = self.block_tree_manager.generate_chain(
-            root_block, num_blocks, params)
+            root_block, num_blocks, params, exclude_head)
 
         head = chain[-1]
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -32,7 +32,7 @@ from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_validator import BlockValidator
-from sawtooth_validator.journal.block_validator import BlockValidationError
+from sawtooth_validator.journal.block_validator import BlockValidationFailure
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.chain_commit_state import DuplicateTransaction
@@ -1301,7 +1301,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          side_effect=BlockValidationError):
+                          side_effect=BlockValidationFailure):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)


### PR DESCRIPTION
Correctly solving the missing predecessor issue requires redesigning how blocks are handled between the completer and chain controller. Currently, they maintain two separate block caches and there is no way for the chain controller to tell the completer it is missing something. This is by design. 

A missing predecessor is an error condition and, since the chain controller can’t request the missing predecessor from the completer by design, the only thing that makes sense to do is purge the chain based on the missing predecessor and hope the completer figures it out.