### PR TITLE
WIP - Share block cache between chain controller and completer

### DIFF
--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -542,9 +542,8 @@ class BlockValidator(object):
     def _wrap_callback(self, block, callback):
         # Internal cleanup after verification
         def wrapper(commit_new_block, result):
-            LOGGER.debug(
-                "Removing block from processing %s",
-                block.identifier[:6])
+            block = result.block
+            LOGGER.debug("Removing block from processing %s", block.identifier)
             try:
                 self._blocks_processing.remove(block.identifier)
             except KeyError:
@@ -595,7 +594,6 @@ class BlockValidator(object):
                     # Get descendants of the descendant
                     blocks_to_remove.extend(
                         self._blocks_pending.pop(block.identifier, []))
-
 
             callback(commit_new_block, result)
 

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -636,7 +636,7 @@ class BlockValidator(object):
                     result.transaction_count += block.num_transactions
                 else:
                     LOGGER.info(
-                        "Block marked invalid(invalid predecessor): %s", blk)
+                        "Block marked invalid (invalid predecessor): %s", blk)
                     blk.status = BlockStatus.Invalid
 
             if not valid:

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -322,7 +322,7 @@ class BlockValidator(object):
             try:
                 prev_state_root = self._get_previous_block_state_root(blkw)
             except KeyError:
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Block {} rejected due to missing predecessor'.format(
                         blkw))
 
@@ -405,7 +405,7 @@ class BlockValidator(object):
             last block in the shorter chain. Ordered newest to oldest.
 
         Raises:
-            BlockValidationFailure
+            BlockValidationError
                 The block is missing a predecessor. Note that normally this
                 shouldn't happen because of the completer."""
         fork_diff = []
@@ -421,15 +421,7 @@ class BlockValidator(object):
             try:
                 blk = self._block_cache[blk.previous_block_id]
             except KeyError:
-                LOGGER.debug(
-                    "Failed to build fork diff due to missing predecessor: %s",
-                    blk)
-
-                # Mark all blocks in the longer chain since the invalid block
-                # as invalid.
-                for blk in fork_diff:
-                    blk.status = BlockStatus.Invalid
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Failed to build fork diff: block {} missing predecessor'
                     .format(blk))
 
@@ -455,9 +447,7 @@ class BlockValidator(object):
             try:
                 new_blkw = self._block_cache[new_blkw.previous_block_id]
             except KeyError:
-                for b in new_chain:
-                    b.status = BlockStatus.Invalid
-                raise BlockValidationFailure(
+                raise BlockValidationError(
                     'Block {} rejected due to missing predecessor {}'.format(
                         new_blkw, new_blkw.previous_block_id))
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -282,15 +282,13 @@ class ChainController(object):
     def on_block_received(self, block):
         try:
             with self._lock:
+                # are we already processing this block
                 if self.has_block(block.header_signature):
-                    # do we already have this block
                     return
 
                 if self.chain_head is None:
                     self._set_genesis(block)
                     return
-
-                self._block_cache[block.identifier] = block
 
                 # schedule this block for validation.
                 self._submit_blocks_for_verification([block])
@@ -302,9 +300,6 @@ class ChainController(object):
 
     def has_block(self, block_id):
         with self._lock:
-            if block_id in self._block_cache:
-                return True
-
             if self._block_validator.in_process(block_id):
                 return True
 

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -21,7 +21,7 @@ from threading import RLock
 
 from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
-from sawtooth_validator.journal.block_validator import BlockValidationError
+from sawtooth_validator.journal.block_validator import BlockValidationFailure
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import \
     TransactionReceipt
 from sawtooth_validator.metrics.wrappers import CounterWrapper
@@ -325,7 +325,7 @@ class ChainController(object):
             else:
                 try:
                     self._block_validator.validate_block(block)
-                except BlockValidationError as err:
+                except BlockValidationFailure as err:
                     LOGGER.warning(
                         'Cannot set chain head; '
                         'genesis block %s is not valid: %s',

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -69,7 +69,7 @@ class Completer(object):
         """
         self.gossip = gossip
         self.batch_cache = TimedCache(cache_keep_time, cache_purge_frequency)
-        self.block_cache = block_cache
+        self._block_cache = block_cache
         self._seen_txns = TimedCache(cache_keep_time, cache_purge_frequency)
         self._incomplete_batches = TimedCache(cache_keep_time,
                                               cache_purge_frequency)
@@ -126,11 +126,11 @@ class Completer(object):
 
         """
 
-        if block.header_signature in self.block_cache:
+        if block.header_signature in self._block_cache:
             LOGGER.debug("Drop duplicate block: %s", block)
             return None
 
-        if block.previous_block_id not in self.block_cache:
+        if block.previous_block_id not in self._block_cache:
             if not self._has_block(block.previous_block_id):
                 if block.previous_block_id not in self._incomplete_blocks:
                     self._incomplete_blocks[block.previous_block_id] = [block]
@@ -241,7 +241,7 @@ class Completer(object):
                 # Check to see if the dependency has been seen or is in the
                 # current chain (block_store)
                 if dependency not in self._seen_txns and not \
-                        self.block_cache.block_store.has_transaction(
+                        self._block_cache.block_store.has_transaction(
                         dependency):
                     self._unsatisfied_dependency_count.inc()
 
@@ -286,7 +286,7 @@ class Completer(object):
                     inc_blocks = self._incomplete_blocks[my_key]
                     for inc_block in inc_blocks:
                         if self._complete_block(inc_block):
-                            self.block_cache[inc_block.header_signature] = \
+                            self._block_cache[inc_block.header_signature] = \
                                 inc_block
                             self._on_block_received(inc_block)
                             to_complete.append(inc_block.header_signature)
@@ -306,7 +306,7 @@ class Completer(object):
             blkw = BlockWrapper(block)
             block = self._complete_block(blkw)
             if block is not None:
-                self.block_cache[block.header_signature] = blkw
+                self._block_cache[block.header_signature] = blkw
                 self._on_block_received(blkw)
                 self._process_incomplete_blocks(block.header_signature)
             self._incomplete_blocks_length.set_value(
@@ -340,12 +340,12 @@ class Completer(object):
             BlockWrapper: The head of the chain.
         """
         with self.lock:
-            return self.block_cache.block_store.chain_head
+            return self._block_cache.block_store.chain_head
 
     def get_block(self, block_id):
         with self.lock:
-            if block_id in self.block_cache:
-                return self.block_cache[block_id]
+            if block_id in self._block_cache:
+                return self._block_cache[block_id]
             return None
 
     def get_batch(self, batch_id):
@@ -354,7 +354,7 @@ class Completer(object):
                 return self.batch_cache[batch_id]
 
             else:
-                block_store = self.block_cache.block_store
+                block_store = self._block_cache.block_store
                 try:
                     return block_store.get_batch(batch_id)
                 except ValueError:
@@ -367,7 +367,7 @@ class Completer(object):
                 return self.get_batch(batch_id)
 
             else:
-                block_store = self.block_cache.block_store
+                block_store = self._block_cache.block_store
                 try:
                     return block_store.get_batch_by_transaction(transaction_id)
                 except ValueError:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -33,6 +33,7 @@ from sawtooth_validator.journal.batch_sender import BroadcastBatchSender
 from sawtooth_validator.journal.block_sender import BroadcastBlockSender
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_cache import BlockCache
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.completer import Completer
 from sawtooth_validator.journal.responder import Responder
 from sawtooth_validator.journal.batch_injector import \
@@ -135,6 +136,7 @@ class Validator(object):
         block_store = BlockStore(block_db)
         block_cache = BlockCache(
             block_store, keep_time=300, purge_frequency=30)
+        block_cache[NULL_BLOCK_IDENTIFIER] = None
 
         # -- Setup Thread Pools -- #
         component_thread_pool = InstrumentedThreadPoolExecutor(
@@ -232,7 +234,7 @@ class Validator(object):
         )
 
         completer = Completer(
-            block_store,
+            block_cache,
             gossip,
             metrics_registry=metrics_registry)
 

--- a/validator/tests/test_completer/test.py
+++ b/validator/tests/test_completer/test.py
@@ -26,6 +26,7 @@ from sawtooth_signing import CryptoFactory
 from sawtooth_validator.journal.completer import Completer
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.journal.block_store import BlockStore
+from sawtooth_validator.journal.block_cache import BlockCache
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader, \
     Transaction
@@ -38,8 +39,10 @@ class TestCompleter(unittest.TestCase):
     def setUp(self):
         self.block_store = BlockStore(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
+        self.block_cache = BlockCache(
+            self.block_store, keep_time=300, purge_frequency=30)
         self.gossip = MockGossip()
-        self.completer = Completer(self.block_store, self.gossip)
+        self.completer = Completer(self.block_cache, self.gossip)
         self.completer._on_block_received = self._on_block_received
         self.completer._on_batch_received = self._on_batch_received
         self.completer._has_block = self._has_block

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -213,7 +213,8 @@ class BlockTreeManager(object):
         LOGGER.debug("Generated %s", dumps_block(block_wrapper))
         return block_wrapper
 
-    def generate_chain(self, root_block, blocks, params=None):
+    def generate_chain(self, root_block, blocks, params=None,
+                       exclude_head=True):
         """
         Generate a new chain based on the root block and place it in the
         block cache.
@@ -229,7 +230,8 @@ class BlockTreeManager(object):
 
         try:
             block_defs = [self._block_def(**params) for _ in range(blocks)]
-            block_defs[-1] = self._block_def()
+            if exclude_head:
+                block_defs[-1] = self._block_def()
         except TypeError:
             block_defs = blocks
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -648,7 +648,7 @@ class TestBlockValidator(unittest.TestCase):
 
         self.validate_block(head)
 
-        self.assert_invalid_block(head)
+        self.assert_unknown_block(head)
         self.assert_new_block_not_committed()
 
     def test_fork_invalid_predecessor(self):
@@ -827,6 +827,11 @@ class TestBlockValidator(unittest.TestCase):
         self.assertEqual(
             block.status, BlockStatus.Invalid,
             "Block should be invalid")
+
+    def assert_unknown_block(self, block):
+        self.assertEqual(
+            block.status, BlockStatus.Unknown,
+            "Block should be unknown")
 
     def assert_new_block_committed(self):
         self.assert_handler_has_result()

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -1138,33 +1138,33 @@ class TestChainController(unittest.TestCase):
         '''
 
         # create forks of various lengths
-        _, a_0 = self.generate_chain(self.init_head, 3)
-        _, b_0 = self.generate_chain(self.init_head, 5)
-        _, c_0 = self.generate_chain(self.init_head, 7)
+        _, a_0 = self.generate_chain(self.init_head, 3, exclude_head=False)
+        _, b_0 = self.generate_chain(self.init_head, 5, exclude_head=False)
+        _, c_0 = self.generate_chain(self.init_head, 7, exclude_head=False)
 
         self.receive_and_process_blocks(a_0, b_0, c_0)
         self.assert_is_chain_head(c_0)
 
         # extend every fork by 2
-        _, a_1 = self.generate_chain(a_0, 2)
-        _, b_1 = self.generate_chain(b_0, 2)
-        _, c_1 = self.generate_chain(c_0, 2)
+        _, a_1 = self.generate_chain(a_0, 2, exclude_head=False)
+        _, b_1 = self.generate_chain(b_0, 2, exclude_head=False)
+        _, c_1 = self.generate_chain(c_0, 2, exclude_head=False)
 
         self.receive_and_process_blocks(a_1, b_1, c_1)
         self.assert_is_chain_head(c_1)
 
         # extend the forks by different lengths
-        _, a_2 = self.generate_chain(a_1, 1)
-        _, b_2 = self.generate_chain(b_1, 6)
-        _, c_2 = self.generate_chain(c_1, 3)
+        _, a_2 = self.generate_chain(a_1, 1, exclude_head=False)
+        _, b_2 = self.generate_chain(b_1, 6, exclude_head=False)
+        _, c_2 = self.generate_chain(c_1, 3, exclude_head=False)
 
         self.receive_and_process_blocks(a_2, b_2, c_2)
         self.assert_is_chain_head(b_2)
 
         # extend every fork by 2
-        _, a_3 = self.generate_chain(a_2, 8)
-        _, b_3 = self.generate_chain(b_2, 8)
-        _, c_3 = self.generate_chain(c_2, 8)
+        _, a_3 = self.generate_chain(a_2, 8, exclude_head=False)
+        _, b_3 = self.generate_chain(b_2, 8, exclude_head=False)
+        _, c_3 = self.generate_chain(c_2, 8, exclude_head=False)
 
         self.receive_and_process_blocks(a_3, b_3, c_3)
         self.assert_is_chain_head(b_3)
@@ -1191,7 +1191,8 @@ class TestChainController(unittest.TestCase):
             block_sig[:8],
             'Not chain head')
 
-    def generate_chain(self, root_block, num_blocks, params=None):
+    def generate_chain(self, root_block, num_blocks, params=None,
+                       exclude_head=True):
         '''Returns (chain, chain_head).
         Usually only the head is needed,
         but occasionally the chain itself is used.
@@ -1200,7 +1201,7 @@ class TestChainController(unittest.TestCase):
             params = {'add_to_cache': True}
 
         chain = self.block_tree_manager.generate_chain(
-            root_block, num_blocks, params)
+            root_block, num_blocks, params, exclude_head)
 
         head = chain[-1]
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -672,7 +672,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a bad batch
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         new_block = self.block_tree_manager.generate_block(
             previous_block=head,
@@ -689,7 +689,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a bad batch
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         new_block = self.block_tree_manager.generate_block(
             previous_block=head,
@@ -707,7 +707,7 @@ class TestBlockValidator(unittest.TestCase):
         dependency.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction(deps=["missing"])
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -728,7 +728,7 @@ class TestBlockValidator(unittest.TestCase):
         the chain.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         batch = self.block_tree_manager.generate_batch()
         new_block = self.block_tree_manager.generate_block(
@@ -753,7 +753,7 @@ class TestBlockValidator(unittest.TestCase):
         Test the case where the new block has a duplicate batches.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         batch = self.block_tree_manager.generate_batch()
 
@@ -773,7 +773,7 @@ class TestBlockValidator(unittest.TestCase):
         committed.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn])
@@ -802,7 +802,7 @@ class TestBlockValidator(unittest.TestCase):
         transactions.
         """
         _, head = self.generate_chain_with_head(
-            self.root, 5, {'add_to_store': True})
+            self.root, 5, {'add_to_store': True}, False)
 
         txn = self.block_tree_manager.generate_transaction()
         batch = self.block_tree_manager.generate_batch(txns=[txn, txn])
@@ -879,9 +879,10 @@ class TestBlockValidator(unittest.TestCase):
 
     # block tree manager interface
 
-    def generate_chain_with_head(self, root_block, num_blocks, params=None):
+    def generate_chain_with_head(self, root_block, num_blocks, params=None,
+                                 exclude_head=True):
         chain = self.block_tree_manager.generate_chain(
-            root_block, num_blocks, params)
+            root_block, num_blocks, params, exclude_head)
 
         head = chain[-1]
 

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -32,7 +32,7 @@ from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_validator import BlockValidator
-from sawtooth_validator.journal.block_validator import BlockValidationError
+from sawtooth_validator.journal.block_validator import BlockValidationFailure
 from sawtooth_validator.journal.chain import ChainController
 from sawtooth_validator.journal.chain_commit_state import ChainCommitState
 from sawtooth_validator.journal.chain_commit_state import DuplicateTransaction
@@ -1301,7 +1301,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
 
         with patch.object(BlockValidator,
                           'validate_block',
-                          side_effect=BlockValidationError):
+                          side_effect=BlockValidationFailure):
             self.chain_ctrl.on_block_received(my_genesis_block)
 
         self.assertIsNone(self.chain_ctrl.chain_head)


### PR DESCRIPTION
This builds on #1464 and tries to solve the data race by just sharing the block cache between the chain controller and completer. This way, if the chain controller removes blocks from the cache because of a missing predecessor, the completer will know to re-request them when a new block is received. This should be followed up with a rewrite of the block cache to be more of a fork manager.