### PR TITLE
Update to enable rust build behind proxy

### DIFF
--- a/bin/build_rust
+++ b/bin/build_rust
@@ -17,6 +17,8 @@
 
 set -e
 
+export https_proxy=$http_proxy
+
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 
 echo -e "\033[0;32m--- Building Rust SDK ---\n\033[0m"

--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -29,6 +29,8 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
+ENV https_proxy $http_proxy
+
 RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \


### PR DESCRIPTION
build_rust fails if https_proxy contains https.
Downgrade https to use http

Signed-off-by: ashish kumar mishra <ashish.k.mishra@intel.com>