### PR TITLE
Updated committed transactions metric

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -240,6 +240,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "$DATASOURCE",
+          "description": "The current count of transactions committed to the blockstore. Note that on forking networks, this is not necessarily monotonic.",
           "fill": 0,
           "id": 3,
           "legend": {
@@ -288,7 +289,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "sawtooth_validator.chain.ChainController.committed_transactions_count",
+              "measurement": "sawtooth_validator.chain.ChainController.committed_transactions_gauge",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",
@@ -297,13 +298,13 @@
                 [
                   {
                     "params": [
-                      "count"
+                      "value"
                     ],
                     "type": "field"
                   },
                   {
                     "params": [],
-                    "type": "last"
+                    "type": "mean"
                   }
                 ]
               ],

--- a/validator/sawtooth_validator/database/database.py
+++ b/validator/sawtooth_validator/database/database.py
@@ -46,6 +46,11 @@ class Database(metaclass=ABCMeta):
     def contains_key(self, key, index=None):
         raise NotImplementedError()
 
+    @abstractmethod
+    def count(self, index=None):
+        """Retrieve the count of entries in the main database or the index."""
+        raise NotImplementedError()
+
     def get(self, key, index=None):
         """Retrieves a value associated with a key from the database
 

--- a/validator/sawtooth_validator/database/dict_database.py
+++ b/validator/sawtooth_validator/database/dict_database.py
@@ -46,6 +46,15 @@ class DictDatabase(database.Database):
 
         return key in self._data
 
+    def count(self, index=None):
+        if index is not None and index not in self._indexes:
+            raise ValueError('Index {} does not exist'.format(index))
+
+        if index:
+            return len(self._indexes[index][0])
+
+        return len(self._data)
+
     def get_multi(self, keys, index=None):
         if index is not None and index not in self._indexes:
             raise ValueError('Index {} does not exist'.format(index))

--- a/validator/sawtooth_validator/database/indexed_database.py
+++ b/validator/sawtooth_validator/database/indexed_database.py
@@ -109,6 +109,16 @@ class IndexedDatabase(database.Database):
         with self._lmdb.begin(db=self._main_db) as txn:
             return txn.stat()['entries']
 
+    def count(self, index=None):
+        if index is None:
+            return len(self)
+        else:
+            if index is not None and index not in self._indexes:
+                raise ValueError('Index {} does not exist'.format(index))
+
+            with self._lmdb.begin(db=self._indexes[index][0]) as txn:
+                return txn.stat()['entries']
+
     def contains_key(self, key, index=None):
         if index is not None and index not in self._indexes:
             raise ValueError('Index {} does not exist'.format(index))

--- a/validator/sawtooth_validator/database/lmdb_nolock_database.py
+++ b/validator/sawtooth_validator/database/lmdb_nolock_database.py
@@ -80,6 +80,12 @@ class LMDBNoLockDatabase(database.Database):
         """
         raise NotImplementedError()
 
+    def count(self, index=None):
+        """
+        This currently is just to satisfy the interface.
+        """
+        raise NotImplementedError()
+
     def update(self, puts, deletes):
         with self._lmdb.begin(write=True, buffers=True) as txn:
             for k in deletes:

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -437,6 +437,30 @@ class BlockStore(MutableMapping):
             for txn_id, block in blocks
         ]
 
+    def get_transaction_count(self):
+        """Returns the count of transactions in the block store.
+
+        Returns:
+            Integer: The count of transactions
+        """
+        return self._block_store.count(index='transaction')
+
+    def get_batch_count(self):
+        """Returns the count of batches in the block store.
+
+        Returns:
+            Integer: The count of batches
+        """
+        return self._block_store.count(index='batch')
+
+    def get_block_count(self):
+        """Returns the count of blocks in the block store.
+
+        Returns:
+            Integer: The count of blocks
+        """
+        return self._block_store.count()
+
     @staticmethod
     def _get_txn_from_block(block, txn_id):
         for batch in block.batches:

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -131,6 +131,9 @@ class ChainController(object):
         self._chain_observers = chain_observers
 
         self._chain_head_gauge = COLLECTOR.gauge('chain_head', instance=self)
+        self._committed_transactions_gauge = COLLECTOR.gauge(
+            'committed_transactions_gauge', instance=self)
+        self._committed_transactions_gauge.set_value(0)
         self._committed_transactions_count = COLLECTOR.counter(
             'committed_transactions_count', instance=self)
         self._block_num_gauge = COLLECTOR.gauge('block_num', instance=self)
@@ -232,6 +235,9 @@ class ChainController(object):
 
                         self._chain_head_gauge.set_value(
                             self._chain_head.identifier[:8])
+
+                        self._committed_transactions_gauge.set_value(
+                            self._block_store.get_transaction_count())
 
                         self._committed_transactions_count.inc(
                             result.transaction_count)

--- a/validator/tests/test_block_store/tests.py
+++ b/validator/tests/test_block_store/tests.py
@@ -185,6 +185,17 @@ class BlockStoreTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             stored = block_store.get_transaction("bad")
 
+    def test_get_count(self):
+        """ Test BlockStore get_*_count operations.
+        """
+        block = self.create_block()
+        block_store = self.create_block_store()
+        block_store.update_chain([block])
+
+        self.assertEqual(1, block_store.get_block_count())
+        self.assertEqual(1, block_store.get_batch_count())
+        self.assertEqual(1, block_store.get_transaction_count())
+
     def assert_blocks_equal(self, stored, reference):
         self.asset_protobufs_equal(stored.block,
                                    reference.block)

--- a/validator/tests/test_indexing/tests.py
+++ b/validator/tests/test_indexing/tests.py
@@ -50,6 +50,9 @@ class IndexedDatabaseTest(unittest.TestCase):
 
         self.assertEqual(3, len(db))
 
+        self.assertEqual(3, db.count())
+        self.assertEqual(3, db.count(index="name"))
+
     def test_contains(self):
         """Given a database with three records and an index, test the
         following:


### PR DESCRIPTION
This adds a gauge metric for committed transactions which shows the actual number of transactions currently in the block store, which can go up and down over time as forks are resolved.