### PR TITLE
Fix empty lines in literalinclude blocks (remove :linenos:)

### DIFF
--- a/docs/source/architecture/transactions_and_batches.rst
+++ b/docs/source/architecture/transactions_and_batches.rst
@@ -27,7 +27,6 @@ message types:
 .. literalinclude:: ../../../protos/transaction.proto
    :language: protobuf
    :caption: File: protos/transaction.proto
-   :linenos:
 
 Header, Signature, and Public Keys
 ----------------------------------
@@ -130,7 +129,6 @@ message types:
 .. literalinclude:: ../../../protos/batch.proto
    :language: protobuf
    :caption: File: protos/batch.proto
-   :linenos:
 
 Header, Signature, and Public Keys
 ----------------------------------


### PR DESCRIPTION
There's a line-height bug when line numbers are displayed with :linenos:

Signed-off-by: Anne Chenette <chenette@bitwise.io>