### PR TITLE
Message handler preprocessors

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -194,10 +194,7 @@ class GossipBatchResponseHandler(Handler):
         self._block_publisher_has_batch = block_publisher_has_batch
 
     def handle(self, connection_id, message_content):
-        batch_response_message = GossipBatchResponse()
-        batch_response_message.ParseFromString(message_content)
-        batch = Batch()
-        batch.ParseFromString(batch_response_message.content)
+        batch, _ = message_content
 
         batch_id = batch.header_signature
 
@@ -278,5 +275,16 @@ def gossip_block_response_preprocessor(message_content_bytes):
     block.ParseFromString(block_response.content)
 
     content = block, message_content_bytes
+
+    return PreprocessorResult(content=content)
+
+
+def gossip_batch_response_preprocessor(message_content_bytes):
+    batch_response = GossipBatchResponse()
+    batch_response.ParseFromString(message_content_bytes)
+    batch = Batch()
+    batch.ParseFromString(batch_response.content)
+
+    content = batch, message_content_bytes
 
     return PreprocessorResult(content=content)

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -160,10 +160,7 @@ class GossipBlockResponseHandler(Handler):
         self._chain_controller_has_block = chain_controller_has_block
 
     def handle(self, connection_id, message_content):
-        block_response_message = GossipBlockResponse()
-        block_response_message.ParseFromString(message_content)
-        block = Block()
-        block.ParseFromString(block_response_message.content)
+        block, _ = message_content
 
         block_id = block.header_signature
 
@@ -270,5 +267,16 @@ def gossip_message_preprocessor(message_content_bytes):
         obj.ParseFromString(gossip_message.content)
 
     content = obj, tag, gossip_message.time_to_live
+
+    return PreprocessorResult(content=content)
+
+
+def gossip_block_response_preprocessor(message_content_bytes):
+    block_response = GossipBlockResponse()
+    block_response.ParseFromString(message_content_bytes)
+    block = Block()
+    block.ParseFromString(block_response.content)
+
+    content = block, message_content_bytes
 
     return PreprocessorResult(content=content)

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -17,6 +17,7 @@ import logging
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
+from sawtooth_validator.networking.dispatch import PreprocessorResult
 from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import Block
@@ -123,29 +124,27 @@ class GossipMessageDuplicateHandler(Handler):
         self._has_batch = has_batch
 
     def handle(self, connection_id, message_content):
-        gossip_message = GossipMessage()
-        gossip_message.ParseFromString(message_content)
-        if gossip_message.content_type == gossip_message.BLOCK:
-            block = Block()
-            block.ParseFromString(gossip_message.content)
+        obj, tag, _ = message_content
+
+        header_signature = obj.header_signature
+
+        if tag == GossipMessage.BLOCK:
             has_block = False
-            if self._completer.get_block(block.header_signature) is not None:
+            if self._completer.get_block(header_signature) is not None:
                 has_block = True
 
-            if not has_block and self._has_block(block.header_signature):
+            if not has_block and self._has_block(header_signature):
                 has_block = True
 
             if has_block:
                 return HandlerResult(HandlerStatus.DROP)
 
-        if gossip_message.content_type == gossip_message.BATCH:
-            batch = Batch()
-            batch.ParseFromString(gossip_message.content)
+        if tag == GossipMessage.BATCH:
             has_batch = False
-            if self._completer.get_batch(batch.header_signature) is not None:
+            if self._completer.get_batch(header_signature) is not None:
                 has_batch = True
 
-            if not has_batch and self._has_batch(batch.header_signature):
+            if not has_batch and self._has_batch(header_signature):
                 has_batch = True
 
             if has_batch:
@@ -234,30 +233,42 @@ class GossipBroadcastHandler(Handler):
         self._completer = completer
 
     def handle(self, connection_id, message_content):
+        obj, tag, ttl = message_content
+
         exclude = [connection_id]
-        gossip_message = GossipMessage()
-        gossip_message.ParseFromString(message_content)
-        if gossip_message.time_to_live == 0:
+
+        ttl -= 1
+
+        if ttl <= 0:
             # Do not forward message if it has reached its time to live limit
             return HandlerResult(status=HandlerStatus.PASS)
 
-        else:
-            # decrement time_to_live
-            ttl = gossip_message.time_to_live - 1
-
-        if gossip_message.content_type == GossipMessage.BATCH:
-            batch = Batch()
-            batch.ParseFromString(gossip_message.content)
+        if tag == GossipMessage.BATCH:
             # If we already have this batch, don't forward it
-            if not self._completer.get_batch(batch.header_signature):
-                self._gossip.broadcast_batch(batch, exclude, time_to_live=ttl)
-        elif gossip_message.content_type == GossipMessage.BLOCK:
-            block = Block()
-            block.ParseFromString(gossip_message.content)
+            if not self._completer.get_batch(obj.header_signature):
+                self._gossip.broadcast_batch(obj, exclude, time_to_live=ttl)
+        elif tag == GossipMessage.BLOCK:
             # If we already have this block, don't forward it
-            if not self._completer.get_block(block.header_signature):
-                self._gossip.broadcast_block(block, exclude, time_to_live=ttl)
+            if not self._completer.get_block(obj.header_signature):
+                self._gossip.broadcast_block(obj, exclude, time_to_live=ttl)
         else:
-            LOGGER.info("received %s, not BATCH or BLOCK",
-                        gossip_message.content_type)
+            LOGGER.info("received %s, not BATCH or BLOCK", tag)
         return HandlerResult(status=HandlerStatus.PASS)
+
+
+def gossip_message_preprocessor(message_content_bytes):
+    gossip_message = GossipMessage()
+    gossip_message.ParseFromString(message_content_bytes)
+
+    tag = gossip_message.content_type
+
+    if tag == GossipMessage.BLOCK:
+        obj = Block()
+        obj.ParseFromString(gossip_message.content)
+    elif tag == GossipMessage.BATCH:
+        obj = Batch()
+        obj.ParseFromString(gossip_message.content)
+
+    content = obj, tag, gossip_message.time_to_live
+
+    return PreprocessorResult(content=content)

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -26,7 +26,6 @@ from sawtooth_validator.protobuf.authorization_pb2 import \
 from sawtooth_validator.protobuf.authorization_pb2 import RoleType
 from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
-from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
@@ -425,15 +424,13 @@ class NetworkConsensusPermissionHandler(Handler):
         self._gossip = gossip
 
     def handle(self, connection_id, message_content):
-        message = GossipMessage()
-        message.ParseFromString(message_content)
-        if message.content_type == GossipMessage.BLOCK:
+        obj, tag, _ = message_content
+
+        if tag == GossipMessage.BLOCK:
             public_key = \
                 self._network.connection_id_to_public_key(connection_id)
-            block = Block()
-            block.ParseFromString(message.content)
             header = BlockHeader()
-            header.ParseFromString(block.header)
+            header.ParseFromString(obj.header)
             if header.signer_public_key == public_key:
                 permitted = \
                     self._permission_verifier.check_network_consensus_role(

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -25,10 +25,8 @@ from sawtooth_signing.secp256k1 import Secp256k1PublicKey
 from sawtooth_validator.protobuf import client_batch_submit_pb2
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
-from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
-from sawtooth_validator.protobuf.network_pb2 import GossipBatchResponse
 from sawtooth_validator import metrics
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
@@ -188,11 +186,8 @@ class GossipBatchResponseSignatureVerifier(Handler):
             'already_validated_batch_dropped_count', instance=self)
 
     def handle(self, connection_id, message_content):
-        batch_response_message = GossipBatchResponse()
-        batch_response_message.ParseFromString(message_content)
+        batch, _ = message_content
 
-        batch = Batch()
-        batch.ParseFromString(batch_response_message.content)
         if batch.header_signature in self._seen_cache:
             self._batch_dropped_count.inc()
             return HandlerResult(status=HandlerStatus.DROP)

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -27,9 +27,7 @@ from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
-from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
-from sawtooth_validator.protobuf.network_pb2 import GossipBlockResponse
 from sawtooth_validator.protobuf.network_pb2 import GossipBatchResponse
 from sawtooth_validator import metrics
 from sawtooth_validator.networking.dispatch import HandlerResult
@@ -168,10 +166,8 @@ class GossipBlockResponseSignatureVerifier(Handler):
             'already_validated_block_dropped_count', instance=self)
 
     def handle(self, connection_id, message_content):
-        block_response_message = GossipBlockResponse()
-        block_response_message.ParseFromString(message_content)
-        block = Block()
-        block.ParseFromString(block_response_message.content)
+        block, _ = message_content
+
         if block.header_signature in self._seen_cache:
             self.block_dropped_count.inc()
             return HandlerResult(status=HandlerStatus.DROP)

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -15,9 +15,6 @@
 
 import logging
 import hashlib
-# pylint: disable=import-error,no-name-in-module
-# needed for google.protobuf import
-from google.protobuf.message import DecodeError
 
 from sawtooth_signing import create_context
 from sawtooth_signing.secp256k1 import Secp256k1PublicKey
@@ -211,18 +208,12 @@ class BatchListSignatureVerifier(Handler):
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
 
-        try:
-            request = client_batch_submit_pb2.ClientBatchSubmitRequest()
-            request.ParseFromString(message_content)
-        except DecodeError:
-            return make_response(response_proto.INTERNAL_ERROR)
-
-        for batch in request.batches:
+        for batch in message_content.batches:
             if batch.trace:
                 LOGGER.debug("TRACE %s: %s", batch.header_signature,
                              self.__class__.__name__)
 
-        if not all(map(is_valid_batch, request.batches)):
+        if not all(map(is_valid_batch, message_content.batches)):
             return make_response(response_proto.INVALID_BATCH)
 
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -85,23 +85,19 @@ def is_valid_batch(batch):
 
 class GossipHandlerStructureVerifier(Handler):
     def handle(self, connection_id, message_content):
-        gossip_message = network_pb2.GossipMessage()
-        gossip_message.ParseFromString(message_content)
-        if gossip_message.content_type == network_pb2.GossipMessage.BLOCK:
-            block = Block()
-            block.ParseFromString(gossip_message.content)
-            if not is_valid_block(block):
+        obj, tag, _ = message_content
+
+        if tag == network_pb2.GossipMessage.BLOCK:
+            if not is_valid_block(obj):
                 LOGGER.debug("block's batches structure is invalid: %s",
-                             block.header_signature)
+                             obj.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
             return HandlerResult(status=HandlerStatus.PASS)
-        elif gossip_message.content_type == network_pb2.GossipMessage.BATCH:
-            batch = Batch()
-            batch.ParseFromString(gossip_message.content)
-            if not is_valid_batch(batch):
+        elif tag == network_pb2.GossipMessage.BATCH:
+            if not is_valid_batch(obj):
                 LOGGER.debug("batch structure is invalid: %s",
-                             batch.header_signature)
+                             obj.header_signature)
                 return HandlerResult(status=HandlerStatus.DROP)
 
             return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -14,9 +14,6 @@
 # ------------------------------------------------------------------------------
 
 import logging
-# pylint: disable=import-error,no-name-in-module
-# needed for google.protobuf import
-from google.protobuf.message import DecodeError
 
 from sawtooth_validator.protobuf import client_batch_submit_pb2
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
@@ -135,18 +132,12 @@ class BatchListStructureVerifier(Handler):
                 message_out=response_proto(status=out_status),
                 message_type=Message.CLIENT_BATCH_SUBMIT_RESPONSE)
 
-        try:
-            request = client_batch_submit_pb2.ClientBatchSubmitRequest()
-            request.ParseFromString(message_content)
-        except DecodeError:
-            return make_response(response_proto.INTERNAL_ERROR)
-
-        for batch in request.batches:
+        for batch in message_content.batches:
             if batch.trace:
                 LOGGER.debug("TRACE %s: %s", batch.header_signature,
                              self.__class__.__name__)
 
-        if not all(map(is_valid_batch, request.batches)):
+        if not all(map(is_valid_batch, message_content.batches)):
             return make_response(response_proto.INVALID_BATCH)
 
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -19,11 +19,9 @@ import logging
 from google.protobuf.message import DecodeError
 
 from sawtooth_validator.protobuf import client_batch_submit_pb2
-from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf import network_pb2
-from sawtooth_validator.protobuf.network_pb2 import GossipBatchResponse
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
 from sawtooth_validator.networking.dispatch import HandlerStatus
@@ -117,11 +115,8 @@ class GossipBlockResponseStructureVerifier(Handler):
 
 class GossipBatchResponseStructureVerifier(Handler):
     def handle(self, connection_id, message_content):
-        batch_response_message = GossipBatchResponse()
-        batch_response_message.ParseFromString(message_content)
+        batch, _ = message_content
 
-        batch = Batch()
-        batch.ParseFromString(batch_response_message.content)
         if not is_valid_batch(batch):
             LOGGER.debug("requested batch's structure is invalid: %s",
                          batch.header_signature)

--- a/validator/sawtooth_validator/gossip/structure_verifier.py
+++ b/validator/sawtooth_validator/gossip/structure_verifier.py
@@ -21,10 +21,8 @@ from google.protobuf.message import DecodeError
 from sawtooth_validator.protobuf import client_batch_submit_pb2
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
-from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf import network_pb2
-from sawtooth_validator.protobuf.network_pb2 import GossipBlockResponse
 from sawtooth_validator.protobuf.network_pb2 import GossipBatchResponse
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
@@ -107,11 +105,8 @@ class GossipHandlerStructureVerifier(Handler):
 
 class GossipBlockResponseStructureVerifier(Handler):
     def handle(self, connection_id, message_content):
-        block_response_message = GossipBlockResponse()
-        block_response_message.ParseFromString(message_content)
+        block, _ = message_content
 
-        block = Block()
-        block.ParseFromString(block_response_message.content)
         if not is_valid_block(block):
             LOGGER.debug("requested block's batches structure is invalid: %s",
                          block.header_signature)

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -22,8 +22,6 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
-from sawtooth_validator.protobuf.client_batch_submit_pb2 \
-    import ClientBatchSubmitRequest
 from sawtooth_validator.protobuf import network_pb2
 from sawtooth_validator.networking.dispatch import Handler
 from sawtooth_validator.networking.dispatch import HandlerResult
@@ -374,9 +372,7 @@ class CompleterBatchListBroadcastHandler(Handler):
         self._gossip = gossip
 
     def handle(self, connection_id, message_content):
-        request = ClientBatchSubmitRequest()
-        request.ParseFromString(message_content)
-        for batch in request.batches:
+        for batch in message_content.batches:
             if batch.trace:
                 LOGGER.debug("TRACE %s: %s", batch.header_signature,
                              self.__class__.__name__)

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -392,16 +392,12 @@ class CompleterGossipHandler(Handler):
         self._completer = completer
 
     def handle(self, connection_id, message_content):
-        gossip_message = network_pb2.GossipMessage()
-        gossip_message.ParseFromString(message_content)
-        if gossip_message.content_type == network_pb2.GossipMessage.BLOCK:
-            block = Block()
-            block.ParseFromString(gossip_message.content)
-            self._completer.add_block(block)
-        elif gossip_message.content_type == network_pb2.GossipMessage.BATCH:
-            batch = Batch()
-            batch.ParseFromString(gossip_message.content)
-            self._completer.add_batch(batch)
+        obj, tag, _ = message_content
+
+        if tag == network_pb2.GossipMessage.BLOCK:
+            self._completer.add_block(obj)
+        elif tag == network_pb2.GossipMessage.BATCH:
+            self._completer.add_batch(obj)
         return HandlerResult(status=HandlerStatus.PASS)
 
 

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -22,7 +22,6 @@ from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf.batch_pb2 import Batch
-from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.client_batch_submit_pb2 \
     import ClientBatchSubmitRequest
@@ -406,11 +405,7 @@ class CompleterGossipBlockResponseHandler(Handler):
         self._completer = completer
 
     def handle(self, connection_id, message_content):
-        block_response_message = network_pb2.GossipBlockResponse()
-        block_response_message.ParseFromString(message_content)
-
-        block = Block()
-        block.ParseFromString(block_response_message.content)
+        block, _ = message_content
         self._completer.add_block(block)
 
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -21,7 +21,6 @@ from sawtooth_validator.journal.block_cache import BlockCache
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.timed_cache import TimedCache
-from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.client_batch_submit_pb2 \
     import ClientBatchSubmitRequest
@@ -416,11 +415,7 @@ class CompleterGossipBatchResponseHandler(Handler):
         self._completer = completer
 
     def handle(self, connection_id, message_content):
-        batch_response_message = network_pb2.GossipBatchResponse()
-        batch_response_message.ParseFromString(message_content)
-
-        batch = Batch()
-        batch.ParseFromString(batch_response_message.content)
+        batch, _ = message_content
         self._completer.add_batch(batch)
 
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -22,7 +22,6 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf import network_pb2
 from sawtooth_validator.protobuf import validator_pb2
-from sawtooth_validator.protobuf import block_pb2
 from sawtooth_validator.protobuf import batch_pb2
 
 LOGGER = logging.getLogger(__name__)
@@ -143,10 +142,8 @@ class ResponderBlockResponseHandler(Handler):
         self._gossip = gossip
 
     def handle(self, connection_id, message_content):
-        block_response = network_pb2.GossipBlockResponse()
-        block_response.ParseFromString(message_content)
-        block = block_pb2.Block()
-        block.ParseFromString(block_response.content)
+        block, message_content = message_content
+
         open_request = self._responder.get_request(block.header_signature)
 
         if open_request is None:

--- a/validator/sawtooth_validator/journal/responder.py
+++ b/validator/sawtooth_validator/journal/responder.py
@@ -22,7 +22,6 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.protobuf import network_pb2
 from sawtooth_validator.protobuf import validator_pb2
-from sawtooth_validator.protobuf import batch_pb2
 
 LOGGER = logging.getLogger(__name__)
 
@@ -329,10 +328,8 @@ class ResponderBatchResponseHandler(Handler):
         self._gossip = gossip
 
     def handle(self, connection_id, message_content):
-        batch_response = network_pb2.GossipBatchResponse()
-        batch_response.ParseFromString(message_content)
-        batch = batch_pb2.Batch()
-        batch.ParseFromString(batch_response.content)
+        batch, message_content = message_content
+
         open_request = self._responder.get_request(batch.header_signature)
 
         if open_request is None:

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -60,6 +60,7 @@ class Dispatcher(InstrumentedThread):
         self._condition = Condition()
         self._dispatch_timers = {}
         self._priority = {}
+        self._preprocessors = {}
 
     def _get_dispatch_timer(self, tag):
         if tag not in self._dispatch_timers:
@@ -174,10 +175,86 @@ class Dispatcher(InstrumentedThread):
         if priority is not None:
             self._priority[message_type] = priority
 
+    def set_preprocessor(self, message_type, preprocessor, executor):
+        '''
+        Sets PREPROCESSOR to run on MESSAGE_TYPE in EXECUTOR.
+
+        PREPROCESSOR: fn(message_content: bytes) -> PreprocessorResult
+        '''
+        self._preprocessors[message_type] = \
+            _PreprocessorManager(
+                executor=executor,
+                preprocessor=preprocessor)
+
     def set_message_priority(self, message_type, priority):
         self._priority[message_type] = priority
 
     def _process(self, message_id):
+        message_info = self._message_information[message_id]
+
+        try:
+            preprocessor = self._preprocessors[message_info.message_type]
+        except KeyError:
+            self._process_next(message_id)
+            return
+
+        def do_next(result):
+            message_info = self._message_information[message_id]
+
+            try:
+                # check for a None result
+                if result is None:
+                    LOGGER.error(
+                        "%s preprocessor returned None result for messsage %s",
+                        preprocessor,
+                        message_id)
+                    return
+
+                # check for result status
+                if result.status == HandlerStatus.RETURN:
+                    del self._message_information[message_id]
+
+                    message = validator_pb2.Message(
+                        content=result.message_out.SerializeToString(),
+                        correlation_id=message_info.correlation_id,
+                        message_type=result.message_type)
+
+                    try:
+                        self._send_message[message_info.connection](
+                            msg=message,
+                            connection_id=message_info.connection_id)
+                    except KeyError:
+                        LOGGER.warning(
+                            "Can't send message %s back to "
+                            "%s because connection %s not in dispatcher",
+                            get_enum_name(message.message_type),
+                            message_info.connection_id,
+                            message_info.connection)
+
+                    return
+
+                # store the preprocessor result
+                self._message_information[message_id] = \
+                    _MessageInformation(
+                        connection=message_info.connection,
+                        connection_id=message_info.connection_id,
+                        content=result.content,
+                        correlation_id=message_info.correlation_id,
+                        collection=message_info.collection,
+                        message_type=message_info.message_type)
+
+                self._process_next(message_id)
+
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception(
+                    "Unhandled exception after preprocessing")
+
+        preprocessor.execute(
+            connection_id=message_info.connection_id,
+            message_content=message_info.content,
+            callback=do_next)
+
+    def _process_next(self, message_id):
         message_info = self._message_information[message_id]
 
         try:
@@ -213,7 +290,7 @@ class Dispatcher(InstrumentedThread):
             del self._message_information[message_id]
 
         elif result.status == HandlerStatus.PASS:
-            self._process(message_id)
+            self._process_next(message_id)
 
         elif result.status == HandlerStatus.RETURN_AND_PASS:
             message_info = self._message_information[message_id]
@@ -235,7 +312,7 @@ class Dispatcher(InstrumentedThread):
                         message_info.connection_id,
                         message_info.connection)
 
-                self._process(message_id)
+                self._process_next(message_id)
             else:
                 LOGGER.error("HandlerResult with status of RETURN_AND_PASS "
                              "is missing message_out or message_type")
@@ -319,6 +396,18 @@ class Dispatcher(InstrumentedThread):
                 self._condition.wait()
 
 
+class _PreprocessorManager:
+    def __init__(self, executor, preprocessor):
+        self._executor = executor
+        self._preprocessor = preprocessor
+
+    def execute(self, connection_id, message_content, callback):
+        def wrapped(message_content):
+            return callback(self._preprocessor(message_content))
+
+        return self._executor.submit(wrapped, message_content)
+
+
 class _HandlerManager(object):
     def __init__(self, executor, handler):
         """
@@ -372,6 +461,19 @@ class HandlerStatus(enum.Enum):
     RETURN_AND_PASS = 3  # Send a message out and process the next handler
     PASS = 4  # Send the message to the next handler
     RETURN_AND_CLOSE = 5  # Send the message out and close connection
+
+
+class PreprocessorResult(HandlerResult):
+    def __init__(self, content=None, status=None,
+                 message_out=None, message_type=None):
+        """
+        :param content: the content returned if preprocessing is successful
+        :param status HandlerStatus: informs the dispatcher on how to proceed
+        :param message_out protobuf Python class:
+        :param message_type: validator_pb2.Message.* enum value
+        """
+        self.content = content
+        super().__init__(status, message_out, message_type)
 
 
 class Handler(object, metaclass=abc.ABCMeta):

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -18,6 +18,7 @@ import logging
 from threading import Condition
 import queue
 import uuid
+from collections import namedtuple
 
 from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.networking.interconnect import get_enum_name
@@ -36,6 +37,15 @@ class Priority(enum.IntEnum):
 
 def _gen_message_id():
     return uuid.uuid4().hex.encode()
+
+
+_MessageInformation = namedtuple('_MessageInformation', (
+    'connection',
+    'connection_id',
+    'content',
+    'correlation_id',
+    'collection',
+    'message_type'))
 
 
 class Dispatcher(InstrumentedThread):
@@ -129,13 +139,17 @@ class Dispatcher(InstrumentedThread):
         if message.message_type in self._msg_type_handlers:
             priority = self._priority.get(message.message_type, Priority.LOW)
             message_id = _gen_message_id()
-            self._message_information[message_id] = (
-                connection,
-                connection_id,
-                message,
-                _ManagerCollection(
-                    self._msg_type_handlers[message.message_type])
-            )
+
+            self._message_information[message_id] = \
+                _MessageInformation(
+                    connection=connection,
+                    connection_id=connection_id,
+                    content=message.content,
+                    correlation_id=message.correlation_id,
+                    message_type=message.message_type,
+                    collection=_ManagerCollection(
+                        self._msg_type_handlers[message.message_type]))
+
             self._in_queue.put_nowait((priority, message_id))
 
             queue_size = self._in_queue.qsize()
@@ -164,11 +178,10 @@ class Dispatcher(InstrumentedThread):
         self._priority[message_type] = priority
 
     def _process(self, message_id):
-        _, connection_id, \
-            message, collection = self._message_information[message_id]
+        message_info = self._message_information[message_id]
 
         try:
-            handler_manager = next(collection)
+            handler_manager = next(message_info.collection)
         except IndexError:
             # IndexError is raised if done with handlers
             del self._message_information[message_id]
@@ -185,7 +198,10 @@ class Dispatcher(InstrumentedThread):
                 LOGGER.exception(
                     "Unhandled exception while determining next")
 
-        handler_manager.execute(connection_id, message.content, do_next)
+        handler_manager.execute(
+            message_info.connection_id,
+            message_info.content,
+            do_next)
 
     def _determine_next(self, message_id, result):
         if result is None:
@@ -200,24 +216,24 @@ class Dispatcher(InstrumentedThread):
             self._process(message_id)
 
         elif result.status == HandlerStatus.RETURN_AND_PASS:
-            connection, connection_id, \
-                original_message, _ = self._message_information[message_id]
+            message_info = self._message_information[message_id]
 
             if result.message_out and result.message_type:
                 message = validator_pb2.Message(
                     content=result.message_out.SerializeToString(),
-                    correlation_id=original_message.correlation_id,
+                    correlation_id=message_info.correlation_id,
                     message_type=result.message_type)
                 try:
-                    self._send_message[connection](msg=message,
-                                                   connection_id=connection_id)
+                    self._send_message[message_info.connection](
+                        msg=message,
+                        connection_id=message_info.connection_id)
                 except KeyError:
                     LOGGER.warning(
                         "Can't send message %s back to "
                         "%s because connection %s not in dispatcher",
                         get_enum_name(message.message_type),
-                        connection_id,
-                        connection)
+                        message_info.connection_id,
+                        message_info.connection)
 
                 self._process(message_id)
             else:
@@ -225,56 +241,55 @@ class Dispatcher(InstrumentedThread):
                              "is missing message_out or message_type")
 
         elif result.status == HandlerStatus.RETURN:
-            connection, connection_id,  \
-                original_message, _ = self._message_information[message_id]
+            message_info = self._message_information[message_id]
 
             del self._message_information[message_id]
 
             if result.message_out and result.message_type:
                 message = validator_pb2.Message(
                     content=result.message_out.SerializeToString(),
-                    correlation_id=original_message.correlation_id,
+                    correlation_id=message_info.correlation_id,
                     message_type=result.message_type)
                 try:
-                    self._send_message[connection](msg=message,
-                                                   connection_id=connection_id)
+                    self._send_message[message_info.connection](
+                        msg=message,
+                        connection_id=message_info.connection_id)
                 except KeyError:
                     LOGGER.warning(
                         "Can't send message %s back to "
                         "%s because connection %s not in dispatcher",
                         get_enum_name(message.message_type),
-                        connection_id,
-                        connection)
+                        message_info.connection_id,
+                        message_info.connection)
             else:
                 LOGGER.error("HandlerResult with status of RETURN "
                              "is missing message_out or message_type")
 
         elif result.status == HandlerStatus.RETURN_AND_CLOSE:
-            connection, connection_id,  \
-                original_message, _ = self._message_information[message_id]
+            message_info = self._message_information[message_id]
 
             del self._message_information[message_id]
 
             if result.message_out and result.message_type:
                 message = validator_pb2.Message(
                     content=result.message_out.SerializeToString(),
-                    correlation_id=original_message.correlation_id,
+                    correlation_id=message_info.correlation_id,
                     message_type=result.message_type)
                 try:
                     LOGGER.warning(
                         "Sending hang-up in reply to %s to connection %s",
-                        get_enum_name(original_message.message_type),
-                        connection_id)
-                    self._send_last_message[connection](
+                        get_enum_name(message_info.message_type),
+                        message_info.connection_id)
+                    self._send_last_message[message_info.connection](
                         msg=message,
-                        connection_id=connection_id)
+                        connection_id=message_info.connection_id)
                 except KeyError:
                     LOGGER.warning(
                         "Can't send last message %s back to "
                         "%s because connection %s not in dispatcher",
                         get_enum_name(message.message_type),
-                        connection_id,
-                        connection)
+                        message_info.connection_id,
+                        message_info.connection)
             else:
                 LOGGER.error("HandlerResult with status of RETURN_AND_CLOSE "
                              "is missing message_out or message_type")

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -113,6 +113,11 @@ def add(
         sig_pool)
 
     # Submit
+    dispatcher.set_preprocessor(
+        validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
+        client_handlers.client_batch_submit_request_preprocessor,
+        client_thread_pool)
+
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
         ClientBatchSubmitBackpressureHandler(

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -46,6 +46,8 @@ from sawtooth_validator.gossip.gossip_handlers import \
     GossipBatchResponseHandler
 from sawtooth_validator.gossip.gossip_handlers import \
     gossip_message_preprocessor
+from sawtooth_validator.gossip.gossip_handlers import \
+    gossip_block_response_preprocessor
 from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
 from sawtooth_validator.gossip.gossip_handlers import GetPeersRequestHandler
@@ -269,6 +271,11 @@ def add(
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_BLOCK_REQUEST,
         BlockResponderHandler(responder, gossip),
+        thread_pool)
+
+    dispatcher.set_preprocessor(
+        validator_pb2.Message.GOSSIP_BLOCK_RESPONSE,
+        gossip_block_response_preprocessor,
         thread_pool)
 
     # GOSSIP_BLOCK_RESPONSE 1) Check for duplicate responses

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -44,6 +44,8 @@ from sawtooth_validator.gossip.gossip_handlers import \
     GossipBlockResponseHandler
 from sawtooth_validator.gossip.gossip_handlers import \
     GossipBatchResponseHandler
+from sawtooth_validator.gossip.gossip_handlers import \
+    gossip_message_preprocessor
 from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
 from sawtooth_validator.gossip.gossip_handlers import GetPeersRequestHandler
@@ -191,6 +193,12 @@ def add(
         thread_pool)
 
     # GOSSIP_MESSAGE ) Check if this is a block and if we already have it
+
+    dispatcher.set_preprocessor(
+        validator_pb2.Message.GOSSIP_MESSAGE,
+        gossip_message_preprocessor,
+        thread_pool)
+
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_MESSAGE,
         GossipMessageDuplicateHandler(completer, has_block, has_batch),

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -47,6 +47,8 @@ from sawtooth_validator.gossip.gossip_handlers import \
 from sawtooth_validator.gossip.gossip_handlers import \
     gossip_message_preprocessor
 from sawtooth_validator.gossip.gossip_handlers import \
+    gossip_batch_response_preprocessor
+from sawtooth_validator.gossip.gossip_handlers import \
     gossip_block_response_preprocessor
 from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
@@ -353,6 +355,11 @@ def add(
             permission_verifier=permission_verifier,
             gossip=gossip
         ),
+        thread_pool)
+
+    dispatcher.set_preprocessor(
+        validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
+        gossip_batch_response_preprocessor,
         thread_pool)
 
     # GOSSIP_BATCH_RESPONSE 1) Check for duplicate responses

--- a/validator/tests/test_duplicate_handler/tests.py
+++ b/validator/tests/test_duplicate_handler/tests.py
@@ -40,10 +40,8 @@ class TestDuplicateHandler(unittest.TestCase):
         chain controller, the gossip message is passed.
         """
         block = Block(header_signature="Block1")
-        message = GossipMessage(content_type=GossipMessage.BLOCK,
-                                content=block.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (block, GossipMessage.BLOCK, 2))
         self.assertEqual(handler_status.status, HandlerStatus.PASS)
 
     def test_no_batch(self):
@@ -52,10 +50,8 @@ class TestDuplicateHandler(unittest.TestCase):
         chain controller, the gossip message is passed.
         """
         batch = Batch(header_signature="Batch1")
-        message = GossipMessage(content_type=GossipMessage.BATCH,
-                                content=batch.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (batch, GossipMessage.BATCH, 2))
         self.assertEqual(handler_status.status, HandlerStatus.PASS)
 
     def test_completer_has_block(self):
@@ -65,10 +61,8 @@ class TestDuplicateHandler(unittest.TestCase):
         """
         block = Block(header_signature="Block1")
         self.completer.add_block("Block1")
-        message = GossipMessage(content_type=GossipMessage.BLOCK,
-                                content=block.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (block, GossipMessage.BLOCK, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)
 
     def test_completer_has_batch(self):
@@ -78,10 +72,8 @@ class TestDuplicateHandler(unittest.TestCase):
         """
         batch = Batch(header_signature="Batch1")
         self.completer.add_batch("Batch1")
-        message = GossipMessage(content_type=GossipMessage.BATCH,
-                                content=batch.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (batch, GossipMessage.BATCH, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)
 
     def test_chain_has_block(self):
@@ -91,10 +83,8 @@ class TestDuplicateHandler(unittest.TestCase):
         """
         block = Block(header_signature="Block1")
         self.chain.add_block("Block1")
-        message = GossipMessage(content_type=GossipMessage.BLOCK,
-                                content=block.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (block, GossipMessage.BLOCK, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)
 
     def test_publisher_has_block(self):
@@ -104,8 +94,6 @@ class TestDuplicateHandler(unittest.TestCase):
         """
         batch = Batch(header_signature="Batch1")
         self.publisher.add_batch("Batch1")
-        message = GossipMessage(content_type=GossipMessage.BATCH,
-                                content=batch.SerializeToString())
         handler_status = self.handler.handle(
-            "connection_id", message.SerializeToString())
+            "connection_id", (batch, GossipMessage.BATCH, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -462,7 +462,7 @@ class TestResponder(unittest.TestCase):
             content=batch.SerializeToString())
 
         self.batch_response_handler.handle(
-            "Connection_1", response_message.SerializeToString())
+            "Connection_1", (batch, response_message.SerializeToString()))
 
         # ResponderBlockResponseHandler should not send any messages.
         self.assert_message_not_sent("Connection_1")
@@ -483,7 +483,7 @@ class TestResponder(unittest.TestCase):
         # requested the batch but it could not be fulfilled at that time of the
         # request the received BatchResponse is forwarded to Connection_2
         self.batch_response_handler.handle(
-            "Connection_1", response_message.SerializeToString())
+            "Connection_1", (batch, response_message.SerializeToString()))
 
         self.assert_message_sent(
             connection_id="Connection_2",
@@ -522,7 +522,7 @@ class TestResponder(unittest.TestCase):
 
         # Send Batch Response that contains the batch that has txn "123"
         self.batch_response_handler.handle(
-            "Connection_1", response_message.SerializeToString())
+            "Connection_1", (batch, response_message.SerializeToString()))
 
         # Handle the the BatchResponse Message. Since Connection_2 had
         # requested the txn_id in the batch but it could not be fulfilled at

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -165,7 +165,7 @@ class TestResponder(unittest.TestCase):
             content=block.SerializeToString())
 
         self.block_response_handler.handle(
-            "Connection_1", response_message.SerializeToString())
+            "Connection_1", (block, response_message.SerializeToString()))
 
         # ResponderBlockResponseHandler should not send any messages.
         self.assert_message_not_sent("Connection_1")
@@ -186,7 +186,7 @@ class TestResponder(unittest.TestCase):
         # requested the block but it could not be fulfilled at that time of the
         # request the received BlockResponse is forwarded to Connection_2
         self.block_response_handler.handle(
-            "Connection_1", response_message.SerializeToString())
+            "Connection_1", (block, response_message.SerializeToString()))
 
         self.assert_message_sent(
             connection_id="Connection_2",


### PR DESCRIPTION
This PR implements @aludvik 's idea for cutting down on repeated
message deserialization, namely, adding "preprocessors" on a
message-by-message basis. These preprocessors act on messages before
they reach the handlers, deserializing the message content and also
extracting whatever other message information is required by the
handlers. With gossip messages, for instance, there are handlers that
require the message type tag and the message time-to-live in addition
to the batch or block object contained in the message, so those three
things are extracted and stored in a tuple that is passed to the
handlers.

With these changes, the poet liveness test seems to be able to run
with a higher workload, so I've included a commit to bump the workload
rates. This consistently passes when running locally, but maybe it
won't work on Jenkins.