### PR TITLE
Remove line numbers for --help usage text

### DIFF
--- a/docs/source/cli/identity-tp.rst
+++ b/docs/source/cli/identity-tp.rst
@@ -29,7 +29,6 @@ must be stored in ``sawtooth.identity.allowed_keys``.
 
 .. literalinclude:: output/identity-tp_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/intkey.rst
+++ b/docs/source/cli/intkey.rst
@@ -27,7 +27,6 @@ decrement the value of entries stored in a state dictionary.
 
 .. literalinclude:: output/intkey_usage.out
    :language: console
-   :linenos:
 
 intkey set
 ==========
@@ -38,7 +37,6 @@ This transaction will fail if the value is less than 0 or greater than
 
 .. literalinclude:: output/intkey_set_usage.out
    :language: console
-   :linenos:
 
 intkey inc
 ==========
@@ -49,7 +47,6 @@ would exceed 2\ :sup:`32` - 1.
 
 .. literalinclude:: output/intkey_inc_usage.out
    :language: console
-   :linenos:
 
 intkey dec
 ==========
@@ -60,7 +57,6 @@ would be less than 0.
 
 .. literalinclude:: output/intkey_dec_usage.out
    :language: console
-   :linenos:
 
 intkey show
 ===========
@@ -69,7 +65,6 @@ The ``intkey show`` subcommand displays the value of the specified key (`name`).
 
 .. literalinclude:: output/intkey_show_usage.out
    :language: console
-   :linenos:
 
 intkey list
 ===========
@@ -78,7 +73,6 @@ The ``intkey list`` subcommand displays the value of all keys.
 
 .. literalinclude:: output/intkey_list_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/poet.rst
+++ b/docs/source/cli/poet.rst
@@ -29,7 +29,6 @@ Sawtooth with the PoET consensus method.
 
 .. literalinclude:: output/poet_usage.out
    :language: console
-   :linenos:
 
 poet registration
 =================
@@ -39,7 +38,6 @@ the PoET validator registry.
 
 .. literalinclude:: output/poet_registration_usage.out
    :language: console
-   :linenos:
 
 poet registration create
 ========================
@@ -50,7 +48,6 @@ the validator host wishing to enroll.
 
 .. literalinclude:: output/poet_registration_create_usage.out
    :language: console
-   :linenos:
 
 poet enclave
 ============
@@ -59,7 +56,6 @@ The ``poet enclave`` subcommand generates enclave setup information.
 
 .. literalinclude:: output/poet_enclave_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/sawadm.rst
+++ b/docs/source/cli/sawadm.rst
@@ -26,7 +26,6 @@ initializing a validator.
 
 .. literalinclude:: output/sawadm_usage.out
    :language: console
-   :linenos:
 
 sawadm genesis
 ==============
@@ -66,7 +65,6 @@ Use ``--output`` `filename` to specify a different name for the target file.
 
 .. literalinclude:: output/sawadm_genesis_usage.out
    :language: console
-   :linenos:
 
 
 sawadm keygen
@@ -83,7 +81,6 @@ name.
 
 .. literalinclude:: output/sawadm_keygen_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/sawnet.rst
+++ b/docs/source/cli/sawnet.rst
@@ -24,7 +24,6 @@ network of Sawtooth nodes.
 
 .. literalinclude:: output/sawnet_usage.out
    :language: console
-   :linenos:
 
 
 sawnet compare-chains
@@ -35,14 +34,12 @@ nodes.
 
 .. literalinclude:: output/sawnet_compare-chains_usage.out
    :language: console
-   :linenos:
 
 sawnet peers
 ============
 
 .. literalinclude:: output/sawnet_peers_usage.out
    :language: console
-   :linenos:
 
 sawnet peers list
 =================
@@ -51,7 +48,6 @@ The ``sawnet peers list`` subcommand displays the peers of the specified nodes.
 
 .. literalinclude:: output/sawnet_peers_list_usage.out
    :language: console
-   :linenos:
 
 sawnet peers graph
 ==================
@@ -61,4 +57,3 @@ that describes the peering arrangement of the specified nodes.
 
 .. literalinclude:: output/sawnet_peers_graph_usage.out
    :language: console
-   :linenos:

--- a/docs/source/cli/sawset.rst
+++ b/docs/source/cli/sawset.rst
@@ -28,7 +28,6 @@ that will be set in the genesis block.
 
 .. literalinclude:: output/sawset_usage.out
    :language: console
-   :linenos:
 
 sawset genesis
 ==============
@@ -39,7 +38,6 @@ during genesis block construction.
 
 .. literalinclude:: output/sawset_genesis_usage.out
    :language: console
-   :linenos:
 
 sawset proposal
 ===============
@@ -51,7 +49,6 @@ create and vote on proposed settings.
 
 .. literalinclude:: output/sawset_proposal_usage.out
    :language: console
-   :linenos:
 
 sawset proposal create
 ======================
@@ -62,7 +59,6 @@ series of votes, depending on the vote threshold setting.
 
 .. literalinclude:: output/sawset_proposal_create_usage.out
    :language: console
-   :linenos:
 
 sawset proposal list
 ====================
@@ -73,7 +69,6 @@ proposals can be used to find proposals to vote on.
 
 .. literalinclude:: output/sawset_proposal_list_usage.out
    :language: console
-   :linenos:
 
 sawset proposal vote
 ====================
@@ -84,7 +79,6 @@ find the proposal id.
 
 .. literalinclude:: output/sawset_proposal_vote_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/sawtooth-rest-api.rst
+++ b/docs/source/cli/sawtooth-rest-api.rst
@@ -39,7 +39,6 @@ a response for the validator.
 
 .. literalinclude:: output/sawtooth-rest-api_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/sawtooth-validator.rst
+++ b/docs/source/cli/sawtooth-validator.rst
@@ -61,7 +61,6 @@ validator.
 
 .. literalinclude:: output/sawtooth-validator_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -34,7 +34,6 @@ options and arguments that control their behavior. For example:
 
 .. literalinclude:: output/sawtooth_usage.out
    :language: console
-   :linenos:
 
 sawtooth batch
 ==============
@@ -48,7 +47,6 @@ see “Transactions and Batches!”
 
 .. literalinclude:: output/sawtooth_batch_usage.out
    :language: console
-   :linenos:
 
 sawtooth batch list
 ===================
@@ -66,7 +64,6 @@ processing.
 
 .. literalinclude:: output/sawtooth_batch_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth batch show
 ===================
@@ -85,7 +82,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_batch_show_usage.out
    :language: console
-   :linenos:
 
 sawtooth batch status
 =====================
@@ -105,7 +101,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_batch_status_usage.out
    :language: console
-   :linenos:
 
 sawtooth batch submit
 =====================
@@ -124,7 +119,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_batch_submit_usage.out
    :language: console
-   :linenos:
 
 sawtooth block
 ==============
@@ -134,7 +128,6 @@ blocks in the current blockchain.
 
 .. literalinclude:: output/sawtooth_block_usage.out
    :language: console
-   :linenos:
 
 sawtooth block list
 ===================
@@ -152,7 +145,6 @@ processing.
 
 .. literalinclude:: output/sawtooth_block_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth block show
 ===================
@@ -171,7 +163,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_block_show_usage.out
    :language: console
-   :linenos:
 
 sawtooth identity
 =================
@@ -193,7 +184,6 @@ setting.
 
 .. literalinclude:: output/sawtooth_identity_usage.out
   :language: console
-  :linenos:
 
 sawtooth identity policy
 ========================
@@ -203,7 +193,6 @@ current policies stored in state and to create new policies.
 
 .. literalinclude:: output/sawtooth_identity_policy_usage.out
    :language: console
-   :linenos:
 
 sawtooth identity policy create
 ===============================
@@ -217,7 +206,6 @@ without having to also reset the role.
 
 .. literalinclude:: output/sawtooth_identity_policy_create_usage.out
   :language: console
-  :linenos:
 
 sawtooth identity policy list
 =============================
@@ -228,7 +216,6 @@ which policy name should be set for a new role.
 
 .. literalinclude:: output/sawtooth_identity_policy_list_usage.out
   :language: console
-  :linenos:
 
 sawtooth identity role
 ======================
@@ -238,7 +225,6 @@ current roles stored in state and to create new roles.
 
 .. literalinclude:: output/sawtooth_identity_role_usage.out
   :language: console
-  :linenos:
 
 sawtooth identity role create
 =============================
@@ -254,7 +240,6 @@ to sign transactions.
 
 .. literalinclude:: output/sawtooth_identity_role_create_usage.out
   :language: console
-  :linenos:
 
 sawtooth identity role list
 ===========================
@@ -271,7 +256,6 @@ processing.
 
 .. literalinclude:: output/sawtooth_identity_role_list_usage.out
   :language: console
-  :linenos:
 
 sawtooth keygen
 ===============
@@ -284,7 +268,6 @@ and ``<key_dir>/<key_name>.pub``. By default, ``<key_dir>`` is
 
 .. literalinclude:: output/sawtooth_keygen_usage.out
   :language: console
-  :linenos:
 
 sawtooth peer
 =============
@@ -294,7 +277,6 @@ validator's peers.
 
 .. literalinclude:: output/sawtooth_peer_usage.out
    :language: console
-   :linenos:
 
 sawtooth peer list
 ==================
@@ -308,7 +290,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_peer_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth settings
 =================
@@ -318,7 +299,6 @@ active on-chain settings.
 
 .. literalinclude:: output/sawtooth_settings_usage.out
    :language: console
-   :linenos:
 
 sawtooth settings list
 ======================
@@ -328,7 +308,6 @@ and values of on-chain settings.
 
 .. literalinclude:: output/sawtooth_settings_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth state
 ==============
@@ -338,7 +317,6 @@ entries in the current blockchain state.
 
 .. literalinclude:: output/sawtooth_state_usage.out
    :language: console
-   :linenos:
 
 sawtooth state list
 ===================
@@ -364,7 +342,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_state_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth state show
 ===================
@@ -386,7 +363,6 @@ into a file for further processing.
 
 .. literalinclude:: output/sawtooth_state_show_usage.out
    :language: console
-   :linenos:
 
 sawtooth status
 ===============
@@ -396,7 +372,6 @@ validator's status.
 
 .. literalinclude:: output/sawtooth_status_usage.out
    :language: console
-   :linenos:
 
 sawtooth status show
 ====================
@@ -411,7 +386,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_status_show_usage.out
    :language: console
-   :linenos:
 
 sawtooth transaction
 ====================
@@ -421,7 +395,6 @@ transactions in the current blockchain.
 
 .. literalinclude:: output/sawtooth_transaction_usage.out
    :language: console
-   :linenos:
 
 sawtooth transaction list
 =========================
@@ -439,7 +412,6 @@ processing.
 
 .. literalinclude:: output/sawtooth_transaction_list_usage.out
    :language: console
-   :linenos:
 
 sawtooth transaction show
 =========================
@@ -457,7 +429,6 @@ combination when the REST API is behind a Basic Auth proxy.
 
 .. literalinclude:: output/sawtooth_transaction_show_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/settings-tp.rst
+++ b/docs/source/cli/settings-tp.rst
@@ -40,7 +40,6 @@ submit setting transactions.
 
 .. literalinclude:: output/settings-tp_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/cli/xo.rst
+++ b/docs/source/cli/xo.rst
@@ -36,7 +36,6 @@ The ``xo`` command provides subcommands for playing XO on the command line.
 
 .. literalinclude:: output/xo_usage.out
    :language: console
-   :linenos:
 
 xo create
 =========
@@ -45,7 +44,6 @@ The ``xo create`` subcommand starts an XO game with the specified name.
 
 .. literalinclude:: output/xo_create_usage.out
    :language: console
-   :linenos:
 
 xo list
 =======
@@ -54,7 +52,6 @@ The ``xo list`` subcommand displays information for all XO games in state.
 
 .. literalinclude:: output/xo_list_usage.out
    :language: console
-   :linenos:
 
 xo show
 =======
@@ -63,7 +60,6 @@ The ``xo show`` subcommand displays information about the specified XO game.
 
 .. literalinclude:: output/xo_show_usage.out
    :language: console
-   :linenos:
 
 xo take
 =======
@@ -74,7 +70,6 @@ already taken.
 
 .. literalinclude:: output/xo_take_usage.out
    :language: console
-   :linenos:
 
 xo delete
 =========
@@ -83,7 +78,6 @@ The ``xo delete`` subcommand deletes an existing xo game.
 
 .. literalinclude:: output/xo_delete_usage.out
    :language: console
-   :linenos:
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -99,11 +99,9 @@ processor and the REST API are running.
 
 .. literalinclude:: ../cli/output/sawtooth_identity_policy_create_usage.out
   :language: console
-  :linenos:
 
 .. literalinclude:: ../cli/output/sawtooth_identity_role_create_usage.out
   :language: console
-  :linenos:
 
 For example, running the following will create a policy that permits all
 and is named policy_1:


### PR DESCRIPTION
Line numbers aren't appropriate for the --help output shown
in the CLI Command Reference and Sys Admin Guide.

Signed-off-by: Anne Chenette <chenette@bitwise.io>