### PR TITLE
Update verify_state with executor processor manager

### DIFF
--- a/validator/sawtooth_validator/server/state_verifier.py
+++ b/validator/sawtooth_validator/server/state_verifier.py
@@ -155,13 +155,13 @@ def verify_state(bind_network, bind_component, scheduler_type, data_dir=None):
     component_dispatcher.add_handler(
         validator_pb2.Message.TP_REGISTER_REQUEST,
         processor_handlers.ProcessorRegisterHandler(
-            transaction_executor.processors),
+            transaction_executor.processor_manager),
         component_thread_pool)
 
     component_dispatcher.add_handler(
         validator_pb2.Message.TP_UNREGISTER_REQUEST,
         processor_handlers.ProcessorUnRegisterHandler(
-            transaction_executor.processors),
+            transaction_executor.processor_manager),
         component_thread_pool)
 
     component_dispatcher.start()


### PR DESCRIPTION
The processor manager was changed in 810be2d but not applied here.

This bug was able to slip through because there is no state verifier test. I created https://jira.hyperledger.org/browse/STL-1111 to add one.