### PR TITLE
Reduce metrics tags

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -18,7 +18,6 @@
   "hideControls": false,
   "id": null,
   "links": [],
-  "refresh": "5s",
   "rows": [
     {
       "collapse": false,


### PR DESCRIPTION
Adding these tags dramatically increased the cardinality of tags that
needed to be stored on InfluxDB and as a result severely degraded
performance.