### PR TITLE
Override OS Keepalive for ZMQ Sockets

### DIFF
--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -543,6 +543,7 @@ class _SendReceive(object):
             # Put the exception on the queue where in start we are waiting
             # for it.
             complete_or_error_queue.put_nowait(e)
+            self._close_sockets()
             raise
 
         if self._heartbeat:
@@ -557,10 +558,15 @@ class _SendReceive(object):
         # event_loop.stop called elsewhere will cause the loop to break out
         # of run_forever then it can be closed and the context destroyed.
         self._event_loop.close()
-        self._socket.close(linger=0)
+        self._close_sockets()
+
+    def _close_sockets(self):
+        if self._socket:
+            self._socket.close(linger=0)
         if self._monitor:
             self._monitor_sock.close(linger=0)
-        self._context.destroy(linger=0)
+        if self._context:
+            self._context.destroy(linger=0)
 
     @asyncio.coroutine
     def _monitor_disconnects(self):

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -477,6 +477,10 @@ class _SendReceive(object):
             self._context = zmq.asyncio.Context()
             self._socket = self._context.socket(socket_type)
 
+            self._socket.set(zmq.TCP_KEEPALIVE, 1)
+            self._socket.set(zmq.TCP_KEEPALIVE_IDLE, self._connection_timeout)
+            self._socket.set(zmq.TCP_KEEPALIVE_INTVL, self._heartbeat_interval)
+
             if socket_type == zmq.DEALER:
                 self._socket.identity = "{}-{}".format(
                     self._zmq_identity,


### PR DESCRIPTION
Override OS keep-alive, as the underlying FD's will not necessarily be closed when the ZMQ socket it is, based on the underlying default Linux    settings.  Setting this to the same value as the validator's connection timeouts and interval should reduce the amount of time a socket is left open by the OS.

Also includes some minor reordering of the close/shutdown logic for a given Send/Receive thread.

Based on contributor feedback in this issue: https://github.com/zeromq/libzmq/issues/1453