### PR TITLE
Add Intkey workload cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,7 @@
 /perf/smallbank_workload/smallbank.batches
 /perf/smallbank_workload/smallbank.playlist
 /perf/smallbank_workload/smallbank.txns
+/perf/intkey_workload/Cargo.lock
+/perf/intkey_workload/target
 
 *.batch

--- a/perf/intkey_workload/Cargo.toml
+++ b/perf/intkey_workload/Cargo.toml
@@ -10,7 +10,9 @@ path = "./src/main.rs"
 cbor-codec = "0.7.1"
 clap = "2.30"
 log = "0.4"
+protobuf = "1.4"
 rand = "0.4"
 rust-crypto = "^0.2"
 sawtooth_perf = { path = "../sawtooth_perf" }
 sawtooth_sdk = { path = "../../sdk/rust" }
+simplelog = "0.5"

--- a/perf/intkey_workload/Cargo.toml
+++ b/perf/intkey_workload/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "intkey_workload"
+version = "0.1.0"
+
+[[bin]]
+name = "intkey-workload"
+path = "./src/main.rs"
+
+[dependencies]
+cbor-codec = "0.7.1"
+clap = "2.30"
+log = "0.4"
+rand = "0.4"
+rust-crypto = "^0.2"
+sawtooth_perf = { path = "../sawtooth_perf" }
+sawtooth_sdk = { path = "../../sdk/rust" }

--- a/perf/intkey_workload/src/intkey_addresser.rs
+++ b/perf/intkey_workload/src/intkey_addresser.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+
+pub struct IntKeyAddresser {
+    namespace: String,
+    pub family_name: String,
+    pub version: String,
+}
+
+impl IntKeyAddresser {
+    pub fn new() -> IntKeyAddresser {
+        let mut hasher = Sha512::new();
+        hasher.input_str("intkey");
+
+        IntKeyAddresser {
+            namespace: hasher.result_str()[..6].to_string(),
+            family_name: "intkey".to_string(),
+            version: "1.0".to_string(),
+        }
+    }
+
+    pub fn make_address(&self, name: String) -> String {
+        let prefix = self.namespace.clone();
+        let mut hasher = Sha512::new();
+        hasher.input(name.as_bytes());
+        (prefix + &hasher.result_str()[64..]).to_string()
+    }
+}

--- a/perf/intkey_workload/src/intkey_iterator.rs
+++ b/perf/intkey_workload/src/intkey_iterator.rs
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use cbor::value::Value;
+use cbor::value::Key;
+use cbor::value::Text;
+
+use rand::SeedableRng;
+use rand::StdRng;
+use rand::Rng;
+
+const HALF_MAX_VALUE: u32 = 2_147_483_647;
+const INCS_AND_DECS_PER_SET: usize = 200_000;
+const MAX_NAME_LEN: usize = 20;
+
+/// IntKeyPayload is serialized as cbor as a map {"Verb": verb, "Name": name, "Value": value}
+/// and, along with other information, sent to the validator in a Transaction.
+pub struct IntKeyPayload {
+    pub verb: String,
+    pub name: String,
+    pub value: u32,
+}
+
+impl IntKeyPayload {
+    pub fn construct(&self) -> Value {
+        let name = self.name.clone();
+        let verb = self.verb.clone();
+        let value = self.value.clone();
+
+        let mut map = BTreeMap::new();
+        map.insert(
+            wrap_in_cbor_key("Name".to_string()),
+            wrap_in_cbor_value(name),
+        );
+        map.insert(
+            wrap_in_cbor_key("Verb".to_string()),
+            wrap_in_cbor_value(verb),
+        );
+        map.insert(
+            wrap_in_cbor_key("Value".to_string()),
+            wrap_in_cbor_value_u32(value),
+        );
+        Value::Map(map)
+    }
+}
+
+pub struct IntKeyIterator {
+    num_names: usize,
+    invalid: f32,
+
+    rng: StdRng,
+
+    names: HashMap<String, u32>,
+    incs_and_decs_per_set: u32,
+    set_value: u32,
+}
+
+impl IntKeyIterator {
+    pub fn new(num_names: usize, invalid: f32, seed: &[usize]) -> IntKeyIterator {
+        IntKeyIterator {
+            num_names: num_names,
+            invalid: invalid,
+
+            rng: SeedableRng::from_seed(seed),
+
+            names: HashMap::new(),
+            incs_and_decs_per_set: INCS_AND_DECS_PER_SET as u32,
+            set_value: HALF_MAX_VALUE,
+        }
+    }
+
+    fn gen_name(&mut self) -> String {
+        self.rng.gen_ascii_chars().take(MAX_NAME_LEN).collect()
+    }
+
+    /// Generate a RNG chosen inc or dec payload with the name supplied if not None,
+    /// else if name is None, choose a random name.
+    fn gen_inc_or_dec(&mut self, name: Option<String>) -> IntKeyPayload {
+        let verb = if self.rng.gen::<bool>() { "inc" } else { "dec" };
+
+        IntKeyPayload {
+            name: name.unwrap_or_else(|| self.gen_name()),
+            verb: verb.to_string(),
+            value: self.rng.gen_range(1, 10),
+        }
+    }
+}
+
+impl Iterator for IntKeyIterator {
+    type Item = IntKeyPayload;
+
+    /// First use RNG to choose between invalid and valid txn.
+    /// If valid, determine if there have been enough sets. If so choose between inc or dec.
+    /// If not generate a random name to set.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rng.gen_range(0.0, 1.0) >= self.invalid {
+            // Valid transaction
+            if self.names.len() < self.num_names {
+                let name = self.gen_name();
+                self.names.insert(name.clone(), 0);
+                return Some(IntKeyPayload {
+                    name: name,
+                    verb: "set".to_string(),
+                    value: self.set_value,
+                });
+            } else {
+                let names_map_clone = self.names.clone();
+                let index = self.rng.gen_range(0, self.names.len());
+                let name = names_map_clone
+                    .keys()
+                    .nth(index)
+                    .expect("There is an indexing bug in the intkey iterator");
+
+                let value = self.names
+                    .get(name)
+                    .expect("There is an indexing bug in the intkey iterator")
+                    .to_owned();
+
+                if value < self.incs_and_decs_per_set {
+                    self.names.insert(name.to_string(), value + 1);
+                } else {
+                    self.names.remove(name);
+                }
+                return Some(self.gen_inc_or_dec(Some(name.to_string())));
+            }
+        } else {
+            // invalid transaction
+
+            return Some(IntKeyPayload {
+                name: self.gen_name(),
+                verb: "invalid".to_string(),
+                value: 0,
+            });
+        };
+    }
+}
+
+fn wrap_in_cbor_key(key: String) -> Key {
+    Key::Text(Text::Text(key))
+}
+
+fn wrap_in_cbor_value(value: String) -> Value {
+    Value::Text(Text::Text(value))
+}
+
+fn wrap_in_cbor_value_u32(value: u32) -> Value {
+    Value::U32(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IntKeyIterator;
+    use super::HALF_MAX_VALUE;
+    use super::INCS_AND_DECS_PER_SET;
+
+    const MAX_VALUE: u32 = 4_294_967_295;
+
+    #[test]
+    fn test_sets_incs_and_decs() {
+        let mut intkey_iterator =
+            IntKeyIterator::new(2, 0.0, &[2, 3, 45, 95, 18, 81, 222, 2, 252, 2, 45]);
+
+        let payload1 = intkey_iterator.next();
+        assert!(payload1.is_some());
+        assert!(payload1.unwrap().verb.as_str() == "set");
+
+        let payload2 = intkey_iterator.next();
+        assert!(payload2.is_some());
+        assert!(payload2.unwrap().verb.as_str() == "set");
+
+        let payload3 = intkey_iterator.next();
+        assert!(payload3.is_some());
+        assert!(vec!["inc", "dec"].contains(&payload3.unwrap().verb.as_ref()));
+
+        assert!(
+            intkey_iterator
+                .take(INCS_AND_DECS_PER_SET)
+                .fold(HALF_MAX_VALUE, |acc, p| if p.verb == "inc".to_string() {
+                    acc + p.value
+                } else if p.verb == "dec".to_string() {
+                    acc - p.value
+                } else {
+                    acc
+                }) < MAX_VALUE
+        );
+    }
+
+    #[test]
+    fn test_invalid() {
+        let intkey_iterator =
+            IntKeyIterator::new(2, 1.0, &[2, 3, 45, 95, 18, 81, 222, 2, 252, 2, 45]);
+
+        assert!(
+            intkey_iterator
+                .take(INCS_AND_DECS_PER_SET)
+                .fold(0, |acc, p| if p.verb == "invalid".to_string() {
+                    acc + 1
+                } else {
+                    acc
+                }) == INCS_AND_DECS_PER_SET
+        );
+    }
+}

--- a/perf/intkey_workload/src/intkey_transformer.rs
+++ b/perf/intkey_workload/src/intkey_transformer.rs
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+use std::error::Error;
+
+use cbor::GenericEncoder;
+
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+
+use protobuf::Message;
+use protobuf::RepeatedField;
+
+use rand::SeedableRng;
+use rand::StdRng;
+use rand::Rng;
+
+use sawtooth_sdk::messages::transaction::Transaction;
+use sawtooth_sdk::messages::transaction::TransactionHeader;
+use sawtooth_sdk::signing;
+
+use intkey_iterator::IntKeyPayload;
+use intkey_addresser::IntKeyAddresser;
+
+/// IntKeyTransformer a function (and associated state) used to transform
+/// an IntKeyPayload into a Sawtooth Transaction.
+pub struct IntKeyTransformer<'a> {
+    unsatisfiable: f32,
+    wildcard: f32,
+    num_names: usize,
+    signer: &'a signing::Signer<'a>,
+
+    addresser: IntKeyAddresser,
+
+    rng: StdRng,
+
+    txn_id_by_name: HashMap<String, String>,
+    txn_id_and_name: Vec<(String, String)>,
+}
+
+impl<'a> IntKeyTransformer<'a> {
+    pub fn new(
+        signer: &'a signing::Signer<'a>,
+        seed: &[usize],
+        unsatisfiable: f32,
+        wildcard: f32,
+        num_names: usize,
+    ) -> IntKeyTransformer<'a> {
+        IntKeyTransformer {
+            unsatisfiable: unsatisfiable,
+            wildcard: wildcard,
+            num_names: num_names,
+            signer: signer,
+            rng: SeedableRng::from_seed(seed),
+            addresser: IntKeyAddresser::new(),
+            txn_id_by_name: HashMap::new(),
+            txn_id_and_name: Vec::new(),
+        }
+    }
+
+    fn payload_to_cbor_bytes(&mut self, payload: &IntKeyPayload) -> Result<Vec<u8>, Box<Error>> {
+        let mut encoder = GenericEncoder::new(Vec::new());
+        encoder.value(&payload.construct())?;
+        Ok(encoder.into_inner().into_writer())
+    }
+
+    pub fn intkey_payload_to_transaction(
+        &mut self,
+        payload: IntKeyPayload,
+    ) -> Result<Transaction, Box<Error>> {
+        let mut txn = Transaction::new();
+        let mut txn_header = TransactionHeader::new();
+
+        txn_header.set_family_name(self.addresser.family_name.clone());
+        txn_header.set_family_version(self.addresser.version.clone());
+
+        txn_header.set_nonce(self.rng.gen_ascii_chars().take(50).collect());
+
+        let payload_bytes = self.payload_to_cbor_bytes(&payload)?;
+
+        let mut sha = Sha512::new();
+        sha.input(payload_bytes.as_slice());
+
+        txn_header.set_payload_sha512(sha.result_str());
+
+        txn_header.set_signer_public_key(self.signer.get_public_key()?.as_hex());
+        txn_header.set_batcher_public_key(self.signer.get_public_key()?.as_hex());
+
+        let addresser = IntKeyAddresser::new();
+
+        let addresses = RepeatedField::from_vec(vec![addresser.make_address(payload.name.clone())]);
+
+        txn_header.set_inputs(addresses.clone());
+
+        txn_header.set_outputs(addresses.clone());
+
+        if payload.verb == "inc".to_string() || payload.verb == "dec".to_string() {
+            match self.txn_id_by_name.get(&payload.name) {
+                Some(txn_id) => {
+                    let dependencies = RepeatedField::from_vec(vec![txn_id.clone().to_string()]);
+                    txn_header.set_dependencies(dependencies);
+                }
+                None => {}
+            }
+        }
+        let header_bytes = txn_header.write_to_bytes()?;
+
+        let signature = self.signer.sign(&header_bytes.to_vec())?;
+
+        if payload.verb == "set".to_string() {
+            if !self.txn_id_by_name.contains_key(&payload.name) {
+                self.txn_id_by_name
+                    .insert(payload.name.clone(), signature.clone());
+                self.txn_id_and_name
+                    .push((payload.name.clone(), signature.clone()));
+            }
+            if self.txn_id_and_name.len() > self.num_names {
+                let (name, _) = self.txn_id_and_name.remove(0);
+                self.txn_id_by_name.remove(&name);
+            }
+        }
+
+        txn.set_header(header_bytes);
+        txn.set_header_signature(signature);
+        txn.set_payload(payload_bytes);
+
+        Ok(txn)
+    }
+}

--- a/perf/intkey_workload/src/main.rs
+++ b/perf/intkey_workload/src/main.rs
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate cbor;
+extern crate clap;
+extern crate crypto;
+#[macro_use]
+extern crate log;
+extern crate rand;
+extern crate sawtooth_perf;
+
+mod intkey_addresser;
+mod intkey_iterator;
+
+use clap::{App, Arg, ArgMatches};
+
+const APP_NAME: &'static str = env!("CARGO_PKG_NAME");
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    get_arg_matches();
+}
+
+fn get_arg_matches<'a>() -> ArgMatches<'a> {
+    App::new(APP_NAME)
+        .version(VERSION)
+        .about("Submit intkey workload at a continuous rate")
+        .arg(
+            Arg::with_name("display")
+                .short("d")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("30")
+                .value_name("TIME_BETWEEN_DISPLAYS")
+                .help("Seconds between statistics displays"),
+        )
+        .arg(
+            Arg::with_name("key")
+                .short("k")
+                .long("key-file")
+                .value_name("KEY_FILE")
+                .help("File containing a private key to sign transactions and batches"),
+        )
+        .arg(
+            Arg::with_name("batch-size")
+                .short("n")
+                .long("batch-size")
+                .takes_value(true)
+                .default_value("1")
+                .number_of_values(1)
+                .value_name("BATCH_SIZE")
+                .help("Transactions in a batch"),
+        )
+        .arg(
+            Arg::with_name("names")
+                .long("num-names")
+                .takes_value(true)
+                .default_value("100")
+                .number_of_values(1)
+                .value_name("NUM_NAMES")
+                .help("Number of IntKey Names to set"),
+        )
+        .arg(
+            Arg::with_name("rate")
+                .short("r")
+                .long("rate")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("10")
+                .value_name("RATE")
+                .help("Batches per second to send to a Sawtooth REST Api"),
+        )
+        .arg(
+            Arg::with_name("seed")
+                .short("s")
+                .long("seed")
+                .takes_value(true)
+                .number_of_values(1)
+                .value_name("SEED")
+                .help("Comma separated list of u8 to make the workload reproduceable"),
+        )
+        .arg(
+            Arg::with_name("unsatisfiable")
+                .long("unsatisfiable")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("0.0")
+                .value_name("UNSATISFIABLE")
+                .help("Probability of a transaction having an unsatisfiable dependency"),
+        )
+        .arg(
+            Arg::with_name("urls")
+                .short("u")
+                .long("urls")
+                .value_name("URLS")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("http://127.0.0.1:8008")
+                .help("Comma separated list of Sawtooth REST Apis"),
+        )
+        .arg(
+            Arg::with_name("validity")
+                .long("invalid")
+                .value_name("INVALID")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("0.0")
+                .help("Probability of a transaction being invalid"),
+        )
+        .arg(
+            Arg::with_name("wildcard")
+                .long("wildcard")
+                .value_name("WILDCARD")
+                .takes_value(true)
+                .number_of_values(1)
+                .default_value("0.0")
+                .help("Probability of a transaction having a wildcarded input/output"),
+        )
+        .arg(
+            Arg::with_name("username")
+                .long("auth-username")
+                .value_name("BASIC_AUTH_USERNAME")
+                .help("Basic auth username to authenticate with the Sawtooth REST Api"),
+        )
+        .arg(
+            Arg::with_name("password")
+                .long("auth-password")
+                .value_name("BASIC_AUTH_PASSWORD")
+                .help("Basic auth password to authenticate with the Sawtooth REST Api"),
+        )
+        .get_matches()
+}


### PR DESCRIPTION
```
USAGE:
    intkey-workload [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -n, --batch-size <BATCH_SIZE>                Transactions in a batch [default: 1]
        --display <TIME_BETWEEN_DISPLAYS>        Seconds between statistics displays [default: 30]
        --invalid <INVALID>                      Probability of a transaction being invalid [default: 0.0]
    -k, --key-file <KEY_FILE>                    File containing a private key to sign transactions and batches
        --num-names <NUM_NAMES>                  Number of IntKey Names to set [default: 100]
        --auth-password <BASIC_AUTH_PASSWORD>    Basic auth password to authenticate with the Sawtooth REST Api
    -r, --rate <RATE>                            Batches per second to send to a Sawtooth REST Api [default: 10]
    -s, --seed <SEED>                            Comma separated list of u8 to make the workload reproduceable
        --unsatisfiable <UNSATISFIABLE>
            Probability of a transaction having an unsatisfiable dependency [default: 0.0]

    -u, --urls <URLS>
            Comma separated list of Sawtooth REST Apis [default: http://127.0.0.1:8008]

        --auth-username <BASIC_AUTH_USERNAME>    Basic auth username to authenticate with the Sawtooth REST Api
        --wildcard <WILDCARD>
            Probability of a transaction having a wildcarded input/output [default: 0.0]
```