### PR TITLE
Convert all dashboard derivates to 10s/10

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -1016,9 +1016,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -1479,9 +1485,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -1518,9 +1530,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -1648,9 +1666,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -1772,9 +1796,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -1896,9 +1926,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -2156,9 +2192,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -2281,7 +2323,7 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
                   },
@@ -2423,9 +2465,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -2479,9 +2527,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   },
                   {
                     "params": [
@@ -2609,9 +2663,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -2665,9 +2725,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   },
                   {
                     "params": [
@@ -2813,9 +2879,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -2875,9 +2947,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -3175,9 +3253,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
-                    "type": "derivative"
+                    "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -3227,7 +3311,13 @@
                     "params": [
                       "10s"
                     ],
-                    "type": "derivative"
+                    "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -3841,9 +3931,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],
@@ -3958,9 +4054,15 @@
                   },
                   {
                     "params": [
-                      "1s"
+                      "10s"
                     ],
                     "type": "non_negative_derivative"
+                  },
+                  {
+                    "params": [
+                      "/10"
+                    ],
+                    "type": "math"
                   }
                 ]
               ],


### PR DESCRIPTION
Using non_negative_derivative(1s) hurts dashboard performance without
improving accuracy since we are only reporting every 10s.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>