### PR TITLE
Logging improvements around Auth Rejection

### DIFF
--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -264,6 +264,10 @@ class Dispatcher(InstrumentedThread):
                     correlation_id=original_message.correlation_id,
                     message_type=res.message_type)
                 try:
+                    LOGGER.warning(
+                        "Sending hang-up in reply to %s to connection %s",
+                        get_enum_name(original_message.message_type),
+                        connection_id)
                     self._send_last_message[connection](
                         msg=message,
                         connection_id=connection_id)

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -415,8 +415,8 @@ class AuthorizationChallengeSubmitHandler(Handler):
         try:
             payload = self._challenge_payload_cache[connection_id]
         except KeyError:
-            LOGGER.debug("Connection's challenge payload expired before a"
-                         "response was received. %s", connection_id)
+            LOGGER.warning("Connection's challenge payload expired before a"
+                           "response was received. %s", connection_id)
             return AuthorizationChallengeSubmitHandler \
                 ._network_violation_result()
 
@@ -434,7 +434,7 @@ class AuthorizationChallengeSubmitHandler(Handler):
         if not context.verify(auth_challenge_submit.signature,
                               payload,
                               public_key):
-            LOGGER.warning("Signature was not able to be verifed. Remove "
+            LOGGER.warning("Signature was not able to be verified. Remove "
                            "connection to %s", connection_id)
             return AuthorizationChallengeSubmitHandler \
                 ._network_violation_result()


### PR DESCRIPTION
In order to track down the root cause of [STL-1020](https://jira.hyperledger.org/browse/STL-1020), several logging additions have been made.  This should give a better indication as to where in the peering process a messages is being sent at the wrong time (i.e. before the auth/trust handshake has been completed).