### PR TITLE
Fix typo in AWS procedure (remove unused heading)

### DIFF
--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -88,6 +88,8 @@ If you're uncertain about the state or would like to start over, see
 `Resetting the Environment`_.
 
 
+.. _confirming-connectivity-aws-label:
+
 Checking the Status of Sawtooth Components
 ==========================================
 
@@ -256,10 +258,6 @@ In the example above, the ``intkey create_batch`` command created the file
 ``batches.intkey``.  Rather than using ``intkey load`` to submit these
 transactions, you could use the following command to submit them:
 
-.. _confirming-connectivity-aws-label:
-
-Connecting To the REST API
-==========================
 
 .. code-block:: console
 


### PR DESCRIPTION
Signed-off-by: Anne Chenette <chenette@bitwise.io>