### PR TITLE
Enable amd64 arch in sawtooth repository links

### DIFF
--- a/ci/sawtooth-block-info-tp
+++ b/ci/sawtooth-block-info-tp
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-build-debs
+++ b/ci/sawtooth-build-debs
@@ -44,7 +44,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add sawtooth repo
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -28,7 +28,7 @@
 
 FROM ubuntu:xenial
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/ci/sawtooth-identity-tp
+++ b/ci/sawtooth-identity-tp
@@ -22,7 +22,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-intkey-tp-go
+++ b/ci/sawtooth-intkey-tp-go
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-intkey-tp-python
+++ b/ci/sawtooth-intkey-tp-python
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-poet-validator-registry-tp
+++ b/ci/sawtooth-poet-validator-registry-tp
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-publish-js-sdk
+++ b/ci/sawtooth-publish-js-sdk
@@ -53,7 +53,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add sawtooth repo and dependencies
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \

--- a/ci/sawtooth-rest-api
+++ b/ci/sawtooth-rest-api
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-settings-tp
+++ b/ci/sawtooth-settings-tp
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-shell
+++ b/ci/sawtooth-shell
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-smallbank-tp-go
+++ b/ci/sawtooth-smallbank-tp-go
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-test-debs
+++ b/ci/sawtooth-test-debs
@@ -43,7 +43,7 @@ COPY ${host_pkg_dir}/*.deb ${pkg_dir}/
 
 RUN echo "deb file:${pkg_dir} ./" >> \
         /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> \
         /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
         --recv-keys 8AA7AF1F1091A5FD \

--- a/ci/sawtooth-validator
+++ b/ci/sawtooth-validator
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-xo-tp-go
+++ b/ci/sawtooth-xo-tp-go
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/ci/sawtooth-xo-tp-python
+++ b/ci/sawtooth-xo-tp-python
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="repo"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docker/sawtooth-av
+++ b/docker/sawtooth-av
@@ -27,7 +27,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="local-debs"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docker/sawtooth-debug-python
+++ b/docker/sawtooth-debug-python
@@ -15,8 +15,8 @@
 
 FROM ubuntu:xenial
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/debug/ xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/debug/ xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
     --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
  && apt-get update \

--- a/docker/sawtooth-dev-cxx
+++ b/docker/sawtooth-dev-cxx
@@ -32,7 +32,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && echo "deb http://archive.ubuntu.com/ubuntu xenial-backports universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \

--- a/docker/sawtooth-dev-poet-sgx
+++ b/docker/sawtooth-dev-poet-sgx
@@ -27,7 +27,7 @@
 FROM ubuntu:xenial
 
 # Add sawtooth repo
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -33,7 +33,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \

--- a/docker/sawtooth-int-block-info-tp
+++ b/docker/sawtooth-int-block-info-tp
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-identity-tp
+++ b/docker/sawtooth-int-identity-tp
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-intkey-tp-cxx
+++ b/docker/sawtooth-int-intkey-tp-cxx
@@ -29,7 +29,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docker/sawtooth-int-intkey-tp-go
+++ b/docker/sawtooth-int-intkey-tp-go
@@ -38,7 +38,7 @@ COPY sawtooth-intkey-tp-go*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-intkey-tp-python
+++ b/docker/sawtooth-int-intkey-tp-python
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-poet-validator-registry-tp
+++ b/docker/sawtooth-int-poet-validator-registry-tp
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-rest-api
+++ b/docker/sawtooth-int-rest-api
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-settings-tp
+++ b/docker/sawtooth-int-settings-tp
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-smallbank-tp-go
+++ b/docker/sawtooth-int-smallbank-tp-go
@@ -38,7 +38,7 @@ COPY sawtooth-smallbank-tp-go*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-validator
+++ b/docker/sawtooth-int-validator
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-xo-tp-go
+++ b/docker/sawtooth-int-xo-tp-go
@@ -38,7 +38,7 @@ COPY sawtooth-xo-tp-go*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-int-xo-tp-python
+++ b/docker/sawtooth-int-xo-tp-python
@@ -39,7 +39,7 @@ COPY python3-sawtooth-*.deb /debs/
 RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
- && echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update
 

--- a/docker/sawtooth-validator-mounted
+++ b/docker/sawtooth-validator-mounted
@@ -17,7 +17,7 @@ FROM ubuntu:xenial
 
 LABEL "install-type"="mounted"
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
  && apt-get update \
  && apt-get install -y -q \

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -82,7 +82,7 @@ stable or nightly.  We recommend using the stable repository.
      .. code-block:: console
 
        $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
-       $ sudo add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
+       $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
        $ sudo apt-get update
 
    * To use the nightly repository, run the following commands:

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -135,7 +135,7 @@ Install Sawtooth
 .. code-block:: console
 
     $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
-    $ sudo add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
+    $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
     $ sudo apt-get update
     $ sudo apt-get install -y -q \
       sawtooth \

--- a/docs/source/sysadmin_guide/installation.rst
+++ b/docs/source/sysadmin_guide/installation.rst
@@ -16,7 +16,7 @@ host system:
 .. code-block:: console
 
   $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
-  $ sudo add-apt-repository 'deb http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
+  $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe'
 
 Nightly Builds:
 
@@ -28,7 +28,7 @@ following commands in a terminal window on your host system:
 .. code-block:: console
 
   $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
-  $ sudo apt-add-repository "deb http://repo.sawtooth.me/ubuntu/nightly xenial universe"
+  $ sudo apt-add-repository "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe"
 
 Update your package lists and install Sawtooth:
 


### PR DESCRIPTION
Enabled only amd64 architecture for sawtooth: stable and nightly repo used in add-apt-repository