### PR TITLE
Short-circuit test-state-verifier shutdown

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -274,7 +274,6 @@ test_validator() {
     run_docker_test test_namespace_permission
     copy_coverage .coverage.namespace_permission
     run_docker_test test_state_verifier --timeout 30
-    copy_coverage .coverage.state_verifier
 }
 
 test_go_sdk() {

--- a/integration/sawtooth_integration/tests/test_state_verifier.py
+++ b/integration/sawtooth_integration/tests/test_state_verifier.py
@@ -16,6 +16,7 @@
 import logging
 import hashlib
 import unittest
+import os
 import cbor
 
 from sawtooth_signing import create_context
@@ -196,3 +197,9 @@ class TestStateVerifier(unittest.TestCase):
             blockstore,
             "tcp://eth0:4004",
             "serial")
+
+        # There is a bug in the shutdown code for some component this depends
+        # on, which causes it to occassionally hang during shutdown. Just kill
+        # the process for now.
+        # pylint: disable=protected-access
+        os._exit(0)


### PR DESCRIPTION
There is a bug in the shutdown code for some component this depends on, which causes it to occasionally hang during shutdown. I tried a number of things to get this test passing while avoiding depending on the shutdown code to work properly, but none of them worked 100% of the time. This test is still valid, since an exception will be raised if there is a problem with state verifying before the `os._exit(0)` line is run. In other words, the `os._exit(0)` line will only be run if the test was successful.

The reason this test is failing because of the shutdown code is that the transaction execution components are being run from the same container as the test itself, which no other integration or unit test does to the same extent as here. In the other tests, only the exit code of the test container matters, so when it exits, all of the other containers are just killed without checking whether they shut down cleanly or not.