### PR TITLE
Log networking irregularities as warnings

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -238,9 +238,9 @@ class Gossip(object):
                 self._topology.set_connection_status(connection_id,
                                                      PeerStatus.TEMP)
             else:
-                LOGGER.debug("Connection unregister failed as connection "
-                             "was not registered: %s",
-                             connection_id)
+                LOGGER.warning("Connection unregister failed as connection "
+                               "was not registered: %s",
+                               connection_id)
 
     def get_time_to_live(self):
         time_to_live = \

--- a/validator/sawtooth_validator/gossip/permission_verifier.py
+++ b/validator/sawtooth_validator/gossip/permission_verifier.py
@@ -390,8 +390,8 @@ class NetworkPermissionHandler(Handler):
         public_key = self._network.connection_id_to_public_key(connection_id)
 
         if public_key is None:
-            LOGGER.debug("No public key found, %s is not permitted. "
-                         "Close connection.", connection_id)
+            LOGGER.warning("No public key found, %s is not permitted. "
+                           "Close connection.", connection_id)
             violation = AuthorizationViolation(
                 violation=RoleType.Value("NETWORK"))
             self._gossip.unregister_peer(connection_id)

--- a/validator/sawtooth_validator/networking/dispatch.py
+++ b/validator/sawtooth_validator/networking/dispatch.py
@@ -102,10 +102,10 @@ class Dispatcher(InstrumentedThread):
             LOGGER.debug("Removed send_message function "
                          "for connection %s", connection)
         else:
-            LOGGER.debug("Attempted to remove send_message "
-                         "function for connection %s, but no "
-                         "send_message function was registered",
-                         connection)
+            LOGGER.warning("Attempted to remove send_message "
+                           "function for connection %s, but no "
+                           "send_message function was registered",
+                           connection)
 
     def remove_send_last_message(self, connection):
         """Removes a send_last_message function previously registered
@@ -120,10 +120,10 @@ class Dispatcher(InstrumentedThread):
             LOGGER.debug("Removed send_last_message function "
                          "for connection %s", connection)
         else:
-            LOGGER.debug("Attempted to remove send_last_message "
-                         "function for connection %s, but no "
-                         "send_last_message function was registered",
-                         connection)
+            LOGGER.warning("Attempted to remove send_last_message "
+                           "function for connection %s, but no "
+                           "send_last_message function was registered",
+                           connection)
 
     def dispatch(self, connection, message, connection_id):
         if message.message_type in self._msg_type_handlers:
@@ -212,11 +212,13 @@ class Dispatcher(InstrumentedThread):
                     self._send_message[connection](msg=message,
                                                    connection_id=connection_id)
                 except KeyError:
-                    LOGGER.info("Can't send message %s back to "
-                                "%s because connection %s not in dispatcher",
-                                get_enum_name(message.message_type),
-                                connection_id,
-                                connection)
+                    LOGGER.warning(
+                        "Can't send message %s back to "
+                        "%s because connection %s not in dispatcher",
+                        get_enum_name(message.message_type),
+                        connection_id,
+                        connection)
+
                 self._process(message_id)
             else:
                 LOGGER.error("HandlerResult with status of RETURN_AND_PASS "
@@ -237,11 +239,12 @@ class Dispatcher(InstrumentedThread):
                     self._send_message[connection](msg=message,
                                                    connection_id=connection_id)
                 except KeyError:
-                    LOGGER.info("Can't send message %s back to "
-                                "%s because connection %s not in dispatcher",
-                                get_enum_name(message.message_type),
-                                connection_id,
-                                connection)
+                    LOGGER.warning(
+                        "Can't send message %s back to "
+                        "%s because connection %s not in dispatcher",
+                        get_enum_name(message.message_type),
+                        connection_id,
+                        connection)
             else:
                 LOGGER.error("HandlerResult with status of RETURN "
                              "is missing message_out or message_type")
@@ -266,11 +269,12 @@ class Dispatcher(InstrumentedThread):
                         msg=message,
                         connection_id=connection_id)
                 except KeyError:
-                    LOGGER.info("Can't send last message %s back to "
-                                "%s because connection %s not in dispatcher",
-                                get_enum_name(message.message_type),
-                                connection_id,
-                                connection)
+                    LOGGER.warning(
+                        "Can't send last message %s back to "
+                        "%s because connection %s not in dispatcher",
+                        get_enum_name(message.message_type),
+                        connection_id,
+                        connection)
             else:
                 LOGGER.error("HandlerResult with status of RETURN_AND_CLOSE "
                              "is missing message_out or message_type")

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -212,10 +212,10 @@ class PingHandler(Handler):
         if connection_id in self._last_message:
             if time.time() - self._last_message[connection_id] < \
                     self._allowed_frequency:
-                LOGGER.debug("Too many Pings in %s seconds before "
-                             "authorization is complete: %s",
-                             self._allowed_frequency,
-                             connection_id)
+                LOGGER.warning("Too many Pings in %s seconds before "
+                               "authorization is complete: %s",
+                               self._allowed_frequency,
+                               connection_id)
                 violation = AuthorizationViolation(
                     violation=RoleType.Value("NETWORK"))
 

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -210,10 +210,12 @@ class PingHandler(Handler):
                 message_type=validator_pb2.Message.PING_RESPONSE)
 
         if connection_id in self._last_message:
-            if time.time() - self._last_message[connection_id] < \
-                    self._allowed_frequency:
-                LOGGER.warning("Too many Pings in %s seconds before "
+            ping_frequency = time.time() - self._last_message[connection_id]
+
+            if ping_frequency < self._allowed_frequency:
+                LOGGER.warning("Too many Pings (%s) in %s seconds before "
                                "authorization is complete: %s",
+                               ping_frequency,
                                self._allowed_frequency,
                                connection_id)
                 violation = AuthorizationViolation(


### PR DESCRIPTION
These messages indicate states that should not normally arise, e.g.
trying to unregister a connection only to find that the connection
wasn't registered in the first place. They should be logged at least
at warning level.