### PR TITLE
Add unit test yaml files for perf rust modules missing them

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -331,6 +331,8 @@ test_python_sdk() {
 test_rust_sdk() {
     run_docker_test ./sdk/rust/unit_rust_sdk.yaml
     run_docker_test ./perf/sawtooth_workload/unit_perf_workload.yaml
+    run_docker_test ./perf/intkey_workload/unit_intkey_workload.yaml
+    run_docker_test ./perf/sawtooth_perf/unit_sawtooth_perf.yaml
     run_docker_test ./sdk/examples/intkey_python/tests/test_tp_intkey_rust.yaml
     run_docker_test test_intkey_smoke_rust
 }

--- a/perf/intkey_workload/unit_intkey_workload.yaml
+++ b/perf/intkey_workload/unit_intkey_workload.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  unit-intkey-workload:
+    image: sawtooth-dev-rust:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/perf/intkey_workload
+    command: cargo test

--- a/perf/sawtooth_perf/src/batch_gen.rs
+++ b/perf/sawtooth_perf/src/batch_gen.rs
@@ -427,6 +427,12 @@ mod tests {
         {
             Ok(Box::new(MockPublicKey))
         }
+
+        fn new_random_private_key(&self)
+            -> Result<Box<signing::PrivateKey>, signing::Error>
+        {
+            Ok(Box::new(MockPrivateKey))
+        }
     }
 
     struct MockPublicKey;

--- a/perf/sawtooth_perf/unit_sawtooth_perf.yaml
+++ b/perf/sawtooth_perf/unit_sawtooth_perf.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  unit-sawtooth-perf:
+    image: sawtooth-dev-rust:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/perf/sawtooth_perf
+    command: cargo test


### PR DESCRIPTION
This PR turns on running the perf/sawtooth_perf and perf/intkey_workload unit tests. This corrects an oversight on my part.