### PR TITLE
More database optimizations

### DIFF
--- a/validator/sawtooth_validator/database/lmdb_nolock_database.py
+++ b/validator/sawtooth_validator/database/lmdb_nolock_database.py
@@ -65,6 +65,15 @@ class LMDBNoLockDatabase(database.Database):
         with self._lmdb.begin() as txn:
             return txn.get(key.encode()) is not None
 
+    def get(self, key, index=None):
+        with self._lmdb.begin() as txn:
+            packed = txn.get(key.encode())
+
+        try:
+            return cbor.loads(packed)
+        except ValueError:
+            return None
+
     def get_multi(self, keys, index=None):
         with self._lmdb.begin() as txn:
             result = []

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -187,6 +187,8 @@ class TransactionExecutorThread(object):
                 "Unhandled exception while executing schedule: %s", exc)
 
     def _execute_schedule(self):
+        configs = {}
+
         for txn_info in self._scheduler:
             self._transaction_execution_count.inc()
 
@@ -198,8 +200,12 @@ class TransactionExecutorThread(object):
                 header.family_name,
                 header.family_version)
 
-            config = self._settings_view_factory.create_settings_view(
-                txn_info.state_hash)
+            try:
+                config = configs[txn_info.state_hash]
+            except KeyError:
+                config = self._settings_view_factory.create_settings_view(
+                    txn_info.state_hash)
+                configs[txn_info.state_hash] = config
 
             transaction_families = config.get_setting(
                 key=self._tp_settings_key,


### PR DESCRIPTION
This PR contains a couple of database-related performance
improvements.

The profiling method I'm using here will be a little different from
usual. Rather than running transactions through a network, I'm running
the state verifier over a 300-block blockstore that was taken from an
actual LR network run (many of the functions in the graphs below are
called exactly 300 times). This profiles just the components involved
in transaction execution. Notably, it does not involve the block
publisher or any inter-validator communication, although does include
communcation between the validator and several transaction processors.

Here is a Yappi graph of this setup running master:

![master](https://user-images.githubusercontent.com/25748894/37427040-1ea3b2f2-2796-11e8-9077-986a58ad7747.png)

The first commit adds a dedicated single-key `get` method to
`LMDBNoLockDatabase`, where previously `get` was delegated to
`get_multi`. This shaves off almost 2% of CPU time from
`LMDBNoLockDatabase.get`. It also slightly reduces (by ~0.2%) the time
taken by `LMDBNoLockDatabase.update`. I'm not sure why this is; maybe
the database writes don't have to wait as long for the reads?

Here is a Yappi graph after this change:

![db-get](https://user-images.githubusercontent.com/25748894/37427057-2c1ef4be-2796-11e8-8cf1-b20bd1b3eeda.png)

The second commit caches the settings views obtained by the executor.
This seems to be an impactful change. For one thing, database reads
are reduced by about one third. The total CPU time taken by
`TransactionExecutorThread._execute_schedule` goes from ~18% to ~15%.

Here is a Yappi graph after this change:

![config](https://user-images.githubusercontent.com/25748894/37427083-3dfa7cee-2796-11e8-8711-5a90056615be.png)
