### PR TITLE
Only request peers from connections which have completed handshake

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -761,7 +761,11 @@ class ConnectionManager(InstrumentedThread):
 
             # If the connection does exist, request peers.
             if conn_id is not None:
-                if conn_id in peers:
+                if not self._network.is_connection_handshake_complete(conn_id):
+                    # has not finished the authorization (trust/challenge)
+                    # process yet.
+                    continue
+                elif conn_id in peers:
                     # connected and peered - we've already sent peer request
                     continue
                 else:

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -735,28 +735,34 @@ class Interconnect(object):
         """
         Get stored public key for a connection.
         """
-        if connection_id in self._connections:
-            connection_info = self._connections[connection_id]
-            return connection_info.public_key
-        return None
+        with self._connections_lock:
+            try:
+                connection_info = self._connections[connection_id]
+                return connection_info.public_key
+            except KeyError:
+                return None
 
     def connection_id_to_endpoint(self, connection_id):
         """
         Get stored public key for a connection.
         """
-        if connection_id in self._connections:
-            connection_info = self._connections[connection_id]
-            return connection_info.uri
-        return None
+        with self._connections_lock:
+            try:
+                connection_info = self._connections[connection_id]
+                return connection_info.uri
+            except KeyError:
+                return None
 
     def get_connection_status(self, connection_id):
         """
         Get status of the connection during Role enforcement.
         """
-        if connection_id in self._connections:
-            connection_info = self._connections[connection_id]
-            return connection_info.status
-        return None
+        with self._connections_lock:
+            try:
+                connection_info = self._connections[connection_id]
+                return connection_info.status
+            except KeyError:
+                return None
 
     def is_connection_handshake_complete(self, connection_id):
         """
@@ -767,10 +773,8 @@ class Interconnect(object):
             bool - True if the connection handshake is complete, False
                 otherwise
         """
-        if connection_id in self._connections:
-            connection_info = self._connections[connection_id]
-            return connection_info.status == ConnectionStatus.CONNECTED
-        return False
+        return self.get_connection_status(connection_id) == \
+            ConnectionStatus.CONNECTED
 
     def set_check_connections(self, function):
         self._send_receive_thread.set_check_connections(function)

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -758,6 +758,20 @@ class Interconnect(object):
             return connection_info.status
         return None
 
+    def is_connection_handshake_complete(self, connection_id):
+        """
+        Indicates whether or not a connection has completed the authorization
+        handshake.
+
+        Returns:
+            bool - True if the connection handshake is complete, False
+                otherwise
+        """
+        if connection_id in self._connections:
+            connection_info = self._connections[connection_id]
+            return connection_info.status == ConnectionStatus.CONNECTED
+        return False
+
     def set_check_connections(self, function):
         self._send_receive_thread.set_check_connections(function)
 


### PR DESCRIPTION
In permissioned networks, it is possible for the network to request peers from connections which have not completed the authorization handshake.  Get Peer Messages will not be sent to connections that have not completed this handshake.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>