### PR TITLE
Correct rust sdk authors in cargo.toml

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,7 +16,7 @@
 [package]
 name = "sawtooth_sdk"
 version = "0.1.0"
-authors = ["sawtooth"]
+authors = ["Bitwise IO, Inc.", "Intel Corporation"]
 build = "build.rs"
 
 [dependencies]


### PR DESCRIPTION
Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>