### PR TITLE
STL-1085 Go TP Reconnect

### DIFF
--- a/sdk/go/src/sawtooth_sdk/messaging/connection.go
+++ b/sdk/go/src/sawtooth_sdk/messaging/connection.go
@@ -93,11 +93,12 @@ func NewConnection(context *zmq.Context, t zmq.Type, uri string) (*ZmqConnection
 	identity := GenerateId()
 	socket.SetIdentity(identity)
 
-	logger.Info("Connecting to ", uri)
 	switch t {
 	case zmq.ROUTER:
+		logger.Info("Binding to ", uri)
 		err = socket.Bind(uri)
 	case zmq.DEALER:
+		logger.Info("Connecting to ", uri)
 		err = socket.Connect(uri)
 	}
 	if err != nil {

--- a/sdk/go/src/sawtooth_sdk/messaging/connection.go
+++ b/sdk/go/src/sawtooth_sdk/messaging/connection.go
@@ -84,7 +84,7 @@ type storedMsg struct {
 
 // NewConnection establishes a new connection using the given ZMQ context and
 // socket type to the given URI.
-func NewConnection(context *zmq.Context, t zmq.Type, uri string) (*ZmqConnection, error) {
+func NewConnection(context *zmq.Context, t zmq.Type, uri string, bind bool) (*ZmqConnection, error) {
 	socket, err := context.NewSocket(t)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create ZMQ socket: %v", err)
@@ -93,16 +93,15 @@ func NewConnection(context *zmq.Context, t zmq.Type, uri string) (*ZmqConnection
 	identity := GenerateId()
 	socket.SetIdentity(identity)
 
-	switch t {
-	case zmq.ROUTER:
+	if bind {
 		logger.Info("Binding to ", uri)
 		err = socket.Bind(uri)
-	case zmq.DEALER:
+	} else {
 		logger.Info("Connecting to ", uri)
 		err = socket.Connect(uri)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to %v: %v", uri, err)
+		return nil, fmt.Errorf("Failed to establish connection to %v: %v", uri, err)
 	}
 
 	return &ZmqConnection{

--- a/sdk/go/src/sawtooth_sdk/processor/processor.go
+++ b/sdk/go/src/sawtooth_sdk/processor/processor.go
@@ -29,6 +29,7 @@ import (
 	"sawtooth_sdk/protobuf/network_pb2"
 	"sawtooth_sdk/protobuf/processor_pb2"
 	"sawtooth_sdk/protobuf/validator_pb2"
+	"time"
 )
 
 var logger *logging.Logger = logging.Get()
@@ -39,24 +40,24 @@ const DEFAULT_MAX_WORK_QUEUE_SIZE = 100
 // and routing transaction processing requests to a registered handler. It uses
 // ZMQ and channels to handle requests concurrently.
 type TransactionProcessor struct {
-	uri      string
-	ids      map[string]string
-	handlers []TransactionHandler
-	nThreads uint
-	maxQueue uint
-	shutdown chan bool
+	uri         string
+	ids         map[string]string
+	handlers    []TransactionHandler
+	nThreads    uint
+	maxQueue    uint
+	shutdown_tx messaging.Connection
 }
 
 // NewTransactionProcessor initializes a new Transaction Process and points it
 // at the given URI. If it fails to initialize, it will panic.
 func NewTransactionProcessor(uri string) *TransactionProcessor {
 	return &TransactionProcessor{
-		uri:      uri,
-		ids:      make(map[string]string),
-		handlers: make([]TransactionHandler, 0),
-		nThreads: uint(runtime.GOMAXPROCS(0)),
-		maxQueue: DEFAULT_MAX_WORK_QUEUE_SIZE,
-		shutdown: make(chan bool),
+		uri:         uri,
+		ids:         make(map[string]string),
+		handlers:    make([]TransactionHandler, 0),
+		nThreads:    uint(runtime.GOMAXPROCS(0)),
+		maxQueue:    DEFAULT_MAX_WORK_QUEUE_SIZE,
+		shutdown_tx: nil,
 	}
 }
 
@@ -101,11 +102,10 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 	restart := false
 
 	// Establish a connection to the validator
-	validator, err := messaging.NewConnection(context, zmq.DEALER, self.uri)
+	validator, err := messaging.NewConnection(context, zmq.DEALER, self.uri, false)
 	if err != nil {
 		return restart, fmt.Errorf("Could not connect to validator: %v", err)
 	}
-	defer validator.Close()
 
 	monitor, err := validator.Monitor(zmq.EVENT_DISCONNECTED)
 	if err != nil {
@@ -113,13 +113,23 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 	}
 
 	// Setup connection to internal worker thread pool
-	workers, err := messaging.NewConnection(context, zmq.ROUTER, "inproc://workers")
+	workers, err := messaging.NewConnection(context, zmq.ROUTER, "inproc://workers", true)
 	if err != nil {
 		return restart, fmt.Errorf("Could not create thread pool router: %v", err)
 	}
 
+	// Setup shutdown listening socket
+	shutdown_rx, err := messaging.NewConnection(context, zmq.PAIR, "inproc://shutdown", true)
+	if err != nil {
+		return restart, fmt.Errorf("Could not create shutdown connection: %v", err)
+	}
+	self.shutdown_tx, err = messaging.NewConnection(context, zmq.PAIR, "inproc://shutdown", false)
+
 	// Make work queue. Buffer so the router doesn't block
 	queue := make(chan *validator_pb2.Message, self.maxQueue)
+
+	// Make done channel for tracking thread shutdown
+	workers_done := make(chan bool, self.nThreads)
 
 	// Keep track of which correlation ids go to which worker threads, i.e. map
 	// corrId->workerThreadId
@@ -127,18 +137,8 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 
 	// Startup worker thread pool
 	for i := uint(0); i < self.nThreads; i++ {
-		go worker(context, "inproc://workers", queue, self.handlers)
+		go worker(context, "inproc://workers", queue, workers_done, self.handlers)
 	}
-	// Setup shutdown thread
-	go shutdown(context, "inproc://workers", queue, self.shutdown)
-
-	workersLeft := self.nThreads + 1
-
-	// Setup ZMQ poller for routing messages between worker threads and validator
-	poller := zmq.NewPoller()
-	poller.Add(validator.Socket(), zmq.POLLIN)
-	poller.Add(monitor, zmq.POLLIN)
-	poller.Add(workers.Socket(), zmq.POLLIN)
 
 	// Register all handlers with the validator
 	for _, handler := range self.handlers {
@@ -148,7 +148,7 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 				handler.FamilyName(),
 				version,
 				handler.Namespaces())
-			err := register(validator, handler, version, queue, uint32(self.maxQueue))
+			err := register(validator, shutdown_rx, handler, version, queue, uint32(self.maxQueue))
 			if err != nil {
 				return restart, fmt.Errorf(
 					"Error registering handler (%v, %v, %v): %v",
@@ -158,6 +158,13 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 			}
 		}
 	}
+
+	// Setup ZMQ poller for routing messages between worker threads and validator
+	poller := zmq.NewPoller()
+	poller.Add(validator.Socket(), zmq.POLLIN)
+	poller.Add(monitor, zmq.POLLIN)
+	poller.Add(workers.Socket(), zmq.POLLIN)
+	poller.Add(shutdown_rx.Socket(), zmq.POLLIN)
 
 	// Poll for messages from worker threads or validator
 	for {
@@ -171,13 +178,14 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 				receiveValidator(ids, validator, workers, queue)
 
 			case monitor:
-				restart = receiveMonitor(monitor, self.shutdown)
+				restart = receiveMonitor(monitor, self.shutdown_tx)
 
 			case workers.Socket():
-				receiveWorkers(ids, validator, workers, &workersLeft)
-				if workersLeft == 0 {
-					return restart, nil
-				}
+				receiveWorkers(ids, validator, workers)
+
+			case shutdown_rx.Socket():
+				restart = receiveShutdown(queue, self.nThreads, workers_done, shutdown_rx, validator, workers, monitor)
+				return restart, nil
 			}
 		}
 	}
@@ -186,7 +194,12 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 // Shutdown sends a message to the processor telling it to deregister.
 func (self *TransactionProcessor) Shutdown() {
 	// Initiate a clean shutdown
-	self.shutdown <- false
+	if self.shutdown_tx != nil {
+		err := self.shutdown_tx.SendData("", []byte("shutdown"))
+		if err != nil {
+			logger.Errorf("Failed to send restart command")
+		}
+	}
 }
 
 // ShutdownOnSignal sets up signal handling to shutdown the processor when one
@@ -297,7 +310,7 @@ func receiveValidator(ids map[string]string, validator, workers messaging.Connec
 }
 
 // Handle monitor events
-func receiveMonitor(monitor *zmq.Socket, shutdown chan bool) bool {
+func receiveMonitor(monitor *zmq.Socket, shutdown messaging.Connection) bool {
 	restart := false
 	event, endpoint, _, err := monitor.RecvEvent(0)
 	if err != nil {
@@ -309,13 +322,16 @@ func receiveMonitor(monitor *zmq.Socket, shutdown chan bool) bool {
 		} else {
 			logger.Errorf("Received unexpected event on monitor socket: %v", event)
 		}
-		shutdown <- true
+		err = shutdown.SendData("", []byte("restart"))
+		if err != nil {
+			logger.Errorf("Failed to send restart command")
+		}
 	}
 	return restart
 }
 
 // Handle incoming messages from the workers
-func receiveWorkers(ids map[string]string, validator, workers messaging.Connection, workersLeft *uint) {
+func receiveWorkers(ids map[string]string, validator, workers messaging.Connection) {
 	// Receive a mesasge from the workers
 	workerId, data, err := workers.RecvData()
 	if err != nil {
@@ -332,11 +348,6 @@ func receiveWorkers(ids map[string]string, validator, workers messaging.Connecti
 	t := msg.GetMessageType()
 	corrId := msg.GetCorrelationId()
 
-	if t == validator_pb2.Message_DEFAULT && corrId == "shutdown" {
-		*workersLeft = *workersLeft - 1
-		return
-	}
-
 	// Store which thread the response should be routed to
 	if t != validator_pb2.Message_TP_PROCESS_RESPONSE {
 		ids[corrId] = workerId
@@ -350,8 +361,103 @@ func receiveWorkers(ids map[string]string, validator, workers messaging.Connecti
 	}
 }
 
+// Handle shutdown
+func receiveShutdown(queue chan *validator_pb2.Message, worker_count uint, done <-chan bool, shutdown_rx, validator, workers messaging.Connection, monitor *zmq.Socket) bool {
+	_, data, err := shutdown_rx.RecvData()
+	if err != nil {
+		logger.Errorf("Error receiving shutdown: %v", err)
+	}
+
+	restart := false
+	cmd := string(data)
+	if cmd == "restart" {
+		restart = true
+	} else if cmd != "shutdown" {
+		fmt.Errorf("Received unexpected shutdown command: %v", cmd)
+		return false
+	}
+
+	logger.Infof("Received command to %v", cmd)
+	err = shutdown(queue, worker_count, done, shutdown_rx, validator, workers, monitor, restart)
+	if err != nil {
+		logger.Errorf("Error shutting down: %v", err)
+		return false
+	}
+	return restart
+}
+
+func shutdown(queue chan *validator_pb2.Message, worker_count uint, workers_done <-chan bool, shutdown_rx, validator, workers messaging.Connection, monitor *zmq.Socket, force bool) error {
+	// Close the work queue, telling the worker threads there's no more work
+	close(queue)
+
+	// Close the workers connection, causing any workers that try to send/recv
+	// to get an error
+	workers.Close()
+
+	// Close the monitor socket
+	monitor.Close()
+
+	if !force {
+		// Send a request to be unregistered
+		data, err := proto.Marshal(&processor_pb2.TpUnregisterRequest{})
+		if err != nil {
+			logger.Errorf(
+				"Failed to unregister: %v", err,
+			)
+		}
+		corrId, err := validator.SendNewMsg(
+			validator_pb2.Message_TP_UNREGISTER_REQUEST, data,
+		)
+		if err != nil {
+			logger.Errorf(
+				"Failed to unregister: %v", err,
+			)
+		}
+
+		// Wait for a response, or timeout
+		unregistered := make(chan bool, 1)
+		go func() {
+			_, msg, err := validator.RecvMsgWithId(corrId)
+			if err != nil {
+				logger.Errorf("Failed to receive TpUnregisterResponse: %v", err)
+			}
+			if msg.GetCorrelationId() != corrId {
+				logger.Errorf(
+					"Expected message with correlation id %v but got %v",
+					corrId, msg.GetCorrelationId(),
+				)
+			}
+			if msg.GetMessageType() != validator_pb2.Message_TP_UNREGISTER_RESPONSE {
+				logger.Errorf(
+					"Expected TP_UNREGISTER_RESPONSE but got %v", msg.GetMessageType(),
+				)
+			}
+		}()
+
+		select {
+		case <-unregistered:
+			logger.Infof("Unregister successful")
+		case <-time.After(3 * time.Second):
+			logger.Warnf("Waiting for unregister response timed out")
+		}
+
+	}
+
+	validator.Close()
+	shutdown_rx.Close()
+
+	// Wait for worker threads to die
+	for i := uint(0); i < worker_count; i++ {
+		logger.Debugf("Workers done %v/%v", i, worker_count)
+		<-workers_done
+	}
+	logger.Debugf("Workers done %v/%v", worker_count, worker_count)
+
+	return nil
+}
+
 // Register a handler with the validator
-func register(validator messaging.Connection, handler TransactionHandler, version string, queue chan *validator_pb2.Message, maxOccupancy uint32) error {
+func register(validator, shutdown_rx messaging.Connection, handler TransactionHandler, version string, queue chan *validator_pb2.Message, maxOccupancy uint32) error {
 	regRequest := &processor_pb2.TpRegisterRequest{
 		Family:       handler.FamilyName(),
 		Version:      version,
@@ -372,40 +478,55 @@ func register(validator messaging.Connection, handler TransactionHandler, versio
 		return err
 	}
 
-	// The validator is impatient and will send requests before confirming
-	// registration.
-	var msg *validator_pb2.Message
+	// Need to also watch the shutdown socket so we can abort registration
+	poller := zmq.NewPoller()
+	poller.Add(validator.Socket(), zmq.POLLIN)
+	poller.Add(shutdown_rx.Socket(), zmq.POLLIN)
+
 	for {
-		_, msg, err = validator.RecvMsg()
+		polled, err := poller.Poll(-1)
 		if err != nil {
-			return err
+			return fmt.Errorf("Polling failed: %v", err)
 		}
+		for _, ready := range polled {
+			switch socket := ready.Socket; socket {
+			case validator.Socket():
+				var msg *validator_pb2.Message
+				_, msg, err = validator.RecvMsg()
+				if err != nil {
+					return err
+				}
 
-		if msg.GetCorrelationId() != corrId {
-			queue <- msg
-		} else {
-			break
+				// The validator is impatient and will send requests before confirming
+				// registration.
+				if msg.GetCorrelationId() != corrId {
+					queue <- msg
+				}
+
+				if msg.GetMessageType() != validator_pb2.Message_TP_REGISTER_RESPONSE {
+					return fmt.Errorf("Received unexpected message type: %v", msg.GetMessageType())
+				}
+
+				regResponse := &processor_pb2.TpRegisterResponse{}
+				err = proto.Unmarshal(msg.GetContent(), regResponse)
+				if err != nil {
+					return err
+				}
+
+				if regResponse.GetStatus() != processor_pb2.TpRegisterResponse_OK {
+					return fmt.Errorf("Got response: %v", regResponse.GetStatus())
+				}
+				logger.Infof(
+					"Successfully registered handler (%v, %v, %v)",
+					handler.FamilyName(), version,
+					handler.Namespaces(),
+				)
+
+				return nil
+
+			case shutdown_rx.Socket():
+				return fmt.Errorf("Received shutdown while registering")
+			}
 		}
 	}
-
-	if msg.GetMessageType() != validator_pb2.Message_TP_REGISTER_RESPONSE {
-		return fmt.Errorf("Received unexpected message type: %v", msg.GetMessageType())
-	}
-
-	regResponse := &processor_pb2.TpRegisterResponse{}
-	err = proto.Unmarshal(msg.GetContent(), regResponse)
-	if err != nil {
-		return err
-	}
-
-	if regResponse.GetStatus() != processor_pb2.TpRegisterResponse_OK {
-		return fmt.Errorf("Got response: %v", regResponse.GetStatus())
-	}
-	logger.Infof(
-		"Successfully registered handler (%v, %v, %v)",
-		handler.FamilyName(), version,
-		handler.Namespaces(),
-	)
-
-	return nil
 }

--- a/sdk/go/src/sawtooth_sdk/processor/processor.go
+++ b/sdk/go/src/sawtooth_sdk/processor/processor.go
@@ -143,6 +143,11 @@ func (self *TransactionProcessor) start(context *zmq.Context) (bool, error) {
 	// Register all handlers with the validator
 	for _, handler := range self.handlers {
 		for _, version := range handler.FamilyVersions() {
+			logger.Debugf(
+				"Registering (%v, %v, %v)",
+				handler.FamilyName(),
+				version,
+				handler.Namespaces())
 			err := register(validator, handler, version, queue, uint32(self.maxQueue))
 			if err != nil {
 				return restart, fmt.Errorf(

--- a/sdk/go/src/sawtooth_sdk/processor/worker.go
+++ b/sdk/go/src/sawtooth_sdk/processor/worker.go
@@ -28,7 +28,7 @@ import (
 )
 
 // The main worker thread finds an appropriate handler and processes the request
-func worker(context *zmq.Context, uri string, queue chan *validator_pb2.Message, handlers []TransactionHandler) {
+func worker(context *zmq.Context, uri string, queue <-chan *validator_pb2.Message, handlers []TransactionHandler) {
 	// Connect to the main send/receive thread
 	connection, err := messaging.NewConnection(context, zmq.DEALER, uri)
 	if err != nil {

--- a/sdk/go/src/sawtooth_sdk/processor/worker.go
+++ b/sdk/go/src/sawtooth_sdk/processor/worker.go
@@ -28,11 +28,12 @@ import (
 )
 
 // The main worker thread finds an appropriate handler and processes the request
-func worker(context *zmq.Context, uri string, queue <-chan *validator_pb2.Message, handlers []TransactionHandler) {
+func worker(context *zmq.Context, uri string, queue <-chan *validator_pb2.Message, done chan<- bool, handlers []TransactionHandler) {
 	// Connect to the main send/receive thread
-	connection, err := messaging.NewConnection(context, zmq.DEALER, uri)
+	connection, err := messaging.NewConnection(context, zmq.DEALER, uri, false)
 	if err != nil {
 		logger.Errorf("Failed to connect to main thread: %v", err)
+		done <- false
 		return
 	}
 	defer connection.Close()
@@ -110,15 +111,7 @@ func worker(context *zmq.Context, uri string, queue <-chan *validator_pb2.Messag
 		}
 	}
 
-	// Queue has closed, so send shutdown signal
-	logger.Infof("(%v) No more work in queue, shutting down", id)
-	err = connection.SendMsg(
-		validator_pb2.Message_DEFAULT,
-		[]byte{byte(0)}, "shutdown",
-	)
-	if err != nil {
-		logger.Errorf("(%v) Error sending shutdown: %v", id, err)
-	}
+	done <- true
 }
 
 // Searches for and returns a handler that matches the header. If a suitable
@@ -148,66 +141,4 @@ func findHandler(handlers []TransactionHandler, header *transaction_pb2.Transact
 		"Unknown handler: (%v, %v)", header.GetFamilyName(),
 		header.GetFamilyVersion(),
 	)
-}
-
-// Waits for something to come along a channel and then initiates processor shutdown
-func shutdown(context *zmq.Context, uri string, queue chan *validator_pb2.Message, wait chan bool) {
-	// Wait for a request to shutdown
-	connection, err := messaging.NewConnection(context, zmq.DEALER, uri)
-	if err != nil {
-		logger.Errorf("Failed to connect to main thread: %v", err)
-		return
-	}
-	defer connection.Close()
-	id := "shutdown"
-
-	force := <-wait
-
-	if !force {
-		// Send a request to be unregistered
-		data, err := proto.Marshal(&processor_pb2.TpUnregisterRequest{})
-		if err != nil {
-			logger.Errorf(
-				"Failed to unregister: %v", err,
-			)
-		}
-		corrId, err := connection.SendNewMsg(
-			validator_pb2.Message_TP_UNREGISTER_REQUEST, data,
-		)
-		if err != nil {
-			logger.Errorf(
-				"Failed to unregister: %v", err,
-			)
-		}
-
-		// Wait for a response
-		_, msg, err := connection.RecvMsgWithId(corrId)
-		if err != nil {
-			logger.Errorf("Failed to receive TpUnregisterResponse: %v", err)
-		}
-		if msg.GetCorrelationId() != corrId {
-			logger.Errorf(
-				"Expected message with correlation id %v but got %v",
-				corrId, msg.GetCorrelationId(),
-			)
-		}
-		if msg.GetMessageType() != validator_pb2.Message_TP_UNREGISTER_RESPONSE {
-			logger.Errorf(
-				"Expected TP_UNREGISTER_RESPONSE but got %v", msg.GetMessageType(),
-			)
-		}
-	}
-
-	// Close the work queue, telling the worker threads there's no more work
-	close(queue)
-
-	err = connection.SendMsg(
-		validator_pb2.Message_DEFAULT,
-		[]byte{byte(0)}, "shutdown",
-	)
-	if err != nil {
-		logger.Errorf("(%v) Error sending shutdown message to router: %v", id, err)
-	} else {
-		logger.Infof("(%v) Sent shutdown message to router", id)
-	}
 }


### PR DESCRIPTION
Previously, there were a number of problems with the shutdown and
reconnect code. Graceful shutdown would hang if the processor was
registering or if the validator never responded with an unregister
response. Reconnection could fail when a validator disconnected
because threads were blocked waiting for a response and would never
stop.

This commit solves these problems by using a ZMQ socket to signal
shutdown so it can be included in a poll with a receiving socket
and by aggresively closing sockets that worker threads depend on
so any send/receives will unblock and the worker threads can shutdown.