### PR TITLE
Revert "Update package versioning to include commit hash"

### DIFF
--- a/bin/get_version
+++ b/bin/get_version
@@ -58,10 +58,9 @@ def auto_version(default, strict):
             parts[0] = default
 
     if len(parts) > 1:
-        parts[0] = "+dev".join([parts[0], parts[1].replace("-", ".")])
-        parts[0] = parts[0] + "." + parts[2]
+        parts[0] = ".dev".join([parts[0], parts[1].replace("-", ".")])
         if len(parts) == 4:
-            parts[0] = parts[0] + "." + parts[3]
+            parts[0] = parts[0] + "-" + parts[3]
         return parts[0]
     else:
         return parts[0]


### PR DESCRIPTION
The original commit fails one upgrade test.

This reverts commit dc10fa536b312fcf8660304d18abb444bfbfdf95.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>