### PR TITLE
Add rust build step prior to building debian packages

### DIFF
--- a/bin/build_all
+++ b/bin/build_all
@@ -122,6 +122,7 @@ main() {
 
     if [[ $BUILD_MODE == $DEBS ]]
     then
+        build_rust
         build_debs
     fi
 
@@ -424,14 +425,28 @@ then
         rm -rf $build_dir
         mkdir -p $build_dir
 
+        cp $top_dir/docker/sawtooth-dev-rust $build_dir
+        docker_build $build_dir/sawtooth-dev-rust $build_dir/ sawtooth-dev-rust
+        docker_build $build_dir/sawtooth-dev-rust $build_dir/ sawtooth-intkey-tp-rust
+        docker_run sawtooth-dev-rust
+
         cp $top_dir/bin/install_packaging_deps $build_dir
         cp $top_dir/ci/sawtooth-build-debs $build_dir
         docker_build $build_dir/sawtooth-build-debs $build_dir sawtooth-build-debs
         docker_run sawtooth-build-debs rust
 
+    }
+fi
+
+if [[ $BUILD_MODE == $DEBS ]]
+then
+    build_rust() {
+        build_dir=/tmp/build-docker$ISOLATION_ID
+        rm -rf $build_dir
+        mkdir -p $build_dir
+
         cp $top_dir/docker/sawtooth-dev-rust $build_dir
         docker_build $build_dir/sawtooth-dev-rust $build_dir/ sawtooth-dev-rust
-        docker_build $build_dir/sawtooth-dev-rust $build_dir/ sawtooth-intkey-tp-rust
         docker_run sawtooth-dev-rust
     }
 fi

--- a/bin/build_debs
+++ b/bin/build_debs
@@ -210,17 +210,9 @@ build_rust() {
     rm -f $output_dir/*.deb
 
     info "sawadm"
-    rm -rf $top_dir/adm/bin
-    mkdir -p $top_dir/adm/bin
-    cd $top_dir/adm
-    cargo build && cp ./target/debug/sawadm $top_dir/adm/bin/sawadm
     build_rust_pkg sawadm $top_dir/adm $output_dir
 
     info "smallbank-workload"
-    rm -rf $top_dir/perf/smallbank_workload/bin
-    mkdir -p $top_dir/perf/smallbank_workload/bin
-    cd $top_dir/perf/smallbank_workload
-    cargo build && cp ./target/debug/smallbank-workload $top_dir/perf/smallbank_workload/bin/smallbank-workload
     build_rust_pkg smallbank-workload $top_dir/perf/smallbank_workload $output_dir
 
     for pkg in $output_dir/*.deb


### PR DESCRIPTION
The rust debian packages were missing the built executables.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>