### PR TITLE
Correct config file paths in Sys Admin Guide

### DIFF
--- a/docs/source/sysadmin_guide/configuring_sawtooth/cli_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/cli_configuration.rst
@@ -14,9 +14,12 @@ run. (By default, the config directory is /etc/sawtooth/; see
 Specifying command-line options will override the settings in the
 configuration file.
 
-An example configuration file is in
+Note: By default, the config directory is /etc/sawtooth/.
+See :doc:`path_configuration_file` for more information.
+
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/cli/cli.toml.example``. To create a CLI configuration
-file, copy the example file to the config directory and name it
+file, download this example file to the config directory and name it
 ``cli.toml``.
 
 The example file shows the format of the ``url`` option. To use it,

--- a/docs/source/sysadmin_guide/configuring_sawtooth/identity_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/identity_tp_configuration.rst
@@ -13,11 +13,12 @@ file.
 Note: By default, the config directory is /etc/sawtooth/.
 See :doc:`path_configuration_file` for more information.
 
-An example configuration file is in
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/families/identity/packaging/identity.toml.example``.
-To create a Identity transaction processor configuration file, copy the example
-file to the config directory and name it ``identity.toml``. Then edit the file
-to change the example configuration options as necessary for your system.
+To create an Identity transaction processor configuration file, download this
+example file to the config directory and name it ``identity.toml``. Then edit
+the file to change the example configuration options as necessary for your
+system.
 
 The ``identity.toml`` configuration file has the following option:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
@@ -15,6 +15,11 @@ Unix-based operating systems do not use ``/var/lib``, so it would be appropriate
 to use this file to set ``data_dir`` to the natural operating system default
 path for application data.
 
+An example file is in ``/etc/sawtooth/path.toml.example``. To create a path
+configuration file, copy the example file to the config directory and name it
+``path.toml``. Then edit the file to change the example configuration options as
+necessary for your system.
+
 This file configures the following settings:
 
 - ``key_dir`` = `path`

--- a/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
@@ -10,11 +10,14 @@ config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
 more information.) Specifying a command-line option will override the setting
 in the configuration file.
 
-An example configuration file is in
+Note: By default, the config directory is /etc/sawtooth/.
+See :doc:`path_configuration_file` for more information.
+
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/consensus/poet/sgx/packaging/poet_enclave_sgx.toml.example``.
-To create a PoET SGX enclave configuration file, copy the example file to the
-config directory and name it ``poet_enclave_sgx.toml``. Then edit the file to
-change the example configuration options as necessary for your system.
+To create a PoET SGX enclave configuration file, download this example file to
+the config directory and name it ``poet_enclave_sgx.toml``. Then edit the file
+to change the example configuration options as necessary for your system.
 
 .. Note::
 
@@ -48,10 +51,10 @@ The ``poet_enclave_sgx.toml`` configuration file has the following options:
 
   Identifies the PEM-encoded certificate file that was submitted to Intel in
   order to obtain a SPID. Default: none. Specify the full path to the
-  certificate file. This pem file can be created from ``cert.crt`` and 
+  certificate file. This pem file can be created from ``cert.crt`` and
   ``cert.key`` files with this command:
 
-  .. code-block:: console 
+  .. code-block:: console
 
     $ cat cert.crt cert.key > cert.pem
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -11,10 +11,13 @@ config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
 more information.) Specifying a command-line option will override the setting
 in the configuration file.
 
-An example configuration file is in
+Note: By default, the config directory is /etc/sawtooth/.
+See :doc:`path_configuration_file` for more information.
+
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/rest_api/packaging/rest_api.toml.example``.
-To create a REST API configuration file, copy the example file to the config
-directory and name it ``rest_api.toml``. Then edit the file to change the
+To create a REST API configuration file, download this example file to the
+config directory and name it ``rest_api.toml``. Then edit the file to change the
 example configuration options as necessary for your system.
 
 The ``rest_api.toml`` configuration file has the following options:

--- a/docs/source/sysadmin_guide/configuring_sawtooth/settings_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/settings_tp_configuration.rst
@@ -13,11 +13,12 @@ file.
 Note: By default, the config directory is /etc/sawtooth/.
 See :doc:`path_configuration_file` for more information.
 
-An example configuration file is in
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/families/settings/packaging/settings.toml.example``.
-To create a Settings transaction processor configuration file, copy the example
-file to the config directory and name it ``settings.toml``. Then edit the file
-to change the example configuration options as necessary for your system.
+To create a Settings transaction processor configuration file, download this
+example file to the config directory and name it ``settings.toml``. Then edit
+the file to change the example configuration options as necessary for your
+system.
 
 The ``settings.toml`` configuration file has the following option:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -13,8 +13,10 @@ config directory is ``/etc/sawtooth/``; see :doc:`path_configuration_file` for
 more information.) Specifying an option on the command line overrides the
 setting in the configuration file.
 
-An example configuration file is in
-``/sawtooth-core/validator/packaging/validator.toml.example``.
+Note: By default, the config directory is /etc/sawtooth/.
+See :doc:`path_configuration_file` for more information.
+
+An example configuration file is in ``/etc/sawtooth/validator.toml.example``.
 To create a validator configuration file, copy the example file to the config
 directory and name it ``validator.toml``. Then edit the file to change the
 example configuration options as necessary for your system.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -14,7 +14,7 @@ more information.) Specifying an option on the command line overrides the
 setting in the configuration file.
 
 An example configuration file is in
-``/sawtooth-core/packaging/validator.toml.example``.
+``/sawtooth-core/validator/packaging/validator.toml.example``.
 To create a validator configuration file, copy the example file to the config
 directory and name it ``validator.toml``. Then edit the file to change the
 example configuration options as necessary for your system.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
@@ -13,9 +13,9 @@ file.
 Note: By default, the config directory is /etc/sawtooth/.
 See :doc:`path_configuration_file` for more information.
 
-An example configuration file is in
+An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/sdk/examples/xo_python/packaging/xo.toml.example``.
-To create a XO transaction processor configuration file, copy the example
+To create a XO transaction processor configuration file, download this example
 file to the config directory and name it ``xo.toml``. Then edit the file
 to change the example configuration options as necessary for your system.
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
@@ -14,7 +14,7 @@ Note: By default, the config directory is /etc/sawtooth/.
 See :doc:`path_configuration_file` for more information.
 
 An example configuration file is in
-``/sawtooth-core/families/xo/packaging/xo.toml.example``.
+``/sawtooth-core/sdk/examples/xo_python/packaging/xo.toml.example``.
 To create a XO transaction processor configuration file, copy the example
 file to the config directory and name it ``xo.toml``. Then edit the file
 to change the example configuration options as necessary for your system.

--- a/docs/source/sysadmin_guide/log_configuration.rst
+++ b/docs/source/sysadmin_guide/log_configuration.rst
@@ -48,7 +48,9 @@ To change the default logging behavior of a Sawtooth component, such as the
 validator, put a log configuration file in the config directory (see
 :doc:`configuring_sawtooth/path_configuration_file`).
 
-The validator log config file should be named ``log_config.toml``.
+An example log configuration file is at
+``/etc/sawtooth/log_config.toml.example``. To create a log configuration file,
+copy the example file to ``/etc/sawtooth`` and name it ``log_config.toml``.
 
 Each transaction processor can define its own config file. The name of
 this file is determined by the author. The transaction processors included in


### PR DESCRIPTION
Correct all config file paths and associated text in Sys Admin Guide:
    
* The installed /etc/sawtooth directory includes these example config files:
   log_config.toml.example, path.toml.example, validator.toml.example
   Changed these paths in the appropriate doc section; added new content where
   necessary.
  
    Note that the Validator topic had the wrong path to the file in sawtooth-core. The
    first commit in this PR corrects that path, but the last (and largest) changes it to 
    /etc/sawtooth/validator.toml.example.

* The other example config files must be downloaded from the sawtooth-core repo.
   Corrected the path for the xo config file; changed text for all to say "download" 
   instead of "copy".
    
* Also added a note about the default config directory to the topics that were
   missing the note (Validator, REST API, CLI, and PoET).