### PR TITLE
Only broadcast to fully connected peers

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -347,7 +347,9 @@ class Gossip(object):
             if exclude is None:
                 exclude = []
             for connection_id in self._peers.copy():
-                if connection_id not in exclude:
+                if connection_id not in exclude and \
+                        self._network.is_connection_handshake_complete(
+                            connection_id):
                     self.send(
                         message_type,
                         gossip_message.SerializeToString(),


### PR DESCRIPTION
In order to prevent a validator from attempting to broadcast to connections that have not fully peered, the connections should be filtered based on whether or not they have completed their authorization handshake.

This should prevent the issue where validators fail to re-peer when there is a slowdown in message processing.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>