### PR TITLE
Create initial MAINTAINERS list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,16 @@
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Andi Gunderson | agunde406 | agunde |
+| Anne Chenette | chenette | achenette |
+| Boyd Johnson | boydjohnson | boydjohnson |
+| Cian Montgomery | cianx | cianx |
+| Dan Middleton | dcmiddle | Dan |
+| Darian Plumb | dplumb94 | dplumb |
+| James Mitchell | jsmitchell | jsmitchell |
+| Jamie Jason | jjason | jjason |
+| Nick Drozd | nick-drozd | drozd |
+| Peter Schwarz | peterschwarz | pschwarz |
+| Ryan Beck-Buysse | rbuysse | rbuysse |
+| Shawn Amundson | vaporos | amundson |
+| Zac Delventhal | delventhalz | zac |


### PR DESCRIPTION
This list is intended to recognize current contributors to the
sawtooth-core repository who have:

- Been actively involved for a substantial amount of time
- Made significant contributions that have been critical to the success
  of the project
- Frequently reviewed pull requests and left thoughtful and
  constructive feedback

To come up with this list objectively, I took all contributors who have
made 50 or more commits since Jan 1, 2017. This list can be reproduced
using the GitHub insights tool. This link should take you directly to
the list.

https://github.com/hyperledger/sawtooth-core/graphs/contributors?from=2017-01-01&to=2018-03-28&type=c

The list has been sorted by first name.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>