### PR TITLE
BACKPORT: Add client_max_size to rest api config

### DIFF
--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -46,6 +46,17 @@ The ``rest_api.toml`` configuration file has the following options:
 
     timeout = 900
 
+- ``client_max_size`` = `value`
+
+  Specifies the size, in bytes, that the REST API will accept for the body of
+  requests. If the body is larger a ``413: Request Entity Too Large`` will be
+  returned
+  Default: none. For example:
+
+  .. code-block:: none
+
+    client_max_size = 1048576
+
 - ``opentsdb_url`` = "`value`"
 
   Sets the host and port for Open TSDB database (used for metrics).

--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -51,11 +51,11 @@ The ``rest_api.toml`` configuration file has the following options:
   Specifies the size, in bytes, that the REST API will accept for the body of
   requests. If the body is larger a ``413: Request Entity Too Large`` will be
   returned
-  Default: none. For example:
+  Default: 10485760 (or 10 MB). For example:
 
   .. code-block:: none
 
-    client_max_size = 1048576
+    client_max_size = 10485760
 
 - ``opentsdb_url`` = "`value`"
 

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -28,7 +28,8 @@ def load_default_rest_api_config():
     return RestApiConfig(
         bind=["127.0.0.1:8008"],
         connect="tcp://localhost:4004",
-        timeout=300)
+        timeout=300,
+        client_max_size=10485760)
 
 
 def load_toml_rest_api_config(filename):

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -54,7 +54,7 @@ def load_toml_rest_api_config(filename):
 
     invalid_keys = set(toml_config.keys()).difference(
         ['bind', 'connect', 'timeout', 'opentsdb_db', 'opentsdb_url',
-         'opentsdb_username', 'opentsdb_password'])
+         'opentsdb_username', 'opentsdb_password', 'client_max_size'])
     if invalid_keys:
         raise RestApiConfigurationError(
             "Invalid keys in rest api config: {}".format(
@@ -67,6 +67,7 @@ def load_toml_rest_api_config(filename):
         opentsdb_db=toml_config.get('opentsdb_db', None),
         opentsdb_username=toml_config.get('opentsdb_username', None),
         opentsdb_password=toml_config.get('opentsdb_password', None),
+        client_max_size=toml_config.get('client_max_size', None)
     )
 
     return config
@@ -84,6 +85,7 @@ def merge_rest_api_config(configs):
     opentsdb_db = None
     opentsdb_username = None
     opentsdb_password = None
+    client_max_size = None
 
     for config in reversed(configs):
         if config.bind is not None:
@@ -100,6 +102,8 @@ def merge_rest_api_config(configs):
             opentsdb_username = config.opentsdb_username
         if config.opentsdb_password is not None:
             opentsdb_password = config.opentsdb_password
+        if config.client_max_size is not None:
+            client_max_size = config.client_max_size
 
     return RestApiConfig(
         bind=bind,
@@ -108,7 +112,8 @@ def merge_rest_api_config(configs):
         opentsdb_url=opentsdb_url,
         opentsdb_db=opentsdb_db,
         opentsdb_username=opentsdb_username,
-        opentsdb_password=opentsdb_password)
+        opentsdb_password=opentsdb_password,
+        client_max_size=client_max_size)
 
 
 class RestApiConfig:
@@ -120,7 +125,8 @@ class RestApiConfig:
             opentsdb_url=None,
             opentsdb_db=None,
             opentsdb_username=None,
-            opentsdb_password=None):
+            opentsdb_password=None,
+            client_max_size=None):
         self._bind = bind
         self._connect = connect
         self._timeout = timeout
@@ -128,6 +134,7 @@ class RestApiConfig:
         self._opentsdb_db = opentsdb_db
         self._opentsdb_username = opentsdb_username
         self._opentsdb_password = opentsdb_password
+        self._client_max_size = client_max_size
 
     @property
     def bind(self):
@@ -157,11 +164,16 @@ class RestApiConfig:
     def opentsdb_password(self):
         return self._opentsdb_password
 
+    @property
+    def client_max_size(self):
+        return self._client_max_size
+
     def __repr__(self):
         # skip opentsdb_db password
         return \
             "{}(bind={}, connect={}, timeout={}," \
-            "opentsdb_url={}, opentsdb_db={}, opentsdb_username={})" \
+            "opentsdb_url={}, opentsdb_db={}, opentsdb_username={}," \
+            "client_max_size={})" \
             .format(
                 self.__class__.__name__,
                 repr(self._bind),
@@ -169,7 +181,8 @@ class RestApiConfig:
                 repr(self._timeout),
                 repr(self._opentsdb_url),
                 repr(self._opentsdb_db),
-                repr(self._opentsdb_username))
+                repr(self._opentsdb_username),
+                repr(self._client_max_size))
 
     def to_dict(self):
         return collections.OrderedDict([
@@ -180,6 +193,7 @@ class RestApiConfig:
             ('opentsdb_db', self._opentsdb_db),
             ('opentsdb_username', self._opentsdb_username),
             ('opentsdb_password', self._opentsdb_password),
+            ('client_max_size', self._client_max_size)
         ])
 
     def to_toml_string(self):

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -62,6 +62,9 @@ def parse_args(args):
     parser.add_argument('-t', '--timeout',
                         help='set time (in seconds) to wait for validator \
                         response')
+    parser.add_argument('--client-max-size',
+                        type=int,
+                        help='the max size (in bytes) of a request body')
     parser.add_argument('-v', '--verbose',
                         action='count',
                         default=0,
@@ -87,12 +90,13 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def start_rest_api(host, port, connection, timeout, registry):
+def start_rest_api(host, port, connection, timeout, registry,
+                   client_max_size=None):
     """Builds the web app, adds route handlers, and finally starts the app.
     """
     loop = asyncio.get_event_loop()
     connection.open()
-    app = web.Application(loop=loop)
+    app = web.Application(loop=loop, client_max_size=client_max_size)
     app.on_cleanup.append(lambda app: connection.close())
 
     # Add routes to the web app
@@ -177,7 +181,8 @@ def main():
             connect=opts.connect,
             timeout=opts.timeout,
             opentsdb_url=opts.opentsdb_url,
-            opentsdb_db=opts.opentsdb_db)
+            opentsdb_db=opts.opentsdb_db,
+            client_max_size=opts.client_max_size)
         rest_api_config = load_rest_api_config(opts_config)
         url = None
         if "tcp://" not in rest_api_config.connect:
@@ -237,7 +242,8 @@ def main():
             port,
             connection,
             int(rest_api_config.timeout),
-            wrapped_registry)
+            wrapped_registry,
+            client_max_size=rest_api_config.client_max_size)
         # pylint: disable=broad-except
     except Exception as e:
         LOGGER.exception(e)


### PR DESCRIPTION
Before the REST API defaulted to only allowing a
request body size of 1MB. Now the size limit can be
configured with the config file or using the command
line. If there is not a size configured there will be
no limit on the request body size.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>