### PR TITLE
Fix new pycodestyle issues

### DIFF
--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -78,7 +78,8 @@ def add_block_parser(subparsers, parent_parser):
 
 
 def do_block(args):
-    """Runs the block list or block show command, printing output to the console
+    """Runs the block list or block show command, printing output to the
+    console
 
         Args:
             args: The parsed arguments sent to the command at runtime

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -318,8 +318,8 @@ def _create_batch(signer, transactions):
 
 
 def _create_propose_txn(signer, setting_key_value):
-    """Creates an individual sawtooth_settings transaction for the given key and
-    value.
+    """Creates an individual sawtooth_settings transaction for the given
+    key and value.
     """
     setting_key, setting_value = setting_key_value
     nonce = str(datetime.datetime.utcnow().timestamp())

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -80,7 +80,8 @@ def add_state_parser(subparsers, parent_parser):
 
 
 def do_state(args):
-    """Runs the batch list or batch show command, printing output to the console
+    """Runs the batch list or batch show command, printing output to the
+    console
 
         Args:
             args: The parsed arguments sent to the command at runtime

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -311,8 +311,8 @@ class ConsensusState(object):
 
     @staticmethod
     def _block_for_id(block_id, block_cache):
-        """A convenience method retrieving a block given a block ID.  Takes care
-        of the special case of NULL_BLOCK_IDENTIFIER.
+        """A convenience method retrieving a block given a block ID. Takes
+        care of the special case of NULL_BLOCK_IDENTIFIER.
 
         Args:
             block_id (str): The ID of block to retrieve.

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/consensus_state.py
@@ -905,8 +905,8 @@ class ConsensusState(object):
                         observed_wins > expected_wins:
                     probability = expected_wins / block_count
                     standard_deviation = \
-                        math.sqrt(block_count * probability *
-                                  (1.0 - probability))
+                        math.sqrt(
+                            block_count * probability * (1.0 - probability))
                     z_score = \
                         (observed_wins - expected_wins) / \
                         standard_deviation

--- a/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
+++ b/consensus/poet/families/sawtooth_validator_registry/validator_registry/processor/handler.py
@@ -420,8 +420,8 @@ class ValidatorRegistryTransactionHandler(TransactionHandler):
         hash_value = hashlib.sha256(hash_input).digest()
         expected_report_data = \
             hash_value + \
-            (b'\x00' *
-             (sgx_structs.SgxReportData.STRUCT_SIZE - len(hash_value)))
+            (b'\x00'
+             * (sgx_structs.SgxReportData.STRUCT_SIZE - len(hash_value)))
 
         if sgx_quote.report_body.report_data.d != expected_report_data:
             raise \

--- a/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
+++ b/consensus/poet/simulator/sawtooth_poet_simulator/poet_enclave_simulator/poet_enclave_simulator.py
@@ -435,8 +435,7 @@ class _PoetEnclaveSimulator(object):
                         'Validator is not using the current wait timer')
 
             is_not_genesis_block = \
-                (wait_timer.previous_certificate_id !=
-                 NULL_BLOCK_IDENTIFIER)
+                (wait_timer.previous_certificate_id != NULL_BLOCK_IDENTIFIER)
 
             now = time.time()
             expire_time = \

--- a/families/settings/tests/test_tp_settings.py
+++ b/families/settings/tests/test_tp_settings.py
@@ -269,9 +269,9 @@ class TestSettings(TransactionProcessorTestCase):
 
         self._vote(proposal_id, 'my.config.setting', SettingVote.ACCEPT)
 
-        self._expect_get('sawtooth.settings.vote.authorized_keys',
-                         self._public_key +
-                         ',some_other_public_key,third_public_key')
+        self._expect_get(
+            'sawtooth.settings.vote.authorized_keys',
+            self._public_key + ',some_other_public_key,third_public_key')
         self._expect_get('sawtooth.settings.vote.proposals',
                          base64.b64encode(candidates.SerializeToString()))
         self._expect_get('sawtooth.settings.vote.approval_threshold', '3')

--- a/integration/sawtooth_integration/tests/test_dynamic_network.py
+++ b/integration/sawtooth_integration/tests/test_dynamic_network.py
@@ -131,8 +131,7 @@ class TestDynamicNetwork(unittest.TestCase):
                     # If the process doesn't shut down cleanly, kill it
                     proc.kill()
 
-
-# utilities
+    # utilities
 
     def send_txns_all_at_once(self, batches, time_between_batches):
         for client in self.clients.values():

--- a/rest_api/sawtooth_rest_api/route_handlers.py
+++ b/rest_api/sawtooth_rest_api/route_handlers.py
@@ -614,8 +614,8 @@ class RouteHandler(object):
         return self._message_to_dict(content)
 
     async def _send_request(self, request_type, payload):
-        """Uses an executor to send an asynchronous ZMQ request to the validator
-        with the handler's Connection
+        """Uses an executor to send an asynchronous ZMQ request to the
+        validator with the handler's Connection
         """
         try:
             return await self._connection.send(

--- a/rest_api/tests/unit/components.py
+++ b/rest_api/tests/unit/components.py
@@ -166,7 +166,8 @@ class BaseApiTest(AioHTTPTestCase):
 
     @staticmethod
     def build_handlers(loop, connection):
-        """Returns Rest Api route handlers modified with some a mock connection.
+        """Returns Rest Api route handlers modified with some a mock
+        connection.
 
         Args:
             connection (object): The MockConnection set to `self.connection`
@@ -400,8 +401,8 @@ class Mocks(object):
 
     @staticmethod
     def make_sort_controls(keys, reverse=False):
-        """Returns a ClientSortControls Protobuf in a list. Use concatenation to
-        combine multiple sort controls.
+        """Returns a ClientSortControls Protobuf in a list. Use concatenation
+        to combine multiple sort controls.
         """
         return [ClientSortControls(
             keys=[keys],

--- a/rest_api/tests/unit/test_txn_requests.py
+++ b/rest_api/tests/unit/test_txn_requests.py
@@ -245,7 +245,8 @@ class TransactionListTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_txn_list_with_head_and_ids(self):
-        """Verifies GET /transactions with head and id parameters work properly.
+        """Verifies GET /transactions with head and id parameters work
+        properly.
 
         It should send a Protobuf request with:
             - a head_id property of ID_B
@@ -538,7 +539,8 @@ class TransactionGetTests(BaseApiTest):
 
     @unittest_run_loop
     async def test_txn_get_with_bad_id(self):
-        """Verifies a GET /transactions/{transaction_id} with unfound id breaks.
+        """Verifies a GET /transactions/{transaction_id} with unfound id
+        breaks.
 
         It will receive a Protobuf response with:
             - a status of NO_RESOURCE

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/workload/workload_generator.py
@@ -104,14 +104,14 @@ class WorkloadGenerator(object):
                         'Transaction submission rate for last %d sample(s)'
                         ' is %.2f tps',
                         len(self._submitted_batch_samples),
-                        sum(self._submitted_batch_samples) /
-                        len(self._submitted_batch_samples))
+                        sum(self._submitted_batch_samples)
+                        / len(self._submitted_batch_samples))
                     LOGGER.warning(
                         'Transaction commit rate for last %d sample(s)'
                         ' is %.2f tps',
                         len(self._committed_batch_samples),
-                        sum(self._committed_batch_samples) /
-                        len(self._committed_batch_samples))
+                        sum(self._committed_batch_samples)
+                        / len(self._committed_batch_samples))
 
                     self._submitted_batches_sample = 0
                     self._committed_batches_sample = 0

--- a/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
+++ b/sdk/examples/xo_python/sawtooth_xo/processor/handler.py
@@ -87,10 +87,10 @@ class XoTransactionHandler(TransactionHandler):
             if game.state in ('P1-WIN', 'P2-WIN', 'TIE'):
                 raise InvalidTransaction('Invalid Action: Game has ended')
 
-            if (game.player1 and game.state == 'P1-NEXT' and
-                game.player1 != signer) or \
-                    (game.player2 and game.state == 'P2-NEXT' and
-                     game.player2 != signer):
+            if (game.player1 and game.state == 'P1-NEXT'
+                and game.player1 != signer) or \
+                    (game.player2 and game.state == 'P2-NEXT'
+                     and game.player2 != signer):
                 raise InvalidTransaction(
                     "Not this player's turn: {}".format(signer[:6]))
 
@@ -118,8 +118,8 @@ class XoTransactionHandler(TransactionHandler):
             _display(
                 "Player {} takes space: {}\n\n".format(
                     signer[:6],
-                    xo_payload.space) +
-                _game_data_to_str(
+                    xo_payload.space)
+                + _game_data_to_str(
                     game.board,
                     game.state,
                     game.player1,

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -247,8 +247,8 @@ class TransactionExecutorThread(object):
                 # the transaction match one namespace listed
                 transaction_family = \
                     next(t for t in transaction_families
-                         if t.get('family') == header.family_name and
-                         t.get('version') == header.family_version)
+                         if t.get('family') == header.family_name
+                         and t.get('version') == header.family_version)
 
                 # if no namespaces are indicated, then the empty prefix is
                 # inserted by default

--- a/validator/sawtooth_validator/execution/scheduler.py
+++ b/validator/sawtooth_validator/execution/scheduler.py
@@ -229,9 +229,9 @@ class SchedulerIterator(object):
             # and we have returned all the scheduler's transactions or the
             # scheduler was cancelled.
             while True:
-                if (self._scheduler.complete(block=False) and
-                        self._scheduler.count() == self._next_index or
-                        self._scheduler.is_cancelled()):
+                if (self._scheduler.complete(block=False)
+                        and self._scheduler.count() == self._next_index
+                        or self._scheduler.is_cancelled()):
                     raise StopIteration()
 
                 txn = self._scheduler.next_transaction()

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -80,8 +80,8 @@ class SerialScheduler(Scheduler):
             self, txn_signature, is_valid, context_id, state_changes=None,
             events=None, data=None, error_message="", error_data=b""):
         with self._condition:
-            if (self._in_progress_transaction is None or
-                    self._in_progress_transaction != txn_signature):
+            if (self._in_progress_transaction is None
+                    or self._in_progress_transaction != txn_signature):
                 return
 
             self._in_progress_transaction = None

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -562,9 +562,9 @@ class ConnectionManager(InstrumentedThread):
 
             with self._lock:
                 unpeered_candidates = list(
-                    set(self._candidate_peer_endpoints) -
-                    set(peered_endpoints) -
-                    set([self._endpoint]))
+                    set(self._candidate_peer_endpoints)
+                    - set(peered_endpoints)
+                    - set([self._endpoint]))
 
             LOGGER.debug(
                 "Peers are: %s. "

--- a/validator/sawtooth_validator/journal/consensus/consensus_factory.py
+++ b/validator/sawtooth_validator/journal/consensus/consensus_factory.py
@@ -59,8 +59,8 @@ class ConsensusFactory(object):
 
     @staticmethod
     def get_configured_consensus_module(block_id, state_view):
-        """Returns the consensus_module based on the consensus module set by the
-        "sawtooth_settings" transaction family.
+        """Returns the consensus_module based on the consensus module set by
+        the "sawtooth_settings" transaction family.
 
         Args:
             block_id (str): the block id associated with the current state_view

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -58,8 +58,8 @@ class BlockPublisher(BlockPublisherInterface):
         return block_header.previous_block_id == NULL_BLOCK_IDENTIFIER
 
     def finalize_block(self, block_header):
-        """Returns `True`, as the genesis block is always considered good by the
-        genesis node.
+        """Returns `True`, as the genesis block is always considered good by
+        the genesis node.
         """
         return block_header.previous_block_id == NULL_BLOCK_IDENTIFIER
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -231,15 +231,15 @@ class _CandidateBlock(object):
         is already in the pending queue.
         :param batch: the batch to check
         """
-        return (self._block_store.has_batch(batch.header_signature) or
-                batch.header_signature in self._pending_batch_ids)
+        return (self._block_store.has_batch(batch.header_signature)
+                or batch.header_signature in self._pending_batch_ids)
 
     def _is_txn_already_committed(self, txn, committed_txn_cache):
         """ Test if a transaction is already committed to the chain or
         is already in the pending queue.
         """
-        return (self._block_store.has_batch(txn.header_signature) or
-                txn.header_signature in committed_txn_cache)
+        return (self._block_store.has_batch(txn.header_signature)
+                or txn.header_signature in committed_txn_cache)
 
     def _poll_injectors(self, poller, batch_list):
         for injector in self._batch_injectors:
@@ -381,7 +381,7 @@ class _CandidateBlock(object):
                                                       committed_txn_cache):
                     LOGGER.debug("Batch %s invalid, due to missing txn "
                                  "dependency.", batch.header_signature)
-                    LOGGER.debug("Abandoning block %s:" +
+                    LOGGER.debug("Abandoning block %s:"
                                  "root state hash has invalid txn applied",
                                  builder)
                     # Update the pending batch list to be all the
@@ -763,10 +763,11 @@ class BlockPublisher(object):
                         and self._pending_batches):
                     self._build_candidate_block(self._chain_head)
 
-                if self._candidate_block and (
-                    force or
-                    self._candidate_block.has_pending_batches()) and \
-                        self._candidate_block.check_publish_block():
+                if (self._candidate_block
+                        and (
+                            force
+                            or self._candidate_block.has_pending_batches())
+                        and self._candidate_block.check_publish_block()):
 
                     pending_batches = []  # will receive the list of batches
                     # that were not added to the block

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -166,8 +166,7 @@ class _SendReceive(object):
         return self._connection
 
     def _is_connection_lost(self, last_timestamp):
-        return (time.time() - last_timestamp >
-                self._connection_timeout)
+        return (time.time() - last_timestamp) > self._connection_timeout
 
     def _identity_to_connection_id(self, zmq_identity):
         if zmq_identity not in self._identities_to_connection_ids:

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -512,9 +512,9 @@ class _Sorter(object):
             """Applies sort control logic to fetch from two resources the
             values that should actually be compared.
             """
-            if (self._had_explicit_header or
-                    self._header_proto and
-                    not hasattr(resource_a, self._keys[0])):
+            if (self._had_explicit_header
+                    or self._header_proto
+                    and not hasattr(resource_a, self._keys[0])):
                 resource_a = self._get_header(resource_a)
                 resource_b = self._get_header(resource_b)
 

--- a/validator/sawtooth_validator/state/state_view.py
+++ b/validator/sawtooth_validator/state/state_view.py
@@ -54,7 +54,8 @@ class StateViewFactory(object):
 
 
 class StateView(object):
-    """The StateView provides read-only access to a particular merkle tree root.
+    """The StateView provides read-only access to a particular merkle tree
+    root.
 
     The StateView is a read-only view of a merkle tree. Access is limited to
     available addresses, collections of leaf nodes, and specific leaf nodes.

--- a/validator/tests/test_client_request_handlers/base_case.py
+++ b/validator/tests/test_client_request_handlers/base_case.py
@@ -77,7 +77,8 @@ class ClientHandlerTestCase(unittest.TestCase):
         self._store.clear()
 
     def add_blocks(self, *base_ids):
-        """Adds new blocks to a test case's block store with specified base_ids.
+        """Adds new blocks to a test case's block store with specified
+        base_ids.
         """
         for base_id in base_ids:
             self._store.add_block(base_id)

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -202,7 +202,8 @@ class MockStateViewFactory(object):
 
 
 class MockStateView(object):
-    """The StateView provides read-only access to a particular merkle tree root.
+    """The StateView provides read-only access to a particular merkle tree
+    root.
 
     The StateView is a read-only view of a merkle tree. Access is limited to
     available addresses, collections of leaf nodes, and specific leaf nodes.

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -1392,8 +1392,8 @@ class TestJournal(unittest.TestCase):
             chain_controller.queue_block(block)
 
             # wait for the chain_head to be updated.
-            wait_until(lambda: btm.chain_head.identifier ==
-                       block.identifier, 2)
+            wait_until(
+                lambda: btm.chain_head.identifier == block.identifier, 2)
             self.assertTrue(btm.chain_head.identifier == block.identifier)
         finally:
             if block_publisher is not None:

--- a/validator/tests/test_journal/utils.py
+++ b/validator/tests/test_journal/utils.py
@@ -32,7 +32,7 @@ def wait_until(lbd, time_out=None):
     if time_out is not None:
         end_time = time.time() + time_out
 
-    while (end_time is None or
-            time.time() < end_time) and \
+    while (end_time is None
+           or time.time() < end_time) and \
             not lbd():
         time.sleep(0.1)

--- a/validator/tests/test_permission_verifier/tests.py
+++ b/validator/tests/test_permission_verifier/tests.py
@@ -161,8 +161,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
-                                                           self.public_key])
+        self._identity_view_factory.add_policy(
+            "policy1", ["PERMIT_KEY " + self.public_key])
         self._identity_view_factory.add_role("transactor", "policy1")
         batch = self._create_batches(1, 1)[0]
         allowed = self.permission_verifier.is_batch_signer_authorized(batch)
@@ -181,8 +181,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
-                                                           self.public_key])
+        self._identity_view_factory.add_policy(
+            "policy1", ["PERMIT_KEY " + self.public_key])
         self._identity_view_factory.add_role("transactor.batch_signer",
                                              "policy1")
         batch = self._create_batches(1, 1)[0]
@@ -203,8 +203,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
-                                                           self.public_key])
+        self._identity_view_factory.add_policy(
+            "policy1", ["PERMIT_KEY " + self.public_key])
         self._identity_view_factory.add_role("transactor.transaction_signer",
                                              "policy1")
         batch = self._create_batches(1, 1)[0]
@@ -226,8 +226,8 @@ class TestPermissionVerifier(unittest.TestCase):
             1. Set policy to permit signing key. Batch should be allowed.
             2. Set policy to permit some other key. Batch should be rejected.
         """
-        self._identity_view_factory.add_policy("policy1", ["PERMIT_KEY " +
-                                                           self.public_key])
+        self._identity_view_factory.add_policy(
+            "policy1", ["PERMIT_KEY " + self.public_key])
         self._identity_view_factory.add_role(
             "transactor.transaction_signer.intkey",
             "policy1")

--- a/validator/tests/test_responder/tests.py
+++ b/validator/tests/test_responder/tests.py
@@ -551,8 +551,8 @@ class TestResponder(unittest.TestCase):
 
     def assert_message_sent(self, connection_id, message_type):
         self.assertIsNotNone(self.gossip.sent.get(connection_id))
-        self.assertTrue(self.gossip.sent.get(connection_id)[0][0] ==
-                        message_type)
+        self.assertTrue(
+            self.gossip.sent.get(connection_id)[0][0] == message_type)
 
     def assert_request_pending(self, requested_id, connection_id):
         self.assertIn(connection_id, self.responder.get_request(requested_id))

--- a/validator/tests/utils.py
+++ b/validator/tests/utils.py
@@ -32,7 +32,7 @@ def wait_until(lbd, time_out=None):
     if time_out is not None:
         end_time = time.time() + time_out
 
-    while (end_time is None or
-            time.time() < end_time) and \
+    while (end_time is None
+           or time.time() < end_time) and \
             not lbd():
         time.sleep(0.1)


### PR DESCRIPTION
A new version of `pycodestyle` was released yesterday (4/10/18). It introduced a new rule that binary operators should come after a line break rather than before:

```
# No: operators sit far away from their operands
income = (gross_wages +
          taxable_interest +
          (dividends - qualified_dividends) -
          ira_deduction -
          student_loan_interest)

# Yes: easy to match operators with operands
income = (gross_wages
          + taxable_interest
          + (dividends - qualified_dividends)
          - ira_deduction
          - student_loan_interest)
```

(See https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator)

It also fixed a bug where docstrings' first lines weren't being checked for length.