### PR TITLE
Set default client_max_size to 10MB

### DIFF
--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -54,11 +54,11 @@ The ``rest_api.toml`` configuration file has the following options:
   Specifies the size, in bytes, that the REST API will accept for the body of
   requests. If the body is larger a ``413: Request Entity Too Large`` will be
   returned
-  Default: none. For example:
+  Default: 10485760 (or 10 MB). For example:
 
   .. code-block:: none
 
-    client_max_size = 1048576
+    client_max_size = 10485760
 
 - ``opentsdb_url`` = "`value`"
 

--- a/rest_api/sawtooth_rest_api/config.py
+++ b/rest_api/sawtooth_rest_api/config.py
@@ -28,7 +28,8 @@ def load_default_rest_api_config():
     return RestApiConfig(
         bind=["127.0.0.1:8008"],
         connect="tcp://localhost:4004",
-        timeout=300)
+        timeout=300,
+        client_max_size=10485760)
 
 
 def load_toml_rest_api_config(filename):


### PR DESCRIPTION
This commit changes the default from being
unlimited to 10MB, which is a common default for the
limit of the request body.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>