### PR TITLE
Keyserver fallback

### DIFF
--- a/ci/sawtooth-block-info-tp
+++ b/ci/sawtooth-block-info-tp
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-block-info \

--- a/ci/sawtooth-build-debs
+++ b/ci/sawtooth-build-debs
@@ -45,7 +45,8 @@ RUN apt-get update \
 
 # Add sawtooth repo
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -29,7 +29,8 @@
 FROM ubuntu:xenial
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/ci/sawtooth-identity-tp
+++ b/ci/sawtooth-identity-tp
@@ -23,7 +23,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-identity \

--- a/ci/sawtooth-intkey-tp-go
+++ b/ci/sawtooth-intkey-tp-go
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-intkey-tp-go \

--- a/ci/sawtooth-intkey-tp-python
+++ b/ci/sawtooth-intkey-tp-python
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-intkey \

--- a/ci/sawtooth-poet-validator-registry-tp
+++ b/ci/sawtooth-poet-validator-registry-tp
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-poet-families \

--- a/ci/sawtooth-publish-js-sdk
+++ b/ci/sawtooth-publish-js-sdk
@@ -54,7 +54,8 @@ RUN apt-get update \
 
 # Add sawtooth repo and dependencies
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
  && apt-get install -y -q \

--- a/ci/sawtooth-rest-api
+++ b/ci/sawtooth-rest-api
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-rest-api \

--- a/ci/sawtooth-settings-tp
+++ b/ci/sawtooth-settings-tp
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-settings \

--- a/ci/sawtooth-shell
+++ b/ci/sawtooth-shell
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     curl \

--- a/ci/sawtooth-smallbank-tp-go
+++ b/ci/sawtooth-smallbank-tp-go
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-smallbank-tp-go \

--- a/ci/sawtooth-test-debs
+++ b/ci/sawtooth-test-debs
@@ -45,8 +45,8 @@ RUN echo "deb file:${pkg_dir} ./" >> \
         /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> \
         /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && apt-get update
 

--- a/ci/sawtooth-validator
+++ b/ci/sawtooth-validator
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-block-info \

--- a/ci/sawtooth-xo-tp-go
+++ b/ci/sawtooth-xo-tp-go
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     sawtooth-xo-tp-go \

--- a/ci/sawtooth-xo-tp-python
+++ b/ci/sawtooth-xo-tp-python
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="repo"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-xo \

--- a/docker/sawtooth-av
+++ b/docker/sawtooth-av
@@ -28,7 +28,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="local-debs"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/1.0/stable xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     python3-sawtooth-validator \

--- a/docker/sawtooth-debug-python
+++ b/docker/sawtooth-debug-python
@@ -17,8 +17,10 @@ FROM ubuntu:xenial
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/debug/ xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
-    --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 \
+     --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
+     --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \

--- a/docker/sawtooth-dev-cxx
+++ b/docker/sawtooth-dev-cxx
@@ -33,7 +33,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \

--- a/docker/sawtooth-dev-go
+++ b/docker/sawtooth-dev-go
@@ -31,7 +31,8 @@ LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
  && echo "deb http://archive.ubuntu.com/ubuntu xenial-backports universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/docker/sawtooth-dev-poet-sgx
+++ b/docker/sawtooth-dev-poet-sgx
@@ -28,7 +28,8 @@ FROM ubuntu:xenial
 
 # Add sawtooth repo
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/docker/sawtooth-dev-python
+++ b/docker/sawtooth-dev-python
@@ -34,7 +34,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \

--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/docker/sawtooth-int-block-info-tp
+++ b/docker/sawtooth-int-block-info-tp
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-identity-tp
+++ b/docker/sawtooth-int-identity-tp
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-intkey-tp-cxx
+++ b/docker/sawtooth-int-intkey-tp-cxx
@@ -30,7 +30,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \

--- a/docker/sawtooth-int-intkey-tp-go
+++ b/docker/sawtooth-int-intkey-tp-go
@@ -39,7 +39,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get update \

--- a/docker/sawtooth-int-intkey-tp-python
+++ b/docker/sawtooth-int-intkey-tp-python
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-poet-validator-registry-tp
+++ b/docker/sawtooth-int-poet-validator-registry-tp
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-rest-api
+++ b/docker/sawtooth-int-rest-api
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-settings-tp
+++ b/docker/sawtooth-int-settings-tp
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-smallbank-tp-go
+++ b/docker/sawtooth-int-smallbank-tp-go
@@ -39,7 +39,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get update \

--- a/docker/sawtooth-int-validator
+++ b/docker/sawtooth-int-validator
@@ -41,7 +41,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-int-xo-tp-go
+++ b/docker/sawtooth-int-xo-tp-go
@@ -39,7 +39,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get update \

--- a/docker/sawtooth-int-xo-tp-python
+++ b/docker/sawtooth-int-xo-tp-python
@@ -40,7 +40,8 @@ RUN cd /debs \
  && dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz \
  && echo "deb file:/debs ./" >> /etc/apt/sources.list \
  && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q --allow-unauthenticated \

--- a/docker/sawtooth-validator-mounted
+++ b/docker/sawtooth-validator-mounted
@@ -18,7 +18,8 @@ FROM ubuntu:xenial
 LABEL "install-type"="mounted"
 
 RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
- && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update \
  && apt-get install -y -q \
     apt-transport-https \


### PR DESCRIPTION
If primary keyserver - keyserver.ubuntu.com is down, fallback to secondary pool.sks-keyserver and continue. Both keyservers would use port 80 to communicate, to allow communication in proxy environments.

This addresses a common exception scenario with keyservers.