### PR TITLE
More logging when validator claims blocks too frequently

### DIFF
--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -536,9 +536,11 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 block_cache=self._block_cache,
                 poet_enclave_module=poet_enclave_module):
             LOGGER.info(
-                'Reject building on block %s: Validator is claiming blocks '
+                'Reject building on block %s: '
+                'Validator (signing public key: %s) is claiming blocks '
                 'too frequently.',
-                block_header.previous_block_id[:8])
+                block_header.previous_block_id[:8],
+                block_header.signer_public_key)
             return False
 
         # At this point, we know that if we are able to claim the block we are

--- a/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
+++ b/consensus/poet/core/tests/test_consensus/test_poet_block_publisher.py
@@ -621,7 +621,7 @@ class TestPoetBlockPublisher(TestCase):
             # function fails for the reason we expect.
 
             (message, *_), _ = mock_logger.info.call_args
-            self.assertTrue('Validator is claiming blocks too '
+            self.assertTrue('is claiming blocks too '
                             'frequently' in message)
 
     @mock.patch('sawtooth_poet.poet_consensus.poet_block_publisher.'


### PR DESCRIPTION
Add logging the public key of the validator when claiming blocks too frequently.

Signed-off-by: Benoit Razet <benoit.razet@pokitdok.com>