### PR TITLE
sawtooth batch submit with --wait throws a stack trace

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -281,6 +281,6 @@ def do_batch_submit(args):
             time.sleep(0.2)
 
         print('Wait timed out! Some batches have not yet been committed...')
-        for batch_id, status in statuses.items():
-            print('{:128.128}  {:10.10}'.format(batch_id, status))
+        for batch_id, status in statuses[0].items():
+            print('{}  {}'.format(batch_id, status))
         exit(1)

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -551,7 +551,10 @@ def _format_batch_statuses(statuses, batch_ids, tracker):
            client_batch_submit_pb2.ClientBatchStatus.INVALID:
             invalid_txns = tracker.get_invalid_txn_info(batch_id)
             for txn_info in invalid_txns:
-                txn_info['transaction_id'] = txn_info.pop('id')
+                try:
+                    txn_info['transaction_id'] = txn_info.pop('id')
+                except KeyError as e:
+                    LOGGER.debug(e)
         else:
             invalid_txns = None
 


### PR DESCRIPTION
sawtooth batch submit with --wait throws a stack trace.
this changeset contains fix for this issue.

Signed-off-by: mithun shashidhara <mithunx.shashidhara@intel.com>