### PR TITLE
Disable Rust clippy

### DIFF
--- a/bin/run_lint_rust
+++ b/bin/run_lint_rust
@@ -67,15 +67,6 @@ for dir in $dirs; do
         fi
     fi
 
-    echo "-- clippy"
-
-    cargo +nightly clippy -- -D warnings -A redundant-field-names -A cyclomatic-complexity -A new-without-default -A print-literal -A useless-format
-    clippy_exit=$?
-
-    if [[ $clippy_exit != 0 ]]; then
-        exitcode=1
-    fi
-
 done
 
 exit $exitcode

--- a/bin/run_lint_validator
+++ b/bin/run_lint_validator
@@ -60,15 +60,6 @@ for dir in $dirs; do
         fi
     fi
 
-    echo "-- clippy"
-
-    cargo +nightly clippy -- -D warnings -A redundant-field-names -A cyclomatic-complexity -A new-without-default -A print-literal -A useless-format
-    clippy_exit=$?
-
-    if [[ $clippy_exit != 0 ]]; then
-        exitcode=1
-    fi
-
 done
 
 exit $exitcode

--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -56,9 +56,7 @@ RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
 ENV PATH=$PATH:/protoc3/bin:/project/sawtooth-core/bin:/root/.cargo/bin \
     CARGO_INCREMENTAL=0
 
-RUN rustup component add rustfmt-preview \
- && rustup toolchain add nightly \
- && cargo +nightly install clippy
+RUN rustup component add rustfmt-preview
 
 WORKDIR /
 

--- a/docker/sawtooth-dev-validator
+++ b/docker/sawtooth-dev-validator
@@ -115,9 +115,7 @@ RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
 ENV PATH=$PATH:/project/sawtooth-core/bin:/protoc3/bin:/project/sawtooth-core/bin:/root/.cargo/bin \
     CARGO_INCREMENTAL=0
 
-RUN rustup component add rustfmt-preview \
- && rustup toolchain add nightly \
- && cargo +nightly install clippy
+RUN rustup component add rustfmt-preview
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 

--- a/sdk/rust/src/processor/handler.rs
+++ b/sdk/rust/src/processor/handler.rs
@@ -276,7 +276,6 @@ impl TransactionContext {
     /// # Arguments
     ///
     /// * `addresses` - the addresses to fetch
-    #[allow(needless_pass_by_value)]
     pub fn delete_state(
         &mut self,
         addresses: Vec<String>,


### PR DESCRIPTION
It turns out that clippy is too unstable to use in CI.

Signed-off-by: Nick Drozd <drozd@bitwise.io>