### PR TITLE
Implement Merkle Trie in Rust

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -7,6 +7,11 @@ authors = ["Intel Corporation"]
 clap = "2"
 cpython = "0.2"
 log = { version = "0.4", features = ["std"] }
+libc = ">=0.2.35"
+lmdb-zero = ">=0.4.1"
+
+[lib]
+crate-type = ["dylib"]
 
 [[bin]]
 name = "sawtooth-validator"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -9,6 +9,11 @@ cpython = "0.2"
 log = { version = "0.4", features = ["std"] }
 libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
+cbor-codec = "0.7"
+rust-crypto = "0.2"
+
+[dev-dependencies]
+rand = "0.4"
 
 [lib]
 crate-type = ["dylib"]

--- a/validator/src/database/database.rs
+++ b/validator/src/database/database.rs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std;
+
+#[derive(Debug)]
+pub enum DatabaseError {
+    InitError(String),
+    ReaderError(String),
+    WriterError(String),
+    CorruptionError(String),
+    NotFoundError(String),
+}
+
+impl std::fmt::Display for DatabaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            DatabaseError::InitError(ref msg) => write!(f, "InitError: {}", msg),
+            DatabaseError::ReaderError(ref msg) => write!(f, "ReaderError: {}", msg),
+            DatabaseError::WriterError(ref msg) => write!(f, "WriterError: {}", msg),
+            DatabaseError::CorruptionError(ref msg) => write!(f, "CorruptionError: {}", msg),
+            DatabaseError::NotFoundError(ref msg) => write!(f, "NotFoundError: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for DatabaseError {
+    fn description(&self) -> &str {
+        match *self {
+            DatabaseError::InitError(ref msg) => msg,
+            DatabaseError::ReaderError(ref msg) => msg,
+            DatabaseError::WriterError(ref msg) => msg,
+            DatabaseError::CorruptionError(ref msg) => msg,
+            DatabaseError::NotFoundError(ref msg) => msg,
+        }
+    }
+
+    fn cause(&self) -> Option<&std::error::Error> {
+        match *self {
+            DatabaseError::InitError(_) => None,
+            DatabaseError::ReaderError(_) => None,
+            DatabaseError::WriterError(_) => None,
+            DatabaseError::CorruptionError(_) => None,
+            DatabaseError::NotFoundError(_) => None,
+        }
+    }
+}

--- a/validator/src/database/lmdb.rs
+++ b/validator/src/database/lmdb.rs
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use lmdb_zero as lmdb;
+
+use database::database::DatabaseError;
+
+const DEFAULT_SIZE: usize = 1 << 40; // 1024 ** 4
+
+#[derive(Clone)]
+pub struct LmdbContext {
+    pub env: Arc<lmdb::Environment>,
+}
+
+impl LmdbContext {
+    pub fn new(filepath: &Path, indexes: u32, size: Option<usize>) -> Result<Self, DatabaseError> {
+        let flags = lmdb::open::MAPASYNC | lmdb::open::WRITEMAP | lmdb::open::NORDAHEAD
+            | lmdb::open::NOSUBDIR;
+
+        let filepath_str = filepath
+            .to_str()
+            .ok_or_else(|| DatabaseError::InitError(format!("Invalid filepath: {:?}", filepath)))?;
+
+        let mut builder = lmdb::EnvBuilder::new().map_err(|err| {
+            DatabaseError::InitError(format!("Failed to initialize environment: {}", err))
+        })?;
+        builder
+            .set_maxdbs(indexes + 1)
+            .map_err(|err| DatabaseError::InitError(format!("Failed to set MAX_DBS: {}", err)))?;
+        builder
+            .set_mapsize(size.unwrap_or(DEFAULT_SIZE))
+            .map_err(|err| DatabaseError::InitError(format!("Failed to set MAP_SIZE: {}", err)))?;
+
+        let env = unsafe {
+            builder
+                .open(filepath_str, flags, 0o600)
+                .map_err(|err| DatabaseError::InitError(format!("Database not found: {}", err)))
+        }?;
+        Ok(LmdbContext { env: Arc::new(env) })
+    }
+}
+
+#[derive(Clone)]
+pub struct LmdbDatabase {
+    ctx: LmdbContext,
+    main: Arc<lmdb::Database<'static>>,
+    indexes: Arc<HashMap<String, lmdb::Database<'static>>>,
+}
+
+impl LmdbDatabase {
+    pub fn new(ctx: LmdbContext, indexes: &[&str]) -> Result<Self, DatabaseError> {
+        let main = lmdb::Database::open(
+            ctx.env.clone(),
+            Some("main"),
+            &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+        ).map_err(|err| {
+            DatabaseError::InitError(format!("Failed to open database: {:?}", err))
+        })?;
+
+        let mut index_dbs = HashMap::with_capacity(indexes.len());
+        for name in indexes {
+            let db = lmdb::Database::open(
+                ctx.env.clone(),
+                Some(name),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+            ).map_err(|err| {
+                DatabaseError::InitError(format!("Failed to open database: {:?}", err))
+            })?;
+            index_dbs.insert(String::from(*name), db);
+        }
+        Ok(LmdbDatabase {
+            ctx,
+            main: Arc::new(main),
+            indexes: Arc::new(index_dbs),
+        })
+    }
+
+    pub fn reader(&self) -> Result<LmdbDatabaseReader, DatabaseError> {
+        let txn = lmdb::ReadTransaction::new(self.ctx.env.clone()).map_err(|err| {
+            DatabaseError::ReaderError(format!("Failed to create reader: {}", err))
+        })?;
+        Ok(LmdbDatabaseReader { db: self, txn })
+    }
+
+    pub fn writer(&self) -> Result<LmdbDatabaseWriter, DatabaseError> {
+        let txn = lmdb::WriteTransaction::new(self.ctx.env.clone()).map_err(|err| {
+            DatabaseError::WriterError(format!("Failed to create writer: {}", err))
+        })?;
+        Ok(LmdbDatabaseWriter { db: self, txn })
+    }
+}
+
+pub struct LmdbDatabaseReader<'a> {
+    db: &'a LmdbDatabase,
+    txn: lmdb::ReadTransaction<'a>,
+}
+
+impl<'a> LmdbDatabaseReader<'a> {
+    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
+        let access = self.txn.access();
+        let val: Result<&[u8], _> = access.get(&self.db.main, key);
+        val.ok().map(Vec::from)
+    }
+
+    pub fn index_get(&self, index: &str, key: &[u8]) -> Result<Option<Vec<u8>>, DatabaseError> {
+        let index = self.db
+            .indexes
+            .get(index)
+            .ok_or_else(|| DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        let access = self.txn.access();
+        let val: Result<&[u8], _> = access.get(index, key);
+        Ok(val.ok().map(Vec::from))
+    }
+
+    pub fn cursor(&self) -> Result<LmdbDatabaseReaderCursor, DatabaseError> {
+        let cursor = self.txn
+            .cursor(self.db.main.clone())
+            .map_err(|err| DatabaseError::ReaderError(format!("{}", err)))?;
+        let access = self.txn.access();
+        Ok(LmdbDatabaseReaderCursor { access, cursor })
+    }
+
+    pub fn index_cursor(&self, index: &str) -> Result<LmdbDatabaseReaderCursor, DatabaseError> {
+        let index = self.db
+            .indexes
+            .get(index)
+            .ok_or_else(|| DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        let cursor = self.txn
+            .cursor(index)
+            .map_err(|err| DatabaseError::ReaderError(format!("{}", err)))?;
+        let access = self.txn.access();
+        Ok(LmdbDatabaseReaderCursor { access, cursor })
+    }
+
+    pub fn count(&self) -> Result<usize, DatabaseError> {
+        self.txn
+            .db_stat(&self.db.main)
+            .map_err(|err| {
+                DatabaseError::CorruptionError(format!("Failed to get database stats: {}", err))
+            })
+            .map(|stat| stat.entries)
+    }
+
+    pub fn index_count(&self, index: &str) -> Result<usize, DatabaseError> {
+        let index = self.db
+            .indexes
+            .get(index)
+            .ok_or_else(|| DatabaseError::ReaderError(format!("Not an index: {}", index)))?;
+        self.txn
+            .db_stat(index)
+            .map_err(|err| {
+                DatabaseError::CorruptionError(format!("Failed to get database stats: {}", err))
+            })
+            .map(|stat| stat.entries)
+    }
+}
+
+pub struct LmdbDatabaseReaderCursor<'a> {
+    access: lmdb::ConstAccessor<'a>,
+    cursor: lmdb::Cursor<'a, 'a>,
+}
+
+impl<'a> LmdbDatabaseReaderCursor<'a> {
+    pub fn first(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.cursor
+            .first(&self.access)
+            .ok()
+            .map(|(key, value): (&[u8], &[u8])| (Vec::from(key), Vec::from(value)))
+    }
+
+    pub fn last(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.cursor
+            .last(&self.access)
+            .ok()
+            .map(|(key, value): (&[u8], &[u8])| (Vec::from(key), Vec::from(value)))
+    }
+}
+
+pub struct LmdbDatabaseWriter<'a> {
+    db: &'a LmdbDatabase,
+    txn: lmdb::WriteTransaction<'a>,
+}
+
+impl<'a> LmdbDatabaseWriter<'a> {
+    pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), DatabaseError> {
+        self.txn
+            .access()
+            .put(&self.db.main, key, value, lmdb::put::Flags::empty())
+            .map_err(|err| DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn delete(&mut self, key: &[u8]) -> Result<(), DatabaseError> {
+        self.txn
+            .access()
+            .del_key(&self.db.main, key)
+            .map_err(|err| DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn index_put(
+        &mut self,
+        index: &str,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<(), DatabaseError> {
+        let index = self.db
+            .indexes
+            .get(index)
+            .ok_or_else(|| DatabaseError::WriterError(format!("Not an index: {}", index)))?;
+        self.txn
+            .access()
+            .put(index, key, value, lmdb::put::Flags::empty())
+            .map_err(|err| DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn index_delete(&mut self, index: &str, key: &[u8]) -> Result<(), DatabaseError> {
+        let index = self.db
+            .indexes
+            .get(index)
+            .ok_or_else(|| DatabaseError::WriterError(format!("Not an index: {}", index)))?;
+        self.txn
+            .access()
+            .del_key(index, key)
+            .map_err(|err| DatabaseError::WriterError(format!("{}", err)))
+    }
+
+    pub fn commit(self) -> Result<(), DatabaseError> {
+        self.txn
+            .commit()
+            .map_err(|err| DatabaseError::WriterError(format!("{}", err)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    use std::fs::remove_file;
+    use std::path::Path;
+    use std::panic;
+    use std::thread;
+
+    /// Asserts that there are COUNT many objects in DB.
+    fn assert_database_count(count: usize, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert_eq!(reader.count().unwrap(), count,);
+    }
+
+    /// Asserts that there are are COUNT many objects in DB's INDEX.
+    fn assert_index_count(index: &str, count: usize, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert_eq!(reader.index_count(index).unwrap(), count,);
+    }
+
+    /// Asserts that KEY is associated with VAL in DB.
+    fn assert_key_value(key: u8, val: u8, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert_eq!(reader.get(&[key]).unwrap(), [val],);
+    }
+
+    /// Asserts that KEY is associated with VAL in DB's INDEX.
+    fn assert_index_key_value(index: &str, key: u8, val: u8, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert_eq!(reader.index_get(index, &[key]).unwrap().unwrap(), [val],);
+    }
+
+    /// Asserts that KEY is not in DB.
+    fn assert_not_in_database(key: u8, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert!(reader.get(&[key]).is_none());
+    }
+
+    /// Asserts that KEY is not in DB's INDEX.
+    fn assert_not_in_index(index: &str, key: u8, db: &LmdbDatabase) {
+        let reader = db.reader().unwrap();
+
+        assert!(reader.index_get(index, &[key]).unwrap().is_none());
+    }
+
+    /// Opens an LmdbDatabase and executes its basic operations
+    /// (adding keys, deleting keys, etc), making assertions about the
+    /// database contents at each step.
+    #[test]
+    fn test_lmdb() {
+        run_test(|blockstore_path| {
+            let ctx = LmdbContext::new(Path::new(blockstore_path), 3, Some(1024 * 1024))
+                .map_err(|err| DatabaseError::InitError(format!("{}", err)))
+                .unwrap();
+
+            let database = LmdbDatabase::new(ctx, &["a", "b"])
+                .map_err(|err| DatabaseError::InitError(format!("{}", err)))
+                .unwrap();
+
+            assert_database_count(0, &database);
+            assert_not_in_database(3, &database);
+            assert_not_in_database(5, &database);
+
+            // Add {3: 4}
+            let mut writer = database.writer().unwrap();
+            writer.put(&[3], &[4]).unwrap();
+
+            assert_database_count(0, &database);
+            assert_not_in_database(3, &database);
+
+            writer.commit().unwrap();
+
+            assert_database_count(1, &database);
+            assert_key_value(3, 4, &database);
+
+            // Add {5: 6}
+            let mut writer = database.writer().unwrap();
+            writer.put(&[5], &[6]).unwrap();
+            writer.commit().unwrap();
+
+            assert_database_count(2, &database);
+            assert_key_value(5, 6, &database);
+            assert_key_value(3, 4, &database);
+
+            // Delete {3: 4}
+            let mut writer = database.writer().unwrap();
+            writer.delete(&[3]).unwrap();
+
+            assert_database_count(2, &database);
+
+            writer.commit().unwrap();
+
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+
+            // Add {55: 5} in "a"
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            let mut writer = database.writer().unwrap();
+            writer.index_put("a", &[55], &[5]).unwrap();
+
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            writer.commit().unwrap();
+
+            assert_index_count("a", 1, &database);
+            assert_index_count("b", 0, &database);
+            assert_index_key_value("a", 55, 5, &database);
+            assert_not_in_index("b", 5, &database);
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+
+            // Delete {55: 5} in "a"
+            let mut writer = database.writer().unwrap();
+            writer.index_delete("a", &[55]).unwrap();
+
+            assert_index_count("a", 1, &database);
+            assert_index_count("b", 0, &database);
+            assert_index_key_value("a", 55, 5, &database);
+            assert_not_in_index("b", 5, &database);
+
+            writer.commit().unwrap();
+
+            assert_index_count("a", 0, &database);
+            assert_index_count("b", 0, &database);
+            assert_not_in_index("a", 5, &database);
+            assert_not_in_index("b", 5, &database);
+            assert_database_count(1, &database);
+            assert_key_value(5, 6, &database);
+            assert_not_in_database(3, &database);
+        })
+    }
+
+    fn run_test<T>(test: T) -> ()
+    where
+        T: FnOnce(&str) -> () + panic::UnwindSafe,
+    {
+        let dbpath = temp_db_path();
+
+        let testpath = dbpath.clone();
+        let result = panic::catch_unwind(move || test(&testpath));
+
+        remove_file(dbpath).unwrap();
+
+        assert!(result.is_ok())
+    }
+
+    fn temp_db_path() -> String {
+        let mut temp_dir = env::temp_dir();
+
+        let thread_id = thread::current().id();
+        temp_dir.push(format!("merkle-{:?}.lmdb", thread_id));
+        temp_dir.to_str().unwrap().to_string()
+    }
+}

--- a/validator/src/database/lmdb_ffi.rs
+++ b/validator/src/database/lmdb_ffi.rs
@@ -50,7 +50,7 @@ pub extern "C" fn lmdb_database_new(
     let ctx = match LmdbContext::new(Path::new(&db_path), 1, Some(file_size)) {
         Ok(ctx) => ctx,
         Err(err) => {
-            println!(
+            error!(
                 "Unable to create LMDB context for db at {}: {:?}",
                 db_path, err
             );
@@ -66,7 +66,7 @@ pub extern "C" fn lmdb_database_new(
             ErrorCode::Success
         }
         Err(err) => {
-            println!("Unable to create Database at {}: {:?}", db_path, err);
+            error!("Unable to create Database at {}: {:?}", db_path, err);
             ErrorCode::InitializeDatabaseError
         }
     }

--- a/validator/src/database/lmdb_ffi.rs
+++ b/validator/src/database/lmdb_ffi.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use database::lmdb::*;
+use std::ffi::CStr;
+use std::path::Path;
+use std::os::raw::{c_char, c_void};
+
+#[repr(u32)]
+pub enum ErrorCode {
+    Success = 0,
+    NullPointerProvided = 0x01,
+    InvalidFilePath = 0x02,
+
+    InitializeContextError = 0x11,
+    InitializeDatabaseError = 0x12,
+}
+
+#[no_mangle]
+pub extern "C" fn lmdb_database_new(
+    path: *const c_char,
+    file_size: usize,
+    db_ptr: *mut *const c_void,
+) -> ErrorCode {
+    if path.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let db_path = unsafe {
+        match CStr::from_ptr(path).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidFilePath,
+        }
+    };
+
+    // Note, no indexes are being specified yet
+    let ctx = match LmdbContext::new(Path::new(&db_path), 1, Some(file_size)) {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            println!(
+                "Unable to create LMDB context for db at {}: {:?}",
+                db_path, err
+            );
+            return ErrorCode::InitializeContextError;
+        }
+    };
+
+    match LmdbDatabase::new(ctx, &[]) {
+        Ok(db) => {
+            unsafe {
+                *db_ptr = Box::into_raw(Box::new(db)) as *const c_void;
+            }
+            ErrorCode::Success
+        }
+        Err(err) => {
+            println!("Unable to create Database at {}: {:?}", db_path, err);
+            ErrorCode::InitializeDatabaseError
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn lmdb_database_drop(lmdb_database: *mut c_void) -> ErrorCode {
+    if lmdb_database.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    unsafe { Box::from_raw(lmdb_database as *mut LmdbDatabase) };
+    ErrorCode::Success
+}

--- a/validator/src/database/mod.rs
+++ b/validator/src/database/mod.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+pub mod database;
+pub mod lmdb;

--- a/validator/src/database/mod.rs
+++ b/validator/src/database/mod.rs
@@ -17,3 +17,4 @@
 
 pub mod database;
 pub mod lmdb;
+pub mod lmdb_ffi;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+extern crate libc;
+extern crate lmdb_zero;
+
+// exported modules
+pub mod database;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -19,6 +19,8 @@ extern crate cpython;
 extern crate crypto;
 extern crate libc;
 extern crate lmdb_zero;
+#[macro_use]
+extern crate log;
 
 #[cfg(test)]
 extern crate rand;

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -1,0 +1,918 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::io::Cursor;
+
+use cbor;
+use cbor::encoder::{EncodeError, GenericEncoder};
+use cbor::decoder::{DecodeError, GenericDecoder};
+use cbor::value::Value;
+use cbor::value::Key;
+use cbor::value::Bytes;
+use cbor::value::Text;
+
+use crypto::digest::Digest;
+use crypto::sha2::Sha512;
+
+use database::database::DatabaseError;
+use database::lmdb::LmdbDatabase;
+
+const TOKEN_SIZE: usize = 2;
+
+/// Merkle Database
+pub struct MerkleDatabase {
+    root_hash: String,
+    db: LmdbDatabase,
+    root_node: Node,
+}
+
+#[derive(Debug)]
+pub enum MerkleDatabaseError {
+    NotFound(String),
+    DeserializationError(DecodeError),
+    SerializationError(EncodeError),
+    InvalidRecord,
+    DatabaseError(DatabaseError),
+    UnknownError,
+}
+
+impl From<DatabaseError> for MerkleDatabaseError {
+    fn from(err: DatabaseError) -> Self {
+        MerkleDatabaseError::DatabaseError(err)
+    }
+}
+
+impl From<EncodeError> for MerkleDatabaseError {
+    fn from(err: EncodeError) -> Self {
+        MerkleDatabaseError::SerializationError(err)
+    }
+}
+
+impl From<DecodeError> for MerkleDatabaseError {
+    fn from(err: DecodeError) -> Self {
+        MerkleDatabaseError::DeserializationError(err)
+    }
+}
+
+impl MerkleDatabase {
+    /// Constructs a new MerkleDatabase, backed by a given Database
+    ///
+    /// An optional starting merkle root may be provided.
+    pub fn new(db: LmdbDatabase, merkle_root: Option<&str>) -> Result<Self, MerkleDatabaseError> {
+        let root_hash = merkle_root.map_or_else(|| initialize_db(&db), |s| Ok(s.into()))?;
+        let root_node = get_node_by_hash(&db, &root_hash)?;
+
+        Ok(MerkleDatabase {
+            root_hash,
+            root_node,
+            db,
+        })
+    }
+
+    /// Returns the current merkle root for this MerkleDatabase
+    pub fn get_merkle_root(&self) -> String {
+        self.root_hash.clone()
+    }
+
+    /// Sets the current merkle root for this MerkleDatabase
+    pub fn set_merkle_root<S: Into<String>>(
+        &mut self,
+        merkle_root: S,
+    ) -> Result<(), MerkleDatabaseError> {
+        let new_root = merkle_root.into();
+        self.root_node = get_node_by_hash(&self.db, &new_root)?;
+        self.root_hash = new_root;
+        Ok(())
+    }
+
+    /// Returns true if the given address exists in the MerkleDatabase;
+    /// false, otherwise.
+    pub fn contains(&self, address: &str) -> Result<bool, MerkleDatabaseError> {
+        match self.get_by_address(address) {
+            Ok(_) => Ok(true),
+            Err(MerkleDatabaseError::NotFound(_)) => Ok(false),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Returns the data for a given address, if they exist at that node.  If
+    /// not, returns None.  Will return an MerkleDatabaseError::NotFound, if the
+    /// given address is not in the tree
+    pub fn get(&self, address: &str) -> Result<Option<Vec<u8>>, MerkleDatabaseError> {
+        Ok(self.get_by_address(address)?.value)
+    }
+
+    /// Sets the given data at the given address.
+    ///
+    /// Returns a Result with the new merkle root hash, or an error if the
+    /// address is not in the tree.
+    ///
+    /// Note, continued calls to get, without changing the merkle root to the
+    /// result of this function, will not retrieve the results provided here.
+    pub fn set(&self, address: &str, data: &[u8]) -> Result<String, MerkleDatabaseError> {
+        let tokens = tokenize_address(address);
+
+        let path_addresses = path_addresses_from_tokens(&tokens, false);
+
+        let mut path_map = self.get_path_by_tokens(&tokens)?;
+
+        let mut child = path_map
+            .remove(&path_addresses[0])
+            .expect("Path map not correctly generated");
+        child.value = Some(data.to_vec());
+
+        let mut batch = Vec::with_capacity(path_addresses.len());
+        // initializing this to empty, to make the compiler happy
+        let mut key_hash = String::new();
+        for path_address in path_addresses {
+            let (child_key, child_packed) = encode_and_hash(child)?;
+            key_hash = child_key;
+
+            let (parent_address, path_branch) = parent_and_branch(&path_address);
+            let mut parent = path_map
+                .remove(parent_address)
+                .expect("Path map not correctly generated");
+
+            parent
+                .children
+                .insert(path_branch.to_string(), key_hash.clone());
+
+            batch.push((key_hash.clone(), child_packed));
+
+            child = parent;
+        }
+
+        let mut new_root = self.root_node.clone();
+        new_root
+            .children
+            .insert(tokens[0].to_string(), key_hash.clone());
+
+        let (root_hash, packed) = encode_and_hash(new_root)?;
+
+        batch.push((root_hash.clone(), packed));
+
+        self.put_batch(batch)?;
+
+        Ok(root_hash)
+    }
+
+    /// Deletes the value at the given address.
+    ///
+    /// Returns a Result with the new merkle root hash, or an error if the
+    /// address is not in the tree.
+    ///
+    /// Note, continued calls to get, without changing the merkle root to the
+    /// result of this function, will still retrieve the data at the address
+    /// provided
+    pub fn delete(&self, address: &str) -> Result<String, MerkleDatabaseError> {
+        let tokens = tokenize_address(address);
+        let mut path_map = self.get_path_by_tokens(&tokens)?;
+        let mut leaf_branch = true;
+
+        let paths = path_addresses_from_tokens(&tokens, true);
+
+        // initializing this to empty, to make the compiler happy
+        let mut key_hash = String::new();
+        let mut batch = Vec::with_capacity(paths.len());
+        for path in paths {
+            let (parent_address, path_branch) = parent_and_branch(&path);
+
+            let node = path_map
+                .remove(&path)
+                .expect("Path map not correctly generated");
+
+            if path == "" || !node.children.is_empty() {
+                leaf_branch = false;
+            }
+
+            if !leaf_branch {
+                let (hash_key, packed) = encode_and_hash(node)?;
+                key_hash = hash_key.clone();
+
+                if path != "" {
+                    let mut parent = path_map
+                        .get_mut(parent_address)
+                        .expect("Path map not correctly generated");
+                    parent
+                        .children
+                        .insert(path_branch.to_string(), hash_key.clone());
+                }
+
+                batch.push((hash_key, packed));
+            } else if path != "" {
+                let mut parent = path_map
+                    .get_mut(parent_address)
+                    .expect("Path map not correctly generated");
+                if parent.children.remove(path_branch).is_none() {
+                    return Err(MerkleDatabaseError::NotFound(format!(
+                        "{} is not a key of an existing record",
+                        address
+                    )));
+                }
+            }
+        }
+
+        self.put_batch(batch)?;
+        Ok(key_hash)
+    }
+
+    /// Updates the tree with multiple changes.  Applies both set and deletes,
+    /// as given.
+    ///
+    /// If the flag `is_virtual` is set, the values are not written to the
+    /// underlying database.
+    ///
+    /// Returns a Result with the new root hash.
+    pub fn update(
+        &self,
+        set_items: &HashMap<String, Vec<u8>>,
+        delete_items: &[String],
+        is_virtual: bool,
+    ) -> Result<String, MerkleDatabaseError> {
+        let mut path_map = HashMap::new();
+
+        for (set_address, set_value) in set_items {
+            let tokens = tokenize_address(set_address);
+            let mut set_path_map = self.get_path_by_tokens(&tokens)?;
+
+            {
+                let node = set_path_map
+                    .get_mut(set_address)
+                    .expect("Path map not correctly generated");
+                node.value = Some(set_value.to_vec());
+            }
+            path_map.extend(set_path_map);
+        }
+
+        for del_address in delete_items.iter() {
+            let tokens = tokenize_address(del_address);
+            let del_path_map = self.get_path_by_tokens(&tokens)?;
+            path_map.extend(del_path_map);
+        }
+
+        for del_address in delete_items.iter() {
+            path_map.remove(del_address);
+            let (mut parent_address, mut path_branch) = parent_and_branch(del_address);
+            while parent_address != "" {
+                let remove_parent = {
+                    let parent_node = path_map
+                        .get_mut(parent_address)
+                        .expect("Path map not correctly generated");
+                    parent_node.children.remove(path_branch);
+
+                    parent_node.children.is_empty()
+                };
+
+                if remove_parent {
+                    // empty node delete it.
+                    path_map.remove(parent_address);
+                } else {
+                    // found a node that is not empty no need to continue
+                    break;
+                }
+
+                let (next_parent, next_branch) = parent_and_branch(parent_address);
+                parent_address = next_parent;
+                path_branch = next_branch;
+
+                if parent_address == "" {
+                    let parent_node = path_map
+                        .get_mut(parent_address)
+                        .expect("Path map not correctly generated");
+                    parent_node.children.remove(path_branch);
+                }
+            }
+        }
+
+        let mut sorted_paths: Vec<_> = path_map.keys().cloned().collect();
+        // Sort by longest to shortest
+        sorted_paths.sort_by(|a, b| b.len().cmp(&a.len()));
+
+        // initializing this to empty, to make the compiler happy
+        let mut key_hash = String::new();
+        let mut batch = Vec::with_capacity(sorted_paths.len());
+        for path in sorted_paths {
+            let node = path_map
+                .remove(&path)
+                .expect("Path map keys are out of sink");
+            let (hash_key, packed) = encode_and_hash(node)?;
+            key_hash = hash_key.clone();
+
+            if path != "" {
+                let (parent_address, path_branch) = parent_and_branch(&path);
+                let mut parent = path_map
+                    .get_mut(parent_address)
+                    .expect("Path map not correctly generated");
+                parent
+                    .children
+                    .insert(path_branch.to_string(), hash_key.clone());
+            }
+
+            batch.push((hash_key, packed));
+        }
+
+        if !is_virtual {
+            self.put_batch(batch)?;
+        }
+
+        Ok(key_hash)
+    }
+
+    pub fn leaves<'a>(
+        &'a self,
+        prefix: Option<&'a str>,
+    ) -> Result<MerkleLeafIterator, MerkleDatabaseError> {
+        MerkleLeafIterator::new(self, prefix)
+    }
+
+    /// Puts all the items into the database.
+    fn put_batch(&self, batch: Vec<(String, Vec<u8>)>) -> Result<(), MerkleDatabaseError> {
+        let mut db_writer = self.db.writer()?;
+        for (key, value) in batch {
+            db_writer.put(key.as_bytes(), &value)?;
+        }
+        db_writer.commit()?;
+        Ok(())
+    }
+
+    fn get_by_address(&self, address: &str) -> Result<Node, MerkleDatabaseError> {
+        let tokens = tokenize_address(address);
+
+        // There's probably a better way to do this than a clone
+        let mut node = self.root_node.clone();
+
+        for token in tokens.iter() {
+            node = match node.children.get(&token.to_string()) {
+                None => {
+                    return Err(MerkleDatabaseError::NotFound(format!(
+                        "invalid address {} from root {}",
+                        address, self.root_hash
+                    )))
+                }
+                Some(child_hash) => get_node_by_hash(&self.db, child_hash)?,
+            }
+        }
+        Ok(node)
+    }
+
+    fn get_path_by_tokens(
+        &self,
+        tokens: &[&str],
+    ) -> Result<HashMap<String, Node>, MerkleDatabaseError> {
+        let mut nodes = HashMap::new();
+
+        let mut path = String::new();
+        nodes.insert(path.clone(), self.root_node.clone());
+
+        let mut new_branch = false;
+
+        for token in tokens {
+            let node = {
+                // this is safe to unwrap, because we've just inserted the path in the previous loop
+                let child_address = &nodes[&path].children.get(&token.to_string());
+                if !new_branch && child_address.is_some() {
+                    get_node_by_hash(&self.db, child_address.unwrap())?
+                } else {
+                    new_branch = true;
+                    Node::default()
+                }
+            };
+
+            path.push_str(token);
+            nodes.insert(path.clone(), node);
+        }
+        Ok(nodes)
+    }
+}
+
+pub struct MerkleLeafIterator<'a> {
+    merkle_db: &'a MerkleDatabase,
+    visited: VecDeque<(String, Node)>,
+}
+
+impl<'a> MerkleLeafIterator<'a> {
+    fn new(
+        merkle_db: &'a MerkleDatabase,
+        prefix: Option<&'a str>,
+    ) -> Result<Self, MerkleDatabaseError> {
+        let path = prefix.unwrap_or("");
+
+        let mut visited = VecDeque::new();
+        let initial_node = merkle_db.get_by_address(path)?;
+        visited.push_front((path.to_string(), initial_node));
+
+        Ok(MerkleLeafIterator { merkle_db, visited })
+    }
+}
+
+impl<'a> Iterator for MerkleLeafIterator<'a> {
+    type Item = Result<(String, Vec<u8>), MerkleDatabaseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.visited.is_empty() {
+            return None;
+        }
+
+        loop {
+            if let Some((path, node)) = self.visited.pop_front() {
+                if node.value.is_some() {
+                    return Some(Ok((path, node.value.unwrap())));
+                }
+
+                // Reverse the list, such that we have an in-order traversal of the
+                // children, based on the natural path order.
+                for (child_path, hash_key) in node.children.iter().rev() {
+                    let child = match get_node_by_hash(&self.merkle_db.db, hash_key) {
+                        Ok(node) => node,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    let mut child_address = path.clone();
+                    child_address.push_str(child_path);
+                    self.visited.push_front((child_address, child));
+                }
+            } else {
+                return None;
+            }
+        }
+    }
+}
+
+fn initialize_db(db: &LmdbDatabase) -> Result<String, MerkleDatabaseError> {
+    let (hash, packed) = encode_and_hash(Node::default())?;
+
+    let mut db_writer = db.writer()?;
+    db_writer.put(hash.as_bytes(), &packed)?;
+    db_writer.commit()?;
+
+    Ok(hash)
+}
+
+fn encode_and_hash(node: Node) -> Result<(String, Vec<u8>), MerkleDatabaseError> {
+    let packed = node.into_bytes()?;
+    let hash = hash(&packed);
+    Ok((hash, packed))
+}
+
+fn parent_and_branch(path: &str) -> (&str, &str) {
+    let parent_address = if !path.is_empty() {
+        &path[..path.len() - TOKEN_SIZE]
+    } else {
+        ""
+    };
+
+    let path_branch = if !path.is_empty() {
+        &path[(path.len() - TOKEN_SIZE)..]
+    } else {
+        ""
+    };
+
+    (parent_address, path_branch)
+}
+
+fn tokenize_address(address: &str) -> Box<[&str]> {
+    let mut tokens: Vec<&str> = Vec::with_capacity(address.len() / 2);
+    let mut i = 0;
+    while i < address.len() {
+        tokens.push(&address[i..i + 2]);
+        i += 2;
+    }
+    tokens.into_boxed_slice()
+}
+
+fn path_addresses_from_tokens(tokens: &[&str], include_root: bool) -> Vec<String> {
+    let mut path_addresses = Vec::new();
+    let mut i = tokens.len();
+    while i > 0 {
+        path_addresses.push(
+            tokens
+                .iter()
+                .take(i)
+                .map(|s| String::from(*s))
+                .collect::<Vec<_>>()
+                .join(""),
+        );
+        i -= 1;
+    }
+
+    if include_root {
+        path_addresses.push(String::new())
+    }
+
+    path_addresses
+}
+
+/// Fetch a node by its hash
+fn get_node_by_hash(db: &LmdbDatabase, hash: &str) -> Result<Node, MerkleDatabaseError> {
+    match db.reader()?.get(hash.as_bytes()) {
+        Some(bytes) => Node::from_bytes(&bytes),
+        None => Err(MerkleDatabaseError::NotFound(hash.to_string())),
+    }
+}
+
+/// Internal Node structure of the Radix tree
+#[derive(Default, Debug, PartialEq, Clone)]
+struct Node {
+    value: Option<Vec<u8>>,
+    children: BTreeMap<String, String>,
+}
+
+impl Node {
+    /// Consumes this node and serializes it to bytes
+    fn into_bytes(self) -> Result<Vec<u8>, MerkleDatabaseError> {
+        let mut e = GenericEncoder::new(Cursor::new(Vec::new()));
+
+        let mut map = BTreeMap::new();
+        map.insert(
+            Key::Text(Text::Text("v".to_string())),
+            match self.value {
+                Some(bytes) => Value::Bytes(Bytes::Bytes(bytes)),
+                None => Value::Null,
+            },
+        );
+
+        let children = self.children
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    Key::Text(Text::Text(k.to_string())),
+                    Value::Text(Text::Text(v.to_string())),
+                )
+            })
+            .collect();
+
+        map.insert(Key::Text(Text::Text("c".to_string())), Value::Map(children));
+
+        e.value(&Value::Map(map))?;
+
+        Ok(e.into_inner().into_writer().into_inner())
+    }
+
+    /// Deserializes the given bytes to a Node
+    fn from_bytes(bytes: &[u8]) -> Result<Node, MerkleDatabaseError> {
+        let input = Cursor::new(bytes);
+        let mut decoder = GenericDecoder::new(cbor::Config::default(), input);
+        let decoder_value = decoder.value()?;
+        let (val, children_raw) = match decoder_value {
+            Value::Map(mut root_map) => (
+                root_map.remove(&Key::Text(Text::Text("v".to_string()))),
+                root_map.remove(&Key::Text(Text::Text("c".to_string()))),
+            ),
+            _ => return Err(MerkleDatabaseError::InvalidRecord),
+        };
+
+        let value = match val {
+            Some(Value::Bytes(Bytes::Bytes(bytes))) => Some(bytes),
+            Some(Value::Null) => None,
+            _ => return Err(MerkleDatabaseError::InvalidRecord),
+        };
+
+        let children = match children_raw {
+            Some(Value::Map(mut child_map)) => {
+                let mut result = BTreeMap::new();
+                for (k, v) in child_map {
+                    result.insert(key_to_string(k)?, text_to_string(v)?);
+                }
+                result
+            }
+            None => BTreeMap::new(),
+            _ => return Err(MerkleDatabaseError::InvalidRecord),
+        };
+
+        Ok(Node { value, children })
+    }
+}
+
+/// Converts a CBOR Key to its String content
+fn key_to_string(key_val: Key) -> Result<String, MerkleDatabaseError> {
+    match key_val {
+        Key::Text(Text::Text(s)) => Ok(s),
+        _ => Err(MerkleDatabaseError::InvalidRecord),
+    }
+}
+
+/// Converts a CBOR Text Value to its String content
+fn text_to_string(text_val: Value) -> Result<String, MerkleDatabaseError> {
+    match text_val {
+        Value::Text(Text::Text(s)) => Ok(s),
+        _ => Err(MerkleDatabaseError::InvalidRecord),
+    }
+}
+
+/// Creates a hash of the given bytes
+fn hash(input: &[u8]) -> String {
+    let mut sha = Sha512::new();
+    sha.input(input);
+    String::from(&(sha.result_str())[..64])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use database::database::DatabaseError;
+    use database::lmdb::LmdbContext;
+    use database::lmdb::LmdbDatabase;
+
+    use std::env;
+    use std::fs::remove_file;
+    use std::path::Path;
+    use std::panic;
+    use std::str::from_utf8;
+    use std::thread;
+    use rand::{seq, thread_rng};
+
+    #[test]
+    fn node_serialize() {
+        let n = Node {
+            value: Some(b"hello".to_vec()),
+            children: vec![("ab".to_string(), "123".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let packed = n.into_bytes()
+            .unwrap()
+            .iter()
+            .map(|b| format!("{:x}", b))
+            .collect::<Vec<_>>()
+            .join("");
+        // This expected output was generated using the python structures
+        let output = "a26163a16261626331323361764568656c6c6f";
+
+        assert_eq!(output, packed);
+    }
+
+    #[test]
+    fn node_deserialize() {
+        let packed = from_hex("a26163a162303063616263617647676f6f64627965");
+
+        let unpacked = Node::from_bytes(&packed).unwrap();
+        assert_eq!(
+            Node {
+                value: Some(b"goodbye".to_vec()),
+                children: vec![("00".to_string(), "abc".to_string())]
+                    .into_iter()
+                    .collect(),
+            },
+            unpacked
+        );
+    }
+
+    #[test]
+    fn node_roundtrip() {
+        let n = Node {
+            value: Some(b"hello".to_vec()),
+            children: vec![("ab".to_string(), "123".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let packed = n.into_bytes().unwrap();
+        let unpacked = Node::from_bytes(&packed).unwrap();
+
+        assert_eq!(
+            Node {
+                value: Some(b"hello".to_vec()),
+                children: vec![("ab".to_string(), "123".to_string())]
+                    .into_iter()
+                    .collect(),
+            },
+            unpacked
+        )
+    }
+
+    #[test]
+    fn merkle_trie_root_advance() {
+        run_test(|merkle_path| {
+            let mut merkle_db = make_db(&merkle_path);
+
+            let orig_root = merkle_db.get_merkle_root();
+            let new_root = merkle_db.set("abcd", "data_value".as_bytes()).unwrap();
+
+            assert_eq!(merkle_db.get_merkle_root(), orig_root, "Incorrect root");
+            assert_ne!(orig_root, new_root, "root was not changed");
+            assert!(
+                !merkle_db.contains("abcd").unwrap(),
+                "Should not contain the value"
+            );
+
+            merkle_db.set_merkle_root(new_root.clone()).unwrap();
+            assert_eq!(merkle_db.get_merkle_root(), new_root, "Incorrect root");
+
+            assert_value_at_address(&merkle_db, "abcd", "data_value");
+        })
+    }
+
+    #[test]
+    fn merkle_trie_delete() {
+        run_test(|merkle_path| {
+            let mut merkle_db = make_db(&merkle_path);
+
+            let new_root = merkle_db.set("1234", "deletable".as_bytes()).unwrap();
+            merkle_db.set_merkle_root(new_root).unwrap();
+            assert_value_at_address(&merkle_db, "1234", "deletable");
+
+            // deleting an unknown key should return an error
+            assert!(merkle_db.delete("barf").is_err());
+
+            let del_root = merkle_db.delete("1234").unwrap();
+
+            // del_root hasn't been set yet, so address should still have value
+            assert_value_at_address(&merkle_db, "1234", "deletable");
+            merkle_db.set_merkle_root(del_root).unwrap();
+            assert!(!merkle_db.contains("1234").unwrap());
+        })
+    }
+
+    #[test]
+    fn merkle_trie_update() {
+        run_test(|merkle_path| {
+            let mut merkle_db = make_db(&merkle_path);
+            let init_root = merkle_db.get_merkle_root();
+
+            let key_hashes = (0..1000)
+                .map(|i| {
+                    let key = format!("{:016x}", i);
+                    let hash = hash(key.as_bytes());
+                    (key, hash)
+                })
+                .collect::<Vec<_>>();
+
+            let mut values = HashMap::new();
+            for &(ref key, ref hashed) in key_hashes.iter() {
+                let new_root = merkle_db.set(&hashed, key.as_bytes()).unwrap();
+                values.insert(hashed.clone(), key.to_string());
+                merkle_db.set_merkle_root(new_root).unwrap();
+            }
+
+            assert_ne!(init_root, merkle_db.get_merkle_root());
+
+            let mut rng = thread_rng();
+            let mut set_items = HashMap::new();
+            // Perform some updates on the lower keys
+            for i in seq::sample_iter(&mut rng, 0..500, 50).unwrap() {
+                let hash_key = hash(format!("{:016x}", i).as_bytes());
+                set_items.insert(hash_key.clone(), "5.0".as_bytes().to_vec());
+                values.insert(hash_key.clone(), "5.0".to_string());
+            }
+
+            // perform some deletions on the upper keys
+            let delete_items = seq::sample_iter(&mut rng, 500..1000, 50)
+                .unwrap()
+                .into_iter()
+                .map(|i| hash(format!("{:016x}", i).as_bytes()))
+                .collect::<Vec<String>>();
+
+            for hash in delete_items.iter() {
+                values.remove(hash);
+            }
+
+            let virtual_root = merkle_db.update(&set_items, &delete_items, true).unwrap();
+
+            // virtual root shouldn't match actual contents of tree
+            assert!(merkle_db.set_merkle_root(virtual_root.clone()).is_err());
+
+            let actual_root = merkle_db.update(&set_items, &delete_items, false).unwrap();
+            // the virtual root should be the same as the actual root
+            assert_eq!(virtual_root, actual_root);
+            assert_ne!(actual_root, merkle_db.get_merkle_root());
+
+            merkle_db.set_merkle_root(actual_root).unwrap();
+
+            for (address, value) in values {
+                assert_value_at_address(&merkle_db, &address, &value);
+            }
+
+            for address in delete_items {
+                assert!(merkle_db.get(&address).is_err());
+            }
+        })
+    }
+
+    #[test]
+    fn leaf_iteration() {
+        run_test(|merkle_path| {
+            let mut merkle_db = make_db(merkle_path);
+
+            {
+                let mut leaf_iter = merkle_db.leaves(None).unwrap();
+                assert!(
+                    leaf_iter.next().is_none(),
+                    "Empty tree should return no leaves"
+                );
+            }
+
+            let addresses = vec!["ab0000", "aba001", "abff02"];
+            for (i, key) in addresses.iter().enumerate() {
+                let new_root = merkle_db
+                    .set(key, format!("{:04x}", i * 10).as_bytes())
+                    .unwrap();
+                merkle_db.set_merkle_root(new_root).unwrap();
+            }
+
+            assert_value_at_address(&merkle_db, "ab0000", "0000");
+            assert_value_at_address(&merkle_db, "aba001", "000a");
+            assert_value_at_address(&merkle_db, "abff02", "0014");
+
+            let mut leaf_iter = merkle_db.leaves(None).unwrap();
+
+            assert_eq!(
+                ("ab0000".into(), "0000".as_bytes().to_vec()),
+                leaf_iter.next().unwrap().unwrap()
+            );
+            assert_eq!(
+                ("aba001".into(), "000a".as_bytes().to_vec()),
+                leaf_iter.next().unwrap().unwrap()
+            );
+            assert_eq!(
+                ("abff02".into(), "0014".as_bytes().to_vec()),
+                leaf_iter.next().unwrap().unwrap()
+            );
+            assert!(leaf_iter.next().is_none(), "Iterator should be Exhausted");
+
+            // test that we can start from an prefix:
+            let mut leaf_iter = merkle_db.leaves(Some("abff")).unwrap();
+            assert_eq!(
+                ("abff02".into(), "0014".as_bytes().to_vec()),
+                leaf_iter.next().unwrap().unwrap()
+            );
+            assert!(leaf_iter.next().is_none(), "Iterator should be Exhausted");
+        })
+    }
+
+    fn run_test<T>(test: T) -> ()
+    where
+        T: FnOnce(&str) -> () + panic::UnwindSafe,
+    {
+        let dbpath = temp_db_path();
+
+        let testpath = dbpath.clone();
+        let result = panic::catch_unwind(move || test(&testpath));
+
+        remove_file(dbpath).unwrap();
+
+        assert!(result.is_ok())
+    }
+
+    fn assert_value_at_address(merkle_db: &MerkleDatabase, address: &str, expected_value: &str) {
+        let value = merkle_db.get(address);
+        assert!(value.is_ok(), format!("Value not returned: {:?}", value));
+        assert_eq!(Ok(expected_value), from_utf8(&value.unwrap().unwrap()));
+    }
+
+    fn make_db(merkle_path: &str) -> MerkleDatabase {
+        let ctx = LmdbContext::new(Path::new(merkle_path), 1, Some(120 * 1024 * 1024))
+            .map_err(|err| DatabaseError::InitError(format!("{}", err)))
+            .unwrap();
+        let lmdb_db = LmdbDatabase::new(ctx, &[])
+            .map_err(|err| DatabaseError::InitError(format!("{}", err)))
+            .unwrap();
+        MerkleDatabase::new(lmdb_db, None).unwrap()
+    }
+
+    fn temp_db_path() -> String {
+        let mut temp_dir = env::temp_dir();
+
+        let thread_id = thread::current().id();
+        temp_dir.push(format!("merkle-{:?}.lmdb", thread_id));
+        temp_dir.to_str().unwrap().to_string()
+    }
+
+    fn from_hex(s: &str) -> Vec<u8> {
+        assert!(s.len() % 2 == 0);
+        let mut res = Vec::with_capacity(s.len() / 2);
+        let mut buf = 0;
+
+        for (i, b) in s.bytes().enumerate() {
+            buf <<= 4;
+            match b {
+                b'A'...b'F' => buf |= b - b'A' + 10,
+                b'a'...b'f' => buf |= b - b'a' + 10,
+                b'0'...b'9' => buf |= b - b'0',
+                _ => continue,
+            }
+
+            if (i + 1) % 2 == 0 {
+                res.push(buf);
+            }
+        }
+
+        res
+    }
+}

--- a/validator/src/state/merkle_ffi.rs
+++ b/validator/src/state/merkle_ffi.rs
@@ -1,0 +1,477 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+/// This module contains all of the extern C functions for the Merkle trie
+use state::merkle::*;
+use database::lmdb::LmdbDatabase;
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::mem;
+use std::slice;
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum ErrorCode {
+    Success = 0,
+    // Input errors
+    NullPointerProvided = 1,
+    InvalidHashString = 2,
+    InvalidAddress = 3,
+
+    // output errors
+    DatabaseError = 0x11,
+    NotFound = 0x12,
+    StopIteration = 0x13,
+
+    Unknown = 0xFF,
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct Entry {
+    address: *const c_char,
+    data: *mut u8,
+    data_len: usize,
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_new(
+    database: *const c_void,
+    merkle_db: *mut *const c_void,
+) -> ErrorCode {
+    make_merkle_db(database, None, merkle_db)
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_new_with_root(
+    database: *const c_void,
+    root: *const c_char,
+    merkle_db: *mut *const c_void,
+) -> ErrorCode {
+    if root.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let state_root = unsafe {
+        match CStr::from_ptr(root).to_str() {
+            Ok(s) => Some(s),
+            Err(_) => return ErrorCode::InvalidHashString,
+        }
+    };
+
+    make_merkle_db(database, state_root, merkle_db)
+}
+
+fn make_merkle_db(
+    database: *const c_void,
+    root: Option<&str>,
+    merkle_db: *mut *const c_void,
+) -> ErrorCode {
+    if database.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let db_ref = unsafe { (database as *const LmdbDatabase).as_ref().unwrap() };
+    match MerkleDatabase::new(db_ref.clone(), root) {
+        Ok(new_merkle_tree) => {
+            unsafe {
+                *merkle_db = Box::into_raw(Box::new(new_merkle_tree)) as *const c_void;
+            }
+            ErrorCode::Success
+        }
+        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+        _ => ErrorCode::Unknown,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_drop(merkle_db: *mut c_void) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    unsafe { Box::from_raw(merkle_db as *mut MerkleDatabase) };
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_get_merkle_root(
+    merkle_db: *mut c_void,
+    merkle_root: *mut *const u8,
+    merkle_root_len: *mut usize,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    unsafe {
+        let state_root = (*(merkle_db as *mut MerkleDatabase)).get_merkle_root();
+        *merkle_root = state_root.as_ptr();
+        *merkle_root_len = state_root.as_bytes().len();
+
+        mem::forget(state_root);
+
+        ErrorCode::Success
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_set_merkle_root(
+    merkle_db: *mut c_void,
+    root: *const c_char,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+    if root.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let state_root = unsafe {
+        match CStr::from_ptr(root).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidHashString,
+        }
+    };
+
+    match unsafe { (*(merkle_db as *mut MerkleDatabase)).set_merkle_root(state_root) } {
+        Ok(()) => ErrorCode::Success,
+        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+        _ => ErrorCode::Unknown,
+    }
+}
+
+#[no_mangle]
+/// Returns ErrorCode.Success if the address is contained, error otherwise.
+/// Most likely, this error is ErrorCode.NotFound
+pub extern "C" fn merkle_db_contains(merkle_db: *mut c_void, address: *const c_char) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+    if address.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let address_str = unsafe {
+        match CStr::from_ptr(address).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidAddress,
+        }
+    };
+
+    unsafe {
+        match (*(merkle_db as *mut MerkleDatabase)).contains(address_str) {
+            Ok(true) => ErrorCode::Success,
+            Ok(false) => ErrorCode::NotFound,
+            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+            _ => ErrorCode::Unknown,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_get(
+    merkle_db: *mut c_void,
+    address: *const c_char,
+    bytes: *mut *const u8,
+    bytes_len: *mut usize,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+    if address.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let address_str = unsafe {
+        match CStr::from_ptr(address).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidAddress,
+        }
+    };
+
+    unsafe {
+        match (*(merkle_db as *mut MerkleDatabase)).get(address_str) {
+            Ok(Some(data_vec)) => {
+                let data = data_vec.into_boxed_slice();
+                *bytes_len = data.len();
+                *bytes = data.as_ptr();
+
+                // It will be up to the callee to cleanup this memory
+                mem::forget(data);
+
+                ErrorCode::Success
+            }
+            Ok(None) => ErrorCode::NotFound,
+            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+            _ => ErrorCode::Unknown,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_set(
+    merkle_db: *mut c_void,
+    address: *const c_char,
+    data: *const u8,
+    data_len: usize,
+    merkle_root: *mut *const u8,
+    merkle_root_len: *mut usize,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+    if address.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    if data.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let address_str = unsafe {
+        match CStr::from_ptr(address).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidHashString,
+        }
+    };
+
+    let data = unsafe { slice::from_raw_parts(data, data_len) };
+
+    unsafe {
+        match (*(merkle_db as *mut MerkleDatabase)).set(address_str, data) {
+            Ok(state_root) => {
+                *merkle_root = state_root.as_ptr();
+                *merkle_root_len = state_root.as_bytes().len();
+
+                mem::forget(state_root);
+
+                ErrorCode::Success
+            }
+            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            _ => ErrorCode::Unknown,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_delete(
+    merkle_db: *mut c_void,
+    address: *const c_char,
+    merkle_root: *mut *const u8,
+    merkle_root_len: *mut usize,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+    if address.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let address_str = unsafe {
+        match CStr::from_ptr(address).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidHashString,
+        }
+    };
+
+    unsafe {
+        match (*(merkle_db as *mut MerkleDatabase)).delete(address_str) {
+            Ok(state_root) => {
+                *merkle_root = state_root.as_ptr();
+                *merkle_root_len = state_root.as_bytes().len();
+
+                mem::forget(state_root);
+
+                ErrorCode::Success
+            }
+            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+            Err(err) => {
+                println!("Unknown Error!: {:?}", err);
+                ErrorCode::Unknown
+            }
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_update(
+    merkle_db: *mut c_void,
+    updates: *const *const c_void,
+    updates_len: usize,
+    deletes: *const *const c_char,
+    deletes_len: usize,
+    virtual_write: bool,
+    merkle_root: *mut *const u8,
+    merkle_root_len: *mut usize,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    if updates_len > 0 && updates.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    if deletes_len > 0 && deletes.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let update_map: HashMap<String, Vec<u8>> = {
+        let update_vec: Result<Vec<(String, Vec<u8>)>, ErrorCode> = if updates_len > 0 {
+            unsafe { slice::from_raw_parts(updates, updates_len) }
+                .iter()
+                .map(|ptr| unsafe {
+                    let entry = *ptr as *const Entry;
+                    let address = match CStr::from_ptr((*entry).address).to_str() {
+                        Ok(s) => String::from(s),
+                        Err(_) => return Err(ErrorCode::InvalidAddress),
+                    };
+                    let data = slice::from_raw_parts((*entry).data, (*entry).data_len);
+
+                    let data = Vec::from(data);
+                    Ok((address, data))
+                })
+                .collect()
+        } else {
+            Ok(Vec::with_capacity(0))
+        };
+
+        if update_vec.is_err() {
+            return update_vec.unwrap_err();
+        }
+
+        update_vec.unwrap().into_iter().collect()
+    };
+
+    let deletes: Result<Vec<String>, ErrorCode> = if deletes_len > 0 {
+        unsafe { slice::from_raw_parts(deletes, deletes_len) }
+            .iter()
+            .map(|c_str| {
+                unsafe { CStr::from_ptr(*c_str).to_str() }
+                    .map(String::from)
+                    .map_err(|_| ErrorCode::InvalidAddress)
+            })
+            .collect()
+    } else {
+        Ok(Vec::with_capacity(0))
+    };
+
+    if deletes.is_err() {
+        return deletes.unwrap_err();
+    }
+
+    unsafe {
+        match (*(merkle_db as *mut MerkleDatabase)).update(
+            &update_map,
+            &deletes.unwrap(),
+            virtual_write,
+        ) {
+            Ok(state_root) => {
+                *merkle_root = state_root.as_ptr();
+                *merkle_root_len = state_root.as_bytes().len();
+
+                mem::forget(state_root);
+
+                ErrorCode::Success
+            }
+            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            _ => ErrorCode::Unknown,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_leaf_iterator_new(
+    merkle_db: *mut c_void,
+    prefix: *const c_char,
+    iterator: *mut *const c_void,
+) -> ErrorCode {
+    if merkle_db.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    if prefix.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let prefix = unsafe {
+        match CStr::from_ptr(prefix).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidAddress,
+        }
+    };
+
+    match unsafe { (*(merkle_db as *mut MerkleDatabase)).leaves(Some(prefix)) } {
+        Ok(leaf_iterator) => {
+            unsafe {
+                *iterator = Box::into_raw(Box::new(leaf_iterator)) as *const c_void;
+            }
+
+            ErrorCode::Success
+        }
+        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
+        Err(_) => ErrorCode::Unknown,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_leaf_iterator_drop(iterator: *mut c_void) -> ErrorCode {
+    if iterator.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    unsafe { Box::from_raw(iterator as *mut MerkleLeafIterator) };
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn merkle_db_leaf_iterator_next(
+    iterator: *mut c_void,
+    address: *mut *const u8,
+    address_len: *mut usize,
+    bytes: *mut *const u8,
+    bytes_len: *mut usize,
+) -> ErrorCode {
+    if iterator.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    match unsafe { (*(iterator as *mut MerkleLeafIterator)).next() } {
+        Some(Ok((entry_addr, entry_bytes))) => unsafe {
+            *address = entry_addr.as_ptr();
+            *address_len = entry_addr.as_bytes().len();
+
+            let data = entry_bytes.into_boxed_slice();
+            *bytes_len = data.len();
+            *bytes = data.as_ptr();
+
+            mem::forget(data);
+
+            ErrorCode::Success
+        },
+        None => ErrorCode::StopIteration,
+        Some(Err(MerkleDatabaseError::DatabaseError(_))) => ErrorCode::DatabaseError,
+        Some(Err(_)) => ErrorCode::Unknown,
+    }
+}

--- a/validator/src/state/merkle_ffi.rs
+++ b/validator/src/state/merkle_ffi.rs
@@ -95,7 +95,10 @@ fn make_merkle_db(
         }
         Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
-        _ => ErrorCode::Unknown,
+        Err(err) => {
+            error!("Unknown Error!: {:?}", err);
+            ErrorCode::Unknown
+        }
     }
 }
 
@@ -153,7 +156,10 @@ pub extern "C" fn merkle_db_set_merkle_root(
         Ok(()) => ErrorCode::Success,
         Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
-        _ => ErrorCode::Unknown,
+        Err(err) => {
+            error!("Unknown Error!: {:?}", err);
+            ErrorCode::Unknown
+        }
     }
 }
 
@@ -181,7 +187,10 @@ pub extern "C" fn merkle_db_contains(merkle_db: *mut c_void, address: *const c_c
             Ok(false) => ErrorCode::NotFound,
             Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
-            _ => ErrorCode::Unknown,
+            Err(err) => {
+                error!("Unknown Error!: {:?}", err);
+                ErrorCode::Unknown
+            }
         }
     }
 }
@@ -222,7 +231,10 @@ pub extern "C" fn merkle_db_get(
             Ok(None) => ErrorCode::NotFound,
             Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
-            _ => ErrorCode::Unknown,
+            Err(err) => {
+                error!("Unknown Error!: {:?}", err);
+                ErrorCode::Unknown
+            }
         }
     }
 }
@@ -267,7 +279,10 @@ pub extern "C" fn merkle_db_set(
                 ErrorCode::Success
             }
             Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
-            _ => ErrorCode::Unknown,
+            Err(err) => {
+                error!("Unknown Error!: {:?}", err);
+                ErrorCode::Unknown
+            }
         }
     }
 }
@@ -306,7 +321,7 @@ pub extern "C" fn merkle_db_delete(
             Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
             Err(err) => {
-                println!("Unknown Error!: {:?}", err);
+                error!("Unknown Error!: {:?}", err);
                 ErrorCode::Unknown
             }
         }
@@ -395,7 +410,10 @@ pub extern "C" fn merkle_db_update(
                 ErrorCode::Success
             }
             Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
-            _ => ErrorCode::Unknown,
+            Err(err) => {
+                error!("Unknown Error!: {:?}", err);
+                ErrorCode::Unknown
+            }
         }
     }
 }
@@ -431,7 +449,10 @@ pub extern "C" fn merkle_db_leaf_iterator_new(
         }
         Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
-        Err(_) => ErrorCode::Unknown,
+        Err(err) => {
+            error!("Unknown Error!: {:?}", err);
+            ErrorCode::Unknown
+        }
     }
 }
 
@@ -472,6 +493,9 @@ pub extern "C" fn merkle_db_leaf_iterator_next(
         },
         None => ErrorCode::StopIteration,
         Some(Err(MerkleDatabaseError::DatabaseError(_))) => ErrorCode::DatabaseError,
-        Some(Err(_)) => ErrorCode::Unknown,
+        Some(Err(err)) => {
+            error!("Unknown Error!: {:?}", err);
+            ErrorCode::Unknown
+        }
     }
 }

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -16,3 +16,4 @@
  */
 
 pub mod merkle;
+pub mod merkle_ffi;

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -14,15 +14,5 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate libc;
-extern crate lmdb_zero;
 
-#[cfg(test)]
-extern crate rand;
-
-// exported modules
-pub mod database;
-pub mod state;
+pub mod merkle;


### PR DESCRIPTION
This provides a Rust implementation of the Merkle trie, including FFI (on the Rust side) and tests.

Utilizing this code in the validator will be part of a future PR.