### PR TITLE
Improve local development of Sawadm on OS X

### DIFF
--- a/adm/src/blockstore.rs
+++ b/adm/src/blockstore.rs
@@ -242,7 +242,9 @@ mod tests {
 
         let blockstore_path = &path_config.data_dir.join(config::get_blockstore_filename());
 
-        let ctx = LmdbContext::new(blockstore_path, 3, None)
+        // Set the file size to 10MB, so as to support file systems that do
+        // not support sparse files.
+        let ctx = LmdbContext::new(blockstore_path, 3, Some(10 * 1024 * 1024))
             .map_err(|err| DatabaseError::InitError(format!("{}", err)))
             .unwrap();
 


### PR DESCRIPTION
Adds a few minor changes for improving the local development experience on OS X.  Namely:

- Limiting the size of the LMDB db in the tests
- Selecting the `fs::MetadataExt` based on os