### PR TITLE
Fix validator peering on Azure

### DIFF
--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -15,6 +15,9 @@
 import logging
 import os
 import time
+
+from urllib.parse import urlparse
+
 import netifaces
 
 from sawtooth_signing import create_context
@@ -58,6 +61,27 @@ class ConnectHandler(Handler):
     def __init__(self, network):
         self._network = network
 
+    @staticmethod
+    def is_valid_endpoint_host(interfaces, endpoint):
+        """
+        An enpoint host name is valid if it is a URL and if the
+        host is not the name of a network interface.
+        """
+        result = urlparse(endpoint)
+        hostname = result.hostname
+        if hostname is None:
+            LOGGER.debug("Endpoint is not a valid URL : %s", endpoint)
+            return False
+        else:
+            for interface in interfaces:
+                if interface == hostname:
+                    LOGGER.debug("Endpoint host cannot be the "
+                                 "same as a network interface. '%s': %s",
+                                 interface,
+                                 endpoint)
+                    return False
+        return True
+
     def handle(self, connection_id, message_content):
         """
         A connection must use one of the supported authorization types
@@ -84,19 +108,14 @@ class ConnectHandler(Handler):
         # Medium security risk.
         interfaces = ["*", ".".join(["0", "0", "0", "0"])]
         interfaces += netifaces.interfaces()
-        for interface in interfaces:
-            if interface in message.endpoint:
-                LOGGER.debug("Endpoint cannot include '%s': %s",
-                             interface,
-                             message.endpoint)
-
-                connection_response = ConnectionResponse(
-                    status=ConnectionResponse.ERROR)
-                return HandlerResult(
-                    HandlerStatus.RETURN_AND_CLOSE,
-                    message_out=connection_response,
-                    message_type=validator_pb2.Message.
-                    AUTHORIZATION_CONNECTION_RESPONSE)
+        if self.is_valid_endpoint_host(interfaces, message.endpoint) is False:
+            connection_response = ConnectionResponse(
+                status=ConnectionResponse.ERROR)
+            return HandlerResult(
+                HandlerStatus.RETURN_AND_CLOSE,
+                message_out=connection_response,
+                message_type=validator_pb2.Message.
+                AUTHORIZATION_CONNECTION_RESPONSE)
 
         LOGGER.debug("Endpoint of connecting node is %s", message.endpoint)
         self._network.update_connection_endpoint(connection_id,

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -36,6 +36,7 @@ from sawtooth_validator.server.log import log_configuration
 from sawtooth_validator.server import state_verifier
 from sawtooth_validator.exceptions import GenesisError
 from sawtooth_validator.exceptions import LocalConfigurationError
+from sawtooth_validator.networking.handlers import ConnectHandler
 from sawtooth_validator import metrics
 
 
@@ -174,11 +175,9 @@ def main(args):
         interfaces = ["*", ".".join(["0", "0", "0", "0"])]
         interfaces += netifaces.interfaces()
         endpoint = validator_config.bind_network
-        for interface in interfaces:
-            if interface in validator_config.bind_network:
-                LOGGER.error("Endpoint must be set when using %s", interface)
-                init_errors = True
-                break
+        result = ConnectHandler.is_valid_endpoint_host(interfaces, endpoint)
+        if result is False:
+            init_errors = True
 
     if init_errors:
         LOGGER.error("Initialization errors occurred (see previous log "

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -52,11 +52,21 @@ from test_authorization_handlers.mock import MockGossip
 
 
 class TestAuthorizationHandlers(unittest.TestCase):
+    def test_bad_endpoint_host(self):
+        """
+        Test error when the endpoint host is the same as a network interface
+        name.
+        """
+        interfaces = ["*", ".".join(["0", "0", "0", "0"])]
+        endpoint = "tcp://*:80"
+        result = ConnectHandler.is_valid_endpoint_host(interfaces, endpoint)
+        self.assertEqual(result, False)
+
     def test_connect(self):
         """
         Test the ConnectHandler correctly responds to a ConnectionRequest.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles)
         handler = ConnectHandler(network)
@@ -87,7 +97,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes the connection if the role has an
         unsupported role type.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": "other"}
         network = MockNetwork(roles)
         handler = ConnectHandler(network)
@@ -103,7 +113,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes a connection if we are not accepting
         incoming connections
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles, allow_inbound=False)
         handler = ConnectHandler(network)
@@ -119,7 +129,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes a connection if any authorization
         message has been recieved before this connection request.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles,
                               connection_status={"connection_id": "other"})


### PR DESCRIPTION
Validator peering fails when using Azure endpoints such as
tcp://hashblock3.westus2.cloudapp.azure.com:8800 because the 'lo'
network interface characters are characters in 'cloudapp'. This
fix test that the network interface string is not equal to the
host name of the endpoint. The bug number is STL-1125

Signed-off-by: Arthur Greef <arthurgreef@live.com>