### PR TITLE
Replace Python Merkle Trie Implementation with Rust FFI calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@
 /validator/target/
 /validator/Cargo.lock
 /validator/bin/
+/validator/lib/
 
 /sdk/cxx/build/
 

--- a/bin/build_validator
+++ b/bin/build_validator
@@ -16,6 +16,7 @@
 # ------------------------------------------------------------------------------
 
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
+target_dir=./target/release
 
 unset PYTHONPATH
 
@@ -38,8 +39,12 @@ done
 echo -e "\033[0;32m--- Building validator ---\n\033[0m"
 rm -rf $top_dir/validator/bin/
 mkdir -p $top_dir/validator/bin/
+rm -rf $top_dir/validator/lib/
+mkdir -p $top_dir/validator/lib/
 cd $top_dir/validator
-cargo build && cp ./target/debug/sawtooth-validator $top_dir/validator/bin/sawtooth-validator
+cargo build --release && \
+    cp $target_dir/sawtooth-validator $top_dir/validator/bin/sawtooth-validator && \
+    cp $target_dir/libsawtooth_validator.so $top_dir/validator/lib/libsawtooth_validator.so
 
 for pkg in $pkgs
 do

--- a/bin/sawtooth-validator
+++ b/bin/sawtooth-validator
@@ -17,6 +17,7 @@
 
 CORE=$(cd $(dirname $(dirname $0)) && pwd)
 export PYTHONPATH=$PYTHONPATH:$CORE/validator:$CORE/signing
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CORE/validator/lib
 
 bin=$CORE/validator/bin/sawtooth-validator
 

--- a/consensus/poet/common/sawtooth_poet_common/validator_registry_view/validator_registry_view.py
+++ b/consensus/poet/common/sawtooth_poet_common/validator_registry_view/validator_registry_view.py
@@ -51,7 +51,7 @@ class ValidatorRegistryView(object):
         leaves = self._state_view.leaves(_NAMESPACE)
         infos = [
             ValidatorRegistryView._parse_validator_info(state_data)
-            for address, state_data in leaves.items()
+            for address, state_data in leaves
             if address != validator_map_addr
         ]
         return {info.id: info for info in infos}

--- a/consensus/poet/common/tests/test_validator_registry_view/mocks.py
+++ b/consensus/poet/common/tests/test_validator_registry_view/mocks.py
@@ -36,8 +36,8 @@ class MockStateView(object):
 
     def leaves(self, prefix):
         """See sawtooth_validator.state.state_view.StateView.leaves"""
-        return {
+        return ({
             address: data
             for address, data in self._state.items()
             if address.startswith(prefix)
-        }
+        }).items()

--- a/integration/sawtooth_integration/docker/test_state_verifier.yaml
+++ b/integration/sawtooth_integration/docker/test_state_verifier.yaml
@@ -36,6 +36,7 @@ services:
         /project/sawtooth-core/signing:\
         /project/sawtooth-core/validator:\
         /project/sawtooth-core/sdk/examples/intkey_python"
+      SAWTOOTH_LIB_HOME: "/project/sawtooth-core/validator/lib"
 
   intkey-tp:
     image: sawtooth-intkey-tp-go:$ISOLATION_ID

--- a/validator/sawtooth_validator/database/native_lmdb.py
+++ b/validator/sawtooth_validator/database/native_lmdb.py
@@ -1,0 +1,44 @@
+import ctypes
+from enum import IntEnum
+
+from sawtooth_validator.ffi import LIBRARY
+
+
+class NativeLmdbDatabase(object):
+    def __init__(self, path, _size=1024**4):
+        self._db_ptr = ctypes.c_void_p()
+
+        c_path = ctypes.c_char_p(path.encode())
+        c_size = ctypes.c_size_t(_size)
+        res = LIBRARY.call(
+            'lmdb_database_new', c_path, c_size, ctypes.byref(self._db_ptr))
+        if res == ErrorCode.Success:
+            return
+        elif res == ErrorCode.NullPointerProvided:
+            raise TypeError("Path cannot be null")
+        elif res == ErrorCode.InvalidFilePath:
+            raise TypeError("Invalid file path {}".format(path))
+        elif res == ErrorCode.InitializeContextError:
+            raise TypeError("Unable to initialize LMDB Context")
+        elif res == ErrorCode.InitializeDatabaseError:
+            raise TypeError("Unable to initialize LMDB Database")
+        else:
+            raise TypeError("Unknown error occurred: {}".format(res.error))
+
+    def __del__(self):
+        if self._db_ptr:
+            LIBRARY.call('lmdb_database_drop', self._db_ptr)
+            self._db_ptr = None
+
+    @property
+    def pointer(self):
+        return self._db_ptr
+
+
+class ErrorCode(IntEnum):
+    Success = 0
+    NullPointerProvided = 0x01
+    InvalidFilePath = 0x02
+
+    InitializeContextError = 0x11
+    InitializeDatabaseError = 0x12

--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -1,0 +1,77 @@
+# Copyright 2016 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import ctypes
+import logging
+import os
+import sys
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Library:
+
+    def __init__(self):
+        lib_prefix_mapping = {
+            "darwin": "lib",
+            "linux": "lib",
+            "linux2": "lib",
+        }
+        lib_suffix_mapping = {
+            "darwin": ".dylib",
+            "linux": ".so",
+            "linux2": ".so",
+        }
+
+        os_name = sys.platform
+
+        lib_location = os.environ.get('SAWTOOTH_LIB_HOME', '')
+        if lib_location and lib_location[-1:] != '/':
+            lib_location += '/'
+
+        try:
+            lib_prefix = lib_prefix_mapping[os_name]
+            lib_suffix = lib_suffix_mapping[os_name]
+        except KeyError:
+            raise OSError("OS isn't supported: {}".format(os_name))
+
+        library_path = "{}{}sawtooth_validator{}".format(
+            lib_location, lib_prefix, lib_suffix)
+
+        LOGGER.debug("loading library %s", library_path)
+
+        self._cdll = ctypes.CDLL(library_path)
+
+    def call(self, name, *args):
+        return getattr(self._cdll, name)(*args)
+
+
+LIBRARY = Library()
+
+
+def prepare_byte_result():
+    """Returns pair of byte pointer and size value for use as return parameters
+    in a LIBRARY call
+    """
+    return (ctypes.POINTER(ctypes.c_uint8)(), ctypes.c_size_t(0))
+
+
+def from_c_bytes(c_data, c_data_len):
+    """Takes a byte pointer and a length and converts it into a python bytes
+    value.
+    """
+    # pylint: disable=invalid-slice-index
+    return bytes(c_data[:c_data_len.value])

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -25,6 +25,7 @@ from sawtooth_validator.concurrent.threadpool import \
 from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.database.indexed_database import IndexedDatabase
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
+from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
 from sawtooth_validator.journal.block_validator import BlockValidator
 from sawtooth_validator.journal.publisher import BlockPublisher
 from sawtooth_validator.journal.chain import ChainController
@@ -111,7 +112,7 @@ class Validator(object):
             data_dir, 'merkle-{}.lmdb'.format(bind_network[-2:]))
         LOGGER.debug(
             'global state database file is %s', global_state_db_filename)
-        global_state_db = LMDBNoLockDatabase(global_state_db_filename, 'c')
+        global_state_db = NativeLmdbDatabase(global_state_db_filename)
         state_view_factory = StateViewFactory(global_state_db)
 
         # -- Setup Receipt Store -- #

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -691,7 +691,7 @@ class StateListRequest(_ClientRequestHandler):
         self._validate_namespace(request.address)
         entries = [
             client_state_pb2.ClientStateListResponse.Entry(address=a, data=v)
-            for a, v in self._tree.leaves(request.address or '').items()]
+            for a, v in self._tree.leaves(request.address or '')]
 
         # Order entries, remove if tree.entries refactored to be ordered
         entries.sort(key=lambda l: l.address)

--- a/validator/sawtooth_validator/state/identity_view.py
+++ b/validator/sawtooth_validator/state/identity_view.py
@@ -117,10 +117,9 @@ class IdentityView(object):
         """
 
         prefix = _IDENTITY_NS + _ROLE_NS
-        role_list_bytes_dict = self._state_view.leaves(prefix=prefix)
         rolelist_list = [
             _create_from_bytes(d, identity_pb2.RoleList)
-            for d in role_list_bytes_dict.values()
+            for _, d in self._state_view.leaves(prefix=prefix)
         ]
         roles = []
         for role_list in rolelist_list:
@@ -163,10 +162,9 @@ class IdentityView(object):
         """
 
         prefix = _IDENTITY_NS + _POLICY_NS
-        policy_list_bytes_dict = self._state_view.leaves(prefix=prefix)
         policylist_list = [
             _create_from_bytes(d, identity_pb2.PolicyList)
-            for d in policy_list_bytes_dict.values()
+            for _, d in self._state_view.leaves(prefix=prefix)
         ]
         policies = []
         for policy_list in policylist_list:

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -20,12 +20,14 @@ import sys
 from setuptools import setup, find_packages
 
 bin_dir = "/usr/bin"
+lib_dir = "/usr/lib"
 conf_dir = "/etc/sawtooth"
 data_dir = "/var/lib/sawtooth"
 log_dir = "/var/log/sawtooth"
 
 data_files = [
     (bin_dir, ['bin/sawtooth-validator']),
+    (lib_dir, ['lib/libsawtooth_validator.so']),
     (conf_dir, ['packaging/path.toml.example',
                 'packaging/log_config.toml.example',
                 'packaging/validator.toml.example']),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -23,10 +23,15 @@ fn main() {
         .map_err(|err| err.print(*py))
         .unwrap();
 
-    let cli = py.import("sawtooth_validator.server.cli")
-        .map_err(|err| err.print(*py))
-        .unwrap();
-    cli.call(*py, "main", (pydict,), None)
-        .map_err(|err| err.print(*py))
-        .unwrap();
+    let cli = match py.import("sawtooth_validator.server.cli") {
+        Ok(module) => module,
+        Err(err) => {
+            err.print(*py);
+            return;
+        }
+    };
+
+    if let Err(err) = cli.call(*py, "main", (pydict,), None) {
+        err.print(*py);
+    }
 }

--- a/validator/src/state/merkle_ffi.rs
+++ b/validator/src/state/merkle_ffi.rs
@@ -480,13 +480,15 @@ pub extern "C" fn merkle_db_leaf_iterator_next(
 
     match unsafe { (*(iterator as *mut MerkleLeafIterator)).next() } {
         Some(Ok((entry_addr, entry_bytes))) => unsafe {
-            *address = entry_addr.as_ptr();
-            *address_len = entry_addr.as_bytes().len();
+            let address_bytes = entry_addr.into_bytes().into_boxed_slice();
+            *address_len = address_bytes.len();
+            *address = address_bytes.as_ptr();
 
             let data = entry_bytes.into_boxed_slice();
             *bytes_len = data.len();
             *bytes = data.as_ptr();
 
+            mem::forget(address_bytes);
             mem::forget(data);
 
             ErrorCode::Success

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -16,6 +16,7 @@
 # pylint: disable=attribute-defined-outside-init,abstract-method
 
 import logging
+import os
 
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
@@ -25,6 +26,7 @@ from sawtooth_validator.protobuf.transaction_pb2 import Transaction
 from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_store import BlockStore
+from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.state.batch_tracker import BatchTracker
@@ -117,7 +119,7 @@ class MockBlockStore(BlockStore):
         self.update_chain([BlockWrapper(block)], [])
 
 
-def make_db_and_store(size=3):
+def make_db_and_store(base_dir, size=3):
     """
     Creates and returns three related objects for testing:
         * database - dict database with evolving state
@@ -130,7 +132,9 @@ def make_db_and_store(size=3):
         * 3 - {'000...1': b'4', '000...2': b'6',
                '000...3': b'8', '000...4': b'10'}
     """
-    database = DictDatabase()
+    database = NativeLmdbDatabase(
+        os.path.join(base_dir, 'client_handlers_mock_db.lmdb'),
+        _size=10 * 1024 * 1024)
     store = MockBlockStore(size=0)
     roots = []
 

--- a/validator/tests/test_client_request_handlers/test_state_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_state_handlers.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+import shutil
+import tempfile
+
 import sawtooth_validator.state.client_handlers as handlers
 from sawtooth_validator.protobuf import client_state_pb2
 from test_client_request_handlers.base_case import ClientHandlerTestCase
@@ -27,13 +30,17 @@ class TestStateListRequests(ClientHandlerTestCase):
         return [l for l in entries if l.address == address][0].data
 
     def setUp(self):
-        db, store, roots = make_db_and_store()
+        self._temp_dir = tempfile.mkdtemp()
+        db, store, roots = make_db_and_store(self._temp_dir)
         self.initialize(
             handlers.StateListRequest(db, store),
             client_state_pb2.ClientStateListRequest,
             client_state_pb2.ClientStateListResponse,
             store=store,
             roots=roots)
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
 
     def test_state_list_request(self):
         """Verifies requests for data lists without parameters work properly.
@@ -426,13 +433,17 @@ class TestStateListRequests(ClientHandlerTestCase):
 
 class TestStateGetRequests(ClientHandlerTestCase):
     def setUp(self):
-        db, store, roots = make_db_and_store()
+        self._temp_dir = tempfile.mkdtemp()
+        db, store, roots = make_db_and_store(self._temp_dir)
         self.initialize(
             handlers.StateGetRequest(db, store),
             client_state_pb2.ClientStateGetRequest,
             client_state_pb2.ClientStateGetResponse,
             store=store,
             roots=roots)
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
 
     def test_state_get_request(self):
         """Verifies requests for specific data by address work properly.

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
+from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
@@ -68,7 +69,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             self.make_block_store(),  # Empty block store
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -88,7 +89,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -107,7 +108,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -131,7 +132,7 @@ class TestGenesisController(unittest.TestCase):
             Mock(name='txn_executor'),
             Mock('completer'),
             block_store,
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -158,7 +159,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -186,7 +187,7 @@ class TestGenesisController(unittest.TestCase):
             Mock('txn_executor'),
             Mock('completer'),
             block_store,
-            StateViewFactory(DictDatabase()),
+            Mock('StateViewFactory'),
             self._signer,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
@@ -211,7 +212,9 @@ class TestGenesisController(unittest.TestCase):
         genesis_file = self._with_empty_batch_file()
         block_store = self.make_block_store()
 
-        state_database = DictDatabase()
+        state_database = NativeLmdbDatabase(
+            os.path.join(self._temp_dir, 'test_genesis.lmdb'),
+            _size=10 * 1024 * 1024)
         merkle_db = MerkleDatabase(state_database)
 
         ctx_mgr = Mock(name='ContextManager')

--- a/validator/tests/test_identity_view/tests.py
+++ b/validator/tests/test_identity_view/tests.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+import os
+import shutil
+import tempfile
 import unittest
 import hashlib
 
-from sawtooth_validator.database.dict_database import DictDatabase
+from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
 from sawtooth_validator.protobuf import identity_pb2
 from sawtooth_validator.state import identity_view
 from sawtooth_validator.state.merkle import MerkleDatabase
@@ -24,9 +27,20 @@ from sawtooth_validator.state.state_view import StateViewFactory
 
 
 class TestIdentityView(unittest.TestCase):
+    def __init__(self, test_name):
+        super().__init__(test_name)
+        self._temp_dir = None
+
     def setUp(self):
-        self._database = DictDatabase()
+        self._temp_dir = tempfile.mkdtemp()
+
+        self._database = NativeLmdbDatabase(
+            os.path.join(self._temp_dir, 'test_identity_view.lmdb'),
+            _size=10 * 1024 * 1024)
         self._tree = MerkleDatabase(self._database)
+
+    def tearDown(self):
+        shutil.rmtree(self._temp_dir)
 
     def test_identityview_roles(self):
         """Tests get_role and get_roles get the correct Roles and the

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -20,6 +20,7 @@ from collections import deque
 import hashlib
 import itertools
 import logging
+import os
 import time
 import uuid
 import yaml
@@ -27,8 +28,8 @@ import yaml
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
 
-from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.execution.scheduler import BatchExecutionResult
+from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
 from sawtooth_validator.state.merkle import MerkleDatabase
 
 import sawtooth_validator.protobuf.batch_pb2 as batch_pb2
@@ -369,7 +370,7 @@ class SchedulerTester(object):
 
         return batch_results, transactions_to_assert_state
 
-    def compute_state_hashes_wo_scheduler(self):
+    def compute_state_hashes_wo_scheduler(self, base_dir):
         """Creates a state hash from the state updates from each txn in a
         valid batch.
 
@@ -378,7 +379,11 @@ class SchedulerTester(object):
 
         """
 
-        tree = MerkleDatabase(database=DictDatabase())
+        database = NativeLmdbDatabase(
+            os.path.join(base_dir, 'compute_state_hashes_wo_scheduler.lmdb'),
+            _size=10 * 1024 * 1024)
+
+        tree = MerkleDatabase(database=database)
         state_hashes = []
         updates = {}
         for batch in self._batches:

--- a/validator/tests/unit_validator.yaml
+++ b/validator/tests/unit_validator.yaml
@@ -29,3 +29,4 @@ services:
         PYTHONPATH: "/project/sawtooth-core/signing:\
             /project/sawtooth-core/core:\
             /project/sawtooth-core/validator"
+        SAWTOOTH_LIB_HOME: "/project/sawtooth-core/validator/lib"


### PR DESCRIPTION
Replaces the internals of the Python implementation of the Merkle Trie with FFI calls to the rust implementation.