### PR TITLE
Specify grafana version

### DIFF
--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-FROM grafana/grafana:latest
+FROM grafana/grafana:4.6.3
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
The latest grafana version introduced some breaking changes. This locks
it at the previous version.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>