### PR TITLE
Adjust keep times to mitigate missing predecessors

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -132,8 +132,13 @@ class Validator(object):
             flag='c',
             indexes=BlockStore.create_index_configuration())
         block_store = BlockStore(block_db)
+        # The cache keep time for the journal's block cache must be greater
+        # than the cache keep time used by the completer.
+        base_keep_time = 1200
         block_cache = BlockCache(
-            block_store, keep_time=300, purge_frequency=30)
+            block_store,
+            keep_time=int(base_keep_time * 9 / 8),
+            purge_frequency=30)
 
         # -- Setup Thread Pools -- #
         component_thread_pool = InstrumentedThreadPoolExecutor(
@@ -225,7 +230,10 @@ class Validator(object):
 
         completer = Completer(
             block_store,
-            gossip)
+            gossip,
+            cache_keep_time=base_keep_time,
+            cache_purge_frequency=30,
+            requested_keep_time=300)
 
         block_sender = BroadcastBlockSender(completer, gossip)
         batch_sender = BroadcastBatchSender(completer, gossip)


### PR DESCRIPTION
Awhile ago, the amount of time that the Completer holds onto blocks was adjusted in order to resolve a bug dubbed the "flatline bug" (https://github.com/hyperledger/sawtooth-core/commit/df75658011e59dff0be2a8ce45a6ac2770303fec). At that time, the amount of time the Chain Controller holds onto blocks should have also been updated, but this was missed. Because of this, it became much easier for the Chain Controller and Completer to get out of sync with respect to the blocks they thought were in the system. With the two out of sync, it was possible for the Completer to send a block to the Chain Controller that was built on a block that the Chain Controller had dropped. This resulted in a forking bug deemed the "missing predecessor bug" (STL-901). This commit updates the time that the Chain Controller holds onto blocks. This commit is a temporary bandage to mitigate the out of sync problem. A full solution requires the block manager (STL-1189).