### PR TITLE
Add Rust wrapper to Python transaction execution

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -416,12 +416,12 @@ class TransactionExecutor(object):
             first_state_root = self._context_manager.get_first_root()
 
         if self._scheduler_type == "serial":
-            return SerialScheduler(
+            scheduler = SerialScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
                 always_persist=always_persist)
         elif self._scheduler_type == "parallel":
-            return ParallelScheduler(
+            scheduler = ParallelScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
                 always_persist=always_persist)
@@ -430,6 +430,9 @@ class TransactionExecutor(object):
             raise AssertionError(
                 "Scheduler type must be either serial or parallel. Current"
                 " scheduler type is {}.".format(self._scheduler_type))
+
+        self.execute(scheduler=scheduler)
+        return scheduler
 
     def check_connections(self):
         self._executing_threadpool.submit(self._check_connections)

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -410,6 +410,11 @@ class TransactionExecutor(object):
     def create_scheduler(self,
                          first_state_root,
                          always_persist=False):
+
+        # Useful for a logical first state root of ""
+        if not first_state_root:
+            first_state_root = self._context_manager.get_first_root()
+
         if self._scheduler_type == "serial":
             return SerialScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -210,7 +210,6 @@ class BlockValidator(object):
 
             scheduler = self._transaction_executor.create_scheduler(
                 prev_state_root)
-            self._transaction_executor.execute(scheduler)
 
             chain_commit_state.check_for_duplicate_batches(
                 blkw.block.batches)

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -624,7 +624,6 @@ class BlockPublisher(object):
         committed_txn_cache = TransactionCommitCache(
             self._block_cache.block_store)
 
-        self._transaction_executor.execute(scheduler)
         self._candidate_block = _CandidateBlock(
             self._block_cache.block_store,
             consensus, scheduler,

--- a/validator/src/execution/execution_platform.rs
+++ b/validator/src/execution/execution_platform.rs
@@ -15,30 +15,15 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
-extern crate python3_sys as py_ffi;
+use cpython;
 
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
+use scheduler::Scheduler;
 
-// exported modules
-pub mod database;
-pub mod execution;
-pub mod journal;
-mod metrics;
-pub mod proto;
-pub mod scheduler;
-pub mod state;
+/// The logical state hash before state has been added to the
+/// merkle database. May not be the actual first state hash due to
+/// implementation details of the merkle database.
+pub const NULL_STATE_HASH: &str = "";
 
-pub mod batch;
-mod batch_ffi;
-pub mod block;
-pub mod transaction;
+pub trait ExecutionPlatform {
+    fn create_scheduler(&self, state_hash: &str) -> Result<Box<Scheduler>, cpython::PyErr>;
+}

--- a/validator/src/execution/mod.rs
+++ b/validator/src/execution/mod.rs
@@ -15,30 +15,4 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
-extern crate python3_sys as py_ffi;
-
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
-
-// exported modules
-pub mod database;
-pub mod execution;
-pub mod journal;
-mod metrics;
-pub mod proto;
-pub mod scheduler;
-pub mod state;
-
-pub mod batch;
-mod batch_ffi;
-pub mod block;
-pub mod transaction;
+pub mod execution_platform;

--- a/validator/src/execution/mod.rs
+++ b/validator/src/execution/mod.rs
@@ -16,3 +16,4 @@
  */
 
 pub mod execution_platform;
+pub mod py_executor;

--- a/validator/src/execution/py_executor.rs
+++ b/validator/src/execution/py_executor.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cpython;
+use cpython::ObjectProtocol;
+
+use execution::execution_platform::ExecutionPlatform;
+
+use scheduler::Scheduler;
+use scheduler::py_scheduler::PyScheduler;
+
+pub struct PyExecutor {
+    executor: cpython::PyObject,
+}
+
+impl PyExecutor {
+    pub fn new(executor: cpython::PyObject) -> Result<PyExecutor, cpython::PyErr> {
+        Ok(PyExecutor { executor })
+    }
+}
+
+impl ExecutionPlatform for PyExecutor {
+    fn create_scheduler(&self, state_hash: &str) -> Result<Box<Scheduler>, cpython::PyErr> {
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+
+        let scheduler = self.executor
+            .call_method(py, "create_scheduler", (state_hash,), None)
+            .expect(
+                "no method create_scheduler on sawtooth_validator.execution.py_executor.PyExecutor",
+            );
+        Ok(Box::new(PyScheduler::new(scheduler)))
+    }
+}

--- a/validator/src/scheduler/mod.rs
+++ b/validator/src/scheduler/mod.rs
@@ -21,6 +21,8 @@ use proto::transaction_receipt::StateChange;
 mod execution_result_ffi;
 use batch::Batch;
 
+pub mod py_scheduler;
+
 pub trait Scheduler {
     /// Add a batch to the scheduler, optionally specifying that the transactions
     /// in this batch and each of the batches in order up to this one should produce a

--- a/validator/src/scheduler/py_scheduler.rs
+++ b/validator/src/scheduler/py_scheduler.rs
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::error::Error;
+
+use cpython;
+use cpython::ObjectProtocol;
+use cpython::PyResult;
+
+use batch::Batch;
+
+use protobuf::ProtobufError;
+
+use scheduler::{BatchResult, TransactionResult};
+use scheduler::{ExecutionResults, Scheduler, SchedulerError};
+
+impl From<ProtobufError> for SchedulerError {
+    fn from(other: ProtobufError) -> SchedulerError {
+        SchedulerError::Other(other.description().into())
+    }
+}
+
+impl From<cpython::PyErr> for SchedulerError {
+    fn from(other: cpython::PyErr) -> SchedulerError {
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+        SchedulerError::Other(other.get_type(py).name(py).into_owned())
+    }
+}
+
+pub struct PyScheduler {
+    py_scheduler: cpython::PyObject,
+    batch_ids: Vec<String>,
+}
+
+impl PyScheduler {
+    pub fn new(py_scheduler: cpython::PyObject) -> PyScheduler {
+        PyScheduler {
+            py_scheduler,
+            batch_ids: vec![],
+        }
+    }
+}
+
+impl Scheduler for PyScheduler {
+    fn add_batch(
+        &mut self,
+        batch: Batch,
+        expected_state_hash: Option<&str>,
+        required: bool,
+    ) -> Result<(), SchedulerError> {
+        let header_signature = batch.header_signature.clone();
+
+        let state_hash_kwargs: Result<Option<cpython::PyDict>, cpython::PyErr> =
+            expected_state_hash
+                .map(|state_hash| {
+                    let py = unsafe { cpython::Python::assume_gil_acquired() };
+                    let kwargs = cpython::PyDict::new(py);
+                    kwargs.set_item(py, "state_hash", state_hash)?;
+                    kwargs.set_item(py, "required", required)?;
+                    Ok(kwargs)
+                })
+                .map_or(Ok(None), |v: Result<cpython::PyDict, cpython::PyErr>| {
+                    Ok(Some(v?))
+                });
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+        self.py_scheduler
+            .call_method(py, "add_batch", (batch,), state_hash_kwargs?.as_ref())
+            .expect("No method add_batch on python scheduler");
+        self.batch_ids.push(header_signature);
+        Ok(())
+    }
+
+    fn finalize(&mut self, unschedule_incomplete: bool) -> Result<(), SchedulerError> {
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+
+        if unschedule_incomplete {
+            self.py_scheduler
+                .call_method(py, "unschedule_incomplete_batches", cpython::NoArgs, None)
+                .expect("No method unscheduler_incomplete_batches on python scheduler");
+        }
+
+        self.py_scheduler
+            .call_method(py, "finalize", cpython::NoArgs, None)
+            .expect("No method finalize on python scheduler");
+        Ok(())
+    }
+
+    fn cancel(&mut self) -> Result<(), SchedulerError> {
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+
+        self.py_scheduler
+            .call_method(py, "cancel", cpython::NoArgs, None)
+            .expect("No method cancel on python scheduler");
+        Ok(())
+    }
+
+    fn complete(&mut self, block: bool) -> Result<Option<ExecutionResults>, SchedulerError> {
+        let py = unsafe { cpython::Python::assume_gil_acquired() };
+
+        if self.py_scheduler
+            .call_method(py, "complete", (block,), None)
+            .expect("No method complete on python scheduler")
+            .extract::<bool>(py)?
+        {
+            let r: PyResult<Vec<(Vec<TransactionResult>, BatchResult, String)>> = self.batch_ids
+                .iter()
+                .map(|id| {
+                    let batch_result: BatchResult = self.py_scheduler
+                        .call_method(py, "get_batch_execution_result", (id,), None)
+                        .expect("No method get_batch_execution_result on python scheduler")
+                        .extract::<BatchResult>(py)?;
+
+                    let txn_results: Vec<TransactionResult> = self.py_scheduler
+                        .call_method(py, "get_transaction_execution_results", (id,), None)
+                        .expect("No method get_transaction_execution_results on python scheduler")
+                        .extract::<cpython::PyList>(py)?
+                        .iter(py)
+                        .map(|r| r.extract::<TransactionResult>(py))
+                        .collect::<Result<Vec<TransactionResult>, cpython::PyErr>>()?;
+                    Ok((txn_results, batch_result, id.to_owned()))
+                })
+                .collect();
+
+            let results = r?;
+
+            let beginning_state_hash = results
+                .first()
+                .map(|v| v.0.first().map(|r| r.state_hash.clone()))
+                .unwrap_or(None);
+
+            let ending_state_hash = results
+                .iter()
+                .by_ref()
+                .find(|val| val.1.state_hash.is_some())
+                .map(|val| val.1.state_hash.clone())
+                .unwrap_or(None);
+
+            let batch_txn_results = results
+                .into_iter()
+                .map(|val| {
+                    (
+                        val.2.clone(),
+                        val.0
+                            .into_iter()
+                            .map(|v: TransactionResult| v.into())
+                            .collect(),
+                    )
+                })
+                .collect();
+
+            Ok(Some(ExecutionResults {
+                beginning_state_hash: beginning_state_hash,
+                ending_state_hash,
+                batch_results: batch_txn_results,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two traits, ExecutionPlatform and Scheduler, and implements them both with the Python transaction processing capabilities already in master.