### PR TITLE
Rust validator protos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@
 /validator/Cargo.lock
 /validator/bin/
 /validator/lib/
+/validator/src/proto
 
 /sdk/cxx/build/
 

--- a/bin/run_lint_rust
+++ b/bin/run_lint_rust
@@ -38,7 +38,7 @@ for dir in $dirs; do
 
     echo "-- rustfmt"
 
-    _=$(cargo fmt -- --write-mode=diff)
+    diff=$(cargo fmt -- --write-mode=diff)
     rustfmt_exit=$?
 
     # rustfmt returns the following exit codes:
@@ -63,7 +63,8 @@ for dir in $dirs; do
         elif [[ $rustfmt_exit == 2 ]]; then
             echo "Parsing error in $dir"
         else
-            echo "Incorrect formatting: $dir"
+            echo "Incorrect formatting: $dir (error code: $rustfmt_exit)"
+            echo -e $diff
         fi
     fi
 

--- a/bin/run_lint_validator
+++ b/bin/run_lint_validator
@@ -31,7 +31,7 @@ for dir in $dirs; do
 
     echo "-- rustfmt"
 
-    _=$(cargo fmt -- --write-mode=diff)
+    diff=$(cargo fmt -- --write-mode=diff)
     rustfmt_exit=$?
 
     # rustfmt returns the following exit codes:
@@ -57,6 +57,7 @@ for dir in $dirs; do
             echo "Parsing error in $dir"
         else
             echo "Incorrect formatting: $dir"
+            echo -e $diff
         fi
     fi
 

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -10,10 +10,15 @@ log = { version = "0.4", features = ["std"] }
 libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
 cbor-codec = "0.7"
+protobuf = "1.4"
 rust-crypto = "0.2"
 
 [dev-dependencies]
 rand = "0.4"
+
+[build-dependencies]
+protoc-rust = "1.4"
+glob = "0.2"
 
 [lib]
 crate-type = ["dylib"]

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -22,40 +22,11 @@ use std::error::Error;
 use std::fs;
 use std::io::prelude::*;
 use std::path::Path;
+use std::time::{Duration, UNIX_EPOCH};
 
 const PROTO_FILES_DIR: &str = "../protos";
 const PROTOBUF_TARGET_DIR: &str = "src/proto";
-
-fn main() {
-    // Generate protobuf files
-    let proto_src_files = glob_simple(&format!("{}/*.proto", PROTO_FILES_DIR));
-    println!("{:?}", proto_src_files);
-
-    fs::create_dir_all(PROTOBUF_TARGET_DIR).unwrap();
-
-    protoc_rust::run(protoc_rust::Args {
-        out_dir: PROTOBUF_TARGET_DIR,
-        input: &proto_src_files
-            .iter()
-            .map(|&(_, ref a)| a)
-            .map(|s| s.as_ref())
-            .collect::<Vec<&str>>(),
-        includes: &["src", PROTO_FILES_DIR],
-    }).expect("unable to run protoc");
-
-    let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);
-    let mod_file_path = Path::new(&mod_file_name);
-    let mut file = match fs::File::create(&mod_file_path) {
-        Err(err) => panic!(
-            "Unable to create file {}: {}",
-            mod_file_name,
-            err.description()
-        ),
-        Ok(file) => file,
-    };
-
-    let content = format!(
-        r#"
+const GENERATED_SOURCE_HEADER: &str = r#"
 /*
  * THIS IS A GENERATED FILE: DO NOT MODIFY
  *
@@ -63,39 +34,133 @@ fn main() {
  * buffers messages.
  */
 
-{}"#,
-        proto_src_files
-            .iter()
-            .map(|&(ref module, _)| format!("pub mod {};", module))
-            .collect::<Vec<_>>()
-            .join("\n")
+"#;
+
+#[derive(Debug, Clone)]
+struct ProtoFile {
+    module_name: String,
+    file_path: String,
+    last_modified: Duration,
+}
+
+fn main() {
+    // Generate protobuf files
+    let proto_src_files = glob_simple(&format!("{}/*.proto", PROTO_FILES_DIR));
+    let last_build_time = read_last_build_time();
+
+    let latest_change = proto_src_files.iter().fold(
+        Duration::from_secs(0),
+        |max, ref proto_file| {
+            if proto_file.last_modified > max {
+                proto_file.last_modified
+            } else {
+                max
+            }
+        },
     );
-    match file.write_all(content.as_bytes()) {
-        Err(err) => panic!(
-            "Unable to write to {}: {}",
-            mod_file_name,
-            err.description()
-        ),
-        Ok(_) => println!("generated {}", mod_file_name),
+
+    if latest_change > last_build_time {
+        println!("{:?}", proto_src_files);
+        fs::create_dir_all(PROTOBUF_TARGET_DIR).unwrap();
+        protoc_rust::run(protoc_rust::Args {
+            out_dir: PROTOBUF_TARGET_DIR,
+            input: &proto_src_files
+                .iter()
+                .map(|proto_file| proto_file.file_path.as_ref())
+                .collect::<Vec<&str>>(),
+            includes: &["src", PROTO_FILES_DIR],
+        }).expect("unable to run protoc");
+
+        let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);
+        let mod_file_path = Path::new(&mod_file_name);
+        let mut file = match fs::File::create(&mod_file_path) {
+            Err(err) => panic!(
+                "Unable to create file {}: {}",
+                mod_file_name,
+                err.description()
+            ),
+            Ok(file) => file,
+        };
+
+        let content = format!(
+            "{}\n{}",
+            GENERATED_SOURCE_HEADER,
+            proto_src_files
+                .iter()
+                .map(|proto_file| format!("pub mod {};", proto_file.module_name))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        match file.write_all(content.as_bytes()) {
+            Err(err) => panic!(
+                "Unable to write to {}: {}",
+                mod_file_name,
+                err.description()
+            ),
+            Ok(_) => println!("generated {}", mod_file_name),
+        }
+    } else {
+        println!(
+            "No proto files changed; latest modification: {}, last build: {}",
+            latest_change.as_secs(),
+            last_build_time.as_secs()
+        );
     }
 }
 
-fn glob_simple(pattern: &str) -> Vec<(String, String)> {
+fn glob_simple(pattern: &str) -> Vec<ProtoFile> {
     glob::glob(pattern)
         .expect("glob")
-        .map(|g| {
-            let path = g.expect("item");
-
-            let module_name = path.as_path()
-                .file_stem()
-                .expect("file stem")
-                .to_str()
-                .expect("utf-8")
-                .to_owned();
-
-            let file_path = path.as_path().to_str().expect("utf-8").to_owned();
-
-            (module_name, file_path)
-        })
+        .map(|g| protofile_info(g.expect("item").as_path()))
         .collect()
+}
+
+fn protofile_info(path: &Path) -> ProtoFile {
+    let module_name = path.file_stem()
+        .expect("file stem")
+        .to_str()
+        .expect("utf-8")
+        .to_owned();
+
+    let file_path = path.to_str().expect("utf-8").to_owned();
+
+    let file = fs::File::open(path).expect("Unable to open file");
+    let last_modified = file.metadata()
+        .expect("file to have metadata")
+        .modified()
+        .map(|sys_time| {
+            sys_time
+                .duration_since(UNIX_EPOCH)
+                .expect("after UNIX_EPOCH")
+        })
+        .expect("file to have modified time");
+
+    ProtoFile {
+        module_name,
+        file_path,
+        last_modified,
+    }
+}
+
+fn read_last_build_time() -> Duration {
+    let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);
+    match fs::File::open(Path::new(&mod_file_name)) {
+        Err(err) => {
+            println!(
+                "unable to open {}: {}; defaulting to 0",
+                mod_file_name,
+                err.description()
+            );
+            Duration::new(0, 0)
+        }
+        Ok(file) => file.metadata()
+            .expect("file to have metadata")
+            .modified()
+            .map(|sys_time| {
+                sys_time
+                    .duration_since(UNIX_EPOCH)
+                    .expect("after UNIX_EPOCH")
+            })
+            .expect("file to have modified time"),
+    }
 }

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate glob;
+extern crate protoc_rust;
+
+use std::error::Error;
+use std::fs;
+use std::io::prelude::*;
+use std::path::Path;
+
+const PROTO_FILES_DIR: &str = "../protos";
+const PROTOBUF_TARGET_DIR: &str = "src/proto";
+
+fn main() {
+    // Generate protobuf files
+    let proto_src_files = glob_simple(&format!("{}/*.proto", PROTO_FILES_DIR));
+    println!("{:?}", proto_src_files);
+
+    fs::create_dir_all(PROTOBUF_TARGET_DIR).unwrap();
+
+    protoc_rust::run(protoc_rust::Args {
+        out_dir: PROTOBUF_TARGET_DIR,
+        input: &proto_src_files
+            .iter()
+            .map(|&(_, ref a)| a)
+            .map(|s| s.as_ref())
+            .collect::<Vec<&str>>(),
+        includes: &["src", PROTO_FILES_DIR],
+    }).expect("unable to run protoc");
+
+    let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);
+    let mod_file_path = Path::new(&mod_file_name);
+    let mut file = match fs::File::create(&mod_file_path) {
+        Err(err) => panic!(
+            "Unable to create file {}: {}",
+            mod_file_name,
+            err.description()
+        ),
+        Ok(file) => file,
+    };
+
+    let content = format!(
+        r#"
+/*
+ * THIS IS A GENERATED FILE: DO NOT MODIFY
+ *
+ * This is the module which contains the generated sources for the Protocol
+ * buffers messages.
+ */
+
+{}"#,
+        proto_src_files
+            .iter()
+            .map(|&(ref module, _)| format!("pub mod {};", module))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    match file.write_all(content.as_bytes()) {
+        Err(err) => panic!(
+            "Unable to write to {}: {}",
+            mod_file_name,
+            err.description()
+        ),
+        Ok(_) => println!("generated {}", mod_file_name),
+    }
+}
+
+fn glob_simple(pattern: &str) -> Vec<(String, String)> {
+    glob::glob(pattern)
+        .expect("glob")
+        .map(|g| {
+            let path = g.expect("item");
+
+            let module_name = path.as_path()
+                .file_stem()
+                .expect("file stem")
+                .to_str()
+                .expect("utf-8")
+                .to_owned();
+
+            let file_path = path.as_path().to_str().expect("utf-8").to_owned();
+
+            (module_name, file_path)
+        })
+        .collect()
+}

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -27,13 +27,14 @@ use std::time::{Duration, UNIX_EPOCH};
 const PROTO_FILES_DIR: &str = "../protos";
 const PROTOBUF_TARGET_DIR: &str = "src/proto";
 const GENERATED_SOURCE_HEADER: &str = r#"
+#![cfg_attr(rustfmt, rustfmt_skip)]
+
 /*
  * THIS IS A GENERATED FILE: DO NOT MODIFY
  *
  * This is the module which contains the generated sources for the Protocol
  * buffers messages.
  */
-
 "#;
 
 #[derive(Debug, Clone)]
@@ -83,7 +84,7 @@ fn main() {
         };
 
         let content = format!(
-            "{}\n{}",
+            "{}\n{}\n",
             GENERATED_SOURCE_HEADER,
             proto_src_files
                 .iter()

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -19,12 +19,14 @@ extern crate cpython;
 extern crate crypto;
 extern crate libc;
 extern crate lmdb_zero;
+extern crate protobuf;
+
 #[macro_use]
 extern crate log;
-
 #[cfg(test)]
 extern crate rand;
 
 // exported modules
 pub mod database;
+pub mod proto;
 pub mod state;


### PR DESCRIPTION
Add build.rs, which includes code generation based on the files in protos.  Generates the source into `validator/src/proto` and generates a `mod.rs` file with each generated src file referenced in it.

Additionally, the source is only generated again when there are changes to the proto definition files.