### PR TITLE
Add Python Consensus SDK

### DIFF
--- a/sdk/python/sawtooth_sdk/consensus/__init__.py
+++ b/sdk/python/sawtooth_sdk/consensus/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------

--- a/sdk/python/sawtooth_sdk/consensus/driver.py
+++ b/sdk/python/sawtooth_sdk/consensus/driver.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import abc
+
+
+class Driver(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def __init__(self, engine):
+        pass
+
+    @abc.abstractmethod
+    def start(self, endpoint):
+        pass
+
+    @abc.abstractmethod
+    def stop(self):
+        pass

--- a/sdk/python/sawtooth_sdk/consensus/engine.py
+++ b/sdk/python/sawtooth_sdk/consensus/engine.py
@@ -1,0 +1,52 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import abc
+
+
+class Engine(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def start(self, updates, service):
+        '''Called after the engine is initialized, when a connection to the
+        validator has been established. Notifications from the
+        validator are sent along UPDATES. SERVICE is used to send
+        requests to the validator.
+
+        Args:
+            updates (Queue)
+            service (Service)
+        '''
+
+    @abc.abstractmethod
+    def stop(self):
+        '''Called before the engine is dropped in order to give the engine a
+        chance to notify peers and clean up.'''
+
+    @abc.abstractproperty
+    def version(self):
+        '''Get the version of this engine.
+
+        Return:
+            str
+        '''
+
+    @abc.abstractproperty
+    def name(self):
+        '''Get the name of the engine, typically the algorithm being
+        implemented.
+
+        Return:
+            str
+        '''

--- a/sdk/python/sawtooth_sdk/consensus/exceptions.py
+++ b/sdk/python/sawtooth_sdk/consensus/exceptions.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+
+class InvalidState(Exception):
+    pass
+
+
+class ReceiveError(Exception):
+    pass
+
+
+class UnknownBlock(Exception):
+    pass
+
+
+class UnknownPeer(Exception):
+    pass

--- a/sdk/python/sawtooth_sdk/consensus/service.py
+++ b/sdk/python/sawtooth_sdk/consensus/service.py
@@ -1,0 +1,151 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import abc
+
+
+class Block:
+    def __init__(self, block):
+        self.block_id = block.block_id
+        self.previous_id = block.previous_id
+        self.signer_id = block.signer_id
+        self.block_num = block.block_num
+        self.payload = block.payload
+
+
+class Service(metaclass=abc.ABCMeta):
+    '''Provides methods that allow the consensus engine to issue commands
+    and requests.'''
+
+    # -- P2P --
+
+    @abc.abstractmethod
+    def send_to(self, peer_id, message_type, payload):
+        '''Send a consensus message to a specific connected peer.
+
+        Args:
+            peer_id (bytes)
+            message_type (str)
+            payload (bytes)
+        '''
+
+    @abc.abstractmethod
+    def broadcast(self, message_type, payload):
+        '''Broadcast a message to all connected peers.
+
+        Args:
+            message_type (str)
+            payload (bytes)
+        '''
+
+    # -- Block Creation --
+
+    @abc.abstractmethod
+    def initialize_block(self, previous_id):
+        '''Initialize a new block with PREVIOUS_ID and begin adding batches to
+        it. If no PREVIOUS_ID is specified, the current head will be
+        used.
+
+        Args:
+            previous_id (bytes or None)
+        '''
+
+    @abc.abstractmethod
+    def finalize_block(self, data):
+        '''Stop adding batches to the current block and finalize it. Include
+        DATA in the block. If this call is successful, the consensus
+        engine will receive it afterwards.
+
+        Args:
+            data (bytes)
+
+        Return:
+            bytes
+        '''
+
+    @abc.abstractmethod
+    def cancel_block(self):
+        '''Stop adding batches to the current block and abandon it.'''
+
+    # -- Block Directives --
+
+    @abc.abstractmethod
+    def check_blocks(self, priority):
+        '''Update the prioritization of blocks to check to PRIORITY.
+
+        Args:
+            priority (list[bytes])
+        '''
+
+    @abc.abstractmethod
+    def commit_block(self, block_id):
+        '''Update the block that should be committed.
+
+        Args:
+            block_id (bytes)
+        '''
+
+    @abc.abstractmethod
+    def ignore_block(self, block_id):
+        '''Signal that this block is no longer being committed.
+
+        Args:
+            block_id (bytes)
+        '''
+
+    @abc.abstractmethod
+    def fail_block(self, block_id):
+        '''Mark this block as invalid from the perspective of consensus.
+
+        Args:
+            block_id (bytes)
+        '''
+
+    # -- Queries --
+
+    @abc.abstractmethod
+    def get_blocks(self, block_ids):
+        '''Retrive consensus-related information about blocks.
+
+        Args:
+            block_ids (list[bytes])
+
+        Return:
+            dict[bytes, block]
+        '''
+
+    @abc.abstractmethod
+    def get_settings(self, block_id, settings):
+        '''Read the value of settings as of the given block.
+
+        Args:
+            block_id (bytes)
+            settings (list[str])
+
+        Return:
+            dict[str, str]
+        '''
+
+    @abc.abstractmethod
+    def get_state(self, block_id, addresses):
+        '''Read values in state as of the given block.
+
+        Args:
+            block_id (bytes)
+            addresses (list[str])
+
+        Return:
+            dict[str, bytes]
+        '''

--- a/sdk/python/sawtooth_sdk/consensus/zmq_driver.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_driver.py
@@ -1,0 +1,150 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import concurrent
+import logging
+from queue import Queue
+from threading import Thread
+
+from sawtooth_sdk.consensus.driver import Driver
+from sawtooth_sdk.consensus.zmq_service import ZmqService
+from sawtooth_sdk.consensus import exceptions
+from sawtooth_sdk.messaging.stream import Stream
+from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ZmqDriver(Driver):
+    def __init__(self, engine):
+        super().__init__(engine)
+        self._engine = engine
+        self._stream = None
+        self._exit = False
+        self._updates = None
+
+    def start(self, endpoint):
+        self._stream = Stream(endpoint)
+
+        self._register()
+
+        self._updates = Queue()
+
+        engine_thread = Thread(
+            target=self._engine.start,
+            args=(
+                self._updates,
+                ZmqService(
+                    stream=self._stream,
+                    timeout=10,
+                    name=self._engine.name(),
+                    version=self._engine.version())))
+
+        engine_thread.start()
+
+        while True:
+            if self._exit:
+                self._engine.stop()
+                engine_thread.join()
+                break
+
+            try:
+                message = self._stream.receive().result(10)
+            except concurrent.futures.TimeoutError:
+                continue
+
+            result = self._process(message)
+
+            self._updates.put(result)
+
+    def stop(self):
+        self._exit = True
+        self._stream.close()
+
+    def _register(self):
+        self._stream.wait_for_ready()
+
+        future = self._stream.send(
+            message_type=Message.CONSENSUS_REGISTER_REQUEST,
+            content=consensus_pb2.ConsensusRegisterRequest(
+                name=self._engine.name(),
+                version=self._engine.version(),
+            ).SerializeToString(),
+        )
+
+        response = consensus_pb2.ConsensusRegisterResponse()
+        response.ParseFromString(future.result().content)
+
+        if response.status != consensus_pb2.ConsensusRegisterResponse.OK:
+            raise exceptions.ReceiveError(
+                'Registration failed with status {}'.format(response.status))
+
+    def _process(self, message):
+        type_tag = message.message_type
+
+        if type_tag == Message.CONSENSUS_NOTIFY_PEER_CONNECTED:
+            notification = consensus_pb2.ConsensusNotifyPeerConnected()
+            notification.ParseFromString(message.content)
+
+            data = notification.peer_info
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_PEER_DISCONNECTED:
+            notification = consensus_pb2.ConsensusNotifyPeerDisconnected()
+            notification.ParseFromString(message.content)
+
+            data = notification.peer_id
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_PEER_MESSAGE:
+            notification = consensus_pb2.ConsensusNotifyPeerMessage()
+            notification.ParseFromString(message.content)
+
+            data = notification.message
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_BLOCK_NEW:
+            notification = consensus_pb2.ConsensusNotifyBlockNew()
+            notification.ParseFromString(message.content)
+
+            data = notification.block
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_BLOCK_VALID:
+            notification = consensus_pb2.ConsensusNotifyBlockValid()
+            notification.ParseFromString(message.content)
+
+            data = notification.block_id
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_BLOCK_INVALID:
+            notification = consensus_pb2.ConsensusNotifyBlockInvalid()
+            notification.ParseFromString(message.content)
+
+            data = notification.block_id
+
+        elif type_tag == Message.CONSENSUS_NOTIFY_BLOCK_COMMIT:
+            notification = consensus_pb2.ConsensusNotifyBlockCommit()
+            notification.ParseFromString(message.content)
+
+            data = notification.block_id
+
+        else:
+            raise exceptions.ReceiveError(
+                'Received unexpected message type: {}'.format(type_tag))
+
+        self._stream.send_back(
+            message_type=Message.CONSENSUS_NOTIFY_ACK,
+            correlation_id=message.correlation_id,
+            content=consensus_pb2.ConsensusNotifyAck().SerializeToString())
+
+        return type_tag, data

--- a/sdk/python/sawtooth_sdk/consensus/zmq_service.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_service.py
@@ -1,0 +1,302 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+from sawtooth_sdk.consensus.service import Service
+from sawtooth_sdk.consensus.service import Block
+from sawtooth_sdk.consensus import exceptions
+from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+
+
+class ZmqService(Service):
+    def __init__(self, stream, timeout, name, version):
+        self._stream = stream
+        self._timeout = timeout
+        self._name = name
+        self._version = version
+
+    def _send(self, request, message_type, response_type):
+        response = self._stream.send(
+            message_type=message_type,
+            content=request.SerializeToString(),
+        ).result(self._timeout).content
+
+        return response
+
+    # -- P2P --
+
+    def send_to(self, peer_id, message_type, payload):
+        message = consensus_pb2.ConsensusPeerMessage(
+            message_type=message_type,
+            content=payload,
+            name=self._name,
+            version=self._version)
+
+        request = consensus_pb2.ConsensusSendToRequest(
+            message=message,
+            peer_id=peer_id)
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_SEND_TO_REQUEST,
+            response_type=consensus_pb2.ConsensusSendToResponse)
+
+        if response.status != consensus_pb2.ConsensusSendToResponse.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(response.status))
+
+    def broadcast(self, message_type, payload):
+        message = consensus_pb2.ConsensusPeerMessage(
+            message_type=message_type,
+            content=payload,
+            name=self._name,
+            version=self._version)
+
+        request = consensus_pb2.ConsensusBroadcastRequest(message=message)
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_BROADCAST_REQUEST,
+            response_type=consensus_pb2.ConsensusBroadcastResponse)
+
+        if response.status != consensus_pb2.ConsensusBroadcastResponse.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(response.status))
+
+    # -- Block Creation --
+
+    def initialize_block(self, previous_id):
+        request = (
+            consensus_pb2.ConsensusInitializeBlockRequest(
+                previous_id=previous_id)
+            if previous_id
+            else consensus_pb2.ConsensusInitializeBlockRequest()
+        )
+
+        response_type = consensus_pb2.ConsensusInitializeBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_INITIALIZE_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.INVALID_STATE:
+            raise exceptions.InvalidState(
+                'Cannot initialize block in current state')
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    def finalize_block(self, data):
+        request = consensus_pb2.ConsensusFinalizeBlockRequest(data=data)
+
+        response_type = consensus_pb2.ConsensusFinalizeBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_FINALIZE_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.INVALID_STATE:
+            raise exceptions.InvalidState(
+                'Cannot finalize block in current state')
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    def cancel_block(self):
+        request = consensus_pb2.ConsensusCancelBlockRequest()
+
+        response_type = consensus_pb2.ConsensusCancelBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_CANCEL_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.INVALID_STATE:
+            raise exceptions.InvalidState(
+                'Cannot cancel block in current state')
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    # -- Block Directives --
+
+    def check_blocks(self, priority):
+        request = consensus_pb2.ConsensusCheckBlockRequest(block_ids=priority)
+
+        response_type = consensus_pb2.ConsensusCheckBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_CHECK_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    def commit_block(self, block_id):
+        request = consensus_pb2.ConsensusCommitBlockRequest(block_id=block_id)
+
+        response_type = consensus_pb2.ConsensusCommitBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_COMMIT_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    def ignore_block(self, block_id):
+        request = consensus_pb2.ConsensusIgnoreBlockRequest(block_id=block_id)
+
+        response_type = consensus_pb2.ConsensusIgnoreBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_IGNORE_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    def fail_block(self, block_id):
+        request = consensus_pb2.ConsensusFailBlockRequest(block_id=block_id)
+
+        response_type = consensus_pb2.ConsensusFailBlockResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_FAIL_BLOCK_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+    # -- Queries --
+
+    def get_blocks(self, block_ids):
+        request = consensus_pb2.ConsensusBlocksGetRequest(block_ids=block_ids)
+
+        response_type = consensus_pb2.ConsensusBlocksGetResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_BLOCKS_GET_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+        return {
+            block.block_id: Block(block)
+            for block in response.blocks
+        }
+
+    def get_settings(self, block_id, settings):
+        request = consensus_pb2.ConsensusSettingsGetRequest(
+            block_id=block_id,
+            keys=settings)
+
+        response_type = consensus_pb2.ConsensusSettingsGetResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_SETTINGS_GET_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+        return {
+            entry.key: entry.value
+            for entry in response.entries
+        }
+
+    def get_state(self, block_id, addresses):
+        request = consensus_pb2.ConsensusStateGetRequest(
+            block_id=block_id,
+            addresses=addresses)
+
+        response_type = consensus_pb2.ConsensusStateGetResponse
+
+        response = self._send(
+            request=request,
+            message_type=Message.CONSENSUS_STATE_GET_REQUEST,
+            response_type=response_type)
+
+        status = response.status
+
+        if status == response_type.UNKNOWN_BLOCK:
+            raise exceptions.UnknownBlock()
+
+        if status != response_type.OK:
+            raise exceptions.ReceiveError(
+                'Failed with status {}'.format(status))
+
+        return {
+            entry.address: entry.data
+            for entry in response.entries
+        }

--- a/sdk/python/tests/test_zmq_driver.py
+++ b/sdk/python/tests/test_zmq_driver.py
@@ -1,0 +1,174 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import logging
+import threading
+import random
+import string
+import unittest
+
+import zmq
+
+from sawtooth_sdk.consensus.engine import Engine
+from sawtooth_sdk.consensus.zmq_driver import ZmqDriver
+from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MockEngine(Engine):
+    def __init__(self):
+        self.updates = None
+
+    def start(self, updates, service):
+        self.updates = updates
+
+    def stop(self):
+        pass
+
+    def name(self):
+        return 'test-name'
+
+    def version(self):
+        return 'test-version'
+
+
+class TestDriver(unittest.TestCase):
+    def setUp(self):
+        self.ctx = zmq.Context.instance()
+        self.socket = self.ctx.socket(zmq.ROUTER)
+        self.socket.bind('tcp://127.0.0.1:*')
+        self.url = self.socket.getsockopt_string(zmq.LAST_ENDPOINT)
+        self.connection_id = None
+
+        self.engine = MockEngine()
+        self.driver = ZmqDriver(self.engine)
+
+    def tearDown(self):
+        self.socket.close()
+
+    def recv_rep(self, request_type, response, response_type):
+        # pylint: disable=unbalanced-tuple-unpacking
+        connection_id, message_bytes = self.socket.recv_multipart(0)
+
+        self.connection_id = connection_id
+
+        message = Message()
+        message.ParseFromString(message_bytes)
+
+        request = request_type()
+        request.ParseFromString(message.content)
+
+        reply = Message(
+            message_type=response_type,
+            content=response.SerializeToString(),
+            correlation_id=message.correlation_id)
+
+        self.socket.send_multipart(
+            [self.connection_id, reply.SerializeToString()],
+            0)
+
+        return request
+
+    def send_req_rep(self, request, request_type):
+        message = Message(
+            message_type=request_type,
+            correlation_id=generate_correlation_id(),
+            content=request.SerializeToString())
+
+        self.socket.send_multipart(
+            [self.connection_id, message.SerializeToString()],
+            0)
+
+        # pylint: disable=unbalanced-tuple-unpacking
+        _, reply_bytes = self.socket.recv_multipart(0)
+
+        reply = Message()
+        reply.ParseFromString(reply_bytes)
+
+        self.assertEqual(
+            reply.message_type,
+            Message.CONSENSUS_NOTIFY_ACK)
+
+        return reply.content
+
+    def test_driver(self):
+        # Start the driver in a separate thread to simulate the
+        # validator and the driver
+        driver_thread = threading.Thread(
+            target=self.driver.start,
+            args=(self.url,))
+
+        driver_thread.start()
+
+        response = consensus_pb2.ConsensusRegisterResponse(
+            status=consensus_pb2.ConsensusRegisterResponse.OK)
+
+        request = self.recv_rep(
+            consensus_pb2.ConsensusRegisterRequest,
+            response,
+            Message.CONSENSUS_REGISTER_RESPONSE)
+
+        self.assertEqual(request.name, 'test-name')
+        self.assertEqual(request.version, 'test-version')
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyPeerConnected(),
+            Message.CONSENSUS_NOTIFY_PEER_CONNECTED)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyPeerDisconnected(),
+            Message.CONSENSUS_NOTIFY_PEER_DISCONNECTED)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyPeerMessage(),
+            Message.CONSENSUS_NOTIFY_PEER_MESSAGE)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyBlockNew(),
+            Message.CONSENSUS_NOTIFY_BLOCK_NEW)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyBlockValid(),
+            Message.CONSENSUS_NOTIFY_BLOCK_VALID)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyBlockInvalid(),
+            Message.CONSENSUS_NOTIFY_BLOCK_INVALID)
+
+        self.send_req_rep(
+            consensus_pb2.ConsensusNotifyBlockCommit(),
+            Message.CONSENSUS_NOTIFY_BLOCK_COMMIT)
+
+        self.assertEqual(
+            [msg_type for (msg_type, data) in list(self.engine.updates.queue)],
+            [
+                Message.CONSENSUS_NOTIFY_PEER_CONNECTED,
+                Message.CONSENSUS_NOTIFY_PEER_DISCONNECTED,
+                Message.CONSENSUS_NOTIFY_PEER_MESSAGE,
+                Message.CONSENSUS_NOTIFY_BLOCK_NEW,
+                Message.CONSENSUS_NOTIFY_BLOCK_VALID,
+                Message.CONSENSUS_NOTIFY_BLOCK_INVALID,
+                Message.CONSENSUS_NOTIFY_BLOCK_COMMIT,
+            ])
+
+        self.driver.stop()
+        driver_thread.join()
+
+
+def generate_correlation_id():
+    return ''.join(random.choice(string.ascii_letters) for _ in range(16))

--- a/sdk/python/tests/test_zmq_service.py
+++ b/sdk/python/tests/test_zmq_service.py
@@ -1,0 +1,269 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -----------------------------------------------------------------------------
+
+import unittest
+
+from sawtooth_sdk.consensus.zmq_service import ZmqService
+from sawtooth_sdk.messaging.future import Future
+from sawtooth_sdk.messaging.future import FutureResult
+from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.protobuf.validator_pb2 import Message
+
+
+class TestService(unittest.TestCase):
+    def setUp(self):
+        self.mock_stream = unittest.mock.Mock()
+        self.service = ZmqService(
+            stream=self.mock_stream,
+            timeout=10,
+            name='name',
+            version='version')
+
+    def _make_future(self, message_type, content):
+        fut = Future('test')
+        fut.set_result(FutureResult(
+            message_type=message_type,
+            content=content))
+        return fut
+
+    def test_send_to(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_SEND_TO_RESPONSE,
+            content=consensus_pb2.ConsensusSendToResponse(
+                status=consensus_pb2.ConsensusSendToResponse.OK))
+
+        self.service.send_to(
+            peer_id=b'peer_id',
+            message_type='message_type',
+            payload=b'payload')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_SEND_TO_REQUEST,
+            content=consensus_pb2.ConsensusSendToRequest(
+                message=consensus_pb2.ConsensusPeerMessage(
+                    message_type='message_type',
+                    content=b'payload',
+                    name='name',
+                    version='version'),
+                peer_id=b'peer_id').SerializeToString())
+
+    def test_broadcast(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_BROADCAST_RESPONSE,
+            content=consensus_pb2.ConsensusBroadcastResponse(
+                status=consensus_pb2.ConsensusBroadcastResponse.OK))
+
+        self.service.broadcast(
+            message_type='message_type',
+            payload=b'payload')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_BROADCAST_REQUEST,
+            content=consensus_pb2.ConsensusBroadcastRequest(
+                message=consensus_pb2.ConsensusPeerMessage(
+                    message_type='message_type',
+                    content=b'payload',
+                    name='name',
+                    version='version')).SerializeToString())
+
+    def test_initialize_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_INITIALIZE_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusInitializeBlockResponse(
+                status=consensus_pb2.ConsensusInitializeBlockResponse.OK))
+
+        self.service.initialize_block(previous_id=b'test')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_INITIALIZE_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusInitializeBlockRequest(
+                previous_id=b'test').SerializeToString())
+
+    def test_finalize_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_FINALIZE_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusFinalizeBlockResponse(
+                status=consensus_pb2.ConsensusFinalizeBlockResponse.OK))
+
+        self.service.finalize_block(data=b'test')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_FINALIZE_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusFinalizeBlockRequest(
+                data=b'test').SerializeToString())
+
+    def test_cancel_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_CANCEL_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusCancelBlockResponse(
+                status=consensus_pb2.ConsensusCancelBlockResponse.OK))
+
+        self.service.cancel_block()
+
+        request = consensus_pb2.ConsensusCancelBlockRequest()
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_CANCEL_BLOCK_REQUEST,
+            content=request.SerializeToString())
+
+    def test_check_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_CHECK_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusCheckBlockResponse(
+                status=consensus_pb2.ConsensusCheckBlockResponse.OK))
+
+        self.service.check_blocks(priority=[b'test1', b'test2'])
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_CHECK_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusCheckBlockRequest(
+                block_ids=[b'test1', b'test2']).SerializeToString())
+
+    def test_commit_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_COMMIT_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusCommitBlockResponse(
+                status=consensus_pb2.ConsensusCommitBlockResponse.OK))
+
+        self.service.commit_block(block_id=b'test')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_COMMIT_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusCommitBlockRequest(
+                block_id=b'test').SerializeToString())
+
+    def test_ignore_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_IGNORE_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusIgnoreBlockResponse(
+                status=consensus_pb2.ConsensusIgnoreBlockResponse.OK))
+
+        self.service.ignore_block(block_id=b'test')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_IGNORE_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusIgnoreBlockRequest(
+                block_id=b'test').SerializeToString())
+
+    def test_fail_block(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_FAIL_BLOCK_RESPONSE,
+            content=consensus_pb2.ConsensusFailBlockResponse(
+                status=consensus_pb2.ConsensusFailBlockResponse.OK))
+
+        self.service.fail_block(block_id=b'test')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_FAIL_BLOCK_REQUEST,
+            content=consensus_pb2.ConsensusFailBlockRequest(
+                block_id=b'test').SerializeToString())
+
+    def test_get_blocks(self):
+        block_1 = consensus_pb2.ConsensusBlock(
+            block_id=b'block1',
+            previous_id=b'block0',
+            signer_id=b'signer1',
+            block_num=1,
+            payload=b'test1')
+
+        block_2 = consensus_pb2.ConsensusBlock(
+            block_id=b'block2',
+            previous_id=b'block1',
+            signer_id=b'signer2',
+            block_num=2,
+            payload=b'test2')
+
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_BLOCKS_GET_RESPONSE,
+            content=consensus_pb2.ConsensusBlocksGetResponse(
+                status=consensus_pb2.ConsensusBlocksGetResponse.OK,
+                blocks=[block_1, block_2]))
+
+        blocks = self.service.get_blocks(block_ids=[b'id1', b'id2'])
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_BLOCKS_GET_REQUEST,
+            content=consensus_pb2.ConsensusBlocksGetRequest(
+                block_ids=[b'id1', b'id2']).SerializeToString())
+
+        self.assertEqual({
+            block_id: (
+                block.previous_id,
+                block.signer_id,
+                block.block_num,
+                block.payload)
+            for block_id, block in blocks.items()
+        }, {
+            b'block1': (b'block0', b'signer1', 1, b'test1'),
+            b'block2': (b'block1', b'signer2', 2, b'test2'),
+        })
+
+    def test_get_settings(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_SETTINGS_GET_RESPONSE,
+            content=consensus_pb2.ConsensusSettingsGetResponse(
+                status=consensus_pb2.ConsensusSettingsGetResponse.OK,
+                entries=[
+                    consensus_pb2.ConsensusSettingsEntry(
+                        key='key1',
+                        value='value1'),
+                    consensus_pb2.ConsensusSettingsEntry(
+                        key='key2',
+                        value='value2')]))
+
+        entries = self.service.get_settings(
+            block_id=b'test',
+            settings=['test1', 'test2'])
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_SETTINGS_GET_REQUEST,
+            content=consensus_pb2.ConsensusSettingsGetRequest(
+                block_id=b'test',
+                keys=['test1', 'test2']).SerializeToString())
+
+        self.assertEqual(
+            entries, {
+                'key1': 'value1',
+                'key2': 'value2',
+            })
+
+    def test_get_state(self):
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_STATE_GET_RESPONSE,
+            content=consensus_pb2.ConsensusStateGetResponse(
+                status=consensus_pb2.ConsensusStateGetResponse.OK,
+                entries=[
+                    consensus_pb2.ConsensusStateEntry(
+                        address='address1',
+                        data=b'data1'),
+                    consensus_pb2.ConsensusStateEntry(
+                        address='address2',
+                        data=b'data2')]))
+
+        entries = self.service.get_state(
+            block_id=b'test',
+            addresses=['test1', 'test2'])
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_STATE_GET_REQUEST,
+            content=consensus_pb2.ConsensusStateGetRequest(
+                block_id=b'test',
+                addresses=['test1', 'test2']).SerializeToString())
+
+        self.assertEqual(
+            entries, {
+                'address1': b'data1',
+                'address2': b'data2',
+            })


### PR DESCRIPTION
Right now this PR includes interfaces for `Engine`, `Service`, and `Driver`, and implements `ZmqService` with unit tests, but does not include the `ZmqDriver`.

The `Service` interface is slightly different from the Rust one. Specifically, it returns dictionaries instead of lists for `get_{blocks,settings,state}`. This seems to me like a more convenient way to access the data. I can change it to match Rust, or change Rust to match this.