### PR TITLE
BACKPORT: Adjust keep times to mitigate missing predecessors

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -133,8 +133,13 @@ class Validator(object):
             flag='c',
             indexes=BlockStore.create_index_configuration())
         block_store = BlockStore(block_db)
+        # The cache keep time for the journal's block cache must be greater
+        # than the cache keep time used by the completer.
+        base_keep_time = 1200
         block_cache = BlockCache(
-            block_store, keep_time=300, purge_frequency=30)
+            block_store,
+            keep_time=int(base_keep_time * 9 / 8),
+            purge_frequency=30)
 
         # -- Setup Thread Pools -- #
         component_thread_pool = InstrumentedThreadPoolExecutor(
@@ -224,7 +229,12 @@ class Validator(object):
             topology_check_frequency=1
         )
 
-        completer = Completer(block_store, gossip)
+        completer = Completer(
+            block_store,
+            gossip,
+            cache_keep_time=base_keep_time,
+            cache_purge_frequency=30,
+            requested_keep_time=300)
 
         block_sender = BroadcastBlockSender(completer, gossip)
         batch_sender = BroadcastBatchSender(completer, gossip)


### PR DESCRIPTION
Having the completer keep blocks for a longer amount of time then the chain
controller causes the two components to fall out of sync much easier.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>