### PR TITLE
Backport: Fix infinite loop for set & delete(update) context state

### DIFF
--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -251,6 +251,11 @@ class MerkleDatabase(object):
             if path != '':
                 parent_address = path[:-TOKEN_SIZE]
                 path_branch = path[-TOKEN_SIZE:]
+                # Check to reinstate the path_map for an address which
+                # shares its prefix both in set_items and delete_items
+                if path_map.get(parent_address) is None:
+                    path_map[parent_address] = {"v": None, "c": {}}
+                    path_map[parent_address]['c'].update({path_branch: None})
                 path_map[parent_address]['c'][path_branch] = key_hash
 
         if not virtual:

--- a/validator/tests/test_merkle_trie/tests.py
+++ b/validator/tests/test_merkle_trie/tests.py
@@ -140,6 +140,90 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
             with self.assertRaises(KeyError):
                 self.get(address, ishash=True)
 
+    def test_merkle_trie_update_same_address_space(self):
+        """This UT is similar to update except that it will
+        ensure that there are no index errors in path_map
+        within update function in case there are addresses
+        within set_items & delete_items which have a common
+        prefix(of any length).
+
+        A merkle tree is created with some initial values
+        which is then updated(set & delete).
+        """
+        init_root = self.get_merkle_root()
+
+        values = {}
+
+        key_hashes = {
+            "asdfg": "e5542002d3e2892516fa461cde69e05880609f\
+bad3d38ab69435a189e126de672b620c",  # matching prefix e55420
+            "qwert": "c946ee72d38b8c51328f1a5f31eb5bd3300362\
+ad0ca69dab54eff996775c7069216bda",
+            "zxcvb": "487a6a63c71c9b7b63146ef68858e5d010b497\
+8fd70dda0404d4fad5e298ccc9a560eb",
+            "yuiop": "e55420c026596ee643e26fd93927249ea28fb5\
+f359ddbd18bc02562dc7e8dbc93e89b9",  # matching prefix e55420
+            "hjklk": "cc1370ce67aa16c89721ee947e9733b2a3d246\
+0db5b0ea6410288f426ad8d8040ea641",
+            "bnmvc": "d07e69664286712c3d268ca71464f2b3b26043\
+46f833106f3e0f6a72276e57a16f3e0f"
+        }
+
+        for key, hashed in key_hashes.items():
+            value = {key: _random_string(512)}
+            new_root = self.set(hashed, value, ishash=True)
+            values[hashed] = value
+            self.set_merkle_root(new_root)
+
+        self.assert_not_root(init_root)
+
+        for address, value in values.items():
+            self.assert_value_at_address(
+                address, value, ishash=True)
+
+        set_items = {
+            hashed: {
+                key: 2.0
+            }
+            for key, hashed in key_hashes.items()
+        }
+        values.update(set_items)
+        # The first item below(e55420...89b9) shares a common prefix
+        #  with the first in set_items(e55420...620c)
+        delete_items = {
+            'e55420c026596ee643e26fd93927249ea28fb5f359\
+ddbd18bc02562dc7e8dbc93e89b9',
+            'cc1370ce67aa16c89721ee947e9733b2a3d2460db5\
+b0ea6410288f426ad8d8040ea641',
+            'd07e69664286712c3d268ca71464f2b3b2604346f8\
+33106f3e0f6a72276e57a16f3e0f'}
+        for addr in delete_items:
+            del values[addr]
+        virtual_root = self.update(set_items, delete_items, virtual=True)
+        # virtual root shouldn't match actual contents of tree
+        with self.assertRaises(KeyError):
+            self.set_merkle_root(virtual_root)
+        actual_root = self.update(set_items, delete_items, virtual=False)
+        # the virtual root should be the same as the actual root
+        self.assertEqual(virtual_root, actual_root)
+        # neither the virtual root nor the actual root should be the current
+        # merlke root yet.
+        self.assert_not_root(
+            virtual_root,
+            actual_root)
+
+        self.set_merkle_root(actual_root)
+        self.assert_root(actual_root)
+
+        for address, value in values.items():
+            self.assert_value_at_address(
+                address, value, ishash=True)
+
+        for address in delete_items:
+            with self.assertRaises(KeyError):
+                self.get(address, ishash=True)
+                self.get(address, ishash=True)
+
     # assertions
     def assert_value_at_address(self, address, value, ishash=False):
         self.assertEqual(


### PR DESCRIPTION
Validator was getting into infinite loop when trying to set & delete context
state in one go. Set items were being handled before the deletion which was
causing some expected data to be deleted. This threw an error which was kept
the batch from being cleaned up. This further caused the scheduler to pick up
the same batch again and again after the schedule interval(infinte loop).
Proper state is ensured during rehashing bottom-up now.

Signed-off-by: rranjan3 <rajeev2.ranjan@intel.com>