### PR TITLE
Modify Jenkins to build staging branches.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node ('master') {
             checkout scm
         }
 
-        if (!(env.BRANCH_NAME == '1-0' && env.JOB_BASE_NAME == '1-0')) {
+        if (!(env.BRANCH_NAME == '1-0' && env.JOB_BASE_NAME == '1-0') && !(env.BRANCH_NAME ==~ /1-0-staging-\d{2}/ && env.JOB_BASE_NAME ==~ /1-0-staging-\d{2}/)) {
             stage("Check Whitelist") {
                 readTrusted 'bin/whitelist'
                 sh './bin/whitelist "$CHANGE_AUTHOR" /etc/jenkins-authorized-builders'


### PR DESCRIPTION
Modify the whitelist conditional test to skip the committers whitelist
stage for the 1-0-staging branches in addition to 1-0.

Signed-off-by: Richard Berg <rberg@bitwise.io>