### PR TITLE
Add validator rust tests to build

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -275,6 +275,7 @@ test_validator() {
     run_docker_test test_namespace_permission
     copy_coverage .coverage.namespace_permission
     run_docker_test test_state_verifier --timeout 30
+    run_docker_test ./validator/tests/unit_rust_validator.yaml
 }
 
 test_go_sdk() {

--- a/validator/tests/unit_rust_validator.yaml
+++ b/validator/tests/unit_rust_validator.yaml
@@ -1,0 +1,25 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  unit-rust-validator:
+    image: sawtooth-dev-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    working_dir: /project/sawtooth-core/validator
+    command: cargo test


### PR DESCRIPTION
Adds a docker-compose file to run `cargo test` in the validator directory
running any doc tests, unit tests, and any tests in the `validator/tests` directory.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>