### PR TITLE
Write change log on Merkle Trie Changes

### DIFF
--- a/integration/sawtooth_integration/tests/test_state_verifier.py
+++ b/integration/sawtooth_integration/tests/test_state_verifier.py
@@ -26,6 +26,7 @@ from sawtooth_signing import CryptoFactory
 
 from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
+from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
@@ -195,7 +196,8 @@ class TestStateVerifier(unittest.TestCase):
         blockstore = BlockStore(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
         global_state_db = NativeLmdbDatabase(
-            os.path.join(self._temp_dir, 'test_state_verifier.lmdb'))
+            os.path.join(self._temp_dir, 'test_state_verifier.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration())
 
         precalculated_state_roots = [
             "e35490eac6f77453675c3399da7efe451e791272bbc8cf1b032c75030fb455c3",

--- a/protos/merkle.proto
+++ b/protos/merkle.proto
@@ -1,0 +1,42 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "merkle_pb2";
+
+// An Entry in the change log for a given state root.
+message ChangeLogEntry {
+    // A state root that succeed this root.
+    message Successor {
+        // A root hash of a merkle trie based of off this root.
+        bytes successor = 1;
+
+        // The keys (i.e. hashes) that were replaced (i.e. deleted) by this
+        // successor.  These may be deleted during pruning.
+        repeated bytes deletions = 2;
+    }
+
+    // A root hash of a merkle trie this tree was based off.
+    bytes parent = 1;
+
+    // The hashes that were added for this root. These may be deleted during
+    // pruning, if this root is being abandoned.
+    repeated bytes additions = 2;
+
+    // The list of successors.
+    repeated Successor successors = 3;
+}

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Intel Corporation"]
 [dependencies]
 clap = "2"
 cpython = "0.2"
+hex = "0.3"
 log = { version = "0.4", features = ["std"] }
 libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"

--- a/validator/sawtooth_validator/database/native_lmdb.py
+++ b/validator/sawtooth_validator/database/native_lmdb.py
@@ -28,7 +28,7 @@ class NativeLmdbDatabase(object):
             raise TypeError("Path cannot be null")
         elif res == ErrorCode.InvalidFilePath:
             raise TypeError("Invalid file path {}".format(path))
-        elif res = ErrorCode.InvalidIndexString:
+        elif res == ErrorCode.InvalidIndexString:
             raise TypeError("Invalid index string {}".format(indexes))
         elif res == ErrorCode.InitializeContextError:
             raise TypeError("Unable to initialize LMDB Context")

--- a/validator/sawtooth_validator/database/native_lmdb.py
+++ b/validator/sawtooth_validator/database/native_lmdb.py
@@ -37,10 +37,13 @@ class NativeLmdbDatabase(object):
         else:
             raise TypeError("Unknown error occurred: {}".format(res.error))
 
-    def __del__(self):
+    def drop(self):
         if self._db_ptr:
             LIBRARY.call('lmdb_database_drop', self._db_ptr)
             self._db_ptr = None
+
+    def __del__(self):
+        self.drop()
 
     @property
     def pointer(self):

--- a/validator/sawtooth_validator/database/native_lmdb.py
+++ b/validator/sawtooth_validator/database/native_lmdb.py
@@ -5,19 +5,31 @@ from sawtooth_validator.ffi import LIBRARY
 
 
 class NativeLmdbDatabase(object):
-    def __init__(self, path, _size=1024**4):
+    def __init__(self, path, indexes=None, _size=1024**4):
+        if indexes is None:
+            indexes = []
+
         self._db_ptr = ctypes.c_void_p()
 
         c_path = ctypes.c_char_p(path.encode())
+
+        c_indexes = (ctypes.c_char_p * len(indexes))()
+        for (i, index) in enumerate(indexes):
+            c_indexes[i] = ctypes.c_char_p(index.encode())
+
         c_size = ctypes.c_size_t(_size)
         res = LIBRARY.call(
-            'lmdb_database_new', c_path, c_size, ctypes.byref(self._db_ptr))
+            'lmdb_database_new', c_path, c_size,
+            c_indexes, ctypes.c_size_t(len(indexes)),
+            ctypes.byref(self._db_ptr))
         if res == ErrorCode.Success:
             return
         elif res == ErrorCode.NullPointerProvided:
             raise TypeError("Path cannot be null")
         elif res == ErrorCode.InvalidFilePath:
             raise TypeError("Invalid file path {}".format(path))
+        elif res = ErrorCode.InvalidIndexString:
+            raise TypeError("Invalid index string {}".format(indexes))
         elif res == ErrorCode.InitializeContextError:
             raise TypeError("Unable to initialize LMDB Context")
         elif res == ErrorCode.InitializeDatabaseError:
@@ -39,6 +51,7 @@ class ErrorCode(IntEnum):
     Success = 0
     NullPointerProvided = 0x01
     InvalidFilePath = 0x02
+    InvalidIndexString = 0x03
 
     InitializeContextError = 0x11
     InitializeDatabaseError = 0x12

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -236,6 +236,10 @@ def main(args):
         bind_component,
         validator_config.scheduler)
 
+    # Explicitly drop this, so there are not two db instances
+    global_state_db.drop()
+    global_state_db = None
+
     LOGGER.info(
         'Starting validator with %s scheduler',
         validator_config.scheduler)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -42,6 +42,7 @@ from sawtooth_validator.networking.dispatch import Dispatcher
 from sawtooth_validator.journal.chain_id_manager import ChainIdManager
 from sawtooth_validator.execution.executor import TransactionExecutor
 from sawtooth_validator.state.batch_tracker import BatchTracker
+from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.state.settings_view import SettingsViewFactory
 from sawtooth_validator.state.settings_cache import SettingsObserver
 from sawtooth_validator.state.settings_cache import SettingsCache
@@ -112,7 +113,9 @@ class Validator(object):
             data_dir, 'merkle-{}.lmdb'.format(bind_network[-2:]))
         LOGGER.debug(
             'global state database file is %s', global_state_db_filename)
-        global_state_db = NativeLmdbDatabase(global_state_db_filename)
+        global_state_db = NativeLmdbDatabase(
+            global_state_db_filename,
+            indexes=MerkleDatabase.create_index_configuration())
         state_view_factory = StateViewFactory(global_state_db)
 
         # -- Setup Receipt Store -- #

--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -34,6 +34,7 @@ def _encode(value):
 
 
 class MerkleDatabase(object):
+
     def __init__(self, database, merkle_root=None):
         self._merkle_db_ptr = ctypes.c_void_p()
 
@@ -44,6 +45,10 @@ class MerkleDatabase(object):
         else:
             _libexec('merkle_db_new', database.pointer,
                      ctypes.byref(self._merkle_db_ptr))
+
+    @staticmethod
+    def create_index_configuration():
+        return ['change_log']
 
     def __del__(self):
         # check that it has not been deleted, nor is it null

--- a/validator/src/database/lmdb.rs
+++ b/validator/src/database/lmdb.rs
@@ -31,7 +31,11 @@ pub struct LmdbContext {
 }
 
 impl LmdbContext {
-    pub fn new(filepath: &Path, indexes: u32, size: Option<usize>) -> Result<Self, DatabaseError> {
+    pub fn new(
+        filepath: &Path,
+        indexes: usize,
+        size: Option<usize>,
+    ) -> Result<Self, DatabaseError> {
         let flags = lmdb::open::MAPASYNC | lmdb::open::WRITEMAP | lmdb::open::NORDAHEAD
             | lmdb::open::NOSUBDIR;
 
@@ -43,7 +47,7 @@ impl LmdbContext {
             DatabaseError::InitError(format!("Failed to initialize environment: {}", err))
         })?;
         builder
-            .set_maxdbs(indexes + 1)
+            .set_maxdbs((indexes + 1) as u32)
             .map_err(|err| DatabaseError::InitError(format!("Failed to set MAX_DBS: {}", err)))?;
         builder
             .set_mapsize(size.unwrap_or(DEFAULT_SIZE))

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate cbor;
 extern crate cpython;
 extern crate crypto;
+extern crate hex;
 extern crate libc;
 extern crate lmdb_zero;
 extern crate protobuf;

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -454,6 +454,7 @@ impl<'a> Iterator for MerkleLeafIterator<'a> {
     }
 }
 
+/// Initializes a database with an empty Trie
 fn initialize_db(db: &LmdbDatabase) -> Result<String, MerkleDatabaseError> {
     let (hash, packed) = encode_and_hash(Node::default())?;
 
@@ -465,12 +466,23 @@ fn initialize_db(db: &LmdbDatabase) -> Result<String, MerkleDatabaseError> {
     Ok(hex_hash)
 }
 
+/// Encodes the given node, and returns the hash of the bytes.
 fn encode_and_hash(node: Node) -> Result<(Vec<u8>, Vec<u8>), MerkleDatabaseError> {
     let packed = node.into_bytes()?;
     let hash = hash(&packed);
     Ok((hash, packed))
 }
 
+/// Given a path, split it into its parent's path and the specific branch for
+/// this path, such that the following assertion is true:
+///
+/// ```
+/// let (parent_path, branch) = parent_and_branch(some_path);
+/// let mut path = String::new();
+/// path.push(parent_path);
+/// path.push(branch);
+/// assert_eq!(some_path, &path);
+/// ```
 fn parent_and_branch(path: &str) -> (&str, &str) {
     let parent_address = if !path.is_empty() {
         &path[..path.len() - TOKEN_SIZE]
@@ -487,6 +499,7 @@ fn parent_and_branch(path: &str) -> (&str, &str) {
     (parent_address, path_branch)
 }
 
+/// Splits an address into tokens
 fn tokenize_address(address: &str) -> Box<[&str]> {
     let mut tokens: Vec<&str> = Vec::with_capacity(address.len() / 2);
     let mut i = 0;

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -660,7 +660,7 @@ mod tests {
 
     #[test]
     fn node_deserialize() {
-        let packed = from_hex("a26163a162303063616263617647676f6f64627965");
+        let packed = ::hex::decode("a26163a162303063616263617647676f6f64627965").expect("proper hex");
 
         let unpacked = Node::from_bytes(&packed).unwrap();
         assert_eq!(
@@ -986,25 +986,4 @@ mod tests {
         temp_dir.to_str().unwrap().to_string()
     }
 
-    fn from_hex(s: &str) -> Vec<u8> {
-        assert!(s.len() % 2 == 0);
-        let mut res = Vec::with_capacity(s.len() / 2);
-        let mut buf = 0;
-
-        for (i, b) in s.bytes().enumerate() {
-            buf <<= 4;
-            match b {
-                b'A'...b'F' => buf |= b - b'A' + 10,
-                b'a'...b'f' => buf |= b - b'a' + 10,
-                b'0'...b'9' => buf |= b - b'0',
-                _ => continue,
-            }
-
-            if (i + 1) % 2 == 0 {
-                res.push(buf);
-            }
-        }
-
-        res
-    }
 }

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -419,11 +419,11 @@ fn parent_and_branch(path: &str) -> (&str, &str) {
 
 /// Splits an address into tokens
 fn tokenize_address(address: &str) -> Box<[&str]> {
-    let mut tokens: Vec<&str> = Vec::with_capacity(address.len() / 2);
+    let mut tokens: Vec<&str> = Vec::with_capacity(address.len() / TOKEN_SIZE);
     let mut i = 0;
     while i < address.len() {
-        tokens.push(&address[i..i + 2]);
-        i += 2;
+        tokens.push(&address[i..i + TOKEN_SIZE]);
+        i += TOKEN_SIZE;
     }
     tokens.into_boxed_slice()
 }

--- a/validator/src/state/merkle_ffi.rs
+++ b/validator/src/state/merkle_ffi.rs
@@ -93,7 +93,10 @@ fn make_merkle_db(
             }
             ErrorCode::Success
         }
-        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::DatabaseError(err)) => {
+            error!("A Database Error occurred: {}", err);
+            ErrorCode::DatabaseError
+        }
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
         Err(err) => {
             error!("Unknown Error!: {:?}", err);
@@ -154,7 +157,10 @@ pub extern "C" fn merkle_db_set_merkle_root(
 
     match unsafe { (*(merkle_db as *mut MerkleDatabase)).set_merkle_root(state_root) } {
         Ok(()) => ErrorCode::Success,
-        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::DatabaseError(err)) => {
+            error!("A Database Error occurred: {}", err);
+            ErrorCode::DatabaseError
+        }
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
         Err(err) => {
             error!("Unknown Error!: {:?}", err);
@@ -185,7 +191,10 @@ pub extern "C" fn merkle_db_contains(merkle_db: *mut c_void, address: *const c_c
         match (*(merkle_db as *mut MerkleDatabase)).contains(address_str) {
             Ok(true) => ErrorCode::Success,
             Ok(false) => ErrorCode::NotFound,
-            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::DatabaseError(err)) => {
+                error!("A Database Error occurred: {}", err);
+                ErrorCode::DatabaseError
+            }
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
             Err(err) => {
                 error!("Unknown Error!: {:?}", err);
@@ -229,7 +238,10 @@ pub extern "C" fn merkle_db_get(
                 ErrorCode::Success
             }
             Ok(None) => ErrorCode::NotFound,
-            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::DatabaseError(err)) => {
+                error!("A Database Error occurred: {}", err);
+                ErrorCode::DatabaseError
+            }
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
             Err(err) => {
                 error!("Unknown Error!: {:?}", err);
@@ -278,7 +290,10 @@ pub extern "C" fn merkle_db_set(
 
                 ErrorCode::Success
             }
-            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::DatabaseError(err)) => {
+                error!("A Database Error occurred: {}", err);
+                ErrorCode::DatabaseError
+            }
             Err(err) => {
                 error!("Unknown Error!: {:?}", err);
                 ErrorCode::Unknown
@@ -318,7 +333,10 @@ pub extern "C" fn merkle_db_delete(
 
                 ErrorCode::Success
             }
-            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::DatabaseError(err)) => {
+                error!("A Database Error occurred: {}", err);
+                ErrorCode::DatabaseError
+            }
             Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
             Err(err) => {
                 error!("Unknown Error!: {:?}", err);
@@ -409,7 +427,10 @@ pub extern "C" fn merkle_db_update(
 
                 ErrorCode::Success
             }
-            Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+            Err(MerkleDatabaseError::DatabaseError(err)) => {
+                error!("A Database Error occurred: {}", err);
+                ErrorCode::DatabaseError
+            }
             Err(err) => {
                 error!("Unknown Error!: {:?}", err);
                 ErrorCode::Unknown
@@ -447,7 +468,10 @@ pub extern "C" fn merkle_db_leaf_iterator_new(
 
             ErrorCode::Success
         }
-        Err(MerkleDatabaseError::DatabaseError(_)) => ErrorCode::DatabaseError,
+        Err(MerkleDatabaseError::DatabaseError(err)) => {
+            error!("A Database Error occurred: {}", err);
+            ErrorCode::DatabaseError
+        }
         Err(MerkleDatabaseError::NotFound(_)) => ErrorCode::NotFound,
         Err(err) => {
             error!("Unknown Error!: {:?}", err);
@@ -494,7 +518,10 @@ pub extern "C" fn merkle_db_leaf_iterator_next(
             ErrorCode::Success
         },
         None => ErrorCode::StopIteration,
-        Some(Err(MerkleDatabaseError::DatabaseError(_))) => ErrorCode::DatabaseError,
+        Some(Err(MerkleDatabaseError::DatabaseError(err))) => {
+            error!("A Database Error occurred: {}", err);
+            ErrorCode::DatabaseError
+        }
         Some(Err(err)) => {
             error!("Unknown Error!: {:?}", err);
             ErrorCode::Unknown

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -134,6 +134,7 @@ def make_db_and_store(base_dir, size=3):
     """
     database = NativeLmdbDatabase(
         os.path.join(base_dir, 'client_handlers_mock_db.lmdb'),
+        indexes=MerkleDatabase.create_index_configuration(),
         _size=10 * 1024 * 1024)
     store = MockBlockStore(size=0)
     roots = []

--- a/validator/tests/test_config_view/tests.py
+++ b/validator/tests/test_config_view/tests.py
@@ -39,6 +39,7 @@ class TestSettingsView(unittest.TestCase):
         self._temp_dir = tempfile.mkdtemp()
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_config_view.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
         state_view_factory = StateViewFactory(database)
         self._settings_view_factory = SettingsViewFactory(state_view_factory)

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -44,6 +44,7 @@ class TestContextManager(unittest.TestCase):
 
         self.database_of_record = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'db_of_record.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         self.context_manager = context_manager.ContextManager(
@@ -53,6 +54,7 @@ class TestContextManager(unittest.TestCase):
         # used for replicating state hash through direct merkle tree updates
         self.database_results = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'db_results.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
     def tearDown(self):

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -214,6 +214,7 @@ class TestGenesisController(unittest.TestCase):
 
         state_database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_genesis.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
         merkle_db = MerkleDatabase(state_database)
 

--- a/validator/tests/test_identity_view/tests.py
+++ b/validator/tests/test_identity_view/tests.py
@@ -36,6 +36,7 @@ class TestIdentityView(unittest.TestCase):
 
         self._database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_identity_view.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
         self._tree = MerkleDatabase(self._database)
 

--- a/validator/tests/test_merkle_trie/tests.py
+++ b/validator/tests/test_merkle_trie/tests.py
@@ -32,6 +32,7 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
 
         self.lmdb = NativeLmdbDatabase(
             self.file,
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=120 * 1024 * 1024)
 
         self.trie = MerkleDatabase(self.lmdb)

--- a/validator/tests/test_scheduler/test_schedulers_with_yaml.py
+++ b/validator/tests/test_scheduler/test_schedulers_with_yaml.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 
 from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
+from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.execution.scheduler_parallel import ParallelScheduler
 from sawtooth_validator.execution.scheduler_serial import SerialScheduler
@@ -40,6 +41,7 @@ class TestSchedulersWithYaml(unittest.TestCase):
 
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_state_view.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         self._context_manager = ContextManager(database)

--- a/validator/tests/test_scheduler/tests.py
+++ b/validator/tests/test_scheduler/tests.py
@@ -61,6 +61,7 @@ class TestSchedulers(unittest.TestCase):
 
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_schedulers.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         self._context_manager = ContextManager(database)
@@ -868,6 +869,7 @@ class TestSchedulers(unittest.TestCase):
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir,
                          '_add_valid_batch_invalid_batch.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
         merkle_database = MerkleDatabase(database)
         state_root_end = merkle_database.update(
@@ -1019,6 +1021,7 @@ class TestSerialScheduler(unittest.TestCase):
 
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_serial_schedulers.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         self.context_manager = ContextManager(database)
@@ -1255,6 +1258,7 @@ class TestParallelScheduler(unittest.TestCase):
 
         database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_serial_schedulers.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         self.context_manager = ContextManager(database)

--- a/validator/tests/test_scheduler/yaml_scheduler_tester.py
+++ b/validator/tests/test_scheduler/yaml_scheduler_tester.py
@@ -381,6 +381,7 @@ class SchedulerTester(object):
 
         database = NativeLmdbDatabase(
             os.path.join(base_dir, 'compute_state_hashes_wo_scheduler.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
         tree = MerkleDatabase(database=database)

--- a/validator/tests/test_state_view/tests.py
+++ b/validator/tests/test_state_view/tests.py
@@ -34,6 +34,7 @@ class StateViewTest(unittest.TestCase):
 
         self.database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_state_view.lmdb'),
+            indexes=MerkleDatabase.create_index_configuration(),
             _size=10 * 1024 * 1024)
 
     def tearDown(self):


### PR DESCRIPTION
Write a change log entry for each new merkle trie that records the additions for a given root and the deletions made by a successor trie.

This includes:
- some changes to have the hashes stored internally as bytes (though this is not complete)
- Refactor in LmdbDatabase to have a DatabaseReader trait
- ChangeLogEntry protobuf message