### PR TITLE
Only build blocks in publisher thread

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -696,10 +696,6 @@ class BlockPublisher(object):
                     self._pending_batches.update_limit(len(chain_head.batches))
                     self._pending_batches.rebuild(
                         committed_batches, uncommitted_batches)
-                    try:
-                        self.initialize_block(self._chain_head)
-                    except ConsensusNotReady:
-                        self._log_consensus_state()
 
         # pylint: disable=broad-except
         except Exception:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -573,7 +573,7 @@ class BlockPublisher(object):
         else:
             return []
 
-    def _build_candidate_block(self, previous_block):
+    def initialize_block(self, previous_block):
         """ Build a candidate block and construct the consensus object to
         validate it.
         :param previous_block_id: The block to build on top of.
@@ -688,7 +688,7 @@ class BlockPublisher(object):
                     self._pending_batches.update_limit(len(chain_head.batches))
                     self._pending_batches.rebuild(
                         committed_batches, uncommitted_batches)
-                    self._build_candidate_block(chain_head)
+                    self.initialize_block(chain_head)
 
         # pylint: disable=broad-except
         except Exception as exc:
@@ -718,7 +718,7 @@ class BlockPublisher(object):
                 if (self._chain_head is not None
                         and not self._building()
                         and self._pending_batches):
-                    self._build_candidate_block(self._chain_head)
+                    self.initialize_block(self._chain_head)
 
                 if (self._building()
                         and (

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -319,7 +319,7 @@ class _CandidateBlock(object):
         signature = identity_signer.sign(header_bytes)
         block.set_signature(signature)
 
-    def finalize_block(self, identity_signer, pending_batches):
+    def finalize(self, identity_signer, pending_batches):
         """Compose the final Block to publish. This involves flushing
         the scheduler, having consensus bless the block, and signing
         the block.
@@ -747,7 +747,7 @@ class BlockPublisher(object):
                     injected_batch_ids = \
                         self._candidate_block.injected_batch_ids
                     last_batch = self._candidate_block.last_batch
-                    block = self._candidate_block.finalize_block(
+                    block = self._candidate_block.finalize(
                         self._identity_signer,
                         pending_batches)
                     self._candidate_block = None

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -548,11 +548,7 @@ class BlockPublisher(object):
         for observer in self._batch_observers:
             observer.notify_batch_pending(batch)
 
-    def can_accept_batch(self):
-        """Returns whether new batches can be accepted for soft limiting."""
-        return len(self._pending_batches) < self._pending_batches.limit()
-
-    def get_current_queue_info(self):
+    def pending_batch_info(self):
         """Returns a tuple of the current size of the pending batch queue
         and the current queue limit.
         """

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -833,6 +833,7 @@ class PendingBatchesPool:
         last_index = self._batches.index(last_sent)
         unsent = self._batches[last_index + 1:]
         self._batches = still_pending + unsent
+        self._ids = set(b.header_signature for b in self._batches)
 
         self._update_gauge()
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -696,9 +696,9 @@ class BlockPublisher(object):
                         self._log_consensus_state()
 
         # pylint: disable=broad-except
-        except Exception as exc:
-            LOGGER.critical("on_chain_updated exception.")
-            LOGGER.exception(exc)
+        except Exception:
+            LOGGER.exception(
+                "Unhandled exception in BlockPublisher.on_chain_updated")
 
     def cancel_block(self):
         if self._candidate_block:
@@ -770,9 +770,9 @@ class BlockPublisher(object):
                         self.on_chain_updated(None)
 
         # pylint: disable=broad-except
-        except Exception as exc:
-            LOGGER.critical("on_check_publish_block exception.")
-            LOGGER.exception(exc)
+        except Exception:
+            LOGGER.exception(
+                "Unhandled exception in BlockPublisher.on_check_publish_block")
 
     def has_batch(self, batch_id):
         with self._lock:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -563,6 +563,16 @@ class BlockPublisher(object):
 
         return consensus
 
+    def _load_injectors(self, block):
+        if self._batch_injector_factory is not None:
+            batch_injectors = self._batch_injector_factory.create_injectors(
+                block.identifier)
+            if batch_injectors:
+                LOGGER.debug("Loaded batch injectors: %s", batch_injectors)
+            return batch_injectors
+        else:
+            return []
+
     def _build_candidate_block(self, previous_block):
         """ Build a candidate block and construct the consensus object to
         validate it.
@@ -584,13 +594,7 @@ class BlockPublisher(object):
         public_key = self._identity_signer.get_public_key().as_hex()
         consensus = self._load_consensus(
             previous_block, state_view, public_key)
-
-        batch_injectors = []
-        if self._batch_injector_factory is not None:
-            batch_injectors = self._batch_injector_factory.create_injectors(
-                previous_block.identifier)
-            if batch_injectors:
-                LOGGER.debug("Loaded batch injectors: %s", batch_injectors)
+        batch_injectors = self._load_injectors(previous_block)
 
         block_header = BlockHeader(
             block_num=previous_block.block_num + 1,

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -174,7 +174,6 @@ class _CandidateBlock(object):
     def batches(self):
         return self._pending_batches.copy()
 
-    @property
     def can_add_batch(self):
         return (
             self._max_batches == 0
@@ -629,7 +628,7 @@ class BlockPublisher(object):
             public_key)
 
         for batch in self._pending_batches:
-            if self._candidate_block.can_add_batch:
+            if self._candidate_block.can_add_batch():
                 self._candidate_block.add_batch(batch)
             else:
                 break
@@ -649,7 +648,7 @@ class BlockPublisher(object):
                 # if we are building a block then send schedule it for
                 # execution.
                 if self._candidate_block and \
-                        self._candidate_block.can_add_batch:
+                        self._candidate_block.can_add_batch():
                     self._candidate_block.add_batch(batch)
             else:
                 LOGGER.debug("Batch has an unauthorized signer. Batch: %s",

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -701,6 +701,12 @@ class BlockPublisher(object):
 
         self._candidate_block = None
 
+    def _building(self):
+        """Returns whether the block publisher is in the process of building
+        a block or not.
+        """
+        return self._candidate_block is not None
+
     def on_check_publish_block(self, force=False):
         """Ask the consensus module if it is time to claim the candidate block
         if it is then, claim it and tell the world about it.
@@ -710,11 +716,11 @@ class BlockPublisher(object):
         try:
             with self._lock:
                 if (self._chain_head is not None
-                        and self._candidate_block is None
+                        and not self._building()
                         and self._pending_batches):
                     self._build_candidate_block(self._chain_head)
 
-                if (self._candidate_block
+                if (self._building()
                         and (
                             force
                             or self._candidate_block.has_pending_batches())

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -712,6 +712,11 @@ class BlockPublisher(object):
         """
         return self._candidate_block is not None
 
+    def _can_build(self):
+        """Returns whether the block publisher is ready to build a block.
+        """
+        return self._chain_head is not None and self._pending_batches
+
     def _log_consensus_state(self):
         if self._logging_states.consensus_ready:
             LOGGER.debug("Consensus is ready to build candidate block.")
@@ -728,9 +733,7 @@ class BlockPublisher(object):
         """
         try:
             with self._lock:
-                if (self._chain_head is not None
-                        and not self._building()
-                        and self._pending_batches):
+                if not self._building() and self._can_build():
                     try:
                         self.initialize_block(self._chain_head)
                     except ConsensusNotReady:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -132,7 +132,7 @@ class _CandidateBlock(object):
                  max_batches,
                  batch_injectors,
                  settings_view,
-                 signer_public_key,
+                 identity_signer,
                  ):
         self._pending_batches = []
         self._pending_batch_ids = set()
@@ -149,7 +149,7 @@ class _CandidateBlock(object):
         self._batch_injectors = batch_injectors
 
         self._settings_view = settings_view
-        self._signer_public_key = signer_public_key
+        self._identity_signer = identity_signer
 
     def __del__(self):
         self.cancel()
@@ -286,7 +286,7 @@ class _CandidateBlock(object):
 
             if not enforce_validation_rules(
                     self._settings_view,
-                    self._signer_public_key,
+                    self._identity_signer.get_public_key().as_hex(),
                     self._pending_batches + batches_to_add):
                 return
 
@@ -308,7 +308,7 @@ class _CandidateBlock(object):
         return self._consensus.check_publish_block(
             self._block_builder.block_header)
 
-    def _sign_block(self, block, identity_signer):
+    def _sign_block(self, block):
         """ The block should be complete and the final
         signature from the publishing validator(this validator) needs to
         be added.
@@ -316,10 +316,10 @@ class _CandidateBlock(object):
         :param identity_signer: the singer to sign the block with.
         """
         header_bytes = block.block_header.SerializeToString()
-        signature = identity_signer.sign(header_bytes)
+        signature = self._identity_signer.sign(header_bytes)
         block.set_signature(signature)
 
-    def finalize(self, identity_signer, pending_batches):
+    def finalize(self, pending_batches):
         """Compose the final Block to publish. This involves flushing
         the scheduler, having consensus bless the block, and signing
         the block.
@@ -427,7 +427,7 @@ class _CandidateBlock(object):
             return None
 
         builder.set_state_hash(state_hash)
-        self._sign_block(builder, identity_signer)
+        self._sign_block(builder)
         return builder.build_block()
 
 
@@ -631,7 +631,7 @@ class BlockPublisher(object):
             max_batches,
             batch_injectors,
             SettingsView(state_view),
-            public_key)
+            self._identity_signer)
 
         for batch in self._pending_batches:
             if self._candidate_block.can_add_batch():

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -486,8 +486,7 @@ class BlockPublisher(object):
         self._transaction_executor = transaction_executor
         self._block_sender = block_sender
         self._batch_publisher = BatchPublisher(identity_signer, batch_sender)
-        self._pending_batches = PendingBatchesPool()
-        self._publish_count_average = _RollingAverage(
+        self._pending_batches = PendingBatchesPool(
             NUM_PUBLISH_COUNT_SAMPLES, INITIAL_PUBLISH_COUNT)
 
         self._chain_head = chain_head  # block (BlockWrapper)
@@ -535,18 +534,14 @@ class BlockPublisher(object):
             observer.notify_batch_pending(batch)
 
     def can_accept_batch(self):
-        return len(self._pending_batches) < self._get_current_queue_limit()
-
-    def _get_current_queue_limit(self):
-        # Limit the number of batches to 2 times the publishing average.  This
-        # allows the queue to grow geometrically, if the queue is drained.
-        return 2 * self._publish_count_average.value
+        """Returns whether new batches can be accepted for soft limiting."""
+        return len(self._pending_batches) < self._pending_batches.limit()
 
     def get_current_queue_info(self):
         """Returns a tuple of the current size of the pending batch queue
         and the current queue limit.
         """
-        return (len(self._pending_batches), self._get_current_queue_limit())
+        return (len(self._pending_batches), self._pending_batches.limit())
 
     @property
     def chain_head_lock(self):
@@ -648,24 +643,6 @@ class BlockPublisher(object):
                 LOGGER.debug("Batch has an unauthorized signer. Batch: %s",
                              batch.header_signature)
 
-    def _update_pending_queue_limit(self, num_committed_batches):
-        """Take the number of committed batches and use that to update the
-        rolling average of batches, if it is a significant enough change.
-
-        Args:
-            num_committed_batches (int): the number committed batches in a
-                block
-        """
-        if num_committed_batches > 0:
-            # Only update the average if either:
-            # a. Not drained below the current average
-            # b. Drained the queue, but the queue was not bigger than the
-            #    current running average
-            remainder = len(self._pending_batches) - num_committed_batches
-            if remainder > self._publish_count_average.value or \
-                    num_committed_batches > self._publish_count_average.value:
-                self._publish_count_average.update(num_committed_batches)
-
     def on_chain_updated(self, chain_head,
                          committed_batches=None,
                          uncommitted_batches=None):
@@ -696,7 +673,7 @@ class BlockPublisher(object):
                 # we need to make a new _CandidateBlock (if we can) since the
                 # block chain has updated under us.
                 if chain_head is not None:
-                    self._update_pending_queue_limit(len(chain_head.batches))
+                    self._pending_batches.update_limit(len(chain_head.batches))
                     self._pending_batches.rebuild(
                         committed_batches, uncommitted_batches)
                     self._build_candidate_block(chain_head)
@@ -775,11 +752,12 @@ class BlockPublisher(object):
 
 class PendingBatchesPool:
 
-    def __init__(self):
+    def __init__(self, sample_size, initial_value):
         # Ordered batches waiting to be processed
         self._batches = list()
         self._ids = set()
         self._gauge = COLLECTOR.gauge('pending_batch_gauge', instance=self)
+        self._limit = QueueLimit(sample_size, initial_value)
 
     def __len__(self):
         return len(self._batches)
@@ -837,8 +815,41 @@ class PendingBatchesPool:
 
         self._update_gauge()
 
+    def update_limit(self, consumed):
+        self._limit.update(len(self._batches), consumed)
+
+    def limit(self):
+        return self._limit.get()
+
     def _update_gauge(self):
         self._gauge.set_value(len(self._batches))
+
+
+class QueueLimit:
+    def __init__(self, sample_size, initial_value):
+        self._avg = _RollingAverage(sample_size, initial_value)
+
+    def update(self, queue_length, consumed):
+        """Use the current queue size and the number of items consumed to
+        update the queue limit, if there was a significant enough change.
+
+        Args:
+            queue_length (int): the current size of the queue
+            consumed (int): the number items consumed
+        """
+        if consumed > 0:
+            # Only update the average if either:
+            # a. Not drained below the current average
+            # b. Drained the queue, but the queue was not bigger than the
+            #    current running average
+            remainder = queue_length - consumed
+            if remainder > self._avg.value or consumed > self._avg.value:
+                self._avg.update(consumed)
+
+    def get(self):
+        # Limit the number of items to 2 times the publishing average.  This
+        # allows the queue to grow geometrically, if the queue is drained.
+        return 2 * self._avg.value
 
 
 class _RollingAverage(object):

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -22,6 +22,7 @@ import queue
 from threading import RLock
 import time
 
+from sawtooth_validator.concurrent.atomic import ConcurrentSet
 from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.execution.scheduler_exceptions import SchedulerError
 
@@ -501,8 +502,7 @@ class BlockPublisher(object):
         self._blocks_published_count = COLLECTOR.counter(
             'blocks_published_count', instance=self)
 
-        self._batch_queue = queue.Queue()
-        self._queued_batch_ids = []
+        self._batch_queue = IncomingBatchQueue()
         self._batch_observers = batch_observers
         self._check_publish_block_frequency = check_publish_block_frequency
         self._publisher_thread = None
@@ -529,7 +529,6 @@ class BlockPublisher(object):
         inclusion in the next block.
         """
         self._batch_queue.put(batch)
-        self._queued_batch_ids.append(batch.header_signature)
         for observer in self._batch_observers:
             observer.notify_batch_pending(batch)
 
@@ -631,7 +630,6 @@ class BlockPublisher(object):
         :return: None
         """
         with self._lock:
-            self._queued_batch_ids = self._queued_batch_ids[:1]
             if self._permission_verifier.is_batch_signer_authorized(batch):
                 self._pending_batches.append(batch)
                 # if we are building a block then send schedule it for
@@ -744,10 +742,28 @@ class BlockPublisher(object):
         with self._lock:
             if batch_id in self._pending_batches:
                 return True
-            if batch_id in self._queued_batch_ids:
+            if batch_id in self._batch_queue:
                 return True
 
         return False
+
+
+class IncomingBatchQueue:
+    def __init__(self):
+        self._queue = queue.Queue()
+        self._ids = ConcurrentSet()
+
+    def put(self, batch):
+        self._ids.add(batch.header_signature)
+        self._queue.put(batch)
+
+    def get(self, timeout=None):
+        batch = self._queue.get(timeout=timeout)
+        self._ids.remove(batch.header_signature)
+        return batch
+
+    def __contains__(self, batch_id):
+        return batch_id in self._ids
 
 
 class PendingBatchesPool:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -729,12 +729,10 @@ class BlockPublisher(object):
 
                 self._chain_head = chain_head
 
-                if self._candidate_block:
-                    self._candidate_block.cancel()
+                self.cancel_block()
 
-                self._candidate_block = None  # we need to make a new
-                # _CandidateBlock (if we can) since the block chain has updated
-                # under us.
+                # we need to make a new _CandidateBlock (if we can) since the
+                # block chain has updated under us.
                 if chain_head is not None:
                     self._update_pending_queue_limit(len(chain_head.batches))
                     self._rebuild_pending_batches(committed_batches,
@@ -748,6 +746,12 @@ class BlockPublisher(object):
         except Exception as exc:
             LOGGER.critical("on_chain_updated exception.")
             LOGGER.exception(exc)
+
+    def cancel_block(self):
+        if self._candidate_block:
+            self._candidate_block.cancel()
+
+        self._candidate_block = None
 
     def on_check_publish_block(self, force=False):
         """Ask the consensus module if it is time to claim the candidate block

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -751,16 +751,9 @@ class BlockPublisher(object):
 
                 if self._building():
                     try:
-                        result = self._candidate_block.finalize(force)
+                        result = self.finalize_block(force)
                     except (ConsensusNotReady, NoPendingBatchesRemaining):
                         return
-
-                    self._candidate_block = None
-
-                    # Update the _pending_batches to reflect what we learned.
-                    self._pending_batches.update(
-                        result.remaining_batches,
-                        result.last_batch)
 
                     if result.block:
                         blkw = BlockWrapper(result.block)
@@ -781,6 +774,18 @@ class BlockPublisher(object):
         except Exception:
             LOGGER.exception(
                 "Unhandled exception in BlockPublisher.on_check_publish_block")
+
+    def finalize_block(self, force=False):
+        result = self._candidate_block.finalize(force)
+
+        self._candidate_block = None
+
+        # Update the _pending_batches to reflect what we learned.
+        self._pending_batches.update(
+            result.remaining_batches,
+            result.last_batch)
+
+        return result
 
     def has_batch(self, batch_id):
         with self._lock:

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -121,9 +121,7 @@ def add(
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BATCH_SUBMIT_REQUEST,
         ClientBatchSubmitBackpressureHandler(
-            block_publisher.can_accept_batch,
-            block_publisher.get_current_queue_info,
-        ),
+            block_publisher.pending_batch_info),
         client_thread_pool)
 
     dispatcher.add_handler(


### PR DESCRIPTION
on_chain_updated gets run as a callback to ChainController, which in turn gets run as a callback to BlockValidator, which is run in the block validation thread pool. This causes the ChainController to spend time working on block publishing instead of progressing the chain, which is a poor separation of concerns and in fact harms the validator's ability to make progress. This is even more detrimental when you consider that the thread pool used by the BlockValidator only has one worker at this time.

These lines can be safely deleted because the _PublisherThread already polls every 0.1 seconds to see if it can build a block, so in the worst case there will be a small delay before the block gets built.

This PR is built on #1608. Only the last commit is relevant.