### PR TITLE
Correct dashes for --url option in intkey load example

### DIFF
--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -292,7 +292,7 @@ purposes.
 
    .. code-block:: console
 
-      root@client# intkey load -f batches.intkey -url http://rest-api:8008
+      root@client# intkey load -f batches.intkey --url http://rest-api:8008
       batches: 11 batch/sec: 141.7800162868952
 
 #. The terminal window in which you ran the ``docker-compose`` command displays


### PR DESCRIPTION
Signed-off-by: Anne Chenette <chenette@bitwise.io>