### PR TITLE
BACKPORT: Prevent concurrent modification of tracked status

### DIFF
--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -152,12 +152,8 @@ class BatchTracker(ChainObserver,
                 * 'message' - the error message sent by the TP
                 * 'extended_data' - any additional data sent by the TP
         """
-        try:
-            return self._invalid[batch_id]
-        except KeyError:
-            # If batch has been purged from the invalid cache before its txn
-            # info is fetched, return an empty array of txn info
-            return []
+        with self._lock:
+            return [info.copy() for info in self._invalid.get(batch_id, [])]
 
     def watch_statuses(self, observer, batch_ids):
         """Allows a component to register to be notified when a set of

--- a/validator/tests/test_batch_tracker/__init__.py
+++ b/validator/tests/test_batch_tracker/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/tests/test_batch_tracker/tests.py
+++ b/validator/tests/test_batch_tracker/tests.py
@@ -1,0 +1,58 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.protobuf import batch_pb2
+from sawtooth_validator.protobuf import transaction_pb2
+from sawtooth_validator.state.batch_tracker import BatchTracker
+
+
+class BatchTrackerTest(unittest.TestCase):
+    def test_invalid_txn_infos(self):
+        """Test that the invalid batch information is return correctly.
+
+        - Add valid batch info
+        - Add invalid batch info
+        - Ensure that the invalid batch info is returned
+        - Ensure that modifying the returned info does not affect future calls
+        """
+        block_store = Mock()
+        batch_tracker = BatchTracker(block_store)
+
+        batch_tracker.notify_batch_pending(
+            make_batch("good_batch", "good_txn"))
+        batch_tracker.notify_batch_pending(
+            make_batch("bad_batch", "bad_txn"))
+
+        batch_tracker.notify_txn_invalid("bad_txn")
+
+        invalid_info = batch_tracker.get_invalid_txn_info("bad_batch")
+        self.assertEqual(1, len(invalid_info))
+        self.assertEqual("bad_txn", invalid_info[0]["id"])
+
+        invalid_info[0]["header_signature"] = invalid_info[0].pop("id")
+
+        more_invalid_info = batch_tracker.get_invalid_txn_info("bad_batch")
+        self.assertEqual(1, len(more_invalid_info))
+        self.assertEqual("bad_txn", more_invalid_info[0]["id"])
+
+
+def make_batch(batch_id, txn_id):
+    transaction = transaction_pb2.Transaction(header_signature=txn_id)
+    batch = batch_pb2.Batch(
+        header_signature=batch_id, transactions=[transaction])
+
+    return batch


### PR DESCRIPTION
Prevent the caller of get_invalid_txn_info from reading a possibly
concurrently modified collection.

Additionally,

- Add unit test for BatchTracker, with a test to prevent regressions

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>