### PR TITLE
Revert "Clarify Signature Policy selection"

### DIFF
--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -153,11 +153,7 @@ Instructions for creating your own service provider certificate can be found
 After your certificate is created you'll need to register it with the
 attestation service.
 `Click here <https://software.intel.com/formfill/sgx-onboarding>`_ for the
-registration form. Please select ``Linkable`` option when choosing the
-Attestation policy since PoET relies on "Linkable" EPID signatures.
-This means the device will always present a consistent identity within the
-Attestation service. Further details on Signature Policy can be found
-`here <https://software.intel.com/en-us/articles/signature-policy>`_.
+registration form.
 
 Configure the Validator to Use SGX PoET
 ---------------------------------------


### PR DESCRIPTION
This reverts commit 00255c4ca834a3240c38f235cf28d3c23cad015e.

This commit broke doc generation and was merged without being
appropriately tested.

Signed-off-by: James Mitchell <mitchell@bitwise.io>