### PR TITLE
Use correct entries list to generate AuthorizationException in python sdk

### DIFF
--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -97,7 +97,7 @@ class Context(object):
                               request).result(timeout).content)
         if response.status == \
                 state_context_pb2.TpStateSetResponse.AUTHORIZATION_ERROR:
-            addresses = [e.address for e in entries]
+            addresses = [e.address for e in state_entries]
             raise AuthorizationException(
                 'Tried to set unauthorized address: {}'.format(addresses))
         return response.addresses


### PR DESCRIPTION
The `entries` list does not contain `TpStateEntry messages`, so the code will
throw an exception when generating the `AuthorizationException`:

```
  File "/Users/.../lib/python3.6/site-packages/sawtooth_sdk/processor/context.py", line 100, in <listcomp>
    addresses = [e.address for e in entries]
AttributeError: 'str' object has no attribute 'address'
```