### PR TITLE
Implement consensus engine publishing services

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -275,6 +275,7 @@ test_validator() {
     run_docker_test test_namespace_restriction
     copy_coverage .coverage.namespace_restriction
     run_docker_test test_state_verifier --timeout 30
+    run_docker_test test_consensus_engine_api
     run_docker_test ./validator/tests/unit_rust_validator.yaml
 }
 

--- a/integration/sawtooth_integration/docker/test_consensus_engine_api.yaml
+++ b/integration/sawtooth_integration/docker/test_consensus_engine_api.yaml
@@ -1,0 +1,81 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  intkey-tp-python:
+    image: sawtooth-intkey-tp-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: intkey-tp-python -vv -C tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    image: sawtooth-validator:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    # start the validator with an empty genesis batch
+    command: "bash -c \"\
+        sawadm keygen && \
+        sawadm genesis && \
+        sawtooth-validator --endpoint tcp://validator:8800 -v \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5005 \
+    \""
+    stop_signal: SIGKILL
+
+  rest-api:
+    image: sawtooth-rest-api:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
+    stop_signal: SIGKILL
+
+  test-consensus-engine-api:
+    image: sawtooth-dev-python:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8008
+    depends_on:
+      - validator
+      - rest-api
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_consensus_engine_api
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/sdk/examples/intkey_python:\
+        /project/sawtooth-core/integration:\
+        /project/sawtooth-core/validator:\
+        /project/sawtooth-core/signing"

--- a/integration/sawtooth_integration/tests/test_consensus_engine_api.py
+++ b/integration/sawtooth_integration/tests/test_consensus_engine_api.py
@@ -1,0 +1,139 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import json
+import logging
+import time
+import unittest
+import urllib
+
+from sawtooth_sdk.protobuf import validator_pb2
+from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.messaging.stream import Stream
+
+from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
+
+
+REST_API_URL = "http://rest-api:8008"
+INTERBLOCK_PERIOD = 1
+WAIT = 300
+BATCH_KEYS = 'abcd'
+
+
+class TestConsensusEngineAPI(unittest.TestCase):
+    def setUp(self):
+        wait_for_rest_apis([REST_API_URL])
+        self.stream = Stream("tcp://validator:5005")
+
+    def tearDown(self):
+        self.stream.close()
+
+    def test_publishing(self):
+        logging.warning("Starting test")
+        batches = make_batches(BATCH_KEYS)
+        committed = 0
+
+        for batch in batches:
+            self.publish_block(batch)
+            committed += 1
+            logging.warning("Committed")
+
+        self.assertEqual(committed, len(batches))
+        blocks = query_rest_api('/blocks')
+        self.assertEqual(
+            len(blocks['data']),
+            len(BATCH_KEYS) + 1)
+
+    def publish_block(self, batch):
+        # Initialize a new block
+        logging.warning("Initializing")
+        status = self.initialize()
+
+        # Submit a batch and wait
+        response = post_batch(batch)
+        time.sleep(INTERBLOCK_PERIOD)
+
+        # Finalize the block
+        logging.warning("Finalizing")
+        while True:
+            status = self.finalize()
+            if status == consensus_pb2.\
+                    ConsensusFinalizeBlockResponse.BLOCK_NOT_READY:
+                time.sleep(1)
+            else:
+                self.assertEqual(
+                    status,
+                    consensus_pb2.ConsensusFinalizeBlockResponse.OK)
+                break
+
+        # Wait for the validator to respond that the batch was committed
+        wait_for_batch(response)
+
+    def initialize(self):
+        future = self.stream.send(
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusInitializeBlockRequest()
+                         .SerializeToString())
+        result = future.result()
+        self.assertEqual(
+            result.message_type,
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_RESPONSE)
+        response = consensus_pb2.ConsensusInitializeBlockResponse()
+        response.ParseFromString(result.content)
+        return response.status
+
+    def finalize(self):
+        future = self.stream.send(
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusFinalizeBlockRequest(data=b"Devmode")
+                         .SerializeToString())
+        result = future.result()
+        self.assertEqual(
+            result.message_type,
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_RESPONSE)
+        response = consensus_pb2.ConsensusFinalizeBlockResponse()
+        response.ParseFromString(result.content)
+        return response.status
+
+
+def post_batch(batch):
+    headers = {'Content-Type': 'application/octet-stream'}
+    response = query_rest_api(
+        '/batches', data=batch, headers=headers)
+    return response
+
+
+def wait_for_batch(post_response):
+    response = submit_request('{}&wait={}'.format(post_response['link'], WAIT))
+    return response
+
+
+def query_rest_api(suffix='', data=None, headers=None):
+    if headers is None:
+        headers = {}
+    url = REST_API_URL + suffix
+    return submit_request(urllib.request.Request(url, data, headers))
+
+
+def submit_request(request):
+    response = urllib.request.urlopen(request).read().decode('utf-8')
+    return json.loads(response)
+
+
+def make_batches(keys):
+    imf = IntkeyMessageFactory()
+    return [imf.create_batch([('set', k, 0)]) for k in keys]

--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -233,6 +233,7 @@ message ConsensusFinalizeBlockResponse {
     NOT_READY = 4;
 
     INVALID_STATE = 5;
+    BLOCK_NOT_READY = 6;
   }
   Status status = 1;
 

--- a/sdk/python/sawtooth_sdk/consensus/exceptions.py
+++ b/sdk/python/sawtooth_sdk/consensus/exceptions.py
@@ -28,3 +28,7 @@ class UnknownBlock(Exception):
 
 class UnknownPeer(Exception):
     pass
+
+
+class BlockNotReady(Exception):
+    pass

--- a/sdk/python/sawtooth_sdk/consensus/zmq_service.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_service.py
@@ -121,6 +121,10 @@ class ZmqService(Service):
             raise exceptions.InvalidState(
                 'Cannot finalize block in current state')
 
+        if status == response_type.BLOCK_NOT_READY:
+            raise exceptions.BLOCK_NOT_READY(
+                'Block not ready to be finalized')
+
         if status != response_type.OK:
             raise exceptions.ReceiveError(
                 'Failed with status {}'.format(status))

--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -167,6 +167,7 @@ pub enum Error {
     InvalidState(String),
     UnknownBlock(String),
     UnknownPeer(String),
+    BlockNotReady,
 }
 
 impl ::std::error::Error for Error {
@@ -179,6 +180,7 @@ impl ::std::error::Error for Error {
             InvalidState(ref s) => s,
             UnknownBlock(ref s) => s,
             UnknownPeer(ref s) => s,
+            BlockNotReady => "Block not ready to finalize",
         }
     }
 
@@ -191,6 +193,7 @@ impl ::std::error::Error for Error {
             InvalidState(_) => None,
             UnknownBlock(_) => None,
             UnknownPeer(_) => None,
+            BlockNotReady => None,
         }
     }
 }
@@ -205,6 +208,7 @@ impl ::std::fmt::Display for Error {
             InvalidState(ref s) => write!(f, "InvalidState: {}", s),
             UnknownBlock(ref s) => write!(f, "UnknownBlock: {}", s),
             UnknownPeer(ref s) => write!(f, "UnknownPeer: {}", s),
+            BlockNotReady => write!(f, "BlockNotReady"),
         }
     }
 }

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -31,6 +31,7 @@ def load_default_validator_config():
     return ValidatorConfig(
         bind_network='tcp://127.0.0.1:8800',
         bind_component='tcp://127.0.0.1:4004',
+        bind_consensus='',
         endpoint=None,
         peering='static',
         scheduler='serial',
@@ -70,11 +71,14 @@ def load_toml_validator_config(filename):
             "{}".format(", ".join(sorted(list(invalid_keys)))))
     bind_network = None
     bind_component = None
+    bind_consensus = None
     for bind in toml_config.get("bind", []):
         if "network" in bind:
             bind_network = bind[bind.find(":") + 1:]
         if "component" in bind:
             bind_component = bind[bind.find(":") + 1:]
+        if "consensus" in bind:
+            bind_consensus = bind[bind.find(":") + 1:]
 
     network_public_key = None
     network_private_key = None
@@ -88,6 +92,7 @@ def load_toml_validator_config(filename):
     config = ValidatorConfig(
         bind_network=bind_network,
         bind_component=bind_component,
+        bind_consensus=bind_consensus,
         endpoint=toml_config.get("endpoint", None),
         peering=toml_config.get("peering", None),
         seeds=toml_config.get("seeds", None),
@@ -118,6 +123,7 @@ def merge_validator_config(configs):
     """
     bind_network = None
     bind_component = None
+    bind_consensus = None
     endpoint = None
     peering = None
     seeds = None
@@ -139,6 +145,8 @@ def merge_validator_config(configs):
             bind_network = config.bind_network
         if config.bind_component is not None:
             bind_component = config.bind_component
+        if config.bind_consensus is not None:
+            bind_consensus = config.bind_consensus
         if config.endpoint is not None:
             endpoint = config.endpoint
         if config.peering is not None:
@@ -173,6 +181,7 @@ def merge_validator_config(configs):
     return ValidatorConfig(
         bind_network=bind_network,
         bind_component=bind_component,
+        bind_consensus=bind_consensus,
         endpoint=endpoint,
         peering=peering,
         seeds=seeds,
@@ -228,6 +237,7 @@ def parse_permissions(permissions):
 
 class ValidatorConfig:
     def __init__(self, bind_network=None, bind_component=None,
+                 bind_consensus=None,
                  endpoint=None, peering=None, seeds=None,
                  peers=None, network_public_key=None,
                  network_private_key=None,
@@ -239,6 +249,7 @@ class ValidatorConfig:
 
         self._bind_network = bind_network
         self._bind_component = bind_component
+        self._bind_consensus = bind_consensus
         self._endpoint = endpoint
         self._peering = peering
         self._seeds = seeds
@@ -262,6 +273,10 @@ class ValidatorConfig:
     @property
     def bind_component(self):
         return self._bind_component
+
+    @property
+    def bind_consensus(self):
+        return self._bind_consensus
 
     @property
     def endpoint(self):
@@ -326,7 +341,7 @@ class ValidatorConfig:
     def __repr__(self):
         # not including  password for opentsdb
         return (
-            "{}(bind_network={}, bind_component={}, "
+            "{}(bind_network={}, bind_component={}, bind_consensus={}, "
             "endpoint={}, peering={}, seeds={}, peers={}, "
             "network_public_key={}, network_private_key={}, "
             "scheduler={}, permissions={}, roles={} "
@@ -336,6 +351,7 @@ class ValidatorConfig:
             self.__class__.__name__,
             repr(self._bind_network),
             repr(self._bind_component),
+            repr(self._bind_consensus),
             repr(self._endpoint),
             repr(self._peering),
             repr(self._seeds),
@@ -355,6 +371,7 @@ class ValidatorConfig:
         return collections.OrderedDict([
             ('bind_network', self._bind_network),
             ('bind_component', self._bind_component),
+            ('bind_consensus', self._bind_consensus),
             ('endpoint', self._endpoint),
             ('peering', self._peering),
             ('seeds', self._seeds),

--- a/validator/sawtooth_validator/consensus/__init__.py
+++ b/validator/sawtooth_validator/consensus/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+__all__ = []

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -1,0 +1,269 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+import logging
+
+from google.protobuf.message import DecodeError
+
+from sawtooth_validator.protobuf import consensus_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConsensusServiceHandler(Handler):
+    def __init__(
+        self,
+        request_class,
+        request_type,
+        response_class,
+        response_type,
+    ):
+        self._request_class = request_class
+        self._request_type = request_type
+        self._response_class = response_class
+        self._response_type = response_type
+
+    def handle_request(self, request, response):
+        raise NotImplementedError()
+
+    @property
+    def request_class(self):
+        return self._request_class
+
+    @property
+    def response_class(self):
+        return self._response_class
+
+    @property
+    def response_type(self):
+        return self._response_type
+
+    @property
+    def request_type(self):
+        return self._request_type
+
+    def handle(self, connection_id, message_content):
+        request = self._request_class()
+        response = self._response_class()
+        response.status = response.OK
+
+        try:
+            request.ParseFromString(message_content)
+        except DecodeError:
+            response.status = response.BAD_REQUEST
+        else:
+            self.handle_request(request, response)
+
+        return HandlerResult(
+            status=HandlerStatus.RETURN,
+            message_out=response,
+            message_type=self._response_type)
+
+
+class ConsensusRegisterHandler(ConsensusServiceHandler):
+    def __init__(self):
+        super().__init__(
+            consensus_pb2.ConsensusRegisterRequest,
+            validator_pb2.Message.CONSENSUS_REGISTER_REQUEST,
+            consensus_pb2.ConsensusRegisterResponse,
+            validator_pb2.Message.CONSENSUS_REGISTER_RESPONSE)
+
+    def handle_request(self, request, response):
+        LOGGER.info(
+            "Consensus engine registered: %s %s",
+            request.name,
+            request.version)
+
+
+class ConsensusSendToHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusSendToRequest,
+            validator_pb2.Message.CONSENSUS_SEND_TO_REQUEST,
+            consensus_pb2.ConsensusSendToResponse,
+            validator_pb2.Message.CONSENSUS_SEND_TO_RESPONSE)
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.send_to(request.peer_id, request.message)
+
+
+class ConsensusBroadcastHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusBroadcastRequest,
+            validator_pb2.Message.CONSENSUS_BROADCAST_REQUEST,
+            consensus_pb2.ConsensusBroadcastResponse,
+            validator_pb2.Message.CONSENSUS_BROADCAST_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.broadcast(request.message)
+
+
+class ConsensusInitializeBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusInitializeBlockRequest,
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusInitializeBlockResponse,
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        LOGGER.info(
+            "ConsensusInitializeBlockHandler.handle_request(%s, %s)",
+            request,
+            response)
+        self._proxy.initialize_block(request.previous_id)
+
+
+class ConsensusFinalizeBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusFinalizeBlockRequest,
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusFinalizeBlockResponse,
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.finalize_block(request.data)
+        except EmptyBlock:
+            response.status =\
+                consensus_pb2.ConsensusFinalizeBlockResponse.EMPTY_BLOCK
+
+
+class ConsensusCancelBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCancelBlockRequest,
+            validator_pb2.Message.CONSENSUS_CANCEL_BLOCK_REQUEST,
+            consensus_pb2.ConsensusCancelBlockResponse,
+            validator_pb2.Message.CONSENSUS_CANCEL_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.cancel_block()
+
+
+class ConsensusCheckBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCheckBlockRequest,
+            validator_pb2.Message.CONSENSUS_CHECK_BLOCK_REQUEST,
+            consensus_pb2.ConsensusCheckBlockResponse,
+            validator_pb2.Message.CONSENSUS_CHECK_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.check_block(request.block_ids)
+
+
+class ConsensusCommitBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCommitBlockRequest,
+            validator_pb2.Message.CONSENSUS_COMMIT_BLOCK_REQUEST,
+            consensus_pb2.ConsensusCommitBlockResponse,
+            validator_pb2.Message.CONSENSUS_COMMIT_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.commit_block(request.block_id)
+
+
+class ConsensusIgnoreBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusIgnoreBlockRequest,
+            validator_pb2.Message.CONSENSUS_IGNORE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusIgnoreBlockResponse,
+            validator_pb2.Message.CONSENSUS_IGNORE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.ignore_block(request.block_id)
+
+
+class ConsensusFailBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusFailBlockRequest,
+            validator_pb2.Message.CONSENSUS_FAIL_BLOCK_REQUEST,
+            consensus_pb2.ConsensusFailBlockResponse,
+            validator_pb2.Message.CONSENSUS_FAIL_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.fail_block(request.block_id)
+
+
+class ConsensusBlocksGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusBlocksGetRequest,
+            validator_pb2.Message.CONSENSUS_BLOCKS_GET_REQUEST,
+            consensus_pb2.ConsensusBlocksGetResponse,
+            validator_pb2.Message.CONSENSUS_BLOCKS_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.blocks_get(request.block_ids)
+
+
+class ConsensusSettingsGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusSettingsGetRequest,
+            validator_pb2.Message.CONSENSUS_SETTINGS_GET_REQUEST,
+            consensus_pb2.ConsensusSettingsGetResponse,
+            validator_pb2.Message.CONSENSUS_SETTINGS_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.settings_get(request.block_id, request.keys)
+
+
+class ConsensusStateGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusStateGetRequest,
+            validator_pb2.Message.CONSENSUS_STATE_GET_REQUEST,
+            consensus_pb2.ConsensusStateGetResponse,
+            validator_pb2.Message.CONSENSUS_STATE_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.state_get(request.block_id, request.addresses)

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -132,10 +132,6 @@ class ConsensusInitializeBlockHandler(ConsensusServiceHandler):
         self._proxy = proxy
 
     def handle_request(self, request, response):
-        LOGGER.info(
-            "ConsensusInitializeBlockHandler.handle_request(%s, %s)",
-            request,
-            response)
         self._proxy.initialize_block(request.previous_id)
 
 

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConsensusProxy:
+    """Receives requests from the consensus engine handlers and delegates them
+    to the appropriate components."""
+
+    def __init__(self, chain_controller, block_publisher):
+        self._chain_controller = chain_controller
+        self._block_publisher = block_publisher
+
+    # Using network service
+    def send_to(self, peer_id, message):
+        raise NotImplementedError()
+
+    def broadcast(self, message):
+        raise NotImplementedError()
+
+    # Using block publisher
+    def initialize_block(self, previous_id):
+        raise NotImplementedError()
+
+    def finalize_block(self, consensus_data):
+        raise NotImplementedError()
+
+    def cancel_block(self):
+        raise NotImplementedError()
+
+    # Using chain controller
+    def check_block(self, block_ids):
+        raise NotImplementedError()
+
+    def commit_block(self, block_id):
+        raise NotImplementedError()
+
+    def ignore_block(self, block_id):
+        raise NotImplementedError()
+
+    def fail_block(self, block_id):
+        raise NotImplementedError()
+
+    # Using blockstore and state database
+    def blocks_get(self, block_ids):
+        raise NotImplementedError()
+
+    def settings_get(self, block_id, settings):
+        raise NotImplementedError()
+
+    def state_get(self, block_id, addresses):
+        raise NotImplementedError()

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -693,8 +693,6 @@ class BlockPublisher(object):
 
                 self.cancel_block()
 
-                # we need to make a new _CandidateBlock (if we can) since the
-                # block chain has updated under us.
                 if chain_head is not None:
                     self._pending_batches.update_limit(len(chain_head.batches))
                     self._pending_batches.rebuild(

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -663,20 +663,22 @@ class BlockPublisher(object):
                 LOGGER.debug("Batch has an unauthorized signer. Batch: %s",
                              batch.header_signature)
 
-    def on_chain_updated(self, chain_head,
-                         committed_batches=None,
-                         uncommitted_batches=None):
+    def on_chain_updated(
+            self,
+            chain_head,
+            committed_batches=None,
+            uncommitted_batches=None):
         """
-        The existing chain has been updated, the current head block has
-        changed.
+        A new chain head has been committed.
 
-        :param chain_head: the new head of block_chain, can be None if
-        no block publishing is desired.
-        :param committed_batches: the set of batches that were committed
-         as part of the new chain.
-        :param uncommitted_batches: the list of transactions if any that are
-        now de-committed when the new chain was selected.
-        :return: None
+        Args:
+            chain_head (Block): The newly committed block
+            committed_batches (List<Batch>): The list of batches committed as
+                a result of committing this new chain. This list can include
+                batches not directly in the chain head if multiple blocks were
+                committed as a result of committing the new chain.
+            uncommitted_batches (List<Batch>): The list of transactions that
+                were uncommitted as a result of committing this new chain.
         """
         try:
             with self._lock:

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -59,8 +59,8 @@ class ConsensusNotReady(Exception):
     """
 
 
-class NoPendingBatchesRemaining(Exception):
-    """There are no pending batches remaining."""
+class BlockEmpty(Exception):
+    """There are no batches in the block."""
 
 
 class FinalizeBlockResult:
@@ -326,7 +326,7 @@ class _CandidateBlock(object):
         that need to be added to the next Block that is built.
         """
         if not (force or self._pending_batches):
-            raise NoPendingBatchesRemaining()
+            raise BlockEmpty()
 
         if not self._consensus.check_publish_block(
                 self._block_builder.block_header):
@@ -744,7 +744,7 @@ class BlockPublisher(object):
                 if self._building():
                     try:
                         result = self.finalize_block(force)
-                    except (ConsensusNotReady, NoPendingBatchesRemaining):
+                    except (ConsensusNotReady, BlockEmpty):
                         return
 
                     if result.block:

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -101,6 +101,7 @@ def main(args):
         opts_config = ValidatorConfig(
             bind_component=args['bind_component'],
             bind_network=args['bind_network'],
+            bind_consensus=args['bind_consensus'],
             endpoint=args['endpoint'],
             maximum_peer_connectivity=args['maximum_peer_connectivity'],
             minimum_peer_connectivity=args['minimum_peer_connectivity'],
@@ -186,12 +187,16 @@ def main(args):
         sys.exit(1)
     bind_network = validator_config.bind_network
     bind_component = validator_config.bind_component
+    bind_consensus = validator_config.bind_consensus
 
     if "tcp://" not in bind_network:
         bind_network = "tcp://" + bind_network
 
     if "tcp://" not in bind_component:
         bind_component = "tcp://" + bind_component
+
+    if bind_consensus and "tcp://" not in bind_consensus:
+        bind_consensus = "tcp://" + bind_consensus
 
     if validator_config.network_public_key is None or \
             validator_config.network_private_key is None:
@@ -247,6 +252,7 @@ def main(args):
     validator = Validator(
         bind_network,
         bind_component,
+        bind_consensus,
         endpoint,
         validator_config.peering,
         validator_config.seeds,

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -1,0 +1,62 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_validator.consensus import handlers
+
+
+def add(
+        dispatcher,
+        thread_pool,
+        consensus_proxy,
+):
+
+    handler = handlers.ConsensusRegisterHandler()
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusSendToHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusBroadcastHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusInitializeBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusFinalizeBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCancelBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCheckBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCommitBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusIgnoreBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusFailBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusBlocksGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusSettingsGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusStateGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -23,6 +23,7 @@ import threading
 from sawtooth_validator.concurrent.threadpool import \
     InstrumentedThreadPoolExecutor
 from sawtooth_validator.execution.context_manager import ContextManager
+from sawtooth_validator.consensus.proxy import ConsensusProxy
 from sawtooth_validator.database.indexed_database import IndexedDatabase
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
 from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
@@ -60,6 +61,7 @@ from sawtooth_validator.journal.receipt_store import TransactionReceiptStore
 
 from sawtooth_validator.server import network_handlers
 from sawtooth_validator.server import component_handlers
+from sawtooth_validator.server import consensus_handlers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -376,6 +378,14 @@ class Validator(object):
         self._network_thread_pool = network_thread_pool
 
         if consensus_engine_enabled:
+            consensus_proxy = ConsensusProxy(
+                network_service=network_service,
+                chain_controller=chain_controller,
+                block_publisher=block_publisher)
+
+            consensus_handlers.add(
+                consensus_dispatcher, consensus_thread_pool, consensus_proxy)
+
             self._consensus_dispatcher = consensus_dispatcher
             self._consensus_service = consensus_service
             self._consensus_thread_pool = consensus_thread_pool

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -68,6 +68,7 @@ class Validator(object):
     def __init__(self,
                  bind_network,
                  bind_component,
+                 bind_consensus,
                  endpoint,
                  peering,
                  seeds_list,
@@ -107,6 +108,11 @@ class Validator(object):
             identity_signer (str): cryptographic signer the validator uses for
                 signing
         """
+        if bind_consensus != "":
+            LOGGER.warning("Enabling experimental consensus engine feature!")
+            consensus_engine_enabled = True
+        else:
+            consensus_engine_enabled = False
 
         # -- Setup Global State Database and Factory -- #
         global_state_db_filename = os.path.join(

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -9,6 +9,8 @@ mod server;
 use cpython::Python;
 use server::cli;
 
+use std::process;
+
 fn main() {
     let gil = Python::acquire_gil();
     let py = &mut gil.python();
@@ -27,11 +29,12 @@ fn main() {
         Ok(module) => module,
         Err(err) => {
             err.print(*py);
-            return;
+            process::exit(1);
         }
     };
 
     if let Err(err) = cli.call(*py, "main", (pydict,), None) {
         err.print(*py);
+        process::exit(1);
     }
 }

--- a/validator/src/server/cli.rs
+++ b/validator/src/server/cli.rs
@@ -22,12 +22,13 @@ const DISTRIBUTION_NAME: &str = "sawtooth-validator";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn wrap_in_pydict(py: &Python, matches: &ArgMatches) -> PyResult<PyDict> {
-    let (bind_component, bind_network) = parse_bindings(matches);
+    let (bind_component, bind_network, bind_consensus) = parse_bindings(matches);
 
     let pydict = PyDict::new(*py);
 
     pydict.set_item(*py, "bind_component", bind_component)?;
     pydict.set_item(*py, "bind_network", bind_network)?;
+    pydict.set_item(*py, "bind_consensus", bind_consensus)?;
     pydict.set_item(*py, "config_dir", matches.value_of("config_dir"))?;
     pydict.set_item(*py, "endpoint", matches.value_of("endpoint"))?;
     pydict.set_item(
@@ -71,9 +72,9 @@ pub fn parse_args<'a>() -> ArgMatches<'a> {
                 .help(
                     "set the URL for the network or validator \
                      component service endpoints with the format \
-                     network:<endpoint> or component:<endpoint>. \
-                     Use two --bind options to specify both \
-                     endpoints.",
+                     network:<endpoint>, component:<endpoint>, or \
+                     consensus:<endpoint>. Use multiple --bind options \
+                     to specify all endpoints.",
                 ),
         )
         .arg(
@@ -192,9 +193,12 @@ fn parse_roles<'a>(matches: &'a ArgMatches, py: &Python) -> Option<PyDict> {
     }
 }
 
-fn parse_bindings<'a>(matches: &'a ArgMatches) -> (Option<&'a str>, Option<&'a str>) {
+fn parse_bindings<'a>(
+    matches: &'a ArgMatches,
+) -> (Option<&'a str>, Option<&'a str>, Option<&'a str>) {
     let mut bind_network = None;
     let mut bind_component = None;
+    let mut bind_consensus = None;
 
     if let Some(bindings) = parse_multiple_args("bind", matches) {
         for binding in bindings {
@@ -205,10 +209,14 @@ fn parse_bindings<'a>(matches: &'a ArgMatches) -> (Option<&'a str>, Option<&'a s
             if binding.starts_with("component") {
                 bind_component = Some(binding.splitn(2, ':').skip(1).collect::<Vec<_>>()[0]);
             }
+
+            if binding.starts_with("consensus") {
+                bind_consensus = Some(binding.splitn(2, ':').skip(1).collect::<Vec<_>>()[0]);
+            }
         }
     };
 
-    (bind_component, bind_network)
+    (bind_component, bind_network, bind_consensus)
 }
 
 fn parse_comma_separated_args(name: &str, matches: &ArgMatches) -> Option<Vec<String>> {

--- a/validator/tests/test_consensus/__init__.py
+++ b/validator/tests/test_consensus/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -1,0 +1,134 @@
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.consensus import handlers
+
+
+class TestHandlers(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_proxy = Mock()
+
+    def test_consensus_register_handler(self):
+        handler = handlers.ConsensusRegisterHandler()
+        request_class = handler.request_class
+        request = request_class()
+        request.name = "test"
+        request.version = "test"
+        handler.handle(None, request.SerializeToString())
+
+    def test_consensus_send_to_handler(self):
+        handler = handlers.ConsensusSendToHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.peer_id = b"test"
+        request.message.message_type = "test"
+        request.message.content = b"test"
+        request.message.name = "test"
+        request.message.version = "test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.send_to.assert_called_with(
+            request.peer_id,
+            request.message)
+
+    def test_consensus_broadcast_handler(self):
+        handler = handlers.ConsensusBroadcastHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.message.message_type = "test"
+        request.message.content = b"test"
+        request.message.name = "test"
+        request.message.version = "test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.broadcast.assert_called_with(
+            request.message)
+
+    def test_consensus_initialize_block_handler(self):
+        handler = handlers.ConsensusInitializeBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.previous_id = b"test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.initialize_block.assert_called_with(
+            request.previous_id)
+
+    def test_consensus_finalize_block_handler(self):
+        handler = handlers.ConsensusFinalizeBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.data = b"test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.finalize_block.assert_called_with(
+            request.data)
+
+    def test_consensus_cancel_block_handler(self):
+        handler = handlers.ConsensusCancelBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.cancel_block.assert_called_with()
+
+    def test_consensus_check_block_handler(self):
+        handler = handlers.ConsensusCheckBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_ids.extend([b"test"])
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.check_block.assert_called_with(
+            request.block_ids)
+
+    def test_consensus_commit_block_handler(self):
+        handler = handlers.ConsensusCommitBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.commit_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_ignore_block_handler(self):
+        handler = handlers.ConsensusIgnoreBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.ignore_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_fail_block_handler(self):
+        handler = handlers.ConsensusFailBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.fail_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_blocks_get_handler(self):
+        handler = handlers.ConsensusBlocksGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_ids.extend([b"test"])
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.blocks_get.assert_called_with(
+            request.block_ids)
+
+    def test_consensus_settings_get_handler(self):
+        handler = handlers.ConsensusSettingsGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        request.keys.extend(["test"])
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.settings_get.assert_called_with(
+            request.block_id, request.keys)
+
+    def test_consensus_state_get_handler(self):
+        handler = handlers.ConsensusStateGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        request.addresses.extend(["test"])
+        handler.handle(None, request.SerializeToString())
+        self.mock_proxy.state_get.assert_called_with(
+            request.block_id, request.addresses)


### PR DESCRIPTION
This PR sets up a consensus engine message handlers, a skeleton consensus proxy, and implements the consensus engine publisher-related services. It also adds a provisional new type of bind argument type "consensus" which, when passed, enables the consensus engine feature. This argument may be merged with component in the future and is intended to allow for the development of the new consensus engine feature incrementally without breaking existing features.