### PR TITLE
Make rust sdk compatible with protoc 1.6

### DIFF
--- a/adm/src/commands/blockstore.rs
+++ b/adm/src/commands/blockstore.rs
@@ -402,7 +402,7 @@ fn restore_block(source: &mut protobuf::CodedInputStream) -> Result<Option<Block
         return Ok(None);
     }
 
-    let block = protobuf::core::parse_length_delimited_from(source)
+    let block = protobuf::parse_length_delimited_from(source)
         .map_err(|err| CliError::EnvironmentError(format!("Failed to parse block: {}", err)))?;
 
     Ok(Some(block))

--- a/adm/src/commands/blockstore.rs
+++ b/adm/src/commands/blockstore.rs
@@ -16,8 +16,8 @@
  */
 
 use std::collections::HashMap;
-use std::io::{self, Read, Write};
 use std::fs::File;
+use std::io::{self, Read, Write};
 
 use clap::ArgMatches;
 use protobuf;
@@ -28,10 +28,10 @@ use sawtooth_sdk::messages::block::{Block, BlockHeader};
 use sawtooth_sdk::messages::transaction::TransactionHeader;
 
 use blockstore::Blockstore;
-use database::lmdb;
-use database::error::DatabaseError;
-use err::CliError;
 use config;
+use database::error::DatabaseError;
+use database::lmdb;
+use err::CliError;
 use wrappers::Block as BlockWrapper;
 
 const NULL_BLOCK_IDENTIFIER: &str = "0000000000000000";

--- a/adm/src/commands/mod.rs
+++ b/adm/src/commands/mod.rs
@@ -16,5 +16,5 @@
  */
 
 pub mod blockstore;
-pub mod keygen;
 pub mod genesis;
+pub mod keygen;

--- a/families/smallbank/smallbank_rust/Cargo.toml
+++ b/families/smallbank/smallbank_rust/Cargo.toml
@@ -31,5 +31,5 @@ log = "0.3"
 log4rs = "0.7"
 
 [build-dependencies]
-protoc-rust = "1.4"
+protoc-rust = "^1.6"
 glob = "0.2"

--- a/families/smallbank/smallbank_rust/build.rs
+++ b/families/smallbank/smallbank_rust/build.rs
@@ -33,7 +33,7 @@ fn main() {
         includes: &["../protos"],
         customize: Customize {
             ..Default::default()
-        }
+        },
     }).expect("Error generating rust files from smallbank protos");
 }
 

--- a/families/smallbank/smallbank_rust/build.rs
+++ b/families/smallbank/smallbank_rust/build.rs
@@ -18,6 +18,8 @@
 extern crate glob;
 extern crate protoc_rust;
 
+use protoc_rust::Customize;
+
 fn main() {
     let proto_src_files = glob_simple("../protos/*.proto");
     println!("{:?}", proto_src_files);
@@ -29,6 +31,9 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["../protos"],
+        customize: Customize {
+            ..Default::default()
+        }
     }).expect("Error generating rust files from smallbank protos");
 }
 

--- a/families/smallbank/smallbank_rust/src/handler.rs
+++ b/families/smallbank/smallbank_rust/src/handler.rs
@@ -19,10 +19,10 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 use protobuf;
 
+use sawtooth_sdk::messages::processor::TpProcessRequest;
 use sawtooth_sdk::processor::handler::ApplyError;
 use sawtooth_sdk::processor::handler::TransactionContext;
 use sawtooth_sdk::processor::handler::TransactionHandler;
-use sawtooth_sdk::messages::processor::TpProcessRequest;
 
 use smallbank::{Account, SmallbankTransactionPayload,
                 SmallbankTransactionPayload_AmalgamateTransactionData,

--- a/families/smallbank/smallbank_rust/src/main.rs
+++ b/families/smallbank/smallbank_rust/src/main.rs
@@ -28,11 +28,11 @@ extern crate sawtooth_sdk;
 mod handler;
 mod smallbank;
 
-use std::process;
 use log::LogLevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
+use std::process;
 
 use sawtooth_sdk::processor::TransactionProcessor;
 

--- a/perf/intkey_workload/src/intkey_iterator.rs
+++ b/perf/intkey_workload/src/intkey_iterator.rs
@@ -18,13 +18,13 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
-use cbor::value::Value;
 use cbor::value::Key;
 use cbor::value::Text;
+use cbor::value::Value;
 
+use rand::Rng;
 use rand::SeedableRng;
 use rand::StdRng;
-use rand::Rng;
 
 const HALF_MAX_VALUE: u32 = 2_147_483_647;
 const INCS_AND_DECS_PER_SET: usize = 200_000;
@@ -166,9 +166,9 @@ fn wrap_in_cbor_value_u32(value: u32) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::IntKeyIterator;
     use super::HALF_MAX_VALUE;
     use super::INCS_AND_DECS_PER_SET;
+    use super::IntKeyIterator;
 
     const MAX_VALUE: u32 = 4_294_967_295;
 

--- a/perf/intkey_workload/src/intkey_transformer.rs
+++ b/perf/intkey_workload/src/intkey_transformer.rs
@@ -26,16 +26,16 @@ use crypto::sha2::Sha512;
 use protobuf::Message;
 use protobuf::RepeatedField;
 
+use rand::Rng;
 use rand::SeedableRng;
 use rand::StdRng;
-use rand::Rng;
 
 use sawtooth_sdk::messages::transaction::Transaction;
 use sawtooth_sdk::messages::transaction::TransactionHeader;
 use sawtooth_sdk::signing;
 
-use intkey_iterator::IntKeyPayload;
 use intkey_addresser::IntKeyAddresser;
+use intkey_iterator::IntKeyPayload;
 
 const UNNECESSARY_TXNS_NUM: usize = 1_000;
 

--- a/perf/intkey_workload/src/main.rs
+++ b/perf/intkey_workload/src/main.rs
@@ -30,9 +30,9 @@ mod intkey_transformer;
 
 use std::convert::From;
 use std::error::Error;
-use std::io::Read;
 use std::fmt;
 use std::fs::File;
+use std::io::Read;
 use std::num::ParseFloatError;
 use std::num::ParseIntError;
 use std::str::Split;

--- a/perf/sawtooth_perf/src/batch_gen.rs
+++ b/perf/sawtooth_perf/src/batch_gen.rs
@@ -24,10 +24,10 @@ use std::fmt;
 use std::io::Read;
 use std::io::Write;
 
-use sawtooth_sdk::messages::transaction::Transaction;
+use self::protobuf::Message;
 use sawtooth_sdk::messages::batch::Batch;
 use sawtooth_sdk::messages::batch::BatchHeader;
-use self::protobuf::Message;
+use sawtooth_sdk::messages::transaction::Transaction;
 
 use sawtooth_sdk::signing;
 
@@ -220,14 +220,14 @@ impl<'a> Iterator for SignedBatchIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::LengthDelimitedMessageSource;
-    use super::TransactionSource;
     use super::SignedBatchProducer;
-    use std::io::{Cursor, Write};
-    use sawtooth_sdk::signing;
-    use sawtooth_sdk::messages::transaction::{Transaction, TransactionHeader};
-    use sawtooth_sdk::messages::batch::{Batch, BatchHeader};
+    use super::TransactionSource;
     use super::protobuf;
     use super::protobuf::Message;
+    use sawtooth_sdk::messages::batch::{Batch, BatchHeader};
+    use sawtooth_sdk::messages::transaction::{Transaction, TransactionHeader};
+    use sawtooth_sdk::signing;
+    use std::io::{Cursor, Write};
 
     type BatchSource<'a> = LengthDelimitedMessageSource<'a, Batch>;
 

--- a/perf/sawtooth_perf/src/batch_map.rs
+++ b/perf/sawtooth_perf/src/batch_map.rs
@@ -66,9 +66,9 @@ mod tests {
 
     use protobuf::RepeatedField;
 
-    use sawtooth_sdk::signing;
     use sawtooth_sdk::messages::batch::Batch;
     use sawtooth_sdk::messages::batch::BatchList;
+    use sawtooth_sdk::signing;
 
     #[test]
     fn test_2_cycles_of_retries() {

--- a/perf/sawtooth_perf/src/batch_submit.rs
+++ b/perf/sawtooth_perf/src/batch_submit.rs
@@ -23,17 +23,17 @@ use std::fmt;
 use std::io::Read;
 use std::iter::Cycle;
 use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::mpsc;
 use std::thread;
 use std::time;
-use std::sync::Arc;
-use std::sync::mpsc;
-use std::sync::Mutex;
 use std::vec::IntoIter;
 
+use futures::{Future, Stream};
+use hyper::Method;
 use hyper::client::{Client, HttpConnector, Request};
 use hyper::header::{ContentLength, ContentType};
-use hyper::Method;
-use futures::{Future, Stream};
 use protobuf;
 use protobuf::Message;
 use tokio_core::reactor::{Core, Interval};
@@ -43,8 +43,8 @@ use sawtooth_sdk::messages::batch::Batch;
 use sawtooth_sdk::messages::batch::BatchList;
 
 use batch_gen::{BatchResult, BatchingError};
-use source::LengthDelimitedMessageSource;
 use batch_map::BatchMap;
+use source::LengthDelimitedMessageSource;
 use workload;
 
 /// Populates a channel from a stream of length-delimited batches.

--- a/perf/sawtooth_perf/src/lib.rs
+++ b/perf/sawtooth_perf/src/lib.rs
@@ -30,7 +30,7 @@ extern crate tokio_core;
 extern crate tokio_timer;
 
 pub mod batch_gen;
+mod batch_map;
 pub mod batch_submit;
 pub mod source;
-mod batch_map;
 mod workload;

--- a/perf/sawtooth_perf/src/source.rs
+++ b/perf/sawtooth_perf/src/source.rs
@@ -23,7 +23,6 @@ use std::io::Read;
 use std::marker::PhantomData;
 
 use self::protobuf::Message;
-use self::protobuf::MessageStatic;
 
 /// Decodes Protocol Buffer messages from a length-delimited input reader.
 pub struct LengthDelimitedMessageSource<'a, T: 'a> {
@@ -33,7 +32,7 @@ pub struct LengthDelimitedMessageSource<'a, T: 'a> {
 
 impl<'a, T> LengthDelimitedMessageSource<'a, T>
 where
-    T: Message + MessageStatic,
+    T: Message,
 {
     /// Creates a new `LengthDelimitedMessageSource` from a given reader.
     pub fn new(source: &'a mut Read) -> Self {

--- a/perf/sawtooth_perf/src/workload.rs
+++ b/perf/sawtooth_perf/src/workload.rs
@@ -16,7 +16,6 @@
  */
 
 /// Tools for interacting with the Sawtooth Rest API
-
 use std::cell::RefCell;
 use std::error;
 use std::fmt;
@@ -30,13 +29,13 @@ use std::vec::IntoIter;
 
 use chrono;
 use futures::Future;
-use hyper::client::{Client, HttpConnector, Request, Response};
-use hyper::header::{Authorization, Basic, ContentLength, ContentType};
-use hyper::Method;
 use hyper::Error as HyperError;
-use hyper::error::UriError;
+use hyper::Method;
 use hyper::StatusCode;
 use hyper::Uri;
+use hyper::client::{Client, HttpConnector, Request, Response};
+use hyper::error::UriError;
+use hyper::header::{Authorization, Basic, ContentLength, ContentType};
 use protobuf;
 use protobuf::Message;
 use tokio_core::reactor::Handle;

--- a/perf/sawtooth_workload/src/main.rs
+++ b/perf/sawtooth_workload/src/main.rs
@@ -19,9 +19,9 @@ extern crate protobuf;
 extern crate sawtooth_perf;
 extern crate sawtooth_sdk;
 
+use std::error::Error;
 use std::fs::File;
 use std::io::Read;
-use std::error::Error;
 
 use batch_gen::generate_signed_batches;
 use batch_submit::submit_signed_batches;

--- a/perf/smallbank_workload/Cargo.toml
+++ b/perf/smallbank_workload/Cargo.toml
@@ -32,5 +32,5 @@ name = "smallbank-workload"
 path = "./src/main.rs"
 
 [build-dependencies]
-protoc-rust = "1.4"
+protoc-rust = "^1.6"
 glob = "0.2"

--- a/perf/smallbank_workload/build.rs
+++ b/perf/smallbank_workload/build.rs
@@ -33,7 +33,7 @@ fn main() {
         includes: &["../../families/smallbank/protos"],
         customize: Customize {
             ..Default::default()
-        }
+        },
     }).expect("Error generating rust files from smallbank protos");
 }
 

--- a/perf/smallbank_workload/build.rs
+++ b/perf/smallbank_workload/build.rs
@@ -18,6 +18,8 @@
 extern crate glob;
 extern crate protoc_rust;
 
+use protoc_rust::Customize;
+
 fn main() {
     let proto_src_files = glob_simple("../../families/smallbank/protos/*.proto");
     println!("{:?}", proto_src_files);
@@ -29,6 +31,9 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["../../families/smallbank/protos"],
+        customize: Customize {
+            ..Default::default()
+        }
     }).expect("Error generating rust files from smallbank protos");
 }
 

--- a/perf/smallbank_workload/src/main.rs
+++ b/perf/smallbank_workload/src/main.rs
@@ -26,17 +26,17 @@ mod playlist;
 mod smallbank;
 mod smallbank_tranformer;
 
-use std::fs::File;
-use std::io::Write;
-use std::io::Read;
 use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use std::io::Write;
 use std::str::{FromStr, Split};
 
-use batch_gen::generate_signed_batches;
 use batch_gen::SignedBatchIterator;
+use batch_gen::generate_signed_batches;
 use batch_submit::InfiniteBatchListIterator;
-use batch_submit::submit_signed_batches;
 use batch_submit::run_workload;
+use batch_submit::submit_signed_batches;
 use clap::{App, AppSettings, Arg, ArgMatches, SubCommand};
 use playlist::generate_smallbank_playlist;
 use playlist::process_smallbank_playlist;

--- a/perf/smallbank_workload/src/playlist.rs
+++ b/perf/smallbank_workload/src/playlist.rs
@@ -21,22 +21,22 @@ extern crate crypto;
 extern crate rand;
 extern crate yaml_rust;
 
+use std::borrow::Cow;
 use std::error;
+use std::fmt;
+use std::io::Error as StdIoError;
 use std::io::Read;
 use std::io::Write;
-use std::io::Error as StdIoError;
-use std::fmt;
-use std::borrow::Cow;
 use std::time::Instant;
 
+use self::rand::Rng;
+use self::rand::SeedableRng;
+use self::rand::StdRng;
+use self::yaml_rust::EmitError;
+use self::yaml_rust::Yaml;
 use self::yaml_rust::YamlEmitter;
 use self::yaml_rust::YamlLoader;
-use self::yaml_rust::Yaml;
-use self::yaml_rust::EmitError;
 use self::yaml_rust::yaml::Hash;
-use self::rand::Rng;
-use self::rand::StdRng;
-use self::rand::SeedableRng;
 
 use smallbank;
 use smallbank::SmallbankTransactionPayload;
@@ -45,9 +45,9 @@ use smallbank::SmallbankTransactionPayload_PayloadType as SBPayloadType;
 use protobuf;
 use protobuf::Message;
 
-use sawtooth_sdk::signing;
 use sawtooth_sdk::messages::transaction::Transaction;
 use sawtooth_sdk::messages::transaction::TransactionHeader;
+use sawtooth_sdk::signing;
 
 use self::crypto::digest::Digest;
 use self::crypto::sha2::Sha512;
@@ -430,9 +430,8 @@ impl<'a> From<&'a Yaml> for SmallbankTransactionPayload {
                 Some("deposit_checking") => {
                     payload.set_payload_type(SBPayloadType::DEPOSIT_CHECKING);
                     let mut data =
-                        smallbank
-                        ::SmallbankTransactionPayload_DepositCheckingTransactionData
-                        ::new();
+                        smallbank::SmallbankTransactionPayload_DepositCheckingTransactionData::new(
+                        );
                     data.set_customer_id(
                         txn_hash[&Yaml::from_str("customer_id")].as_i64().unwrap() as u32,
                     );
@@ -454,9 +453,8 @@ impl<'a> From<&'a Yaml> for SmallbankTransactionPayload {
                 Some("transact_savings") => {
                     payload.set_payload_type(SBPayloadType::TRANSACT_SAVINGS);
                     let mut data =
-                        smallbank
-                        ::SmallbankTransactionPayload_TransactSavingsTransactionData
-                        ::new();
+                        smallbank::SmallbankTransactionPayload_TransactSavingsTransactionData::new(
+                        );
                     data.set_customer_id(
                         txn_hash[&Yaml::from_str("customer_id")].as_i64().unwrap() as u32,
                     );

--- a/perf/smallbank_workload/src/smallbank_tranformer.rs
+++ b/perf/smallbank_workload/src/smallbank_tranformer.rs
@@ -21,8 +21,8 @@ use std::error::Error;
 use std::hash::Hash;
 use std::time::Instant;
 
-use crypto::sha2::Sha512;
 use crypto::digest::Digest;
+use crypto::sha2::Sha512;
 use protobuf;
 use protobuf::Message;
 

--- a/sdk/examples/intkey_rust/src/handler.rs
+++ b/sdk/examples/intkey_rust/src/handler.rs
@@ -22,18 +22,18 @@ use crypto::sha2::Sha512;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::io::Cursor;
 use std::fmt;
+use std::io::Cursor;
 
 use cbor::encoder::GenericEncoder;
-use cbor::value::Value;
 use cbor::value::Key;
 use cbor::value::Text;
+use cbor::value::Value;
 
+use sawtooth_sdk::messages::processor::TpProcessRequest;
 use sawtooth_sdk::processor::handler::ApplyError;
 use sawtooth_sdk::processor::handler::TransactionContext;
 use sawtooth_sdk::processor::handler::TransactionHandler;
-use sawtooth_sdk::messages::processor::TpProcessRequest;
 
 const MAX_VALUE: u32 = 4_294_967_295;
 const MAX_NAME_LEN: usize = 20;

--- a/sdk/examples/intkey_rust/src/main.rs
+++ b/sdk/examples/intkey_rust/src/main.rs
@@ -27,11 +27,11 @@ extern crate sawtooth_sdk;
 
 mod handler;
 
-use std::process;
 use log::LogLevelFilter;
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};
 use log4rs::encode::pattern::PatternEncoder;
+use std::process;
 
 use sawtooth_sdk::processor::TransactionProcessor;
 

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -40,5 +40,5 @@ env_logger = "0.3"
 
 [build-dependencies]
 cc = "1.0"
-protoc-rust = "1.4"
+protoc-rust = "^1.6"
 glob = "0.2"

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -21,6 +21,8 @@ extern crate protoc_rust;
 
 use std::fs;
 
+use protoc_rust::Customize;
+
 fn main() {
     // Compile C PEM loader file
     if cfg!(feature = "pem") {
@@ -45,6 +47,9 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["src", "../../protos"],
+        customize: Customize {
+            ..Default::default()
+        }
     }).expect("unable to run protoc");
 }
 

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -49,7 +49,7 @@ fn main() {
         includes: &["src", "../../protos"],
         customize: Customize {
             ..Default::default()
-        }
+        },
     }).expect("unable to run protoc");
 }
 

--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -214,8 +214,8 @@ pub mod tests {
     use super::*;
 
     use std::default::Default;
-    use std::sync::{Arc, Mutex};
     use std::sync::mpsc::{channel, RecvTimeoutError};
+    use std::sync::{Arc, Mutex};
 
     use consensus::service::tests::MockService;
 

--- a/sdk/rust/src/consensus/zmq_driver.rs
+++ b/sdk/rust/src/consensus/zmq_driver.rs
@@ -234,7 +234,7 @@ impl ZmqService {
 
     /// Serialize and send a request, wait for the default timeout, and receive and parse an
     /// expected response.
-    pub fn rpc<I: protobuf::Message, O: protobuf::Message + protobuf::MessageStatic>(
+    pub fn rpc<I: protobuf::Message, O: protobuf::Message>(
         &mut self,
         request: &I,
         request_type: Message_MessageType,
@@ -590,7 +590,7 @@ mod tests {
     use consensus::engine::tests::MockEngine;
     use zmq;
 
-    fn send_req_rep<I: protobuf::Message, O: protobuf::Message + protobuf::MessageStatic>(
+    fn send_req_rep<I: protobuf::Message, O: protobuf::Message>(
         connection_id: &[u8],
         socket: &zmq::Socket,
         request: I,
@@ -611,7 +611,7 @@ mod tests {
         protobuf::parse_from_bytes(&msg.get_content()).unwrap()
     }
 
-    fn recv_rep<I: protobuf::Message, O: protobuf::Message + protobuf::MessageStatic>(
+    fn recv_rep<I: protobuf::Message, O: protobuf::Message>(
         socket: &zmq::Socket,
         request_type: Message_MessageType,
         response: I,

--- a/sdk/rust/src/consensus/zmq_driver.rs
+++ b/sdk/rust/src/consensus/zmq_driver.rs
@@ -20,16 +20,16 @@ use protobuf::{Message as ProtobufMessage, ProtobufError};
 use rand;
 use rand::Rng;
 
-use consensus::service::Service;
-use consensus::engine::*;
 use consensus::driver::Driver;
+use consensus::engine::*;
+use consensus::service::Service;
 
 use messaging::stream::MessageConnection;
 use messaging::stream::MessageSender;
-use messaging::zmq_stream::ZmqMessageSender;
-use messaging::stream::SendError;
 use messaging::stream::ReceiveError;
+use messaging::stream::SendError;
 use messaging::zmq_stream::ZmqMessageConnection;
+use messaging::zmq_stream::ZmqMessageSender;
 
 use messages::consensus::*;
 use messages::validator::{Message, Message_MessageType};
@@ -263,9 +263,12 @@ macro_rules! check_ok {
     ($r:expr, $ok:pat) => {
         match $r.get_status() {
             $ok => Ok(()),
-            status => Err(Error::ReceiveError(format!("Failed with status {:?}", status))),
+            status => Err(Error::ReceiveError(format!(
+                "Failed with status {:?}",
+                status
+            ))),
         }
-    }
+    };
 }
 
 impl Service for ZmqService {
@@ -585,9 +588,9 @@ impl From<ReceiveError> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use consensus::engine::tests::MockEngine;
     use std::default::Default;
     use std::sync::Mutex;
-    use consensus::engine::tests::MockEngine;
     use zmq;
 
     fn send_req_rep<I: protobuf::Message, O: protobuf::Message>(
@@ -762,12 +765,9 @@ mod tests {
         ) => {
             let mut response = $rep;
             response.set_status($status);
-            let (_, _): (_, $req_type) = recv_rep(
-                $socket,
-                $req_msg_type,
-                response,
-                $rep_msg_type);
-        }
+            let (_, _): (_, $req_type) =
+                recv_rep($socket, $req_msg_type, response, $rep_msg_type);
+        };
     }
 
     #[test]

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -28,5 +28,5 @@ extern crate zmq;
 pub mod consensus;
 pub mod messages;
 pub mod messaging;
-pub mod signing;
 pub mod processor;
+pub mod signing;

--- a/sdk/rust/src/messages/mod.rs
+++ b/sdk/rust/src/messages/mod.rs
@@ -15,25 +15,25 @@
  * ------------------------------------------------------------------------------
  */
 
-pub mod consensus;
-pub mod validator;
-pub mod transaction;
+pub mod authorization;
 pub mod batch;
 pub mod block;
-pub mod setting;
-pub mod state_context;
-pub mod processor;
-pub mod genesis;
 pub mod client_batch;
-pub mod client_block;
-pub mod client_state;
-pub mod client_transaction;
 pub mod client_batch_submit;
+pub mod client_block;
+pub mod client_event;
 pub mod client_list_control;
 pub mod client_peers;
-pub mod network;
-pub mod events;
-pub mod client_event;
-pub mod authorization;
-pub mod transaction_receipt;
 pub mod client_receipt;
+pub mod client_state;
+pub mod client_transaction;
+pub mod consensus;
+pub mod events;
+pub mod genesis;
+pub mod network;
+pub mod processor;
+pub mod setting;
+pub mod state_context;
+pub mod transaction;
+pub mod transaction_receipt;
+pub mod validator;

--- a/sdk/rust/src/messaging/stream.rs
+++ b/sdk/rust/src/messaging/stream.rs
@@ -14,9 +14,9 @@
  * limitations under the License.
  * -----------------------------------------------------------------------------
  */
-use std;
 use messages::validator::Message;
 use messages::validator::Message_MessageType;
+use std;
 use std::error::Error;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::RecvError;

--- a/sdk/rust/src/messaging/zmq_stream.rs
+++ b/sdk/rust/src/messaging/zmq_stream.rs
@@ -17,16 +17,16 @@
 use uuid;
 use zmq;
 
-use std::sync::{Arc, Mutex};
-use std::sync::mpsc::{channel, sync_channel, Receiver, RecvTimeoutError, Sender, SyncSender};
-use std::thread;
-use std::time::Duration;
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::mpsc::{channel, sync_channel, Receiver, RecvTimeoutError, Sender, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
 
-use protobuf;
 use messages::validator::Message;
 use messages::validator::Message_MessageType;
+use protobuf;
 
 use messaging::stream::*;
 

--- a/sdk/rust/src/processor/handler.rs
+++ b/sdk/rust/src/processor/handler.rs
@@ -22,19 +22,19 @@ extern crate zmq;
 use protobuf::Message as M;
 use protobuf::RepeatedField;
 
-use std::error::Error as StdError;
 use std;
 use std::borrow::Borrow;
+use std::error::Error as StdError;
 
+use messages::events::Event;
+use messages::events::Event_Attribute;
 use messages::processor::TpProcessRequest;
 use messages::state_context::*;
 use messages::validator::Message_MessageType;
-use messages::events::Event;
-use messages::events::Event_Attribute;
 
 use messaging::stream::MessageSender;
-use messaging::stream::SendError;
 use messaging::stream::ReceiveError;
+use messaging::stream::SendError;
 use messaging::zmq_stream::ZmqMessageSender;
 
 use super::generate_correlation_id;

--- a/sdk/rust/src/processor/mod.rs
+++ b/sdk/rust/src/processor/mod.rs
@@ -31,7 +31,7 @@ use self::rand::Rng;
 pub mod handler;
 
 use protobuf::Message as M;
-use protobuf::repeated::RepeatedField;
+use protobuf::RepeatedField;
 use messages::validator::Message_MessageType;
 use messages::network::PingResponse;
 use messages::processor::TpRegisterRequest;

--- a/sdk/rust/src/processor/mod.rs
+++ b/sdk/rust/src/processor/mod.rs
@@ -20,35 +20,35 @@ extern crate protobuf;
 extern crate rand;
 extern crate zmq;
 
-use std::sync::mpsc::RecvTimeoutError;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
 use std::error::Error;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::Duration;
 
 use self::rand::Rng;
 
 pub mod handler;
 
-use protobuf::Message as M;
-use protobuf::RepeatedField;
-use messages::validator::Message_MessageType;
 use messages::network::PingResponse;
-use messages::processor::TpRegisterRequest;
-use messages::processor::TpUnregisterRequest;
 use messages::processor::TpProcessRequest;
 use messages::processor::TpProcessResponse;
 use messages::processor::TpProcessResponse_Status;
+use messages::processor::TpRegisterRequest;
+use messages::processor::TpUnregisterRequest;
+use messages::validator::Message_MessageType;
 use messaging::stream::MessageConnection;
 use messaging::stream::MessageSender;
-use messaging::zmq_stream::ZmqMessageSender;
-use messaging::stream::SendError;
 use messaging::stream::ReceiveError;
+use messaging::stream::SendError;
 use messaging::zmq_stream::ZmqMessageConnection;
+use messaging::zmq_stream::ZmqMessageSender;
+use protobuf::Message as M;
+use protobuf::RepeatedField;
 
+use self::handler::ApplyError;
 use self::handler::TransactionContext;
 use self::handler::TransactionHandler;
-use self::handler::ApplyError;
 
 /// Generates a random correlation id for use in Message
 fn generate_correlation_id() -> String {

--- a/sdk/rust/src/signing/mod.rs
+++ b/sdk/rust/src/signing/mod.rs
@@ -19,9 +19,9 @@
 mod pem_loader;
 pub mod secp256k1;
 
-use std::error::Error as StdError;
 use std;
 use std::borrow::Borrow;
+use std::error::Error as StdError;
 
 #[derive(Debug)]
 pub enum Error {

--- a/sdk/rust/src/signing/pem_loader.rs
+++ b/sdk/rust/src/signing/pem_loader.rs
@@ -31,8 +31,8 @@ mod ffi {
     }
 
 }
-use std::ffi::CString;
 use super::Error;
+use std::ffi::CString;
 
 pub fn load_pem_key(pemstr: &str, password: &str) -> Result<(String, String), Error> {
     let c_pemstr = CString::new(pemstr).unwrap();

--- a/sdk/rust/src/signing/secp256k1.rs
+++ b/sdk/rust/src/signing/secp256k1.rs
@@ -21,10 +21,10 @@ use rand::Rng;
 use rand::os::OsRng;
 use secp256k1;
 
-use signing::PrivateKey;
-use signing::PublicKey;
 use signing::Context;
 use signing::Error;
+use signing::PrivateKey;
+use signing::PublicKey;
 #[cfg(feature = "pem")]
 use signing::pem_loader::load_pem_key;
 
@@ -201,12 +201,12 @@ fn bytes_to_hex_str(b: &[u8]) -> String {
 
 #[cfg(test)]
 mod secp256k1_test {
-    use super::Secp256k1PrivateKey;
-    use super::Secp256k1PublicKey;
     use super::super::CryptoFactory;
     use super::super::PrivateKey;
     use super::super::PublicKey;
     use super::super::create_context;
+    use super::Secp256k1PrivateKey;
+    use super::Secp256k1PublicKey;
 
     static KEY1_PRIV_HEX: &'static str =
         "2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088";

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -18,7 +18,7 @@ rust-crypto = "0.2"
 rand = "0.4"
 
 [build-dependencies]
-protoc-rust = "1.4"
+protoc-rust = "^1.6"
 glob = "0.2"
 
 [lib]

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -74,7 +74,7 @@ fn main() {
             includes: &["src", PROTO_FILES_DIR],
             customize: Customize {
                 ..Default::default()
-            }
+            },
         }).expect("unable to run protoc");
 
         let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -24,6 +24,8 @@ use std::io::prelude::*;
 use std::path::Path;
 use std::time::{Duration, UNIX_EPOCH};
 
+use protoc_rust::Customize;
+
 const PROTO_FILES_DIR: &str = "../protos";
 const PROTOBUF_TARGET_DIR: &str = "src/proto";
 const GENERATED_SOURCE_HEADER: &str = r#"
@@ -70,6 +72,9 @@ fn main() {
                 .map(|proto_file| proto_file.file_path.as_ref())
                 .collect::<Vec<&str>>(),
             includes: &["src", PROTO_FILES_DIR],
+            customize: Customize {
+                ..Default::default()
+            }
         }).expect("unable to run protoc");
 
         let mod_file_name = format!("{}/mod.rs", PROTOBUF_TARGET_DIR);

--- a/validator/src/database/lmdb.rs
+++ b/validator/src/database/lmdb.rs
@@ -340,8 +340,8 @@ mod tests {
     use super::*;
     use std::env;
     use std::fs::remove_file;
-    use std::path::Path;
     use std::panic;
+    use std::path::Path;
     use std::thread;
 
     /// Asserts that there are COUNT many objects in DB.

--- a/validator/src/database/lmdb_ffi.rs
+++ b/validator/src/database/lmdb_ffi.rs
@@ -16,8 +16,8 @@
  */
 use database::lmdb::*;
 use std::ffi::CStr;
-use std::path::Path;
 use std::os::raw::{c_char, c_void};
+use std::path::Path;
 use std::slice;
 
 #[repr(u32)]

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -6,8 +6,8 @@ extern crate log;
 mod pylogger;
 mod server;
 
-use server::cli;
 use cpython::Python;
+use server::cli;
 
 fn main() {
     let gil = Python::acquire_gil();

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -323,7 +323,7 @@ impl MerkleDatabase {
         let mut next_change_log = ChangeLogEntry::new();
         next_change_log.set_parent(root_hash_bytes.clone());
         next_change_log.set_additions(protobuf::RepeatedField::from(
-            batch.iter().map(|&(ref hash, _)| hash.clone()).collect(),
+            batch.iter().map(|&(ref hash, _)| hash.clone()).collect::<Vec<Vec<u8>>>(),
         ));
 
         if current_change_log.is_some() {

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -22,12 +22,12 @@ use std::collections::VecDeque;
 use std::io::Cursor;
 
 use cbor;
-use cbor::encoder::{EncodeError, GenericEncoder};
 use cbor::decoder::{DecodeError, GenericDecoder};
-use cbor::value::Value;
-use cbor::value::Key;
+use cbor::encoder::{EncodeError, GenericEncoder};
 use cbor::value::Bytes;
+use cbor::value::Key;
 use cbor::value::Text;
+use cbor::value::Value;
 
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
@@ -37,8 +37,8 @@ use protobuf::Message;
 use protobuf::ProtobufError;
 
 use database::database::DatabaseError;
-use database::lmdb::LmdbDatabase;
 use database::lmdb::DatabaseReader;
+use database::lmdb::LmdbDatabase;
 
 use proto::merkle::ChangeLogEntry;
 use proto::merkle::ChangeLogEntry_Successor;
@@ -323,7 +323,10 @@ impl MerkleDatabase {
         let mut next_change_log = ChangeLogEntry::new();
         next_change_log.set_parent(root_hash_bytes.clone());
         next_change_log.set_additions(protobuf::RepeatedField::from(
-            batch.iter().map(|&(ref hash, _)| hash.clone()).collect::<Vec<Vec<u8>>>(),
+            batch
+                .iter()
+                .map(|&(ref hash, _)| hash.clone())
+                .collect::<Vec<Vec<u8>>>(),
         ));
 
         if current_change_log.is_some() {
@@ -639,19 +642,19 @@ fn hash(input: &[u8]) -> Vec<u8> {
 mod tests {
     use super::*;
     use database::database::DatabaseError;
+    use database::lmdb::DatabaseReader;
     use database::lmdb::LmdbContext;
     use database::lmdb::LmdbDatabase;
-    use database::lmdb::DatabaseReader;
     use proto::merkle::ChangeLogEntry;
 
+    use protobuf;
+    use rand::{seq, thread_rng};
     use std::env;
     use std::fs::remove_file;
-    use std::path::Path;
     use std::panic;
+    use std::path::Path;
     use std::str::from_utf8;
     use std::thread;
-    use rand::{seq, thread_rng};
-    use protobuf;
 
     #[test]
     fn node_serialize() {

--- a/validator/src/state/merkle_ffi.rs
+++ b/validator/src/state/merkle_ffi.rs
@@ -14,13 +14,13 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+use database::lmdb::LmdbDatabase;
 /// This module contains all of the extern C functions for the Merkle trie
 use state::merkle::*;
-use database::lmdb::LmdbDatabase;
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::os::raw::{c_char, c_void};
 use std::mem;
+use std::os::raw::{c_char, c_void};
 use std::slice;
 
 #[repr(u32)]


### PR DESCRIPTION
Wasn't sure if this had been addressed in some other way or at all.

`protoc_rust` version 1.6 removes the `MessageStatic` trait requires the `customize` field, and moves `RepeatedField`. As such the rust sdk fails to build on a fresh install.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>