### PR TITLE
Fix validator peering on Azure

### DIFF
--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -174,11 +174,11 @@ def main(args):
         interfaces = ["*", ".".join(["0", "0", "0", "0"])]
         interfaces += netifaces.interfaces()
         endpoint = validator_config.bind_network
+        parsed_endpoint = urlparse(validator_config.bind_network)
         for interface in interfaces:
-            if interface in validator_config.bind_network:
+            if interface == parsed_endpoint.hostname:
                 LOGGER.error("Endpoint must be set when using %s", interface)
                 init_errors = True
-                break
 
     if init_errors:
         LOGGER.error("Initialization errors occurred (see previous log "

--- a/validator/tests/test_authorization_handlers/test.py
+++ b/validator/tests/test_authorization_handlers/test.py
@@ -52,11 +52,21 @@ from test_authorization_handlers.mock import MockGossip
 
 
 class TestAuthorizationHandlers(unittest.TestCase):
+    def test_bad_endpoint_host(self):
+        """
+        Test error when the endpoint host is the same as a network interface
+        name.
+        """
+        interfaces = ["*", ".".join(["0", "0", "0", "0"])]
+        endpoint = "tcp://*:80"
+        result = ConnectHandler.is_valid_endpoint_host(interfaces, endpoint)
+        self.assertEqual(result, False)
+
     def test_connect(self):
         """
         Test the ConnectHandler correctly responds to a ConnectionRequest.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles)
         handler = ConnectHandler(network)
@@ -87,7 +97,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes the connection if the role has an
         unsupported role type.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": "other"}
         network = MockNetwork(roles)
         handler = ConnectHandler(network)
@@ -103,7 +113,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes a connection if we are not accepting
         incoming connections
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles, allow_inbound=False)
         handler = ConnectHandler(network)
@@ -119,7 +129,7 @@ class TestAuthorizationHandlers(unittest.TestCase):
         Test the ConnectHandler closes a connection if any authorization
         message has been recieved before this connection request.
         """
-        connect_message = ConnectionRequest(endpoint="endpoint")
+        connect_message = ConnectionRequest(endpoint="tcp://host:80")
         roles = {"network": AuthorizationType.TRUST}
         network = MockNetwork(roles,
                               connection_status={"connection_id": "other"})


### PR DESCRIPTION
Validator peering fails when using Azure endpoints such as tcp://hashblock3.westus2.cloudapp.azure.com:8800 because the 'lo' network interface characters are characters in 'cloudapp'. This fix test that the network interface string is not equal to the
host name of the endpoint. The bug number is STL-1125


Replaces #1592 and corrects the logging usage.