### PR TITLE
Add Rust core datatypes of Block, Batch, Transaction

### DIFF
--- a/validator/src/batch.rs
+++ b/validator/src/batch.rs
@@ -14,24 +14,16 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
 
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
+use transaction::Transaction;
 
-// exported modules
-pub mod database;
-pub mod proto;
-pub mod state;
+#[derive(Clone, Debug, PartialEq)]
+pub struct Batch {
+    pub header_signature: String,
+    pub transactions: Vec<Transaction>,
+    pub signer_public_key: String,
+    pub transaction_ids: Vec<String>,
+    pub trace: bool,
 
-pub mod batch;
-pub mod block;
-pub mod transaction;
+    pub header_bytes: Vec<u8>,
+}

--- a/validator/src/block.rs
+++ b/validator/src/block.rs
@@ -14,24 +14,19 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
 
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
+use batch::Batch;
 
-// exported modules
-pub mod database;
-pub mod proto;
-pub mod state;
+#[derive(Clone, Debug, PartialEq)]
+pub struct Block {
+    pub header_signature: String,
+    pub batches: Vec<Batch>,
+    pub state_root_hash: String,
+    pub consensus: Vec<u8>,
+    pub batch_ids: Vec<String>,
+    pub signer_public_key: String,
+    pub previous_block_id: String,
+    pub block_num: u64,
 
-pub mod batch;
-pub mod block;
-pub mod transaction;
+    pub header_bytes: Vec<u8>,
+}

--- a/validator/src/transaction.rs
+++ b/validator/src/transaction.rs
@@ -14,24 +14,20 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
 
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
+#[derive(Clone, Debug, PartialEq)]
+pub struct Transaction {
+    pub header_signature: String,
+    pub payload: Vec<u8>,
+    pub batcher_public_key: String,
+    pub dependencies: Vec<String>,
+    pub family_name: String,
+    pub family_version: String,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+    pub nonce: String,
+    pub payload_sha512: String,
+    pub signer_public_key: String,
 
-// exported modules
-pub mod database;
-pub mod proto;
-pub mod state;
-
-pub mod batch;
-pub mod block;
-pub mod transaction;
+    pub header_bytes: Vec<u8>,
+}


### PR DESCRIPTION
These Rust structs allow for manipulation of Blocks, Batches, and Transactions
without having to deserialize fields that are bytes.

Later either a From or a TryFrom can be implemented to convert from
proto::{Block, Batch, Transaction}.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>