### PR TITLE
1-0: Set Rust toolchain and dependency versions

### DIFF
--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -53,7 +53,7 @@ EXPOSE 4004/tcp
 ENV PATH=$PATH:/project/sawtooth-core/bin:/root/.cargo/bin\
     CARGO_INCREMENTAL=0
 
-RUN cargo install protobuf
+RUN cargo install --version ~1.4 protobuf
 
 RUN mkdir -p /project/sawtooth-core/ \
  && mkdir -p /var/log/sawtooth \

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.1.0"
 authors = ["sawtooth"]
 
 [dependencies]
-protobuf="1.4.1"
+protobuf = "~1.4"
 secp256k1 = "0.7.1"
 rust-crypto = "0.2.36"
 zmq = "0.8"


### PR DESCRIPTION
This fixes build issues with Rust protoc in the 1-0 branch.