### PR TITLE
Set State for an unauthorized address

### DIFF
--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -97,7 +97,7 @@ class Context(object):
                               request).result(timeout).content)
         if response.status == \
                 state_context_pb2.TpStateSetResponse.AUTHORIZATION_ERROR:
-            addresses = [address for address, encoded in entries.items()]
+            addresses = [address for address, _ in entries.items()]
             raise AuthorizationException(
                 'Tried to set unauthorized address: {}'.format(addresses))
         return response.addresses

--- a/sdk/python/sawtooth_sdk/processor/context.py
+++ b/sdk/python/sawtooth_sdk/processor/context.py
@@ -97,7 +97,7 @@ class Context(object):
                               request).result(timeout).content)
         if response.status == \
                 state_context_pb2.TpStateSetResponse.AUTHORIZATION_ERROR:
-            addresses = [e.address for e in entries]
+            addresses = [address for address, encoded in entries.items()]
             raise AuthorizationException(
                 'Tried to set unauthorized address: {}'.format(addresses))
         return response.addresses


### PR DESCRIPTION
Currently setting state for an unauthorized address throws an error that
is unclear. This is because the addresses array is being built by
accessing a non-existent property (.address) on ```e for e in
entries```.

This commit should resolve this issue.