### PR TITLE
Improve python-rust boundary interaction

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -12,6 +12,7 @@ libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"
 cbor-codec = "0.7"
 protobuf = "2.0"
+python3-sys = "0.2"
 rust-crypto = "0.2"
 
 [dev-dependencies]

--- a/validator/sawtooth_validator/database/native_lmdb.py
+++ b/validator/sawtooth_validator/database/native_lmdb.py
@@ -15,7 +15,7 @@
 import ctypes
 from enum import IntEnum
 
-from sawtooth_validator.ffi import LIBRARY
+from sawtooth_validator.ffi import PY_LIBRARY
 from sawtooth_validator.ffi import CommonErrorCode
 from sawtooth_validator.ffi import OwnedPointer
 
@@ -29,14 +29,10 @@ class NativeLmdbDatabase(OwnedPointer):
 
         c_path = ctypes.c_char_p(path.encode())
 
-        c_indexes = (ctypes.c_char_p * len(indexes))()
-        for (i, index) in enumerate(indexes):
-            c_indexes[i] = ctypes.c_char_p(index.encode())
-
         c_size = ctypes.c_size_t(_size)
-        res = LIBRARY.call(
+        res = PY_LIBRARY.call(
             'lmdb_database_new', c_path, c_size,
-            c_indexes, ctypes.c_size_t(len(indexes)),
+            ctypes.py_object(indexes),
             ctypes.byref(self.pointer))
         if res == ErrorCode.Success:
             return

--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -26,7 +26,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Library:
 
-    def __init__(self):
+    def __init__(self, library_loader):
         lib_prefix_mapping = {
             "darwin": "lib",
             "linux": "lib",
@@ -55,13 +55,14 @@ class Library:
 
         LOGGER.debug("loading library %s", library_path)
 
-        self._cdll = ctypes.CDLL(library_path)
+        self._cdll = library_loader(library_path)
 
     def call(self, name, *args):
         return getattr(self._cdll, name)(*args)
 
 
-LIBRARY = Library()
+LIBRARY = Library(ctypes.CDLL)
+PY_LIBRARY = Library(ctypes.PyDLL)
 
 
 def prepare_byte_result():

--- a/validator/src/database/lmdb.rs
+++ b/validator/src/database/lmdb.rs
@@ -70,7 +70,7 @@ pub struct LmdbDatabase {
 }
 
 impl LmdbDatabase {
-    pub fn new(ctx: LmdbContext, indexes: &[&str]) -> Result<Self, DatabaseError> {
+    pub fn new<S: AsRef<str>>(ctx: LmdbContext, indexes: &[S]) -> Result<Self, DatabaseError> {
         let main = lmdb::Database::open(
             ctx.env.clone(),
             Some("main"),
@@ -83,12 +83,12 @@ impl LmdbDatabase {
         for name in indexes {
             let db = lmdb::Database::open(
                 ctx.env.clone(),
-                Some(name),
+                Some(name.as_ref()),
                 &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
             ).map_err(|err| {
                 DatabaseError::InitError(format!("Failed to open database: {:?}", err))
             })?;
-            index_dbs.insert(String::from(*name), db);
+            index_dbs.insert(String::from(name.as_ref()), db);
         }
         Ok(LmdbDatabase {
             ctx,

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -21,6 +21,7 @@ extern crate hex;
 extern crate libc;
 extern crate lmdb_zero;
 extern crate protobuf;
+extern crate python3_sys as py_ffi;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Improve the python-rust interaction by adding an instance of a ctypes
PYDLL, which maintains the GIL when it calls the underlying c function.
Using the cpython Rust library, the arguments can then be translated
from Python to Rust values and passed to the Rust struct, as needed.

Additionally:

- Added dynamic dispatch on AsRef<str> for the creation of an LMDB
instance, which is needed for handling a list Strings passed by python.
- explicitly import python3-sys to use the raw PyObject pointers

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>