### PR TITLE
Missing Double Quotes in the Creating a Sawtooth Network Instructions

### DIFF
--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -320,7 +320,7 @@ in :doc:`ubuntu`.
       $ sawset proposal create -k /etc/sawtooth/keys/validator.priv \
       -o config.batch \
       sawtooth.consensus.algorithm=poet \
-      sawtooth.poet.report_public_key_pem=$(cat /etc/sawtooth/simulator_rk_pub.pem) \
+      sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
 


### PR DESCRIPTION
Double Quotes are missing in the "Creating a Sawtooth Network", step 1, #6.
This line:
`sawtooth.poet.report_public_key_pem=$(cat /etc/sawtooth/simulator_rk_pub.pem`)
Should be:
`sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)"`

Otherwise, the following error occurs:
> sawset:error : unrecognised argument `sawset proposal create -k`

Signed-off-by: danintel <daniel.anderson@intel.com>