### PR TITLE
docs: Fix Typo in Sawset Documentation

### DIFF
--- a/docs/source/cli/sawset.rst
+++ b/docs/source/cli/sawset.rst
@@ -43,7 +43,7 @@ sawset proposal
 ===============
 
 The Settings transaction family supports a
-simple voting mechanism for applying changes to on-change settings.
+simple voting mechanism for applying changes to on-chain settings.
 The ``sawset proposal`` subcommands provide tools to view,
 create and vote on proposed settings.
 


### PR DESCRIPTION
Change on-change to on-chain.

Signed-off-by: danintel <daniel.anderson@intel.com>