### PR TITLE
docs: Clarify sudo and sawtooth Command

### DIFF
--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -175,6 +175,11 @@ Use the same terminal window as the previous step.
      Processing config-genesis.batch...
      Generating /var/lib/sawtooth/genesis.batch
 
+   .. note::
+
+      The ``-u sawtooth`` option refers to the sawtooth user,
+      not the sawtooth command.
+
 
 .. _generate-root-key-ubuntu:
 


### PR DESCRIPTION
Clarify between sawtooth command and sawtooth user.
Unfortunately, this causes a lot of confusion.

Signed-off-by: danintel <daniel.anderson@intel.com>