### PR TITLE
Implement Chain Controller In Rust

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Intel Corporation"]
 clap = "2"
 cpython = "0.2"
 hex = "0.3"
+lazy_static = "1.0"
 log = { version = "0.4", features = ["std"] }
 libc = ">=0.2.35"
 lmdb-zero = ">=0.4.1"

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -43,10 +43,13 @@ class ChainController(OwnedPointer):
         block_validator,
         chain_head_lock,
         on_chain_updated,
-        data_dir,
+        data_dir=None,
         observers=None
     ):
         super(ChainController, self).__init__('chain_controller_drop')
+
+        if data_dir is None:
+            data_dir = ''
 
         if observers is None:
             observers = []
@@ -79,6 +82,12 @@ class ChainController(OwnedPointer):
     def queue_block(self, block):
         _pylibexec('chain_controller_queue_block', self.pointer,
                    ctypes.py_object(block))
+
+    def on_block_received(self, block_wrapper):
+        """This is exposed for unit tests, and should not be called directly.
+        """
+        _pylibexec('chain_controller_on_block_received', self.pointer,
+                   ctypes.py_object(block_wrapper))
 
     @property
     def chain_head(self):

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -294,15 +294,13 @@ class Validator(object):
             permission_verifier=permission_verifier)
 
         chain_controller = ChainController(
+            block_store=block_store,
             block_cache=block_cache,
             block_validator=block_validator,
-            state_view_factory=state_view_factory,
             chain_head_lock=block_publisher.chain_head_lock,
             on_chain_updated=block_publisher.on_chain_updated,
-            chain_id_manager=chain_id_manager,
             data_dir=data_dir,
-            config_dir=config_dir,
-            chain_observers=[
+            observers=[
                 event_broadcaster,
                 receipt_store,
                 batch_tracker,

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use std::sync::mpsc::Sender;
+
+use batch::Batch;
+use journal::block_wrapper::BlockWrapper;
+
+/// Holds the results of Block Validation.
+pub struct BlockValidationResult {
+    pub chain_head: BlockWrapper,
+    pub block: BlockWrapper,
+
+    pub transaction_count: usize,
+
+    pub new_chain: Vec<BlockWrapper>,
+    pub current_chain: Vec<BlockWrapper>,
+
+    pub committed_batches: Vec<Batch>,
+    pub uncommitted_batches: Vec<Batch>,
+}
+
+#[derive(Debug)]
+pub enum ValidationError {
+    BlockValidationFailure(String),
+}
+
+pub trait BlockValidator: Send + Sync {
+    fn in_process(&self, block_id: &str) -> bool;
+    fn in_pending(&self, block_id: &str) -> bool;
+    fn validate_block(&self, block: BlockWrapper) -> Result<(), ValidationError>;
+
+    fn submit_blocks_for_verification(
+        &self,
+        blocks: &[BlockWrapper],
+        response_sender: Sender<(bool, BlockValidationResult)>,
+    );
+}

--- a/validator/src/journal/block_wrapper.rs
+++ b/validator/src/journal/block_wrapper.rs
@@ -20,7 +20,7 @@ use block::Block;
 use scheduler::TxnExecutionResult;
 use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum BlockStatus {
     Unknown = 0,
     Invalid = 1,

--- a/validator/src/journal/block_wrapper_ffi.rs
+++ b/validator/src/journal/block_wrapper_ffi.rs
@@ -215,3 +215,29 @@ fn proto_txn_to_txn(proto_txn: &mut ProtoTxn) -> Transaction {
         signer_public_key: txn_header.take_signer_public_key(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use block::Block;
+    use cpython::{FromPyObject, PyObject, Python, ToPyObject};
+    use journal::block_wrapper::{BlockStatus, BlockWrapper};
+
+    #[test]
+    fn to_from_python() {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let block_wrapper = BlockWrapper {
+            block: Block::default(),
+            status: BlockStatus::Valid,
+            ..BlockWrapper::default()
+        };
+
+        let py_block_wrapper = block_wrapper.to_py_object(py);
+        let round_trip_obj: BlockWrapper = py_block_wrapper.extract(py).unwrap();
+
+        assert_eq!(BlockStatus::Valid, round_trip_obj.status);
+    }
+
+}

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -1,0 +1,648 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+use std::marker::Send;
+use std::marker::Sync;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::RecvError;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::RwLock;
+use std::thread;
+use std::time::Duration;
+
+use protobuf;
+
+use batch::Batch;
+use journal;
+use journal::block_validator::{BlockValidationResult, BlockValidator, ValidationError};
+use journal::block_wrapper::BlockWrapper;
+use metrics;
+
+use proto::transaction_receipt::TransactionReceipt;
+use scheduler::TxnExecutionResult;
+
+const RECV_TIMEOUT_MILLIS: u64 = 100;
+
+lazy_static! {
+    static ref COLLECTOR: metrics::MetricsCollectorHandle =
+        metrics::get_collector("sawtooth_validator.chain.ChainController");
+}
+
+#[derive(Debug)]
+pub enum ChainControllerError {
+    QueueRecvError(RecvError),
+    ChainIdError(io::Error),
+    ChainUpdateError(String),
+    BlockValidationError(ValidationError),
+    BrokenQueue,
+}
+
+impl From<RecvError> for ChainControllerError {
+    fn from(err: RecvError) -> Self {
+        ChainControllerError::QueueRecvError(err)
+    }
+}
+
+impl From<io::Error> for ChainControllerError {
+    fn from(err: io::Error) -> Self {
+        ChainControllerError::ChainIdError(err)
+    }
+}
+
+impl From<ValidationError> for ChainControllerError {
+    fn from(err: ValidationError) -> Self {
+        ChainControllerError::BlockValidationError(err)
+    }
+}
+
+pub trait ChainObserver: Send + Sync {
+    fn chain_update(&mut self, block: &BlockWrapper, receipts: &[&TransactionReceipt]);
+}
+
+pub trait ExternalLock: Send + Sync {
+    fn lock(&self) -> Box<ExternalLockGuard>;
+}
+
+pub trait ExternalLockGuard: Drop {
+    fn release(&self);
+}
+
+pub trait ChainHeadUpdateObserver: Send + Sync {
+    /// Called when the chain head has updated.
+    ///
+    /// Args:
+    ///     block: the new chain head
+    ///     committed_batches: all of the batches that have been committed
+    ///         on the given fork. This may be across multiple blocks.
+    ///     uncommitted_batches: all of the batches that have been uncommitted
+    ///         from the previous fork, if one was dropped.
+    fn on_chain_head_updated(
+        &mut self,
+        block: BlockWrapper,
+        committed_batches: Vec<Batch>,
+        uncommitted_batches: Vec<Batch>,
+    );
+}
+
+pub trait BlockCache: Send + Sync {
+    fn contains(&self, block_id: &str) -> bool;
+
+    fn put(&mut self, block: BlockWrapper);
+
+    fn get(&self, block_id: &str) -> Option<BlockWrapper>;
+}
+
+#[derive(Debug)]
+pub enum ChainReadError {
+    GeneralReadError(String),
+}
+
+pub trait ChainReader: Send + Sync {
+    fn chain_head(&self) -> Result<Option<BlockWrapper>, ChainReadError>;
+    fn count_committed_transactions(&self) -> Result<usize, ChainReadError>;
+}
+
+pub trait ChainWriter: Send + Sync {
+    fn update_chain(
+        &mut self,
+        new_chain: &[BlockWrapper],
+        old_chain: &[BlockWrapper],
+    ) -> Result<(), ChainControllerError>;
+}
+
+struct ChainControllerState<BC: BlockCache, BV: BlockValidator, CW: ChainWriter> {
+    block_cache: BC,
+    block_validator: BV,
+    chain_writer: CW,
+    chain_reader: Box<ChainReader>,
+    chain_head_lock: Box<ExternalLock>,
+    chain_head: Option<BlockWrapper>,
+    chain_id_manager: ChainIdManager,
+    chain_head_update_observer: Box<ChainHeadUpdateObserver>,
+    observers: Vec<Box<ChainObserver>>,
+}
+
+#[derive(Clone)]
+pub struct ChainController<BC: BlockCache, BV: BlockValidator, CW: ChainWriter> {
+    state: Arc<RwLock<ChainControllerState<BC, BV, CW>>>,
+    stop_handle: Arc<Mutex<Option<ChainThreadStopHandle>>>,
+    block_queue_sender: Option<Sender<BlockWrapper>>,
+    validation_result_sender: Option<Sender<(bool, BlockValidationResult)>>,
+}
+
+impl<BC: BlockCache + 'static, BV: BlockValidator + 'static, CW: ChainWriter + 'static>
+    ChainController<BC, BV, CW>
+{
+    pub fn new(
+        block_cache: BC,
+        block_validator: BV,
+        chain_writer: CW,
+        chain_reader: Box<ChainReader>,
+        chain_head_lock: Box<ExternalLock + 'static>,
+        data_dir: String,
+        chain_head_update_observer: Box<ChainHeadUpdateObserver>,
+        observers: Vec<Box<ChainObserver>>,
+    ) -> Self {
+        ChainController {
+            state: Arc::new(RwLock::new(ChainControllerState {
+                block_cache,
+                block_validator,
+                chain_writer,
+                chain_reader,
+                chain_head_lock,
+                chain_id_manager: ChainIdManager::new(data_dir),
+                chain_head_update_observer,
+                observers,
+                chain_head: None,
+            })),
+            stop_handle: Arc::new(Mutex::new(None)),
+            block_queue_sender: None,
+            validation_result_sender: None,
+        }
+    }
+
+    pub fn chain_head(&self) -> Option<BlockWrapper> {
+        let state = self.state
+            .read()
+            .expect("No lock holder should have poisoned the lock");
+
+        state.chain_head.clone()
+    }
+
+    pub fn on_block_received(&mut self, block: BlockWrapper) -> Result<(), ChainControllerError> {
+        let mut state = self.state
+            .write()
+            .expect("No lock holder should have poisoned the lock");
+
+        if has_block_no_lock(&state, block.header_signature()) {
+            return Ok(());
+        }
+
+        if state.chain_head.is_none() {
+            if let Err(err) = set_genesis(&mut state, block.clone()) {
+                warn!(
+                    "Unable to set chain head; genesis block {} is not valid: {:?}",
+                    block.header_signature(),
+                    err
+                );
+            }
+            return Ok(());
+        }
+
+        state.block_cache.put(block.clone());
+        self.submit_blocks_for_verification(&state.block_validator, &[block])?;
+        Ok(())
+    }
+
+    pub fn has_block(&self, block_id: &str) -> bool {
+        let state = self.state
+            .read()
+            .expect("No lock holder should have poisoned the lock");
+        has_block_no_lock(&state, block_id)
+    }
+
+    fn on_block_validated(&mut self, commit_new_block: bool, result: BlockValidationResult) {
+        let mut state = self.state
+            .write()
+            .expect("No lock holder should have poisoned the lock");
+
+        let mut blocks_considered_count = COLLECTOR.counter("blocks_considered_count", None, None);
+        blocks_considered_count.inc();
+
+        let new_block = result.block;
+        let initial_chain_head = result.chain_head.header_signature().clone();
+        if state
+            .chain_head
+            .as_ref()
+            .map(|block| initial_chain_head != block.header_signature())
+            .unwrap_or(false)
+        {
+            info!(
+                "Chain head updated from {} to {} while processing block {}",
+                result.chain_head,
+                state.chain_head.as_ref().unwrap(),
+                new_block
+            );
+            if let Err(err) =
+                self.submit_blocks_for_verification(&state.block_validator, &[new_block])
+            {
+                error!("Unable to submit block for verification: {:?}", err);
+            }
+        } else if commit_new_block {
+            let _chain_head_guard = state.chain_head_lock.lock();
+            let chain_head_block = new_block.clone();
+            state.chain_head = Some(new_block);
+
+            if let Err(err) = state
+                .chain_writer
+                .update_chain(&result.new_chain, &result.current_chain)
+            {
+                error!("Unable to update chain {:?}", err);
+                return;
+            }
+
+            info!(
+                "Chain head updated to {}",
+                state.chain_head.as_ref().unwrap()
+            );
+
+            let mut chain_head_gauge = COLLECTOR.gauge("chain_head", None, None);
+            chain_head_gauge.set_value(&chain_head_block.header_signature()[0..8]);
+
+            let mut committed_transactions_count =
+                COLLECTOR.counter("committed_transactions_count", None, None);
+            committed_transactions_count.inc_n(result.transaction_count);
+
+            let mut block_num_guage = COLLECTOR.gauge("block_num", None, None);
+            block_num_guage.set_value(chain_head_block.block_num());
+
+            let chain_head = state.chain_head.clone().unwrap();
+            notify_on_chain_updated(
+                &mut state,
+                chain_head,
+                result.committed_batches,
+                result.uncommitted_batches,
+            );
+
+            state.chain_head.as_ref().map(|block| {
+                block.batches().iter().for_each(|batch| {
+                    if batch.trace {
+                        debug!(
+                            "TRACE: {}: ChainController.on_block_validated",
+                            batch.header_signature
+                        )
+                    }
+                })
+            });
+
+            let mut new_chain = result.new_chain;
+            new_chain.reverse();
+
+            for block in new_chain {
+                let receipts: Vec<TransactionReceipt> = block
+                    .execution_results
+                    .iter()
+                    .map(TransactionReceipt::from)
+                    .collect();
+                for observer in state.observers.iter_mut() {
+                    observer.chain_update(&block, &receipts.iter().collect::<Vec<_>>());
+                }
+            }
+            let total_committed_txns = match state.chain_reader.count_committed_transactions() {
+                Ok(count) => count,
+                Err(err) => {
+                    error!(
+                        "Unable to read total committed transactions count: {:?}",
+                        err
+                    );
+                    0
+                }
+            };
+
+            let mut committed_transactions_gauge =
+                COLLECTOR.gauge("committed_transactions_gauge", None, None);
+            committed_transactions_gauge.set_value(total_committed_txns);
+        } else {
+            info!("Rejected new chain head: {}", new_block);
+        }
+    }
+
+    /// Light clone makes a copy of this controller, without access to the stop
+    /// handle.
+    pub fn light_clone(&self) -> Self {
+        ChainController {
+            state: self.state.clone(),
+            // This instance doesn't share the stop handle: it's not a
+            // publicly accessible instance
+            stop_handle: Arc::new(Mutex::new(None)),
+            block_queue_sender: self.block_queue_sender.clone(),
+            validation_result_sender: self.validation_result_sender.clone(),
+        }
+    }
+
+    fn submit_blocks_for_verification(
+        &self,
+        block_validator: &BV,
+        blocks: &[BlockWrapper],
+    ) -> Result<(), ChainControllerError> {
+        let sender = self.validation_result_sender
+            .as_ref()
+            .expect(
+                "Attempted to submit blocks for validation before starting the chain controller",
+            )
+            .clone();
+        block_validator.submit_blocks_for_verification(blocks, sender);
+        Ok(())
+    }
+
+    pub fn queue_block(&self, block: BlockWrapper) {
+        if self.block_queue_sender.is_some() {
+            let sender = self.block_queue_sender.clone();
+            if let Err(err) = sender.as_ref().unwrap().send(block) {
+                error!("Unable to add block to block queue: {}", err);
+            }
+        } else {
+            debug!(
+                "Attempting to queue block {} before chain controller is started; Ignoring",
+                block
+            );
+        }
+    }
+
+    pub fn start(&mut self) {
+        let mut stop_handle = self.stop_handle.lock().unwrap();
+        if stop_handle.is_none() {
+            {
+                // we need to check to see if a genesis block was created and stored,
+                // before this controller was started
+                let mut state = self.state
+                    .write()
+                    .expect("No lock holder should have poisoned the lock");
+
+                let chain_head = state
+                    .chain_reader
+                    .chain_head()
+                    .expect("Invalid block store. Head of the block chain cannot be determined");
+
+                if chain_head.is_some() {
+                    info!(
+                        "Chain controller initialized with chain head: {}",
+                        chain_head.as_ref().unwrap()
+                    );
+                    let notify_block = chain_head.clone().unwrap();
+                    state.chain_head = chain_head;
+                    let mut gauge = COLLECTOR.gauge("chain_head", None, None);
+                    gauge.set_value(&notify_block.header_signature()[0..8]);
+                    notify_on_chain_updated(&mut state, notify_block, vec![], vec![]);
+                }
+            }
+
+            let (block_queue_sender, block_queue_receiver) = channel();
+            let (validation_result_sender, validation_result_receiver) = channel();
+
+            self.block_queue_sender = Some(block_queue_sender);
+            self.validation_result_sender = Some(validation_result_sender);
+
+            let thread_chain_controller = self.light_clone();
+            let exit_flag = Arc::new(AtomicBool::new(false));
+            let mut chain_thread = ChainThread::new(
+                thread_chain_controller,
+                block_queue_receiver,
+                exit_flag.clone(),
+            );
+            *stop_handle = Some(ChainThreadStopHandle::new(exit_flag.clone()));
+            let chain_thread_builder =
+                thread::Builder::new().name("ChainThread:BlockRecevier".into());
+            chain_thread_builder
+                .spawn(move || {
+                    if let Err(err) = chain_thread.run() {
+                        error!("Error occurred during ChainController loop: {:?}", err);
+                    }
+                })
+                .unwrap();
+            let result_thread_builder =
+                thread::Builder::new().name("ChainThread:ValidationResultRecevier".into());
+            let mut result_thread_controller = self.light_clone();
+            let result_thread_exit = exit_flag.clone();
+            result_thread_builder
+                .spawn(move || loop {
+                    let (can_commit, result) = match validation_result_receiver
+                        .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
+                    {
+                        Err(mpsc::RecvTimeoutError::Timeout) => {
+                            if result_thread_exit.load(Ordering::Relaxed) {
+                                break;
+                            } else {
+                                continue;
+                            }
+                        }
+                        Err(_) => {
+                            error!("Result queue shutdown unexpectedly");
+                            break;
+                        }
+                        Ok(res) => res,
+                    };
+
+                    if !result_thread_exit.load(Ordering::Relaxed) {
+                        result_thread_controller.on_block_validated(can_commit, result);
+                    } else {
+                        break;
+                    }
+                })
+                .unwrap();
+        }
+    }
+
+    pub fn stop(&mut self) {
+        let mut stop_handle = self.stop_handle.lock().unwrap();
+        if stop_handle.is_some() {
+            let handle: ChainThreadStopHandle = stop_handle.take().unwrap();
+            handle.stop();
+        }
+    }
+}
+
+fn has_block_no_lock<BC: BlockCache, BV: BlockValidator, CW: ChainWriter>(
+    state: &ChainControllerState<BC, BV, CW>,
+    block_id: &str,
+) -> bool {
+    state.block_cache.contains(block_id) || state.block_validator.in_process(block_id)
+        || state.block_validator.in_pending(block_id)
+}
+
+/// This is used by a non-genesis journal when it has received the
+/// genesis block from the genesis validator
+fn set_genesis<BC: BlockCache, BV: BlockValidator, CW: ChainWriter>(
+    state: &mut ChainControllerState<BC, BV, CW>,
+    block: BlockWrapper,
+) -> Result<(), ChainControllerError> {
+    if block.previous_block_id() == journal::NULL_BLOCK_IDENTIFIER {
+        let chain_id = state.chain_id_manager.get_block_chain_id()?;
+        if chain_id
+            .as_ref()
+            .map(|block_id| block_id != block.header_signature())
+            .unwrap_or(false)
+        {
+            warn!(
+                "Block id does not match block chain id {}. Ignoring initial chain head: {}",
+                chain_id.unwrap(),
+                block.header_signature()
+            );
+        } else {
+            state.block_validator.validate_block(block.clone())?;
+
+            if chain_id.is_none() {
+                state
+                    .chain_id_manager
+                    .save_block_chain_id(block.header_signature())?;
+            }
+
+            state.chain_writer.update_chain(&[block.clone()], &[])?;
+            state.chain_head = Some(block.clone());
+            notify_on_chain_updated(state, block.clone(), vec![], vec![]);
+        }
+    }
+
+    Ok(())
+}
+
+fn notify_on_chain_updated<BC: BlockCache, BV: BlockValidator, CW: ChainWriter>(
+    state: &mut ChainControllerState<BC, BV, CW>,
+    block: BlockWrapper,
+    committed_batches: Vec<Batch>,
+    uncommitted_batches: Vec<Batch>,
+) {
+    state.chain_head_update_observer.on_chain_head_updated(
+        block,
+        committed_batches,
+        uncommitted_batches,
+    );
+}
+
+impl<'a> From<&'a TxnExecutionResult> for TransactionReceipt {
+    fn from(result: &'a TxnExecutionResult) -> Self {
+        let mut receipt = TransactionReceipt::new();
+
+        receipt.set_data(protobuf::RepeatedField::from_vec(
+            result.data.iter().map(|(_, data)| data.clone()).collect(),
+        ));
+        receipt.set_state_changes(protobuf::RepeatedField::from_vec(
+            result.state_changes.clone(),
+        ));
+        receipt.set_events(protobuf::RepeatedField::from_vec(result.events.clone()));
+        receipt.set_transaction_id(result.signature.clone());
+
+        receipt
+    }
+}
+
+struct ChainThread<BC: BlockCache, BV: BlockValidator, CW: ChainWriter> {
+    chain_controller: ChainController<BC, BV, CW>,
+    block_queue: Receiver<BlockWrapper>,
+    exit: Arc<AtomicBool>,
+}
+
+trait StopHandle: Clone {
+    fn stop(&self);
+}
+
+impl<BC: BlockCache + 'static, BV: BlockValidator + 'static, CW: ChainWriter + 'static>
+    ChainThread<BC, BV, CW>
+{
+    fn new(
+        chain_controller: ChainController<BC, BV, CW>,
+        block_queue: Receiver<BlockWrapper>,
+        exit_flag: Arc<AtomicBool>,
+    ) -> Self {
+        ChainThread {
+            chain_controller,
+            block_queue,
+            exit: exit_flag,
+        }
+    }
+
+    fn run(&mut self) -> Result<(), ChainControllerError> {
+        loop {
+            let block = match self.block_queue
+                .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
+            {
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if self.exit.load(Ordering::Relaxed) {
+                        break Ok(());
+                    } else {
+                        continue;
+                    }
+                }
+                Err(_) => break Err(ChainControllerError::BrokenQueue),
+                Ok(block) => block,
+            };
+            self.chain_controller.on_block_received(block)?;
+
+            if self.exit.load(Ordering::Relaxed) {
+                break Ok(());
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ChainThreadStopHandle {
+    exit: Arc<AtomicBool>,
+}
+
+impl ChainThreadStopHandle {
+    fn new(exit_flag: Arc<AtomicBool>) -> Self {
+        ChainThreadStopHandle { exit: exit_flag }
+    }
+}
+
+impl StopHandle for ChainThreadStopHandle {
+    fn stop(&self) {
+        self.exit.store(true, Ordering::Relaxed)
+    }
+}
+
+/// The ChainIdManager is in charge of of keeping track of the block-chain-id
+/// stored in the data_dir.
+#[derive(Clone, Debug)]
+struct ChainIdManager {
+    data_dir: String,
+}
+
+impl ChainIdManager {
+    pub fn new(data_dir: String) -> Self {
+        ChainIdManager { data_dir }
+    }
+
+    pub fn save_block_chain_id(&self, block_chain_id: &str) -> Result<(), io::Error> {
+        let mut path = PathBuf::new();
+        path.push(&self.data_dir);
+        path.push("block-chain-id");
+
+        let mut file = File::create(path)?;
+        file.write_all(block_chain_id.as_bytes())
+    }
+
+    pub fn get_block_chain_id(&self) -> Result<Option<String>, io::Error> {
+        let mut path = PathBuf::new();
+        path.push(&self.data_dir);
+        path.push("block-chain-id");
+
+        match File::open(path) {
+            Ok(mut file) => {
+                let mut contents = String::new();
+                file.read_to_string(&mut contents)?;
+                Ok(Some(contents))
+            }
+            Err(ref err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+#[cfg(tests)]
+mod tests {}

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -122,7 +122,11 @@ pub extern "C" fn chain_controller_new(
 pub extern "C" fn chain_controller_drop(chain_controller: *mut c_void) -> ErrorCode {
     check_null!(chain_controller);
 
-    unsafe { Box::from_raw(chain_controller) };
+    unsafe {
+        Box::from_raw(
+            chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>,
+        )
+    };
     ErrorCode::Success
 }
 

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -1,0 +1,691 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use cpython;
+use cpython::{FromPyObject, ObjectProtocol, PyList, PyObject, Python, PythonObject, ToPyObject};
+use journal::block_validator::{BlockValidationResult, BlockValidator, ValidationError};
+use journal::block_wrapper::BlockWrapper;
+use journal::chain::*;
+use py_ffi;
+use pylogger;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_void};
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use batch::Batch;
+
+use protobuf::Message;
+
+use proto::transaction_receipt::TransactionReceipt;
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum ErrorCode {
+    Success = 0,
+    NullPointerProvided = 0x01,
+    InvalidDataDir = 0x02,
+    InvalidPythonObject = 0x03,
+    InvalidBlockId = 0x04,
+
+    Unknown = 0xff,
+}
+
+macro_rules! check_null {
+    ($($arg:expr) , *) => {
+        $(if $arg.is_null() { return ErrorCode::NullPointerProvided; })*
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_new(
+    block_store: *mut py_ffi::PyObject,
+    block_cache: *mut py_ffi::PyObject,
+    block_validator: *mut py_ffi::PyObject,
+    chain_head_lock: *mut py_ffi::PyObject,
+    on_chain_updated: *mut py_ffi::PyObject,
+    observers: *mut py_ffi::PyObject,
+    data_directory: *const c_char,
+    chain_controller_ptr: *mut *const c_void,
+) -> ErrorCode {
+    check_null!(
+        block_store,
+        block_cache,
+        block_validator,
+        chain_head_lock,
+        on_chain_updated,
+        observers,
+        data_directory
+    );
+
+    let data_dir = unsafe {
+        match CStr::from_ptr(data_directory).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidDataDir,
+        }
+    };
+
+    let py = unsafe { Python::assume_gil_acquired() };
+
+    let py_block_store_reader = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
+    let py_block_store_writer = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
+    let py_block_cache = unsafe { PyObject::from_borrowed_ptr(py, block_cache) };
+    let py_block_validator = unsafe { PyObject::from_borrowed_ptr(py, block_validator) };
+    let py_on_chain_updated = unsafe { PyObject::from_borrowed_ptr(py, on_chain_updated) };
+    let py_observers = unsafe { PyObject::from_borrowed_ptr(py, observers) };
+    let chain_head_lock = PyLock {
+        py_lock: unsafe { PyObject::from_borrowed_ptr(py, chain_head_lock) },
+    };
+
+    let observer_wrappers = if let Ok(py_list) = py_observers.extract::<PyList>(py) {
+        let mut res: Vec<Box<ChainObserver>> = Vec::with_capacity(py_list.len(py));
+        py_list
+            .iter(py)
+            .for_each(|pyobj| res.push(Box::new(PyChainObserver::new(pyobj))));
+        res
+    } else {
+        return ErrorCode::InvalidPythonObject;
+    };
+
+    let chain_controller = ChainController::new(
+        PyBlockCache::new(py_block_cache),
+        PyBlockValidator::new(py_block_validator),
+        PyBlockStore::new(py_block_store_writer),
+        Box::new(PyBlockStore::new(py_block_store_reader)),
+        Box::new(chain_head_lock),
+        data_dir.into(),
+        Box::new(PyChainHeadUpdateObserver::new(py_on_chain_updated)),
+        observer_wrappers,
+    );
+
+    unsafe {
+        *chain_controller_ptr = Box::into_raw(Box::new(chain_controller)) as *const c_void;
+    }
+
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_drop(chain_controller: *mut c_void) -> ErrorCode {
+    check_null!(chain_controller);
+
+    unsafe { Box::from_raw(chain_controller) };
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_start(chain_controller: *mut c_void) -> ErrorCode {
+    check_null!(chain_controller);
+
+    unsafe {
+        (*(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .start();
+    }
+
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_stop(chain_controller: *mut c_void) -> ErrorCode {
+    check_null!(chain_controller);
+
+    unsafe {
+        (*(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .stop();
+    }
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_has_block(
+    chain_controller: *mut c_void,
+    block_id: *const c_char,
+    result: *mut bool,
+) -> ErrorCode {
+    check_null!(chain_controller, block_id);
+
+    let block_id = unsafe {
+        match CStr::from_ptr(block_id).to_str() {
+            Ok(s) => s,
+            Err(_) => return ErrorCode::InvalidBlockId,
+        }
+    };
+
+    unsafe {
+        *result = (*(chain_controller
+            as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .has_block(block_id);
+    }
+
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_queue_block(
+    chain_controller: *mut c_void,
+    block: *mut py_ffi::PyObject,
+) -> ErrorCode {
+    check_null!(chain_controller, block);
+
+    let gil_guard = Python::acquire_gil();
+    let py = gil_guard.python();
+
+    let block: BlockWrapper = unsafe {
+        match PyObject::from_borrowed_ptr(py, block).extract(py) {
+            Ok(val) => val,
+            Err(py_err) => {
+                pylogger::exception(
+                    py,
+                    "chain_controller_queue_block: unable to get block",
+                    py_err,
+                );
+                return ErrorCode::InvalidPythonObject;
+            }
+        }
+    };
+    unsafe {
+        let controller = (*(chain_controller
+            as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .light_clone();
+
+        py.allow_threads(move || {
+            let builder = thread::Builder::new().name("ChainController.queue_block".into());
+            builder
+                .spawn(move || {
+                    controller.queue_block(block);
+                })
+                .unwrap()
+                .join()
+                .unwrap();
+        });
+    }
+
+    ErrorCode::Success
+}
+
+/// This is only exposed for the current python tests, it should be removed
+/// when proper rust tests are written for the ChainController
+#[no_mangle]
+pub extern "C" fn chain_controller_on_block_received(
+    chain_controller: *mut c_void,
+    block: *mut py_ffi::PyObject,
+) -> ErrorCode {
+    check_null!(chain_controller, block);
+
+    let gil_guard = Python::acquire_gil();
+    let py = gil_guard.python();
+
+    let block: BlockWrapper = unsafe {
+        match PyObject::from_borrowed_ptr(py, block).extract(py) {
+            Ok(val) => val,
+            Err(py_err) => {
+                pylogger::exception(
+                    py,
+                    "chain_controller_on_block_received: unable to get block",
+                    py_err,
+                );
+                return ErrorCode::InvalidPythonObject;
+            }
+        }
+    };
+    unsafe {
+        let mut controller = (*(chain_controller
+            as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .light_clone();
+
+        py.allow_threads(move || {
+            // A thread has to be spawned here, otherwise, any subsequent attempt to
+            // re-acquire the GIL and import of python modules will fail.
+            let builder = thread::Builder::new().name("ChainController.on_block_received".into());
+            builder
+                .spawn(move || match controller.on_block_received(block) {
+                    Ok(_) => ErrorCode::Success,
+                    Err(err) => {
+                        error!("Unable to call on_block_received: {:?}", err);
+                        ErrorCode::Unknown
+                    }
+                })
+                .unwrap()
+                .join()
+                .unwrap()
+        })
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn chain_controller_chain_head(
+    chain_controller: *mut c_void,
+    block: *mut *const py_ffi::PyObject,
+) -> ErrorCode {
+    check_null!(chain_controller);
+    unsafe {
+        let chain_head = (*(chain_controller
+            as *mut ChainController<PyBlockCache, PyBlockValidator, PyBlockStore>))
+            .chain_head();
+
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        *block = chain_head.to_py_object(py).steal_ptr();
+    }
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn sender_drop(sender: *const c_void) -> ErrorCode {
+    check_null!(sender);
+
+    unsafe { Box::from_raw(sender as *mut Sender<(bool, BlockValidationResult)>) };
+
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub extern "C" fn sender_send(
+    sender: *const c_void,
+    result_tuple: *mut py_ffi::PyObject,
+) -> ErrorCode {
+    check_null!(sender, result_tuple);
+
+    let gil_guard = Python::acquire_gil();
+    let py = gil_guard.python();
+
+    let py_result_tuple = unsafe { PyObject::from_borrowed_ptr(py, result_tuple) };
+    let (can_commit, result): (bool, BlockValidationResult) = py_result_tuple
+        .extract(py)
+        .expect("Unable to extract result tuple");
+
+    unsafe {
+        match (*(sender as *mut Sender<(bool, BlockValidationResult)>)).send((can_commit, result)) {
+            Ok(_) => ErrorCode::Success,
+            Err(err) => {
+                error!("Unable to send validation result: {:?}", err);
+                ErrorCode::Unknown
+            }
+        }
+    }
+}
+
+struct PyLock {
+    py_lock: PyObject,
+}
+
+impl ExternalLock for PyLock {
+    fn lock(&self) -> Box<ExternalLockGuard> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        self.py_lock
+            .call_method(py, "acquire", cpython::NoArgs, None)
+            .expect("Unable to call release on python lock");
+
+        let py_release_fn = self.py_lock
+            .getattr(py, "release")
+            .expect("unable to get release function");
+        Box::new(PyExternalLockGuard { py_release_fn })
+    }
+}
+
+struct PyExternalLockGuard {
+    py_release_fn: PyObject,
+}
+
+impl ExternalLockGuard for PyExternalLockGuard {
+    fn release(&self) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        self.py_release_fn
+            .call(py, cpython::NoArgs, None)
+            .expect("Unable to call release on python lock");
+    }
+}
+
+impl Drop for PyExternalLockGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+struct PyBlockCache {
+    py_block_cache: PyObject,
+}
+
+impl PyBlockCache {
+    fn new(py_block_cache: PyObject) -> Self {
+        PyBlockCache { py_block_cache }
+    }
+}
+
+impl BlockCache for PyBlockCache {
+    fn contains(&self, block_id: &str) -> bool {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        match self.py_block_cache
+            .call_method(py, "__contains__", (block_id,), None)
+        {
+            Err(py_err) => {
+                pylogger::exception(py, "Unable to call __contains__ on BlockCache", py_err);
+                false
+            }
+            Ok(py_bool) => py_bool.extract(py).expect("Unable to extract boolean"),
+        }
+    }
+
+    fn put(&mut self, block: BlockWrapper) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        match self.py_block_cache
+            .set_item(py, block.header_signature(), &block)
+        {
+            Err(py_err) => {
+                pylogger::exception(py, "Unable to call __setitem__ on BlockCache", py_err);
+                ()
+            }
+            Ok(_) => (),
+        }
+    }
+
+    fn get(&self, block_id: &str) -> Option<BlockWrapper> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        match self.py_block_cache.get_item(py, block_id) {
+            Err(_) => {
+                // This is probably a key error, so we can return none
+                None
+            }
+            Ok(res) => Some(res.extract(py).expect("Unable to extract block")),
+        }
+    }
+}
+
+struct PyBlockValidator {
+    py_block_validator: PyObject,
+    ctypes_c_void: PyObject,
+    py_validation_response_sender: PyObject,
+    py_callback_maker: PyObject,
+}
+
+impl PyBlockValidator {
+    fn new(py_block_validator: PyObject) -> Self {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let ctypes_module = py.import("ctypes").expect("Unable to import ctypes");
+
+        let ctypes_c_void = ctypes_module
+            .get(py, "c_void_p")
+            .expect("Unable to get c_void_p");
+
+        let chain_module = py.import("sawtooth_validator.journal.chain")
+            .expect("Unable to import sawtooth_validator.journal.chain");
+        let py_validation_response_sender = chain_module
+            .get(py, "ValidationResponseSender")
+            .expect("Unable to get ValidationResponseSender");
+
+        let ffi_module = py.import("sawtooth_validator.ffi")
+            .expect("Unable to import sawtooth_validator.ffi");
+        let py_callback_maker = ffi_module
+            .get(py, "python_to_sender_callback")
+            .expect("Unable to get python_to_sender_callback");
+
+        PyBlockValidator {
+            py_block_validator,
+            ctypes_c_void,
+            py_validation_response_sender,
+            py_callback_maker,
+        }
+    }
+
+    fn query_block_status(&self, fn_name: &str, block_id: &str) -> bool {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        match self.py_block_validator
+            .call_method(py, fn_name, (block_id,), None)
+        {
+            Err(_) => {
+                // Presumably a KeyError, so no
+                false
+            }
+            Ok(py_bool) => py_bool.extract(py).expect("Unable to extract boolean"),
+        }
+    }
+}
+
+impl BlockValidator for PyBlockValidator {
+    fn in_process(&self, block_id: &str) -> bool {
+        self.query_block_status("in_process", block_id)
+    }
+
+    fn in_pending(&self, block_id: &str) -> bool {
+        self.query_block_status("in_pending", block_id)
+    }
+
+    fn validate_block(&self, block: BlockWrapper) -> Result<(), ValidationError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_block_validator
+            .call_method(py, "validate_block", (block,), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                ValidationError::BlockValidationFailure(py_err.get_type(py).name(py).into_owned())
+            })
+    }
+
+    fn submit_blocks_for_verification(
+        &self,
+        blocks: &[BlockWrapper],
+        response_sender: Sender<(bool, BlockValidationResult)>,
+    ) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let sender_ptr = Box::into_raw(Box::new(response_sender)) as u64;
+
+        let sender_c_void = self.ctypes_c_void
+            .call(py, (sender_ptr,), None)
+            .expect("unable to create ctypes.c_void_p");
+
+        let py_sender = self.py_validation_response_sender
+            .call(py, (sender_c_void,), None)
+            .expect("unable to create ValidationResponseSender");
+
+        let py_callback = self.py_callback_maker
+            .call(py, (py_sender,), None)
+            .expect("Unable to create py_callback");
+
+        self.py_block_validator
+            .call_method(
+                py,
+                "submit_blocks_for_verification",
+                (blocks, py_callback),
+                None,
+            )
+            .map(|_| ())
+            .map_err(|py_err| {
+                pylogger::exception(py, "Unable to call submit_blocks_for_verification", py_err);
+                ()
+            })
+            .unwrap_or(());
+    }
+}
+
+struct PyBlockStore {
+    py_block_store: PyObject,
+}
+
+impl PyBlockStore {
+    fn new(py_block_store: PyObject) -> Self {
+        PyBlockStore { py_block_store }
+    }
+}
+
+impl ChainWriter for PyBlockStore {
+    fn update_chain(
+        &mut self,
+        new_chain: &[BlockWrapper],
+        old_chain: &[BlockWrapper],
+    ) -> Result<(), ChainControllerError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_block_store
+            .call_method(py, "update_chain", (new_chain, old_chain), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                ChainControllerError::ChainUpdateError(format!(
+                    "An error occurred while executing update_chain: {}",
+                    py_err.get_type(py).name(py)
+                ))
+            })
+    }
+}
+
+impl ChainReader for PyBlockStore {
+    fn chain_head(&self) -> Result<Option<BlockWrapper>, ChainReadError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_block_store
+            .getattr(py, "chain_head")
+            .and_then(|result| result.extract(py))
+            .map_err(|py_err| {
+                pylogger::exception(py, "Unable to call block_store.chain_head", py_err);
+                ChainReadError::GeneralReadError("Unable to read from python block store".into())
+            })
+    }
+
+    fn count_committed_transactions(&self) -> Result<usize, ChainReadError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_block_store
+            .call_method(py, "get_transaction_count", cpython::NoArgs, None)
+            .and_then(|result| result.extract(py))
+            .map_err(|py_err| {
+                pylogger::exception(py, "Unable to call block_store.chain_head", py_err);
+                ChainReadError::GeneralReadError("Unable to read from python block store".into())
+            })
+    }
+}
+
+struct PyChainObserver {
+    py_observer: PyObject,
+}
+
+impl PyChainObserver {
+    fn new(py_observer: PyObject) -> Self {
+        PyChainObserver { py_observer }
+    }
+}
+
+impl ChainObserver for PyChainObserver {
+    fn chain_update(&mut self, block: &BlockWrapper, receipts: &[&TransactionReceipt]) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_observer
+            .call_method(py, "chain_update", (block, receipts), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                pylogger::exception(py, "Unable to call observer.chain_update", py_err);
+                ()
+            })
+            .unwrap_or(())
+    }
+}
+
+struct PyChainHeadUpdateObserver {
+    py_on_chain_updated: PyObject,
+}
+
+impl PyChainHeadUpdateObserver {
+    fn new(py_on_chain_updated: PyObject) -> Self {
+        PyChainHeadUpdateObserver {
+            py_on_chain_updated,
+        }
+    }
+}
+
+impl ChainHeadUpdateObserver for PyChainHeadUpdateObserver {
+    fn on_chain_head_updated(
+        &mut self,
+        block: BlockWrapper,
+        committed_batches: Vec<Batch>,
+        uncommitted_batches: Vec<Batch>,
+    ) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_on_chain_updated
+            .call(py, (block, committed_batches, uncommitted_batches), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    "Unable to call chain head observer on_chain_updated",
+                    py_err,
+                );
+                ()
+            })
+            .unwrap_or(())
+    }
+}
+
+impl ToPyObject for TransactionReceipt {
+    type ObjectType = PyObject;
+
+    fn to_py_object(&self, py: Python) -> PyObject {
+        let txn_receipt_protobuf_mod = py.import(
+            "sawtooth_validator.protobuf.transaction_receipt_pb2",
+        ).expect("Unable to import transaction_receipt_pb2");
+        let py_txn_receipt_class = txn_receipt_protobuf_mod
+            .get(py, "TransactionReceipt")
+            .expect("Unable to get TransactionReceipt");
+
+        let py_txn_receipt = py_txn_receipt_class
+            .call(py, cpython::NoArgs, None)
+            .expect("Unable to instantiate TransactionReceipt");
+        py_txn_receipt
+            .call_method(
+                py,
+                "ParseFromString",
+                (cpython::PyBytes::new(py, &self.write_to_bytes().unwrap()).into_object(),),
+                None,
+            )
+            .expect("Unable to ParseFromString");
+
+        py_txn_receipt
+    }
+}
+
+impl<'source> FromPyObject<'source> for BlockValidationResult {
+    fn extract(py: Python, obj: &'source PyObject) -> cpython::PyResult<Self> {
+        Ok(BlockValidationResult {
+            chain_head: obj.getattr(py, "chain_head")?.extract(py)?,
+            block: obj.getattr(py, "block")?.extract(py)?,
+            transaction_count: obj.getattr(py, "transaction_count")?.extract(py)?,
+            new_chain: obj.getattr(py, "new_chain")?.extract(py)?,
+            current_chain: obj.getattr(py, "current_chain")?.extract(py)?,
+
+            committed_batches: obj.getattr(py, "committed_batches")?.extract(py)?,
+            uncommitted_batches: obj.getattr(py, "uncommitted_batches")?.extract(py)?,
+        })
+    }
+}

--- a/validator/src/journal/mod.rs
+++ b/validator/src/journal/mod.rs
@@ -19,8 +19,10 @@ pub const NULL_BLOCK_IDENTIFIER: &str = "0000000000000000";
 
 pub mod block_manager;
 pub mod block_store;
+pub mod block_validator;
 pub mod block_wrapper;
 pub mod block_wrapper_ffi;
 mod candidate_block;
+pub mod chain;
 mod chain_commit_state;
 pub mod publisher;

--- a/validator/src/journal/mod.rs
+++ b/validator/src/journal/mod.rs
@@ -25,4 +25,5 @@ pub mod block_wrapper_ffi;
 mod candidate_block;
 pub mod chain;
 mod chain_commit_state;
+pub mod chain_ffi;
 pub mod publisher;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -23,7 +23,8 @@ extern crate libc;
 extern crate lmdb_zero;
 extern crate protobuf;
 extern crate python3_sys as py_ffi;
-
+#[macro_use]
+extern crate lazy_static;
 #[macro_use]
 extern crate log;
 #[cfg(test)]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -16,6 +16,7 @@
  */
 
 extern crate cbor;
+#[macro_use]
 extern crate cpython;
 extern crate crypto;
 extern crate hex;

--- a/validator/src/metrics/mod.rs
+++ b/validator/src/metrics/mod.rs
@@ -142,6 +142,14 @@ impl Counter {
             .expect("Failed to call Counter.inc()");
     }
 
+    pub fn inc_n(&mut self, value: usize) {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        self.py_counter
+            .call_method(py, "inc", (value,), None)
+            .expect("Failed to call Counter.inc()");
+    }
+
     pub fn dec(&mut self) {
         let gil = Python::acquire_gil();
         let py = gil.python();

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -182,9 +182,15 @@ class BlockTreeManager(object):
         consensus = mock_consensus.BlockPublisher()
         consensus.finalize_block(block_builder.block_header, weight=weight)
 
+        if invalid_consensus:
+            block_builder.block_header.consensus = b'BAD'
+
         header_bytes = block_builder.block_header.SerializeToString()
-        signature = self.identity_signer.sign(header_bytes)
-        block_builder.set_signature(signature)
+        if invalid_signature:
+            block_builder.set_signature('BAD')
+        else:
+            signature = self.identity_signer.sign(header_bytes)
+            block_builder.set_signature(signature)
 
         block_wrapper = BlockWrapper(block_builder.build_block())
 


### PR DESCRIPTION
This is a fairly large change in the sense that it replaces the implementation of the `ChainController` with a rust implementation.  It is as straight of a 1-1 port as can be managed, given the constraints of both Rust (e.g. its constraints on memory usage, sharing, etc) and FFI calls (how rust interacts with python, across that boundary).

Adds an explicit dependency on [lazy_static](https://crates.io/crates/lazy_static)