### PR TITLE
Add Peripheral Consensus Engine Objects

### DIFF
--- a/families/block_info/sawtooth_block_info/injector.py
+++ b/families/block_info/sawtooth_block_info/injector.py
@@ -35,8 +35,8 @@ from sawtooth_block_info.common import BLOCK_INFO_NAMESPACE
 class BlockInfoInjector(BatchInjector):
     """Inject BlockInfo transactions at the beginning of blocks."""
 
-    def __init__(self, block_store, state_view_factory, signer):
-        self._block_store = block_store
+    def __init__(self, block_cache, state_view_factory, signer):
+        self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._signer = signer
 
@@ -85,7 +85,7 @@ class BlockInfoInjector(BatchInjector):
         Returns:
             A list of batches to inject.
         """
-        previous_block = self._block_store[previous_block_id].get_block()
+        previous_block = self._block_cache[previous_block_id].get_block()
         previous_header = BlockHeader()
         previous_header.ParseFromString(previous_block.header)
 

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -166,6 +166,7 @@ def validator_cmds(num,
         '--endpoint {}'.format(endpoint(num)),
         '--bind component:{}'.format(bind_component(num)),
         '--bind network:{}'.format(bind_network(num)),
+        '--bind consensus:{}'.format(bind_consensus(num)),
         peering_func(num)])
 
     # genesis stuff
@@ -350,6 +351,10 @@ def bind_component(num):
 
 def bind_network(num):
     return 'tcp://127.0.0.1:{}'.format(8800 + num)
+
+
+def bind_consensus(num):
+    return 'tcp://127.0.0.1:{}'.format(5050 + num)
 
 
 # execution

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -31,6 +31,7 @@ def load_default_validator_config():
     return ValidatorConfig(
         bind_network='tcp://127.0.0.1:8800',
         bind_component='tcp://127.0.0.1:4004',
+        bind_consensus='tcp://127.0.0.1:5050',
         endpoint=None,
         peering='static',
         scheduler='serial',
@@ -71,11 +72,14 @@ def load_toml_validator_config(filename):
             "{}".format(", ".join(sorted(list(invalid_keys)))))
     bind_network = None
     bind_component = None
+    bind_consensus = None
     for bind in toml_config.get("bind", []):
         if "network" in bind:
             bind_network = bind[bind.find(":") + 1:]
         if "component" in bind:
             bind_component = bind[bind.find(":") + 1:]
+        if "consensus" in bind:
+            bind_consensus = bind[bind.find(":") + 1:]
 
     network_public_key = None
     network_private_key = None
@@ -89,6 +93,7 @@ def load_toml_validator_config(filename):
     config = ValidatorConfig(
         bind_network=bind_network,
         bind_component=bind_component,
+        bind_consensus=bind_consensus,
         endpoint=toml_config.get("endpoint", None),
         peering=toml_config.get("peering", None),
         seeds=toml_config.get("seeds", None),
@@ -121,6 +126,7 @@ def merge_validator_config(configs):
     """
     bind_network = None
     bind_component = None
+    bind_consensus = None
     endpoint = None
     peering = None
     seeds = None
@@ -143,6 +149,8 @@ def merge_validator_config(configs):
             bind_network = config.bind_network
         if config.bind_component is not None:
             bind_component = config.bind_component
+        if config.bind_consensus is not None:
+            bind_consensus = config.bind_consensus
         if config.endpoint is not None:
             endpoint = config.endpoint
         if config.peering is not None:
@@ -179,6 +187,7 @@ def merge_validator_config(configs):
     return ValidatorConfig(
         bind_network=bind_network,
         bind_component=bind_component,
+        bind_consensus=bind_consensus,
         endpoint=endpoint,
         peering=peering,
         seeds=seeds,
@@ -235,6 +244,7 @@ def parse_permissions(permissions):
 
 class ValidatorConfig:
     def __init__(self, bind_network=None, bind_component=None,
+                 bind_consensus=None,
                  endpoint=None, peering=None, seeds=None,
                  peers=None, network_public_key=None,
                  network_private_key=None,
@@ -247,6 +257,7 @@ class ValidatorConfig:
 
         self._bind_network = bind_network
         self._bind_component = bind_component
+        self._bind_consensus = bind_consensus
         self._endpoint = endpoint
         self._peering = peering
         self._seeds = seeds
@@ -271,6 +282,10 @@ class ValidatorConfig:
     @property
     def bind_component(self):
         return self._bind_component
+
+    @property
+    def bind_consensus(self):
+        return self._bind_consensus
 
     @property
     def endpoint(self):
@@ -339,7 +354,7 @@ class ValidatorConfig:
     def __repr__(self):
         # not including  password for opentsdb
         return (
-            "{}(bind_network={}, bind_component={}, "
+            "{}(bind_network={}, bind_component={}, bind_consensus={}, "
             "endpoint={}, peering={}, seeds={}, peers={}, "
             "network_public_key={}, network_private_key={}, "
             "scheduler={}, permissions={}, roles={} "
@@ -350,6 +365,7 @@ class ValidatorConfig:
             self.__class__.__name__,
             repr(self._bind_network),
             repr(self._bind_component),
+            repr(self._bind_consensus),
             repr(self._endpoint),
             repr(self._peering),
             repr(self._seeds),
@@ -370,6 +386,7 @@ class ValidatorConfig:
         return collections.OrderedDict([
             ('bind_network', self._bind_network),
             ('bind_component', self._bind_component),
+            ('bind_consensus', self._bind_consensus),
             ('endpoint', self._endpoint),
             ('peering', self._peering),
             ('seeds', self._seeds),

--- a/validator/sawtooth_validator/consensus/__init__.py
+++ b/validator/sawtooth_validator/consensus/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+__all__ = []

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -139,7 +139,14 @@ class ConsensusSendToHandler(ConsensusServiceHandler):
         self._proxy = proxy
 
     def handle_request(self, request, response):
-        self._proxy.send_to(request.peer_id, request.message)
+        try:
+            self._proxy.send_to(
+                request.peer_id,
+                request.message.SerializeToString())
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusSendTo")
+            response.status =\
+                consensus_pb2.ConsensusSendToResponse.SERVICE_ERROR
 
 
 class ConsensusBroadcastHandler(ConsensusServiceHandler):
@@ -153,7 +160,12 @@ class ConsensusBroadcastHandler(ConsensusServiceHandler):
         self._proxy = proxy
 
     def handle_request(self, request, response):
-        self._proxy.broadcast(request.message)
+        try:
+            self._proxy.broadcast(request.message.SerializeToString())
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusBroadcast")
+            response.status =\
+                consensus_pb2.ConsensusBroadcastResponse.SERVICE_ERROR
 
 
 class ConsensusInitializeBlockHandler(ConsensusServiceHandler):
@@ -355,7 +367,7 @@ class ConsensusBlocksGetHandler(ConsensusServiceHandler):
                 consensus_pb2.ConsensusBlock(
                     block_id=bytes.fromhex(block.identifier),
                     previous_id=bytes.fromhex(block.previous_block_id),
-                    signer_id=bytes.fromhex(block.header_signature),
+                    signer_id=bytes.fromhex(block.signer_public_key),
                     block_num=block.block_num,
                     payload=block.consensus)
                 for block in self._proxy.blocks_get(request.block_ids)

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -1,0 +1,454 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+import logging
+
+from google.protobuf.message import DecodeError
+
+from sawtooth_validator.consensus.proxy import UnknownBlock
+
+from sawtooth_validator.protobuf import consensus_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+from sawtooth_validator.networking.dispatch import Handler
+from sawtooth_validator.networking.dispatch import HandlerResult
+from sawtooth_validator.networking.dispatch import HandlerStatus
+
+from sawtooth_validator.protobuf.consensus_pb2 import ConsensusSettingsEntry
+from sawtooth_validator.protobuf.consensus_pb2 import ConsensusStateEntry
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BlockEmpty(Exception):
+    """There are no batches in the block."""
+
+
+class BlockInProgress(Exception):
+    """There is already a block in progress."""
+
+
+class BlockNotInitialized(Exception):
+    """There is no block in progress to finalize."""
+
+
+class ConsensusServiceHandler(Handler):
+    def __init__(
+        self,
+        request_class,
+        request_type,
+        response_class,
+        response_type,
+    ):
+        self._request_class = request_class
+        self._request_type = request_type
+        self._response_class = response_class
+        self._response_type = response_type
+
+    def handle_request(self, request, response):
+        raise NotImplementedError()
+
+    @property
+    def request_class(self):
+        return self._request_class
+
+    @property
+    def response_class(self):
+        return self._response_class
+
+    @property
+    def response_type(self):
+        return self._response_type
+
+    @property
+    def request_type(self):
+        return self._request_type
+
+    def handle(self, connection_id, message_content):
+        request = self._request_class()
+        response = self._response_class()
+        response.status = response.OK
+
+        try:
+            request.ParseFromString(message_content)
+        except DecodeError:
+            response.status = response.BAD_REQUEST
+        else:
+            self.handle_request(request, response)
+
+        return HandlerResult(
+            status=HandlerStatus.RETURN,
+            message_out=response,
+            message_type=self._response_type)
+
+
+class ConsensusRegisterHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusRegisterRequest,
+            validator_pb2.Message.CONSENSUS_REGISTER_REQUEST,
+            consensus_pb2.ConsensusRegisterResponse,
+            validator_pb2.Message.CONSENSUS_REGISTER_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        chain_head, peers = self._proxy.register()
+
+        if chain_head is None:
+            response.status = consensus_pb2.ConsensusRegisterResponse.NOT_READY
+            return
+
+        response.chain_head.block_id = bytes.fromhex(chain_head.identifier)
+        response.chain_head.previous_id =\
+            bytes.fromhex(chain_head.previous_block_id)
+        response.chain_head.signer_id =\
+            bytes.fromhex(chain_head.signer_public_key)
+        response.chain_head.block_num = chain_head.block_num
+        response.chain_head.payload = chain_head.consensus
+
+        response.peers.extend(peers)
+
+        LOGGER.info(
+            "Consensus engine registered: %s %s",
+            request.name,
+            request.version)
+
+
+class ConsensusSendToHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusSendToRequest,
+            validator_pb2.Message.CONSENSUS_SEND_TO_REQUEST,
+            consensus_pb2.ConsensusSendToResponse,
+            validator_pb2.Message.CONSENSUS_SEND_TO_RESPONSE)
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.send_to(request.peer_id, request.message)
+
+
+class ConsensusBroadcastHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusBroadcastRequest,
+            validator_pb2.Message.CONSENSUS_BROADCAST_REQUEST,
+            consensus_pb2.ConsensusBroadcastResponse,
+            validator_pb2.Message.CONSENSUS_BROADCAST_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        self._proxy.broadcast(request.message)
+
+
+class ConsensusInitializeBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusInitializeBlockRequest,
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusInitializeBlockResponse,
+            validator_pb2.Message.CONSENSUS_INITIALIZE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.initialize_block(request.previous_id)
+        except BlockInProgress:
+            response.status =\
+                consensus_pb2.ConsensusInitializeBlockResponse.INVALID_STATE
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusInitializeBlock")
+            response.status =\
+                consensus_pb2.ConsensusInitializeBlockResponse.SERVICE_ERROR
+
+
+class ConsensusSummarizeBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusSummarizeBlockRequest,
+            validator_pb2.Message.CONSENSUS_SUMMARIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusSummarizeBlockResponse,
+            validator_pb2.Message.CONSENSUS_SUMMARIZE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            summary = self._proxy.summarize_block()
+            response.summary = summary
+        except BlockNotInitialized:
+            response.status =\
+                consensus_pb2.ConsensusSummarizeBlockResponse.INVALID_STATE
+        except BlockEmpty:
+            response.status =\
+                consensus_pb2.ConsensusSummarizeBlockResponse.BLOCK_NOT_READY
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusSummarizeBlock")
+            response.status =\
+                consensus_pb2.ConsensusSummarizeBlockResponse.SERVICE_ERROR
+
+
+class ConsensusFinalizeBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusFinalizeBlockRequest,
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusFinalizeBlockResponse,
+            validator_pb2.Message.CONSENSUS_FINALIZE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            response.block_id = self._proxy.finalize_block(request.data)
+        except BlockNotInitialized:
+            response.status =\
+                consensus_pb2.ConsensusFinalizeBlockResponse.INVALID_STATE
+        except BlockEmpty:
+            response.status =\
+                consensus_pb2.ConsensusFinalizeBlockResponse.BLOCK_NOT_READY
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusFinalizeBlock")
+            response.status =\
+                consensus_pb2.ConsensusFinalizeBlockResponse.SERVICE_ERROR
+
+
+class ConsensusCancelBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCancelBlockRequest,
+            validator_pb2.Message.CONSENSUS_CANCEL_BLOCK_REQUEST,
+            consensus_pb2.ConsensusCancelBlockResponse,
+            validator_pb2.Message.CONSENSUS_CANCEL_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.cancel_block()
+        except BlockNotInitialized:
+            response.status =\
+                consensus_pb2.ConsensusCancelBlockResponse.INVALID_STATE
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusCancelBlock")
+            response.status =\
+                consensus_pb2.ConsensusCancelBlockResponse.SERVICE_ERROR
+
+
+class ConsensusCheckBlocksHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCheckBlocksRequest,
+            validator_pb2.Message.CONSENSUS_CHECK_BLOCKS_REQUEST,
+            consensus_pb2.ConsensusCheckBlocksResponse,
+            validator_pb2.Message.CONSENSUS_CHECK_BLOCKS_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.check_blocks(request.block_ids)
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusCheckBlocksResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusCheckBlocks")
+            response.status =\
+                consensus_pb2.ConsensusCheckBlocksResponse.SERVICE_ERROR
+
+
+class ConsensusCommitBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusCommitBlockRequest,
+            validator_pb2.Message.CONSENSUS_COMMIT_BLOCK_REQUEST,
+            consensus_pb2.ConsensusCommitBlockResponse,
+            validator_pb2.Message.CONSENSUS_COMMIT_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.commit_block(request.block_id)
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusCommitBlockResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusCommitBlock")
+            response.status =\
+                consensus_pb2.ConsensusCommitBlockResponse.SERVICE_ERROR
+
+
+class ConsensusIgnoreBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusIgnoreBlockRequest,
+            validator_pb2.Message.CONSENSUS_IGNORE_BLOCK_REQUEST,
+            consensus_pb2.ConsensusIgnoreBlockResponse,
+            validator_pb2.Message.CONSENSUS_IGNORE_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.ignore_block(request.block_id)
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusIgnoreBlockResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusIgnoreBlock")
+            response.status =\
+                consensus_pb2.ConsensusIgnoreBlockResponse.SERVICE_ERROR
+
+
+class ConsensusFailBlockHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusFailBlockRequest,
+            validator_pb2.Message.CONSENSUS_FAIL_BLOCK_REQUEST,
+            consensus_pb2.ConsensusFailBlockResponse,
+            validator_pb2.Message.CONSENSUS_FAIL_BLOCK_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            self._proxy.fail_block(request.block_id)
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusFailBlockResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusFailBlock")
+            response.status =\
+                consensus_pb2.ConsensusFailBlockResponse.SERVICE_ERROR
+
+
+class ConsensusBlocksGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusBlocksGetRequest,
+            validator_pb2.Message.CONSENSUS_BLOCKS_GET_REQUEST,
+            consensus_pb2.ConsensusBlocksGetResponse,
+            validator_pb2.Message.CONSENSUS_BLOCKS_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            response.blocks.extend([
+                consensus_pb2.ConsensusBlock(
+                    block_id=bytes.fromhex(block.identifier),
+                    previous_id=bytes.fromhex(block.previous_block_id),
+                    signer_id=bytes.fromhex(block.header_signature),
+                    block_num=block.block_num,
+                    payload=block.consensus)
+                for block in self._proxy.blocks_get(request.block_ids)
+            ])
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusBlocksGetResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusBlocksGet")
+            response.status =\
+                consensus_pb2.ConsensusBlocksGetResponse.SERVICE_ERROR
+
+
+class ConsensusChainHeadGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusChainHeadGetRequest,
+            validator_pb2.Message.CONSENSUS_CHAIN_HEAD_GET_REQUEST,
+            consensus_pb2.ConsensusChainHeadGetResponse,
+            validator_pb2.Message.CONSENSUS_CHAIN_HEAD_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            chain_head = self._proxy.chain_head_get()
+            response.block.block_id = bytes.fromhex(chain_head.identifier)
+            response.block.previous_id =\
+                bytes.fromhex(chain_head.previous_block_id)
+            response.block.signer_id =\
+                bytes.fromhex(chain_head.signer_public_key)
+            response.block.block_num = chain_head.block_num
+            response.block.payload = chain_head.consensus
+        except UnknownBlock:
+            response.status =\
+                consensus_pb2.ConsensusChainHeadGetResponse.NO_CHAIN_HEAD
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusChainHeadGet")
+            response.status =\
+                consensus_pb2.ConsensusChainHeadGetResponse.SERVICE_ERROR
+
+
+class ConsensusSettingsGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusSettingsGetRequest,
+            validator_pb2.Message.CONSENSUS_SETTINGS_GET_REQUEST,
+            consensus_pb2.ConsensusSettingsGetResponse,
+            validator_pb2.Message.CONSENSUS_SETTINGS_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            response.entries.extend([
+                ConsensusSettingsEntry(
+                    key=key,
+                    value=value)
+                for key, value in self._proxy.settings_get(
+                    request.block_id, request.keys)
+            ])
+        except UnknownBlock:
+            response.status = \
+                consensus_pb2.ConsensusSettingsGetResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusSettingsGet")
+            response.status =\
+                consensus_pb2.ConsensusSettingsGetResponse.SERVICE_ERROR
+
+
+class ConsensusStateGetHandler(ConsensusServiceHandler):
+    def __init__(self, proxy):
+        super().__init__(
+            consensus_pb2.ConsensusStateGetRequest,
+            validator_pb2.Message.CONSENSUS_STATE_GET_REQUEST,
+            consensus_pb2.ConsensusStateGetResponse,
+            validator_pb2.Message.CONSENSUS_STATE_GET_RESPONSE)
+
+        self._proxy = proxy
+
+    def handle_request(self, request, response):
+        try:
+            response.entries.extend([
+                ConsensusStateEntry(
+                    address=address,
+                    data=data)
+                for address, data in self._proxy.state_get(
+                    request.block_id, request.addresses)
+            ])
+        except UnknownBlock:
+            response.status = \
+                consensus_pb2.ConsensusStateGetResponse.UNKNOWN_BLOCK
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.exception("ConsensusStateGet")
+            response.status =\
+                consensus_pb2.ConsensusStateGetResponse.SERVICE_ERROR

--- a/validator/sawtooth_validator/consensus/notifier.py
+++ b/validator/sawtooth_validator/consensus/notifier.py
@@ -1,0 +1,95 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import hashlib
+import logging
+
+from sawtooth_validator.protobuf import consensus_pb2
+from sawtooth_validator.protobuf import validator_pb2
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ConsensusNotifier:
+    """Handles sending notifications to the consensus engine using the provided
+    interconnect service."""
+
+    def __init__(self, consensus_service):
+        self._service = consensus_service
+
+    def _notify(self, message_type, message):
+        futures = self._service.send_all(
+            message_type,
+            message.SerializeToString())
+        for future in futures:
+            future.result()
+
+    def notify_peer_connected(self, peer_id):
+        """A new peer was added"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_PEER_CONNECTED,
+            consensus_pb2.ConsensusNotifyPeerConnected(
+                consensus_pb2.ConsensusPeerInfo(
+                    peer_id=bytes.fromhex(peer_id))))
+
+    def notify_peer_disconnected(self, peer_id):
+        """An existing peer was dropped"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_PEER_DISCONNECTED,
+            consensus_pb2.ConsensusNotifyPeerDisconnected(
+                peer_id=bytes.fromhex(peer_id)))
+
+    def notify_peer_message(self, message):
+        """A new message was received from a peer"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_PEER_MESSAGE,
+            consensus_pb2.ConsensusNotifyPeerMessage(message=message))
+
+    def notify_block_new(self, block):
+        """A new block was received and passed initial consensus validation"""
+        summary = hashlib.sha256()
+        for batch in block.batches:
+            summary.update(batch.header_signature.encode())
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_BLOCK_NEW,
+            consensus_pb2.ConsensusNotifyBlockNew(
+                block=consensus_pb2.ConsensusBlock(
+                    block_id=bytes.fromhex(block.identifier),
+                    previous_id=bytes.fromhex(block.previous_block_id),
+                    signer_id=bytes.fromhex(block.header.signer_public_key),
+                    block_num=block.block_num,
+                    payload=block.consensus,
+                    summary=summary.digest())))
+
+    def notify_block_valid(self, block_id):
+        """This block can be committed successfully"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_BLOCK_VALID,
+            consensus_pb2.ConsensusNotifyBlockValid(
+                block_id=bytes.fromhex(block_id)))
+
+    def notify_block_invalid(self, block_id):
+        """This block cannot be committed successfully"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_BLOCK_INVALID,
+            consensus_pb2.ConsensusNotifyBlockInvalid(
+                block_id=bytes.fromhex(block_id)))
+
+    def notify_block_commit(self, block_id):
+        """This block has been committed"""
+        self._notify(
+            validator_pb2.Message.CONSENSUS_NOTIFY_BLOCK_COMMIT,
+            consensus_pb2.ConsensusNotifyBlockCommit(
+                block_id=bytes.fromhex(block_id)))

--- a/validator/sawtooth_validator/consensus/notifier.py
+++ b/validator/sawtooth_validator/consensus/notifier.py
@@ -51,11 +51,13 @@ class ConsensusNotifier:
             consensus_pb2.ConsensusNotifyPeerDisconnected(
                 peer_id=bytes.fromhex(peer_id)))
 
-    def notify_peer_message(self, message):
+    def notify_peer_message(self, message, sender_id):
         """A new message was received from a peer"""
         self._notify(
             validator_pb2.Message.CONSENSUS_NOTIFY_PEER_MESSAGE,
-            consensus_pb2.ConsensusNotifyPeerMessage(message=message))
+            consensus_pb2.ConsensusNotifyPeerMessage(
+                message=message,
+                sender_id=sender_id))
 
     def notify_block_new(self, block):
         """A new block was received and passed initial consensus validation"""

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -22,11 +22,15 @@ class ConsensusProxy:
     """Receives requests from the consensus engine handlers and delegates them
     to the appropriate components."""
 
-    def __init__(self, block_cache, chain_controller, block_publisher,
+    def __init__(self, block_cache, block_publisher,
+                 chain_controller, gossip, identity_signer,
                  settings_view_factory, state_view_factory):
         self._block_cache = block_cache
         self._chain_controller = chain_controller
         self._block_publisher = block_publisher
+        self._gossip = gossip
+        self._identity_signer = identity_signer
+        self._public_key = self._identity_signer.get_public_key().as_bytes()
         self._settings_view_factory = settings_view_factory
         self._state_view_factory = state_view_factory
 
@@ -40,10 +44,15 @@ class ConsensusProxy:
 
     # Using network service
     def send_to(self, peer_id, message):
-        raise NotImplementedError()
+        self._gossip.send_consensus_message(
+            peer_id=peer_id.hex(),
+            message=message,
+            public_key=self._public_key)
 
     def broadcast(self, message):
-        raise NotImplementedError()
+        self._gossip.broadcast_consensus_message(
+            message=message,
+            public_key=self._public_key)
 
     # Using block publisher
     def initialize_block(self, previous_id):

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -1,0 +1,151 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+
+class UnknownBlock(Exception):
+    """The given block could not be found."""
+
+
+class ConsensusProxy:
+    """Receives requests from the consensus engine handlers and delegates them
+    to the appropriate components."""
+
+    def __init__(self, block_cache, chain_controller, block_publisher,
+                 settings_view_factory, state_view_factory):
+        self._block_cache = block_cache
+        self._chain_controller = chain_controller
+        self._block_publisher = block_publisher
+        self._settings_view_factory = settings_view_factory
+        self._state_view_factory = state_view_factory
+
+    def register(self):
+        chain_head = self._chain_controller.chain_head
+
+        # not implemented
+        peers = []
+
+        return chain_head, peers
+
+    # Using network service
+    def send_to(self, peer_id, message):
+        raise NotImplementedError()
+
+    def broadcast(self, message):
+        raise NotImplementedError()
+
+    # Using block publisher
+    def initialize_block(self, previous_id):
+        if previous_id:
+            try:
+                previous_block = self._block_cache[previous_id.hex()]
+            except KeyError:
+                raise UnknownBlock()
+            self._block_publisher.initialize_block(previous_block)
+        else:
+            self._block_publisher.initialize_block(
+                self._chain_controller.chain_head)
+
+    def summarize_block(self):
+        return self._block_publisher.summarize_block()
+
+    def finalize_block(self, consensus_data):
+        result = self._block_publisher.finalize_block(
+            consensus=consensus_data)
+        return bytes.fromhex(
+            self._block_publisher.publish_block(
+                result.block, result.injected_batches))
+
+    def cancel_block(self):
+        self._block_publisher.cancel_block()
+
+    # Using chain controller
+    def check_blocks(self, block_ids):
+        try:
+            blocks = [
+                self._block_cache[block_id.hex()]
+                for block_id in block_ids
+            ]
+        except KeyError as key_error:
+            raise UnknownBlock(key_error.args[0])
+
+        self._chain_controller.submit_blocks_for_verification(blocks)
+
+    def commit_block(self, block_id):
+        try:
+            block = self._block_cache[block_id.hex()]
+        except KeyError as key_error:
+            raise UnknownBlock(key_error.args[0])
+        self._chain_controller.commit_block(block)
+
+    def ignore_block(self, block_id):
+        try:
+            block = self._block_cache[block_id.hex()]
+        except KeyError:
+            raise UnknownBlock()
+        self._chain_controller.ignore_block(block)
+
+    def fail_block(self, block_id):
+        try:
+            block = self._block_cache[block_id.hex()]
+        except KeyError:
+            raise UnknownBlock()
+        self._chain_controller.fail_block(block)
+
+    # Using blockstore and state database
+    def blocks_get(self, block_ids):
+        '''Returns a list of blocks.'''
+        return self._get_blocks(block_ids)
+
+    def chain_head_get(self):
+        '''Returns the chain head.'''
+
+        chain_head = self._chain_controller.chain_head
+
+        if chain_head is None:
+            raise UnknownBlock()
+
+        return chain_head
+
+    def settings_get(self, block_id, settings):
+        '''Returns a list of key/value pairs (str, str).'''
+        settings_view = \
+            self._get_blocks([block_id])[0].get_settings_view(
+                self._settings_view_factory)
+
+        return [
+            (setting, settings_view.get_setting(setting))
+            for setting in settings
+        ]
+
+    def state_get(self, block_id, addresses):
+        '''Returns a list of address/data pairs (str, bytes)'''
+
+        state_view = \
+            self._get_blocks([block_id])[0].get_state_view(
+                self._state_view_factory)
+
+        return [
+            (address, state_view.get(address))
+            for address in addresses
+        ]
+
+    def _get_blocks(self, block_ids):
+        try:
+            return [
+                self._block_cache[block_id.hex()]
+                for block_id in block_ids
+            ]
+        except KeyError:
+            raise UnknownBlock()

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -26,6 +26,7 @@ from enum import Enum
 from sawtooth_validator.concurrent.thread import InstrumentedThread
 from sawtooth_validator.protobuf.network_pb2 import DisconnectMessage
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
+from sawtooth_validator.protobuf.network_pb2 import GossipConsensusMessage
 from sawtooth_validator.protobuf.network_pb2 import GossipBatchByBatchIdRequest
 from sawtooth_validator.protobuf.network_pb2 import \
     GossipBatchByTransactionIdRequest
@@ -312,6 +313,24 @@ class Gossip(object):
         self.broadcast(
             batch_request,
             validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
+
+    def send_consensus_message(self, peer_id, message, public_key):
+        connection_id = self._network.public_key_to_connection_id(peer_id)
+
+        self.send(
+            validator_pb2.Message.GOSSIP_CONSENSUS_MESSAGE,
+            GossipConsensusMessage(
+                message=message,
+                sender_id=public_key,
+                time_to_live=0).SerializeToString(),
+            connection_id)
+
+    def broadcast_consensus_message(self, message, public_key):
+        self.broadcast(
+            GossipConsensusMessage(
+                message=message,
+                time_to_live=self.get_time_to_live()),
+            validator_pb2.Message.GOSSIP_CONSENSUS_MESSAGE)
 
     def send(self, message_type, message, connection_id, one_way=False):
         """Sends a message via the network.

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -57,22 +57,22 @@ class UnknownBatchInjectorError(Exception):
 
 
 class DefaultBatchInjectorFactory:
-    def __init__(self, block_store, state_view_factory, signer):
+    def __init__(self, block_cache, state_view_factory, signer):
         """
         Args:
-            block_store (:obj:`BlockStore`): The block store, for passing to
+            block_cache (:obj:`BlockCache`): The block cache, for passing to
                 batch injectors that require it.
             state_view_factory (:obj:`StateViewFactory`): The state view
                 factory, for passing to injectors that require it.
             signer (:obj:`Signer`): The cryptographic signer of the validator.
         """
-        self._block_store = block_store
+        self._block_cache = block_cache
         self._state_view_factory = state_view_factory
         self._signer = signer
 
     def _read_injector_setting(self, block_id):
         state_view = self._state_view_factory.create_view(
-            self._block_store[block_id].state_root_hash)
+            self._block_cache[block_id].state_root_hash)
         settings_view = SettingsView(state_view)
         batch_injector_setting = settings_view.get_setting(
             "sawtooth.validator.batch_injectors")
@@ -90,6 +90,6 @@ class DefaultBatchInjectorFactory:
                 "sawtooth_block_info.injector")
 
             return block_info_injector.BlockInfoInjector(
-                self._block_store, self._state_view_factory, self._signer)
+                self._block_cache, self._state_view_factory, self._signer)
 
         raise UnknownBatchInjectorError(injector)

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -120,6 +120,10 @@ class BlockWrapper(object):
         """
         return self.header.previous_block_id
 
+    @property
+    def signer_public_key(self):
+        return self.header.signer_public_key
+
     @staticmethod
     def state_view_for_block(block_wrapper, state_view_factory):
         """

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -153,6 +153,40 @@ class BlockWrapper(object):
         """
         return BlockWrapper.state_view_for_block(self, state_view_factory)
 
+    @staticmethod
+    def settings_view_for_block(block_wrapper, settings_view_factory):
+        """
+        Returns the settings view for an arbitrary block.
+
+        Args:
+            block_wrapper (BlockWrapper): The block for which a settings
+                view is to be returned
+            settings_view_factory (SettingsViewFactory): The settings
+                view factory used to create the SettingsView object
+
+        Returns:
+            SettingsView object associated with the block
+        """
+        state_root_hash = \
+            block_wrapper.state_root_hash \
+            if block_wrapper is not None else None
+
+        return settings_view_factory.create_settings_view(state_root_hash)
+
+    def get_settings_view(self, settings_view_factory):
+        """
+        Returns the settings view associated with this block
+
+        Args:
+            settings_view_factory (SettingsViewFactory): The settings
+                view factory used to create the SettingsView object
+
+        Returns:
+            SettingsView object
+        """
+        return BlockWrapper.settings_view_for_block(
+            self, settings_view_factory)
+
     def __repr__(self):
         return "{}({}, S:{}, P:{})". \
             format(self.identifier, self.block_num,

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -741,6 +741,17 @@ class Interconnect(object):
             except KeyError:
                 return None
 
+    def public_key_to_connection_id(self, public_key):
+        """
+        Get stored connection id for a public key.
+        """
+        with self._connections_lock:
+            for connection_id, connection_info in self._connections.items():
+                if connection_info.public_key == public_key:
+                    return connection_id
+
+            return None
+
     def connection_id_to_endpoint(self, connection_id):
         """
         Get stored public key for a connection.

--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -988,6 +988,13 @@ class Interconnect(object):
             LOGGER.debug("Unable to complete Challenge Authorization.")
             self.remove_connection(connection_id)
 
+    def send_all(self, message_type, data):
+        futures = []
+        with self._connections_lock:
+            for connection_id in self._connections:
+                futures.append(self.send(message_type, data, connection_id))
+        return futures
+
     def send(self, message_type, data, connection_id, callback=None,
              one_way=False):
         """

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -101,6 +101,7 @@ def main(args):
         opts_config = ValidatorConfig(
             bind_component=args['bind_component'],
             bind_network=args['bind_network'],
+            bind_consensus=args['bind_consensus'],
             endpoint=args['endpoint'],
             maximum_peer_connectivity=args['maximum_peer_connectivity'],
             minimum_peer_connectivity=args['minimum_peer_connectivity'],
@@ -186,12 +187,16 @@ def main(args):
         sys.exit(1)
     bind_network = validator_config.bind_network
     bind_component = validator_config.bind_component
+    bind_consensus = validator_config.bind_consensus
 
     if "tcp://" not in bind_network:
         bind_network = "tcp://" + bind_network
 
     if "tcp://" not in bind_component:
         bind_component = "tcp://" + bind_component
+
+    if bind_consensus and "tcp://" not in bind_consensus:
+        bind_consensus = "tcp://" + bind_consensus
 
     if validator_config.network_public_key is None or \
             validator_config.network_private_key is None:
@@ -247,6 +252,7 @@ def main(args):
     validator = Validator(
         bind_network,
         bind_component,
+        bind_consensus,
         endpoint,
         validator_config.peering,
         validator_config.seeds,

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -1,0 +1,68 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+from sawtooth_validator.consensus import handlers
+
+
+def add(
+        dispatcher,
+        thread_pool,
+        consensus_proxy,
+):
+
+    handler = handlers.ConsensusRegisterHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusSendToHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusBroadcastHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusInitializeBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusSummarizeBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusFinalizeBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCancelBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCheckBlocksHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusCommitBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusIgnoreBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusFailBlockHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusBlocksGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusChainHeadGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusSettingsGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
+    handler = handlers.ConsensusStateGetHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -68,6 +68,7 @@ class Validator(object):
     def __init__(self,
                  bind_network,
                  bind_component,
+                 bind_consensus,
                  endpoint,
                  peering,
                  seeds_list,
@@ -108,7 +109,6 @@ class Validator(object):
             identity_signer (str): cryptographic signer the validator uses for
                 signing
         """
-
         # -- Setup Global State Database and Factory -- #
         global_state_db_filename = os.path.join(
             data_dir, 'merkle-{}.lmdb'.format(bind_network[-2:]))

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -353,7 +353,7 @@ class Validator(object):
             network_dispatcher, network_service, gossip, completer,
             responder, network_thread_pool, sig_pool,
             chain_controller.has_block, block_publisher.has_batch,
-            permission_verifier, block_publisher)
+            permission_verifier, block_publisher, consensus_notifier)
 
         component_handlers.add(
             component_dispatcher, gossip, context_manager,
@@ -376,6 +376,8 @@ class Validator(object):
             block_cache=block_cache,
             chain_controller=chain_controller,
             block_publisher=block_publisher,
+            gossip=gossip,
+            identity_signer=identity_signer,
             settings_view_factory=SettingsViewFactory(state_view_factory),
             state_view_factory=state_view_factory)
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -23,6 +23,7 @@ import threading
 from sawtooth_validator.concurrent.threadpool import \
     InstrumentedThreadPoolExecutor
 from sawtooth_validator.execution.context_manager import ContextManager
+from sawtooth_validator.consensus.proxy import ConsensusProxy
 from sawtooth_validator.database.indexed_database import IndexedDatabase
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
 from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
@@ -60,6 +61,7 @@ from sawtooth_validator.journal.receipt_store import TransactionReceiptStore
 
 from sawtooth_validator.server import network_handlers
 from sawtooth_validator.server import component_handlers
+from sawtooth_validator.server import consensus_handlers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -366,6 +368,16 @@ class Validator(object):
         self._network_dispatcher = network_dispatcher
         self._network_service = network_service
         self._network_thread_pool = network_thread_pool
+
+        consensus_proxy = ConsensusProxy(
+            block_cache=block_cache,
+            chain_controller=chain_controller,
+            block_publisher=block_publisher,
+            settings_view_factory=SettingsViewFactory(state_view_factory),
+            state_view_factory=state_view_factory)
+
+        consensus_handlers.add(
+            consensus_dispatcher, consensus_thread_pool, consensus_proxy)
 
         self._consensus_dispatcher = consensus_dispatcher
         self._consensus_service = consensus_service

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -265,7 +265,7 @@ class Validator(object):
 
         # -- Setup Journal -- #
         batch_injector_factory = DefaultBatchInjectorFactory(
-            block_store=block_store,
+            block_cache=block_cache,
             state_view_factory=state_view_factory,
             signer=identity_signer)
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -23,6 +23,7 @@ import threading
 from sawtooth_validator.concurrent.threadpool import \
     InstrumentedThreadPoolExecutor
 from sawtooth_validator.execution.context_manager import ContextManager
+from sawtooth_validator.consensus.notifier import ConsensusNotifier
 from sawtooth_validator.consensus.proxy import ConsensusProxy
 from sawtooth_validator.database.indexed_database import IndexedDatabase
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
@@ -278,6 +279,8 @@ class Validator(object):
             max_incoming_connections=20,
             monitor=True,
             max_future_callback_workers=10)
+
+        consensus_notifier = ConsensusNotifier(consensus_service)
 
         # -- Setup Journal -- #
         batch_injector_factory = DefaultBatchInjectorFactory(

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -54,6 +54,8 @@ from sawtooth_validator.gossip.gossip_handlers import PeerRegisterHandler
 from sawtooth_validator.gossip.gossip_handlers import PeerUnregisterHandler
 from sawtooth_validator.gossip.gossip_handlers import GetPeersRequestHandler
 from sawtooth_validator.gossip.gossip_handlers import GetPeersResponseHandler
+from sawtooth_validator.gossip.gossip_handlers import \
+    GossipConsensusMessageHandler
 from sawtooth_validator.networking.dispatch import Priority
 from sawtooth_validator.networking.handlers import PingHandler
 from sawtooth_validator.networking.handlers import ConnectHandler
@@ -82,6 +84,7 @@ def add(
         has_batch,
         permission_verifier,
         block_publisher,
+        consensus_notifier,
 ):
 
     # -- Basic Networking -- #
@@ -390,4 +393,11 @@ def add(
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_BATCH_RESPONSE,
         ResponderBatchResponseHandler(responder, gossip),
+        thread_pool)
+
+    # GOSSIP_CONSENSUS_MESSAGE
+
+    dispatcher.add_handler(
+        validator_pb2.Message.GOSSIP_CONSENSUS_MESSAGE,
+        GossipConsensusMessageHandler(consensus_notifier),
         thread_pool)

--- a/validator/tests/test_consensus/__init__.py
+++ b/validator/tests/test_consensus/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -1,0 +1,385 @@
+import unittest
+from unittest.mock import Mock
+
+from sawtooth_validator.consensus import handlers
+from sawtooth_validator.consensus.proxy import ConsensusProxy
+
+from sawtooth_validator.journal.publisher import FinalizeBlockResult
+
+
+class TestHandlers(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_proxy = Mock()
+
+    def test_consensus_register_handler(self):
+        mock_chain_head = Mock()
+        mock_chain_head.identifier = "dead"
+        mock_chain_head.previous_block_id = "beef"
+        mock_chain_head.signer_public_key = "abcd"
+        mock_chain_head.block_num = 12
+        mock_chain_head.consensus = b"deadbeef"
+        self.mock_proxy.register.return_value = mock_chain_head, []
+        handler = handlers.ConsensusRegisterHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.name = "test"
+        request.version = "test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.register.assert_called_with()
+
+    def test_consensus_send_to_handler(self):
+        handler = handlers.ConsensusSendToHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.peer_id = b"test"
+        request.message.message_type = "test"
+        request.message.content = b"test"
+        request.message.name = "test"
+        request.message.version = "test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.send_to.assert_called_with(
+            request.peer_id,
+            request.message.SerializeToString())
+
+    def test_consensus_broadcast_handler(self):
+        handler = handlers.ConsensusBroadcastHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.message.message_type = "test"
+        request.message.content = b"test"
+        request.message.name = "test"
+        request.message.version = "test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.broadcast.assert_called_with(
+            request.message.SerializeToString())
+
+    def test_consensus_initialize_block_handler(self):
+        handler = handlers.ConsensusInitializeBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.previous_id = b"test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.initialize_block.assert_called_with(
+            request.previous_id)
+
+    def test_consensus_summarize_block_handler(self):
+        self.mock_proxy.summarize_block.return_value = b"1234"
+        handler = handlers.ConsensusSummarizeBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.summarize_block.assert_called_with()
+
+    def test_consensus_finalize_block_handler(self):
+        self.mock_proxy.finalize_block.return_value = b"1234"
+        handler = handlers.ConsensusFinalizeBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.data = b"test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.finalize_block.assert_called_with(
+            request.data)
+
+    def test_consensus_cancel_block_handler(self):
+        handler = handlers.ConsensusCancelBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.cancel_block.assert_called_with()
+
+    def test_consensus_check_blocks_handler(self):
+        handler = handlers.ConsensusCheckBlocksHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_ids.extend([b"test"])
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.check_blocks.assert_called_with(
+            request.block_ids)
+
+    def test_consensus_commit_block_handler(self):
+        handler = handlers.ConsensusCommitBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.commit_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_ignore_block_handler(self):
+        handler = handlers.ConsensusIgnoreBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.ignore_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_fail_block_handler(self):
+        handler = handlers.ConsensusFailBlockHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.fail_block.assert_called_with(
+            request.block_id)
+
+    def test_consensus_blocks_get_handler(self):
+        self.mock_proxy.blocks_get.return_value = [
+            Mock(
+                identifier='abcd',
+                previous_block_id='abcd',
+                header_signature='abcd',
+                signer_public_key='abcd',
+                block_num=1,
+                consensus=b'consensus')]
+        handler = handlers.ConsensusBlocksGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_ids.extend([b"test"])
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.blocks_get.assert_called_with(
+            request.block_ids)
+
+    def test_consensus_chain_head_get_handler(self):
+        self.mock_proxy.chain_head_get.return_value = Mock(
+            identifier='abcd',
+            previous_block_id='abcd',
+            header_signature='abcd',
+            signer_public_key='abcd',
+            block_num=1,
+            consensus=b'consensus')
+        handler = handlers.ConsensusChainHeadGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.chain_head_get.assert_called_with()
+
+    def test_consensus_settings_get_handler(self):
+        self.mock_proxy.settings_get.return_value = [('key', 'value')]
+        handler = handlers.ConsensusSettingsGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        request.keys.extend(["test"])
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.settings_get.assert_called_with(
+            request.block_id, request.keys)
+
+    def test_consensus_state_get_handler(self):
+        self.mock_proxy.state_get.return_value = [('address', b'data')]
+        handler = handlers.ConsensusStateGetHandler(self.mock_proxy)
+        request_class = handler.request_class
+        request = request_class()
+        request.block_id = b"test"
+        request.addresses.extend(["test"])
+        result = handler.handle(None, request.SerializeToString())
+        response = result.message_out
+        self.assertEqual(response.status, handler.response_class.OK)
+        self.mock_proxy.state_get.assert_called_with(
+            request.block_id, request.addresses)
+
+
+class TestProxy(unittest.TestCase):
+
+    def setUp(self):
+        self._mock_block_cache = {}
+        self._mock_block_publisher = Mock()
+        self._mock_chain_controller = Mock()
+        self._mock_settings_view_factory = Mock()
+        self._mock_state_view_factory = Mock()
+        self._proxy = ConsensusProxy(
+            block_cache=self._mock_block_cache,
+            chain_controller=self._mock_chain_controller,
+            block_publisher=self._mock_block_publisher,
+            settings_view_factory=self._mock_settings_view_factory,
+            state_view_factory=self._mock_state_view_factory)
+
+    def test_send_to(self):
+        with self.assertRaises(NotImplementedError):
+            self._proxy.send_to(None, None)
+
+    def test_broadcast(self):
+        with self.assertRaises(NotImplementedError):
+            self._proxy.broadcast(None)
+
+    # Using block publisher
+    def test_initialize_block(self):
+        self._proxy.initialize_block(None)
+        self._mock_block_publisher.initialize_block.assert_called_with(
+            self._mock_chain_controller.chain_head)
+
+        self._mock_block_cache["34"] = "a block"
+        self._proxy.initialize_block(previous_id=bytes([0x34]))
+        self._mock_block_publisher\
+            .initialize_block.assert_called_with("a block")
+
+    def test_summarize_block(self):
+        self._mock_block_publisher.summarize_block.return_value =\
+            b"summary"
+
+        summary = self._proxy.summarize_block()
+        self._mock_block_publisher.summarize_block.assert_called_with()
+        self.assertEqual(summary, b"summary")
+
+    def test_finalize_block(self):
+        self._mock_block_publisher.finalize_block.return_value =\
+            FinalizeBlockResult(
+                block=None,
+                remaining_batches=None,
+                last_batch=None,
+                injected_batches=None)
+        self._mock_block_publisher.publish_block.return_value = "00"
+
+        data = bytes([0x56])
+        self._proxy.finalize_block(data)
+        self._mock_block_publisher.finalize_block.assert_called_with(
+            consensus=data)
+        self._mock_block_publisher.publish_block.assert_called_with(None, None)
+
+    def test_cancel_block(self):
+        self._proxy.cancel_block()
+        self._mock_block_publisher.cancel_block.assert_called_with()
+
+    # Using chain controller
+    def test_check_blocks(self):
+        block_ids = [bytes([0x56]), bytes([0x78])]
+        self._mock_block_cache["56"] = "block0"
+        self._mock_block_cache["78"] = "block1"
+        self._proxy.check_blocks(block_ids)
+        self._mock_chain_controller\
+            .submit_blocks_for_verification\
+            .assert_called_with(["block0", "block1"])
+
+    def test_commit_block(self):
+        self._mock_block_cache["34"] = "a block"
+        self._proxy.commit_block(block_id=bytes([0x34]))
+        self._mock_chain_controller\
+            .commit_block\
+            .assert_called_with("a block")
+
+    def test_ignore_block(self):
+        self._mock_block_cache["34"] = "a block"
+        self._proxy.ignore_block(block_id=bytes([0x34]))
+        self._mock_chain_controller\
+            .ignore_block\
+            .assert_called_with("a block")
+
+    def test_fail_block(self):
+        self._mock_block_cache["34"] = "a block"
+        self._proxy.fail_block(block_id=bytes([0x34]))
+        self._mock_chain_controller\
+            .fail_block\
+            .assert_called_with("a block")
+
+    # Using blockstore and state database
+    def test_blocks_get(self):
+        block_1 = Mock(
+            identifier=b'id-1',
+            previous_block_id=b'prev-1',
+            header_signature=b'sign-1',
+            block_num=1,
+            consensus=b'consensus')
+
+        self._mock_block_cache[b'block1'.hex()] = block_1
+
+        block_2 = Mock(
+            identifier=b'id-2',
+            previous_block_id=b'prev-2',
+            header_signature=b'sign-2',
+            block_num=2,
+            consensus=b'consensus')
+
+        self._mock_block_cache[b'block2'.hex()] = block_2
+
+        proxy_block_1, proxy_block_2 = self._proxy.blocks_get([
+            b'block1',
+            b'block2'])
+
+        self.assertEqual(
+            block_1,
+            proxy_block_1)
+
+        self.assertEqual(
+            block_2,
+            proxy_block_2)
+
+    def test_chain_head_get(self):
+        chain_head = Mock(
+            identifier=b'id-2',
+            previous_block_id=b'prev-2',
+            header_signature=b'sign-2',
+            block_num=2,
+            consensus=b'consensus')
+
+        self._mock_chain_controller.chain_head = chain_head
+
+        self.assertEqual(
+            self._proxy.chain_head_get(),
+            chain_head)
+
+    def test_settings_get(self):
+        self._mock_block_cache[b'block'.hex()] = MockBlock()
+
+        self.assertEqual(
+            self._proxy.settings_get(b'block', ['key1', 'key2']),
+            [
+                ('key1', 'mock-key1'),
+                ('key2', 'mock-key2'),
+            ])
+
+    def test_state_get(self):
+        self._mock_block_cache[b'block'.hex()] = MockBlock()
+
+        self.assertEqual(
+            self._proxy.state_get(b'block', ['address-1', 'address-2']),
+            [
+                ('address-1', b'mock-address-1'),
+                ('address-2', b'mock-address-2'),
+            ])
+
+
+class MockBlock:
+    def get_state_view(self, state_view_factory):
+        return MockStateView()
+
+    def get_settings_view(self, settings_view_factory):
+        return MockSettingsView()
+
+
+class MockStateView:
+    def get(self, address):
+        return 'mock-{}'.format(address).encode()
+
+
+class MockSettingsView:
+    def get_setting(self, key):
+        return 'mock-{}'.format(key)

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -214,22 +214,24 @@ class TestProxy(unittest.TestCase):
         self._mock_block_cache = {}
         self._mock_block_publisher = Mock()
         self._mock_chain_controller = Mock()
+        self._mock_gossip = Mock()
+        self._mock_identity_signer = Mock()
         self._mock_settings_view_factory = Mock()
         self._mock_state_view_factory = Mock()
         self._proxy = ConsensusProxy(
             block_cache=self._mock_block_cache,
             chain_controller=self._mock_chain_controller,
             block_publisher=self._mock_block_publisher,
+            gossip=self._mock_gossip,
+            identity_signer=self._mock_identity_signer,
             settings_view_factory=self._mock_settings_view_factory,
             state_view_factory=self._mock_state_view_factory)
 
     def test_send_to(self):
-        with self.assertRaises(NotImplementedError):
-            self._proxy.send_to(None, None)
+        self._proxy.send_to(peer_id=b'peer_id', message=b'message')
 
     def test_broadcast(self):
-        with self.assertRaises(NotImplementedError):
-            self._proxy.broadcast(None)
+        self._proxy.broadcast(message=b'message')
 
     # Using block publisher
     def test_initialize_block(self):

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -1375,7 +1375,7 @@ class TestJournal(unittest.TestCase):
                 check_publish_block_frequency=0.1,
                 batch_observers=[],
                 batch_injector_factory=DefaultBatchInjectorFactory(
-                    block_store=btm.block_store,
+                    block_cache=btm.block_store,
                     state_view_factory=MockStateViewFactory(btm.state_db),
                     signer=btm.identity_signer))
 


### PR DESCRIPTION
This PR adds the peripheral objects used by the consensus engine API including:
- All consensus engine API message handlers
- A Proxy object that routes requests between message handlers and internal validator objects
- A Notifier object that encapsulates sending updates to consensus engines from internal validator objects

It also implements the query services and networking services.