### PR TITLE
keygen: Fix Public Key Permission in Rust

### DIFF
--- a/adm/src/commands/keygen.rs
+++ b/adm/src/commands/keygen.rs
@@ -107,7 +107,7 @@ pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
         let mut public_key_file = OpenOptions::new()
             .write(true)
             .create(true)
-            .mode(0o640)
+            .mode(0o644)
             .open(public_key_path.as_path())
             .map_err(|err| CliError::EnvironmentError(format!("{}", err)))?;
 


### PR DESCRIPTION
Change permission of public key so it is readable by all.
That is, change from 0640 (rw-r-----) to 0644 (rw-r--r--).

Signed-off-by: danintel <daniel.anderson@intel.com>