### PR TITLE
Python tutorial fix

### DIFF
--- a/docs/source/_templates/partials/submitting_to_validator.rst
+++ b/docs/source/_templates/partials/submitting_to_validator.rst
@@ -43,7 +43,8 @@ prepared the BatchList:
         response = urllib.request.urlopen(request)
 
     except HTTPError as e:
-        response = e.file
+        print(e.response)
+        quit(1)
 
 {% endif %}
 

--- a/docs/source/_templates/sdk_submit_tutorial.rst
+++ b/docs/source/_templates/sdk_submit_tutorial.rst
@@ -116,7 +116,7 @@ SHA-512 hash of the payload bytes.
         family_name='intkey',
         family_version='1.0',
         inputs=['1cf1266e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'],
-        outputs=['1cf1266e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7']
+        outputs=['1cf1266e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7'],
         signer_public_key=signer.get_public_key().as_hex(),
         # In this example, we're signing the batch with the same private key,
         # but the batch can be signed by another party, in which case, the


### PR DESCRIPTION
This PR has two minor fixes for the python tutorial:

1. Adds a missing comma to the python example. 

2. `urllib.error.HTTPError` does not contain a property called `file`, instead we just print the reason for failure and exit.  