### PR TITLE
Add proxy for run_test -m rust_sdk test related files

### DIFF
--- a/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -36,6 +40,10 @@ services:
     build:
       context: ../../../..
       dockerfile: ./sdk/examples/intkey_rust/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-intkey-tp-rust$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -50,6 +58,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -72,6 +84,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -87,6 +103,10 @@ services:
     build:
       context: ../../..
       dockerfile: integration/sawtooth_integration/docker/integration-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: integration-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/perf/intkey_workload/unit_intkey_workload.yaml
+++ b/perf/intkey_workload/unit_intkey_workload.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./perf/perf-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: perf-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/perf/perf-tests.dockerfile
+++ b/perf/perf-tests.dockerfile
@@ -23,6 +23,22 @@ RUN apt-get update \
  pkg-config \
  unzip
 
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+  http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
+  https_proxy=$HTTPS_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+  http_proxy_host=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  http_proxy_port=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[http]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$http_proxy_host:$http_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi;
+
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \

--- a/perf/sawtooth_perf/unit_sawtooth_perf.yaml
+++ b/perf/sawtooth_perf/unit_sawtooth_perf.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./perf/perf-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: perf-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/perf/sawtooth_workload/unit_perf_workload.yaml
+++ b/perf/sawtooth_workload/unit_perf_workload.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./perf/perf-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: perf-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/perf/smallbank_workload/unit_smallbank_workload.yaml
+++ b/perf/smallbank_workload/unit_smallbank_workload.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./perf/perf-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: perf-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/sdk/examples/intkey_python/tests/test_tp_intkey_rust.yaml
+++ b/sdk/examples/intkey_python/tests/test_tp_intkey_rust.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: ../../../..
       dockerfile: ./sdk/examples/intkey_rust/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-intkey-tp-rust$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -36,6 +40,10 @@ services:
     build:
       context: ../../../..
       dockerfile: sdk/python/tests/python-sdk-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: python-sdk-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/sdk/examples/intkey_rust/Dockerfile
+++ b/sdk/examples/intkey_rust/Dockerfile
@@ -25,6 +25,22 @@ RUN apt-get update \
  pkg-config \
  unzip
 
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+  http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
+  https_proxy=$HTTPS_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+  http_proxy_host=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  http_proxy_port=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[http]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$http_proxy_host:$http_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi;
+
 # For Building Protobufs
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \

--- a/sdk/rust/rust-sdk-tests.dockerfile
+++ b/sdk/rust/rust-sdk-tests.dockerfile
@@ -32,6 +32,22 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+  http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $HTTPS_PROXY ] && [ -z $https_proxy ]; then \
+  https_proxy=$HTTPS_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+  http_proxy_host=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\1|');\
+  http_proxy_port=$(printf $http_proxy | sed 's|http.*://\(.*\):\(.*\)$|\2|');\
+  mkdir -p $HOME/.cargo \
+  && echo "[http]" >> $HOME/.cargo/config \
+  && echo 'proxy = "'$http_proxy_host:$http_proxy_port'"' >> $HOME/.cargo/config \
+  && cat $HOME/.cargo/config; \
+ fi;
+
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
  && rm protoc-3.5.1-linux-x86_64.zip

--- a/sdk/rust/unit_rust_sdk.yaml
+++ b/sdk/rust/unit_rust_sdk.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./sdk/rust/rust-sdk-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: rust-sdk-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core


### PR DESCRIPTION
- Added proxy support for all files used during `./run_tests -m rust_sdk` run