### PR TITLE
Add proxy for all run_test -m block_info related files

### DIFF
--- a/cli/tests/unit_cli.yaml
+++ b/cli/tests/unit_cli.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../..
       dockerfile: ./cli/tests/cli-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: cli-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/families/block_info/tests/test_tp_block_info.yaml
+++ b/families/block_info/tests/test_tp_block_info.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./families/block_info/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-block-info-tp$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -33,6 +37,10 @@ services:
     build:
       context: ../../..
       dockerfile: families/block_info/tests/block-info-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: block-info-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core

--- a/integration/sawtooth_integration/docker/test_block_info_injector.yaml
+++ b/integration/sawtooth_integration/docker/test_block_info_injector.yaml
@@ -21,6 +21,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -35,6 +39,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./sdk/examples/intkey_python/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-intkey-tp-python$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -49,6 +57,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./families/block_info/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-block-info-tp$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -63,6 +75,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -94,6 +110,10 @@ services:
     build:
       context: ../../..
       dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
@@ -109,6 +129,10 @@ services:
     build:
       context: ../../..
       dockerfile: integration/sawtooth_integration/docker/integration-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
     image: integration-tests:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core


### PR DESCRIPTION
Add all proxy settings required for all files invoked in `./bin/run_tests -m block_info` run

Signed-off-by: Ashish Kumar Mishra <ashish.k.mishra@intel.com>