### PR TITLE
Validator synchronization issue after transaction processor is restarted

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -351,10 +351,10 @@ class TransactionExecutorThread:
                 {signature: fut}
 
     def remove_broken_connection(self, connection_id):
+        self._processor_manager.remove(connection_id)
         if connection_id not in self._open_futures:
             # Connection has already been removed.
             return
-        self._processor_manager.remove(connection_id)
         futures_to_set = [
             self._open_futures[connection_id][key]
             for key in self._open_futures[connection_id]
@@ -477,8 +477,7 @@ class TransactionExecutor:
 
     def _remove_broken_connection(self, connection_id):
         for t in self._alive_threads:
-            if not t.is_done():
-                t.remove_broken_connection(connection_id)
+            t.remove_broken_connection(connection_id)
 
     def execute(self, scheduler):
         self._remove_done_threads()


### PR DESCRIPTION
When running multiple validators, if transaction processor is restarted
on one of the nodes, the validator on that node stops processing future blocks
even after the transaction processor is up.

A stopped TP is removed after it fails to respond to ping.
The TP removal procedure was not getting carried out properly due to checks of
alive_threads and _open_futures. By removal of these checks TP restart
keeps validators in sync.

Resolves: STL-1115

Signed-off-by: mithunshashidhara <mithunx.shashidhara@intel.com>