### PR TITLE
Modify get_ and set_state for multiple addresses

### DIFF
--- a/families/smallbank/smallbank_rust/src/handler.rs
+++ b/families/smallbank/smallbank_rust/src/handler.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+use std::collections::HashMap;
+
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 use protobuf;
@@ -279,7 +281,7 @@ fn load_account(
     context: &mut TransactionContext,
 ) -> Result<Option<Account>, ApplyError> {
     let response = context
-        .get_state(&create_smallbank_address(&format!("{}", customer_id)))
+        .get_state(vec![create_smallbank_address(&format!("{}", customer_id))])
         .map_err(|err| {
             warn!("Invalid transaction: Failed to load Account: {:?}", err);
             ApplyError::InvalidTransaction(format!("Failed to load Account: {:?}", err))
@@ -300,7 +302,9 @@ fn save_account(account: &Account, context: &mut TransactionContext) -> Result<(
         ApplyError::InvalidTransaction(format!("Failed to serialize Account: {:?}", err))
     })?;
 
-    context.set_state(&address, &data).map_err(|err| {
+    let mut sets = HashMap::new();
+    sets.insert(address, data);
+    context.set_state(sets).map_err(|err| {
         warn!("Invalid transaction: Failed to load Account: {:?}", err);
         ApplyError::InvalidTransaction(format!("Failed to load Account: {:?}", err))
     })

--- a/sdk/examples/intkey_rust/src/handler.rs
+++ b/sdk/examples/intkey_rust/src/handler.rs
@@ -179,8 +179,8 @@ impl<'a> IntkeyState<'a> {
     }
 
     pub fn get(&mut self, name: &str) -> Result<Option<u32>, ApplyError> {
-        let address = &IntkeyState::calculate_address(name);
-        let d = self.context.get_state(address)?;
+        let address = IntkeyState::calculate_address(name);
+        let d = self.context.get_state(vec![address.clone()])?;
         match d {
             Some(packed) => {
                 let input = Cursor::new(packed);
@@ -229,8 +229,10 @@ impl<'a> IntkeyState<'a> {
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
 
         let packed = e.into_inner().into_writer().into_inner();
+        let mut sets = HashMap::new();
+        sets.insert(IntkeyState::calculate_address(name), packed);
         self.context
-            .set_state(&IntkeyState::calculate_address(name), &packed)
+            .set_state(sets)
             .map_err(|err| ApplyError::InternalError(format!("{}", err)))?;
 
         Ok(())

--- a/sdk/examples/xo_rust/src/handler/state.rs
+++ b/sdk/examples/xo_rust/src/handler/state.rs
@@ -86,8 +86,9 @@ impl<'a> XoState<'a> {
         let state_string = Game::serialize_games(games);
         self.address_map
             .insert(address.clone(), Some(state_string.clone()));
-        self.context
-            .set_state(&address, &state_string.into_bytes())?;
+        let mut sets = HashMap::new();
+        sets.insert(address, state_string.into_bytes());
+        self.context.set_state(sets)?;
         Ok(())
     }
 
@@ -117,7 +118,7 @@ impl<'a> XoState<'a> {
                 }
             }
         } else {
-            if let Some(state_bytes) = self.context.get_state(&address)? {
+            if let Some(state_bytes) = self.context.get_state(vec![address.to_string()])? {
                 let state_string = match ::std::str::from_utf8(&state_bytes) {
                     Ok(s) => s,
                     Err(_) => {


### PR DESCRIPTION
Modifies the get_state and set_state methods for TransactionContext in
the Rust SDK to take in a list of addresses to get/set instead of just
one address. This aligns with the functionality of the other SDKs. Also
modifies existing uses of SDK (smallbank_rust, inkey_rust, and xo_rust)
to call methods properly.

Signed-off-by: Logan Seeley <seeley@bitwise.io>