### PR TITLE
Change consensus proxy state_get to handle address prefixes

### DIFF
--- a/sdk/python/sawtooth_sdk/consensus/zmq_service.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_service.py
@@ -80,7 +80,7 @@ class ZmqService(Service):
 
     # -- Block Creation --
 
-    def initialize_block(self, previous_id):
+    def initialize_block(self, previous_id=None):
         request = (
             consensus_pb2.ConsensusInitializeBlockRequest(
                 previous_id=previous_id)

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -141,7 +141,26 @@ class ConsensusProxy:
             self._get_blocks([block_id])[0].get_state_view(
                 self._state_view_factory)
 
-        return _map_with_none(state_view.get, addresses)
+        result = []
+
+        for address in addresses:
+            # a fully specified address
+            if len(address) == 70:
+                try:
+                    value = state_view.get(address)
+                except KeyError:
+                    value = None
+
+                result.append((address, value))
+                continue
+
+            # an address prefix
+            leaves = state_view.leaves(address)
+
+            for leaf in leaves:
+                result.append(leaf)
+
+        return result
 
     def _get_blocks(self, block_ids):
         try:

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -367,11 +367,14 @@ class TestProxy(unittest.TestCase):
     def test_state_get(self):
         self._mock_block_cache[b'block'.hex()] = MockBlock()
 
+        address_1 = '1' * 70
+        address_2 = '2' * 70
+
         self.assertEqual(
-            self._proxy.state_get(b'block', ['address-1', 'address-2']),
+            self._proxy.state_get(b'block', [address_1, address_2]),
             [
-                ('address-1', b'mock-address-1'),
-                ('address-2', b'mock-address-2'),
+                (address_1, 'mock-{}'.format(address_1).encode()),
+                (address_2, 'mock-{}'.format(address_2).encode()),
             ])
 
 


### PR DESCRIPTION
Previously it only accepted a list of fully specifed addresses. Now it
can accept lists containing both full addresses and address prefixes.

Signed-off-by: Nick Drozd <drozd@bitwise.io>