### PR TITLE
Fix delete response in testing message factory

### DIFF
--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -248,7 +248,8 @@ class MessageFactory(object):
     def create_delete_response(self, addresses):
         self._validate_addresses(addresses)
         return TpStateDeleteResponse(
-            addresses=addresses
+            addresses=addresses,
+            status=TpStateDeleteResponse.OK
         )
 
     def create_add_event_request(self, event_type, attributes=None, data=None):


### PR DESCRIPTION
Fixes the response generated by the `create_delete_response()` method of
the message_factory used for testing. This method was not setting the
status of the response.

Signed-off-by: Logan Seeley <seeley@bitwise.io>