### PR TITLE
Adding Battleship family example to run_tests

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -25,6 +25,7 @@ MODULE_LIST="
     settings
     identity
     block_info
+    battleship
     validator
     python_sdk
     rust_sdk
@@ -163,6 +164,9 @@ main() {
                 block_info)
                     test_block_info
                     ;;
+                battleship)
+                    test_battleship
+                    ;;
                 validator)
                     test_validator
                     ;;
@@ -260,6 +264,11 @@ test_block_info() {
   copy_coverage .coverage.block_info
   run_docker_test test_block_info_injector
   copy_coverage .coverage.block_info_injector
+}
+
+test_battleship() {
+    run_docker_test ./families/battleship/tests/test_tp_battleship.yaml
+    copy_coverage .coverage.test_tp_battleship
 }
 
 test_validator() {

--- a/families/battleship/sawtooth_battleship/battleship_client.py
+++ b/families/battleship/sawtooth_battleship/battleship_client.py
@@ -18,8 +18,8 @@ import json
 from base64 import b64encode, b64decode
 import hashlib
 import time
-import yaml
 import requests
+import yaml
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
@@ -104,7 +104,7 @@ class BattleshipClient:
             outputs=[address],
             dependencies=[],
             payload_sha512=self._sha512(payload),
-            batcher_public_key=self.signer.get_public_key().as_hex(),
+            batcher_public_key=self._signer.get_public_key().as_hex(),
             nonce=time.time().hex().encode()
         ).SerializeToString()
 

--- a/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
+++ b/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
@@ -43,7 +43,7 @@ class BattleshipTransaction:
         except ValueError:
             raise InvalidTransaction("Invalid payload serialization")
 
-        LOGGER.debug("payload recieved by battleship tp: %s", repr(payload))
+        LOGGER.debug("payload received by battleship tp: %s", repr(payload))
         self._signer_public_key = header.signer_public_key
         self._name = payload['Name'] if 'Name' in payload else None
         self._action = payload['Action'] if 'Action' in payload else None
@@ -357,7 +357,7 @@ def _get_state_data(game_address, context):
 
 
 def _store_state_data(addr, new_state, context):
-    LOGGER.debug('Storing Upadated State....\nUPDATED STATE:\n%s', new_state)
+    LOGGER.debug('Storing Updated State....\nUPDATED STATE:\n%s', new_state)
     addresses = context.set_state(
         {addr: json.dumps(new_state).encode()}
     )

--- a/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
+++ b/families/battleship/sawtooth_battleship/processor/battleship_transaction.py
@@ -359,7 +359,7 @@ def _get_state_data(game_address, context):
 def _store_state_data(addr, new_state, context):
     LOGGER.debug('Storing Upadated State....\nUPDATED STATE:\n%s', new_state)
     addresses = context.set_state(
-        {addr, json.dumps(new_state).encode()}
+        {addr: json.dumps(new_state).encode()}
     )
 
     if len(addresses) < 1:

--- a/families/battleship/sawtooth_battleship/processor/main.py
+++ b/families/battleship/sawtooth_battleship/processor/main.py
@@ -16,6 +16,7 @@
 import hashlib
 import sys
 import argparse
+import traceback
 import pkg_resources
 
 from sawtooth_sdk.processor.core import TransactionProcessor
@@ -95,7 +96,10 @@ def main(args=None):
     except KeyboardInterrupt:
         pass
     except Exception as e:  # pylint: disable=broad-except
-        print("Error: {}".format(e))
+        if opts.verbose:
+            traceback.print_exc()
+        else:
+            print("Error: {}".format(e))
     finally:
         if processor is not None:
             processor.stop()


### PR DESCRIPTION
Includes a bug fix to make the tests pass and typo fixes. Also includes a change to output a traceback when verbose mode is enabled, which was useful when diagnosing test failures.