### PR TITLE
Remove Example Seeds and Peers Using Port 8001

### DIFF
--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -90,7 +90,7 @@ The ``validator.toml`` configuration file has the following options:
 
   .. code-block:: none
 
-    seeds = ["tcp://127.0.0.1:8801"]
+    seeds = ["tcp://validator-host1:8800"]
 
 - ``peers`` = ["`URL`"]
 
@@ -98,7 +98,7 @@ The ``validator.toml`` configuration file has the following options:
 
   .. code-block:: none
 
-    peers = ["tcp://127.0.0.1:8801"]
+    peers = ["tcp://validator-host1:8800"]
 
 - ``scheduler`` = '`type`'
 

--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -43,12 +43,12 @@ endpoint = "tcp://127.0.0.1:8800"
 
 # Uri(s) to connect to in order to initially connect to the validator network,
 # in the format tcp://hostname:port. This is not needed in static peering mode
-# and defaults to None.
-seeds = ["tcp://127.0.0.1:8801"]
+# and defaults to None. Replace host1 with the seed's hostname or IP address.
+# seeds = ["tcp://host1:8800"]
 
 # A list of peers to attempt to connect to in the format tcp://hostname:port.
-# It defaults to None.
-peers = ["tcp://127.0.0.1:8801"]
+# It defaults to None. Replace host1 with the peer's hostname or IP address.
+# peers = ["tcp://host1:8800"]
 
 # The type of scheduler to use. The choices are 'serial' or 'parallel'.
 scheduler = 'serial'


### PR DESCRIPTION
The validator.toml examples use
`seeds = ["tcp://127.0.0.1:8801"]`
`peers = ["tcp://127.0.0.1:8801"]`

They should vary the hostname, not the port, to show the more common usage.

Signed-off-by: danintel <daniel.anderson@intel.com>