### PR TITLE
Fix ordering error in Scheduler.cancel

### DIFF
--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -1138,6 +1138,7 @@ class ParallelScheduler(Scheduler):
     def cancel(self):
         with self._condition:
             if not self._cancelled and not self._final:
+                self._cancelled = True
                 contexts = [
                     tr.context_id for tr in self._txn_results.values()
                     if tr.context_id
@@ -1147,7 +1148,6 @@ class ParallelScheduler(Scheduler):
                     contexts,
                     persist=False,
                     clean_up=True)
-                self._cancelled = True
                 self._condition.notify_all()
 
     def is_cancelled(self):

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -399,12 +399,12 @@ class SerialScheduler(Scheduler):
         with self._condition:
             if not self._cancelled and not self._final \
                     and self._previous_context_id:
+                self._cancelled = True
                 self._squash(
                     state_root=self._previous_state_hash,
                     context_ids=[self._previous_context_id],
                     persist=False,
                     clean_up=True)
-                self._cancelled = True
                 self._condition.notify_all()
 
     def is_cancelled(self):


### PR DESCRIPTION
The Scheduler needs to set its own state as cancelled to notify the
Executor to stop, before telling the ContextManager to remove all
contexts associated with the schedule.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>

This error causes this logging message to be logged : 
```executor] Error creating context for transaction 191708fa580da5819b5dca39c88a61431785d7aafec07c32d074a86a62c63fc95e450b5537cc88e43baa3fe28133dbd3079cbb438299d1ce24f6cfc4a3b08098, scheduler provided a base context that was not in the context manager.```