### PR TITLE
Use Random Number instead of Timestamp for Nonce

### DIFF
--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -21,6 +21,7 @@ import json
 import os
 import sys
 import time
+import random
 import yaml
 
 from sawtooth_cli.exceptions import CliException
@@ -489,7 +490,7 @@ def _create_policy_txn(signer, policy_name, rules):
         payload_sha512=hashlib.sha512(
             payload.SerializeToString()).hexdigest(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 
@@ -519,7 +520,7 @@ def _create_role_txn(signer, role_name, policy_name):
         payload_sha512=hashlib.sha512(
             payload.SerializeToString()).hexdigest(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 

--- a/cli/sawtooth_cli/sawset.py
+++ b/cli/sawtooth_cli/sawset.py
@@ -16,7 +16,6 @@
 import argparse
 from base64 import b64decode
 import csv
-import datetime
 import getpass
 import hashlib
 import json
@@ -24,6 +23,7 @@ import logging
 import os
 import sys
 import traceback
+import random
 import yaml
 
 import pkg_resources
@@ -322,7 +322,7 @@ def _create_propose_txn(signer, setting_key_value):
     key and value.
     """
     setting_key, setting_value = setting_key_value
-    nonce = str(datetime.datetime.utcnow().timestamp())
+    nonce = hex(random.randint(0, 2**64))
     proposal = SettingProposal(
         setting=setting_key,
         value=setting_value,

--- a/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
+++ b/consensus/poet/core/sawtooth_poet/poet_consensus/poet_block_publisher.py
@@ -18,6 +18,7 @@ import logging
 import hashlib
 import time
 import json
+import random
 
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.consensus.consensus \
@@ -179,7 +180,7 @@ class PoetBlockPublisher(BlockPublisherInterface):
                 dependencies=[],
                 payload_sha512=hashlib.sha512(serialized).hexdigest(),
                 batcher_public_key=block_header.signer_public_key,
-                nonce=time.time().hex().encode()).SerializeToString()
+                nonce=hex(random.randint(0, 2**64))).SerializeToString()
 
         signature = self._batch_publisher.identity_signer.sign(header)
 

--- a/families/battleship/sawtooth_battleship/battleship_client.py
+++ b/families/battleship/sawtooth_battleship/battleship_client.py
@@ -18,6 +18,7 @@ import json
 from base64 import b64encode, b64decode
 import hashlib
 import time
+import random
 import yaml
 import requests
 
@@ -105,7 +106,7 @@ class BattleshipClient:
             dependencies=[],
             payload_sha512=self._sha512(payload),
             batcher_public_key=self.signer.get_public_key().as_hex(),
-            nonce=time.time().hex().encode()
+            nonce=hex(random.randint(0, 2**64))
         ).SerializeToString()
 
         signature = self._signer.sign(header)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/create_batch.py
@@ -97,7 +97,7 @@ def create_intkey_transaction(verb, name, value, deps, signer):
         dependencies=deps,
         payload_sha512=payload.sha512(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/generate.py
@@ -81,7 +81,7 @@ def create_intkey_transaction(verb, name, value, signer):
         dependencies=[],
         payload_sha512=payload.sha512(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/intkey_client.py
@@ -16,6 +16,7 @@
 import hashlib
 import base64
 import time
+import random
 import requests
 import yaml
 import cbor
@@ -166,7 +167,7 @@ class IntkeyClient:
             dependencies=[],
             payload_sha512=_sha512(payload),
             batcher_public_key=self._signer.get_public_key().as_hex(),
-            nonce=time.time().hex().encode()
+            nonce=hex(random.randint(0, 2**64))
         ).SerializeToString()
 
         signature = self._signer.sign(header)

--- a/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/client_cli/populate.py
@@ -23,7 +23,6 @@ import os
 import logging
 import random
 import string
-import time
 
 import cbor
 
@@ -83,7 +82,7 @@ def create_intkey_transaction(verb, name, value, signer):
         dependencies=[],
         payload_sha512=payload.sha512(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
@@ -30,7 +30,7 @@ LOGGER = logging.getLogger(__name__)
 class NoopPayload(object):
     def __init__(self):
         self.nonce = binascii.b2a_hex(random.getrandbits(
-            8 * 8).to_bytes(8, hbyteorder='little'))
+            8 * 8).to_bytes(8, byteorder='little'))
         self._sha512 = None
 
     def sha512(self):

--- a/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
+++ b/sdk/examples/noop_python/sawtooth_noop/client_cli/create_batch.py
@@ -19,7 +19,6 @@ import hashlib
 import logging
 import binascii
 import random
-import time
 
 import sawtooth_sdk.protobuf.batch_pb2 as batch_pb2
 import sawtooth_sdk.protobuf.transaction_pb2 as transaction_pb2
@@ -52,7 +51,7 @@ def create_noop_transaction(signer):
         dependencies=[],
         payload_sha512=payload.sha512(),
         batcher_public_key=signer.get_public_key().as_hex(),
-        nonce=time.time().hex().encode())
+        nonce=hex(random.randint(0, 2**64)))
 
     header_bytes = header.SerializeToString()
 

--- a/sdk/examples/xo_python/sawtooth_xo/xo_client.py
+++ b/sdk/examples/xo_python/sawtooth_xo/xo_client.py
@@ -17,6 +17,7 @@ import hashlib
 import base64
 from base64 import b64encode
 import time
+import random
 import requests
 import yaml
 
@@ -205,7 +206,7 @@ class XoClient:
             dependencies=[],
             payload_sha512=_sha512(payload),
             batcher_public_key=self._signer.get_public_key().as_hex(),
-            nonce=time.time().hex().encode()
+            nonce=hex(random.randint(0, 2**64))
         ).SerializeToString()
 
         signature = self._signer.sign(header)

--- a/sdk/python/sawtooth_processor_test/message_factory.py
+++ b/sdk/python/sawtooth_processor_test/message_factory.py
@@ -15,7 +15,7 @@
 
 import hashlib
 import string
-import time
+import random
 
 from sawtooth_signing import create_context
 from sawtooth_signing import CryptoFactory
@@ -109,7 +109,7 @@ class MessageFactory(object):
                                    set_nonce=True, batcher_pub_key=None):
 
         if set_nonce:
-            nonce = str(time.time())
+            nonce = hex(random.randint(0, 2**64))
         else:
             nonce = ""
         txn_pub_key = self._signer.get_public_key().as_hex()


### PR DESCRIPTION
Timestamps have a greater chance of collision, as use of
parallel transaction processing increases (either through
threads or multiple processes).

Signed-off-by: danintel <daniel.anderson@intel.com>