### PR TITLE
Re-enable cli unit tests

### DIFF
--- a/cli/tests/cli-tests.dockerfile
+++ b/cli/tests/cli-tests.dockerfile
@@ -28,8 +28,11 @@ RUN apt-get install -y -q --allow-downgrades \
     python3-protobuf
 
 RUN apt-get install -y -q --allow-downgrades \
+    python3-colorlog \
     python3-requests \
-    python3-toml
+    python3-toml \
+    python3-yaml \
+    python3-secp256k1
 
 RUN apt-get install -y -q \
     python3-cov-core \

--- a/cli/tests/unit_cli.yaml
+++ b/cli/tests/unit_cli.yaml
@@ -32,7 +32,6 @@ services:
         -c /project/sawtooth-core/cli/nose2.cfg
         -v
         -s /project/sawtooth-core/cli/tests
-        test_network
     environment:
         PYTHONPATH: "/project/sawtooth-core/signing:\
             /project/sawtooth-core/cli"


### PR DESCRIPTION
Some of the CLI unit tests were inadvertently disabled in
d913e57437c18b0bbdcb698469a2f16cc2249d88

Signed-off-by: Dan Middleton <dan.middleton@intel.com>