### PR TITLE
Test Build: Cargo install protobuf-codegen

### DIFF
--- a/docker/sawtooth-dev-rust
+++ b/docker/sawtooth-dev-rust
@@ -53,7 +53,7 @@ EXPOSE 4004/tcp
 ENV PATH=$PATH:/project/sawtooth-core/bin:/root/.cargo/bin\
     CARGO_INCREMENTAL=0
 
-RUN cargo install protobuf
+RUN cargo install protobuf-codegen
 
 RUN mkdir -p /project/sawtooth-core/ \
  && mkdir -p /var/log/sawtooth \


### PR DESCRIPTION
The protobuf package no longer installs the required binaries.

Signed-off-by: Richard Berg <rberg@bitwise.io>