### PR TITLE
Include sent message type info in timeout error

### DIFF
--- a/sdk/python/sawtooth_sdk/messaging/stream.py
+++ b/sdk/python/sawtooth_sdk/messaging/stream.py
@@ -297,7 +297,7 @@ class Stream(object):
             message_type=message_type,
             correlation_id=_generate_id(),
             content=content)
-        future = Future(message.correlation_id)
+        future = Future(message.correlation_id, request_type=message_type)
         self._futures.put(future)
 
         self._send_recieve_thread.put_message(message)


### PR DESCRIPTION
For more informative messages, include the outbound message type in the
timeout error message, to give context about what message we are waiting
on a reply.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>