### PR TITLE
Prevent pruning of leaves via duplicate log

### DIFF
--- a/validator/sawtooth_validator/state/merkle.py
+++ b/validator/sawtooth_validator/state/merkle.py
@@ -48,7 +48,7 @@ class MerkleDatabase(ffi.OwnedPointer):
 
     @staticmethod
     def create_index_configuration():
-        return ['change_log']
+        return ['change_log', 'duplicate_log']
 
     def __iter__(self):
         return self.leaves()

--- a/validator/src/database/database.rs
+++ b/validator/src/database/database.rs
@@ -24,6 +24,7 @@ pub enum DatabaseError {
     WriterError(String),
     CorruptionError(String),
     NotFoundError(String),
+    DuplicateEntry,
 }
 
 impl std::fmt::Display for DatabaseError {
@@ -34,6 +35,7 @@ impl std::fmt::Display for DatabaseError {
             DatabaseError::WriterError(ref msg) => write!(f, "WriterError: {}", msg),
             DatabaseError::CorruptionError(ref msg) => write!(f, "CorruptionError: {}", msg),
             DatabaseError::NotFoundError(ref msg) => write!(f, "NotFoundError: {}", msg),
+            DatabaseError::DuplicateEntry => write!(f, "DuplicateEntry"),
         }
     }
 }
@@ -46,6 +48,7 @@ impl std::error::Error for DatabaseError {
             DatabaseError::WriterError(ref msg) => msg,
             DatabaseError::CorruptionError(ref msg) => msg,
             DatabaseError::NotFoundError(ref msg) => msg,
+            DatabaseError::DuplicateEntry => "DuplicateEntry",
         }
     }
 
@@ -56,6 +59,7 @@ impl std::error::Error for DatabaseError {
             DatabaseError::WriterError(_) => None,
             DatabaseError::CorruptionError(_) => None,
             DatabaseError::NotFoundError(_) => None,
+            DatabaseError::DuplicateEntry => None,
         }
     }
 }


### PR DESCRIPTION
This commit introduces the idea of a duplicate log. The duplicate log is a record of the count of additional collisions at a given hash key.

When node is written to the database, if an entry already exists for it, a count is updated in the duplicate log.   When a node is deleted, the count is decremented.  Once there are no duplicates, the count is removed entirely.  Nodes may be fully deleted at this point.\\

This fixes the issue that can occur with state pruning where a fork produces a duplicate hash, whose original value was produced outside of the state pruning window.  Those values would be deleted when the fork was prune, which would cause errors validating transactions that still expected the value to be in state.