### PR TITLE
Fixing build_all for cxx code relocation

### DIFF
--- a/bin/build_all
+++ b/bin/build_all
@@ -23,7 +23,6 @@ TARGETS=""
 EXCLUDE=""
 
 ALL_TARGETS="
-        cxx
         ext
         go
         java
@@ -146,9 +145,6 @@ main() {
         else
             info "Building $language"
             case $language in
-                cxx)
-                    build_cxx
-                    ;;
                 ext)
                     build_external
                     ;;
@@ -264,10 +260,6 @@ build_poet_sgx() {
 
 if [[ $BUILD_MODE == $MOUNTED ]]
 then
-    build_cxx() {
-        docker_build docker/sawtooth-dev-cxx docker/ sawtooth-dev-cxx
-        docker_run sawtooth-dev-cxx
-    }
 
     build_go() {
         docker_build docker/sawtooth-dev-go docker/ sawtooth-dev-go
@@ -318,19 +310,6 @@ fi
 
 if [[ $BUILD_MODE == $INSTALLED ]]
 then
-    build_cxx() {
-        build_dir=/tmp/build-docker$ISOLATION_ID
-        rm -rf $build_dir
-        mkdir -p $build_dir
-
-        docker_build docker/sawtooth-dev-cxx docker/ sawtooth-dev-cxx
-        docker_run sawtooth-dev-cxx
-
-        cp $top_dir/bin/install_packaging_deps $build_dir
-        cp $top_dir/ci/sawtooth-build-debs $build_dir
-        docker_build $build_dir/sawtooth-build-debs $build_dir sawtooth-build-debs
-        docker_run sawtooth-build-debs cxx
-    }
 
     build_go() {
         build_dir=/tmp/build-docker$ISOLATION_ID


### PR DESCRIPTION
Cleaning up build_all to remove cxx build functions
and module list.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>