### PR TITLE
Fix some clippy lint errors and warnings in merkle_ffi

### DIFF
--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -347,7 +347,7 @@ impl MerkleDatabase {
             match db_writer.put(::hex::encode(key).as_bytes(), &value) {
                 Ok(_) => continue,
                 Err(DatabaseError::DuplicateEntry) => {
-                    increment_ref_count(&mut db_writer, key);
+                    increment_ref_count(&mut db_writer, key)?;
                 }
                 Err(err) => return Err(StateDatabaseError::from(err)),
             }


### PR DESCRIPTION
Putting unsafe on the function definition instead of at each location of unsafe code in the function is debatable, but it reduces the errors by 30+.