### PR TITLE
Cleanup workload package CI

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -257,6 +257,13 @@ services:
     image: sawtooth-smallbank-workload:${ISOLATION_ID}
     container_name: sawtooth-smallbank-workload
 
+  intkey-workload:
+    build:
+      context: .
+      dockerfile: perf/intkey_workload/Dockerfile-installed
+    image: sawtooth-intkey-workload:${ISOLATION_ID}
+    container_name: sawtooth-intkey-workload
+
   devmode-rust:
     build:
       context: .

--- a/docker/compose/copy-debs.yaml
+++ b/docker/compose/copy-debs.yaml
@@ -277,6 +277,15 @@ services:
         cp /tmp/*.deb /build/debs
       "
 
+  intkey-workload:
+    image: sawtooth-intkey-workload:${ISOLATION_ID}
+    volumes:
+      - ../../build/debs:/build/debs
+    command: |
+      bash -c "
+        cp /tmp/*.deb /build/debs
+      "
+
   devmode-rust:
     image: sawtooth-devmode-rust:${ISOLATION_ID}
     volumes:

--- a/perf/intkey_workload/Cargo.toml
+++ b/perf/intkey_workload/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
-name = "intkey_workload"
+name = "sawtooth-intkey-workload"
 version = "0.1.0"
+authors = ["Intel Corporation"]
 
 [[bin]]
 name = "intkey-workload"

--- a/perf/intkey_workload/Dockerfile
+++ b/perf/intkey_workload/Dockerfile
@@ -1,0 +1,43 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# docker build -f perf/intkey_workload/Dockerfile -t intkey-workload-local .
+
+FROM ubuntu:xenial
+
+RUN apt-get update \
+ && apt-get install -y \
+ curl \
+ gcc \
+ libssl-dev \
+ libzmq3-dev \
+ pkg-config \
+ unzip
+
+RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
+ && chmod +x /usr/bin/rustup-init \
+ && rustup-init -y
+
+ENV PATH=$PATH:/project/sawtooth-core/bin:/root/.cargo/bin \
+    CARGO_INCREMENTAL=0
+
+WORKDIR /project/sawtooth-core/
+
+CMD cd perf/intkey_workload \
+ && echo "\033[0;32m--- Building intkey-workload ---\n\033[0m" \
+ && rm -rf ./bin/ \
+ && mkdir -p ./bin/ \
+ && cargo build --release \
+ && cp ./target/release/intkey-workload ./bin/intkey-workload

--- a/perf/intkey_workload/Dockerfile-installed
+++ b/perf/intkey_workload/Dockerfile-installed
@@ -1,0 +1,53 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# docker build -f perf/intkey_workload/Dockerfile-installed -t sawtooth-intkey-workload .
+
+# -------------=== intkey workload build ===-------------
+FROM ubuntu:xenial as intkey-workload-builder
+
+ENV VERSION=AUTO_STRICT
+
+RUN apt-get update \
+ && apt-get install -y \
+ curl \
+ gcc \
+ libssl-dev \
+ libzmq3-dev \
+ pkg-config \
+ unzip
+
+# For Building Protobufs
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
+ && curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
+ && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
+ && rm protoc-3.5.1-linux-x86_64.zip
+
+ENV PATH=$PATH:/protoc3/bin
+RUN /root/.cargo/bin/cargo install cargo-deb
+
+COPY . /project
+
+WORKDIR /project/perf/intkey_workload
+
+RUN /root/.cargo/bin/cargo deb
+
+# -------------=== intkey workload docker build ===-------------
+FROM ubuntu:xenial
+
+COPY --from=intkey-workload-builder /project/perf/intkey_workload/target/debian/sawtooth-intkey-workload*.deb /tmp
+
+RUN apt-get update \
+ && dpkg -i /tmp/sawtooth-intkey-workload*.deb || true \
+ && apt-get -f -y install

--- a/perf/smallbank_workload/Cargo.toml
+++ b/perf/smallbank_workload/Cargo.toml
@@ -13,10 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 [package]
-name = "smallbank_workload"
+name = "sawtooth-smallbank-workload"
 version = "0.1.0"
 build = "build.rs"
-authors = ["sawtooth"]
+authors = ["Intel Corporation"]
 
 [dependencies]
 sawtooth_sdk = { path = "../../sdk/rust" }

--- a/perf/smallbank_workload/Dockerfile-installed
+++ b/perf/smallbank_workload/Dockerfile-installed
@@ -46,8 +46,8 @@ RUN /root/.cargo/bin/cargo deb
 # -------------=== smallbank workload docker build ===-------------
 FROM ubuntu:xenial
 
-COPY --from=smallbank-workload-builder /project/perf/smallbank_workload/target/debian/smallbank_workload*.deb /tmp
+COPY --from=smallbank-workload-builder /project/perf/smallbank_workload/target/debian/sawtooth-smallbank-workload*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/smallbank_workload*.deb || true \
+ && dpkg -i /tmp/sawtooth-smallbank-workload*.deb || true \
  && apt-get -f -y install


### PR DESCRIPTION
Update the package metadata and add intkey workload. This make it easier for other repos to run tests that use these workload packages.