### PR TITLE
Add configuration settings for network, component and signature thread pool workers

### DIFF
--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -67,6 +67,19 @@ minimum_peer_connectivity = 3
 # The maximum number of peers that will be accepted.
 maximum_peer_connectivity = 10
 
+# The following settings are for tuning the thread allocation in several of the
+# thread pools used by the validator.  These settings should be modified by
+# advanced users only.
+
+# The maximum number of threads in the component worker pool
+# component_thread_pool_workers = 10
+
+# The maximum number of threads in the network worker pool
+# network_thread_pool_workers = 10
+
+# The maximum number of threads in the signature verification worker pool
+# signature_thread_pool_workers = 3
+
 # The host and port for Open TSDB database used for metrics
 # opentsdb_url = ""
 

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -39,6 +39,8 @@ def load_default_validator_config():
         maximum_peer_connectivity=10,
         state_pruning_block_depth=100,
         fork_cache_keep_time=300,
+        component_thread_pool_workers=10,
+        network_thread_pool_workers=10
     )
 
 
@@ -68,7 +70,8 @@ def load_toml_validator_config(filename):
          'opentsdb_url', 'opentsdb_db', 'opentsdb_username',
          'opentsdb_password', 'minimum_peer_connectivity',
          'maximum_peer_connectivity', 'state_pruning_block_depth',
-         'fork_cache_keep_time'])
+         'fork_cache_keep_time',
+         'component_thread_pool_workers', 'network_thread_pool_workers'])
     if invalid_keys:
         raise LocalConfigurationError(
             "Invalid keys in validator config: "
@@ -118,6 +121,10 @@ def load_toml_validator_config(filename):
             "state_pruning_block_depth", None),
         fork_cache_keep_time=toml_config.get(
             "fork_cache_keep_time", None),
+        component_thread_pool_workers=toml_config.get(
+            "component_thread_pool_workers", None),
+        network_thread_pool_workers=toml_config.get(
+            "network_thread_pool_workers", None)
     )
 
     return config
@@ -149,6 +156,8 @@ def merge_validator_config(configs):
     maximum_peer_connectivity = None
     state_pruning_block_depth = None
     fork_cache_keep_time = None
+    component_thread_pool_workers = None
+    network_thread_pool_workers = None
 
     for config in reversed(configs):
         if config.bind_network is not None:
@@ -191,6 +200,12 @@ def merge_validator_config(configs):
             state_pruning_block_depth = config.state_pruning_block_depth
         if config.fork_cache_keep_time is not None:
             fork_cache_keep_time = config.fork_cache_keep_time
+        if config.component_thread_pool_workers is not None:
+            component_thread_pool_workers = \
+                config.component_thread_pool_workers
+        if config.network_thread_pool_workers is not None:
+            network_thread_pool_workers = \
+                config.network_thread_pool_workers
 
     return ValidatorConfig(
         bind_network=bind_network,
@@ -213,6 +228,8 @@ def merge_validator_config(configs):
         maximum_peer_connectivity=maximum_peer_connectivity,
         state_pruning_block_depth=state_pruning_block_depth,
         fork_cache_keep_time=fork_cache_keep_time,
+        component_thread_pool_workers=component_thread_pool_workers,
+        network_thread_pool_workers=network_thread_pool_workers
     )
 
 
@@ -264,7 +281,9 @@ class ValidatorConfig:
                  minimum_peer_connectivity=None,
                  maximum_peer_connectivity=None,
                  state_pruning_block_depth=None,
-                 fork_cache_keep_time=None):
+                 fork_cache_keep_time=None,
+                 component_thread_pool_workers=None,
+                 network_thread_pool_workers=None):
 
         self._bind_network = bind_network
         self._bind_component = bind_component
@@ -286,6 +305,8 @@ class ValidatorConfig:
         self._maximum_peer_connectivity = maximum_peer_connectivity
         self._state_pruning_block_depth = state_pruning_block_depth
         self._fork_cache_keep_time = fork_cache_keep_time
+        self._component_thread_pool_workers = component_thread_pool_workers
+        self._network_thread_pool_workers = network_thread_pool_workers
 
     @property
     def bind_network(self):
@@ -367,6 +388,14 @@ class ValidatorConfig:
     def fork_cache_keep_time(self):
         return self._fork_cache_keep_time
 
+    @property
+    def component_thread_pool_workers(self):
+        return self._component_thread_pool_workers
+
+    @property
+    def network_thread_pool_workers(self):
+        return self._network_thread_pool_workers
+
     def __repr__(self):
         # not including  password for opentsdb
         return (
@@ -378,6 +407,8 @@ class ValidatorConfig:
             "minimum_peer_connectivity={}, maximum_peer_connectivity={}, "
             "state_pruning_block_depth={}, "
             "fork_cache_keep_time={})"
+            "component_thread_pool_workers={}, "
+            "network_thread_pool_workers={})"
         ).format(
             self.__class__.__name__,
             repr(self._bind_network),
@@ -399,6 +430,8 @@ class ValidatorConfig:
             repr(self._maximum_peer_connectivity),
             repr(self._state_pruning_block_depth),
             repr(self._fork_cache_keep_time),
+            repr(self._component_thread_pool_workers),
+            repr(self._network_thread_pool_workers)
         )
 
     def to_dict(self):
@@ -422,7 +455,10 @@ class ValidatorConfig:
             ('minimum_peer_connectivity', self._minimum_peer_connectivity),
             ('maximum_peer_connectivity', self._maximum_peer_connectivity),
             ('state_pruning_block_depth', self._state_pruning_block_depth),
-            ('fork_cache_keep_time', self._fork_cache_keep_time)
+            ('fork_cache_keep_time', self._fork_cache_keep_time),
+            ('component_thread_pool_workers',
+                self._component_thread_pool_workers),
+            ('network_thread_pool_workers', self._network_thread_pool_workers)
         ])
 
     def to_toml_string(self):

--- a/validator/sawtooth_validator/config/validator.py
+++ b/validator/sawtooth_validator/config/validator.py
@@ -40,7 +40,8 @@ def load_default_validator_config():
         state_pruning_block_depth=100,
         fork_cache_keep_time=300,
         component_thread_pool_workers=10,
-        network_thread_pool_workers=10
+        network_thread_pool_workers=10,
+        signature_thread_pool_workers=3
     )
 
 
@@ -71,7 +72,8 @@ def load_toml_validator_config(filename):
          'opentsdb_password', 'minimum_peer_connectivity',
          'maximum_peer_connectivity', 'state_pruning_block_depth',
          'fork_cache_keep_time',
-         'component_thread_pool_workers', 'network_thread_pool_workers'])
+         'component_thread_pool_workers', 'network_thread_pool_workers',
+         'signature_thread_pool_workers'])
     if invalid_keys:
         raise LocalConfigurationError(
             "Invalid keys in validator config: "
@@ -124,7 +126,9 @@ def load_toml_validator_config(filename):
         component_thread_pool_workers=toml_config.get(
             "component_thread_pool_workers", None),
         network_thread_pool_workers=toml_config.get(
-            "network_thread_pool_workers", None)
+            "network_thread_pool_workers", None),
+        signature_thread_pool_workers=toml_config.get(
+            "signature_thread_pool_workers", None)
     )
 
     return config
@@ -158,6 +162,7 @@ def merge_validator_config(configs):
     fork_cache_keep_time = None
     component_thread_pool_workers = None
     network_thread_pool_workers = None
+    signature_thread_pool_workers = None
 
     for config in reversed(configs):
         if config.bind_network is not None:
@@ -206,6 +211,9 @@ def merge_validator_config(configs):
         if config.network_thread_pool_workers is not None:
             network_thread_pool_workers = \
                 config.network_thread_pool_workers
+        if config.signature_thread_pool_workers is not None:
+            signature_thread_pool_workers = \
+                config.signature_thread_pool_workers
 
     return ValidatorConfig(
         bind_network=bind_network,
@@ -229,7 +237,8 @@ def merge_validator_config(configs):
         state_pruning_block_depth=state_pruning_block_depth,
         fork_cache_keep_time=fork_cache_keep_time,
         component_thread_pool_workers=component_thread_pool_workers,
-        network_thread_pool_workers=network_thread_pool_workers
+        network_thread_pool_workers=network_thread_pool_workers,
+        signature_thread_pool_workers=signature_thread_pool_workers
     )
 
 
@@ -283,7 +292,8 @@ class ValidatorConfig:
                  state_pruning_block_depth=None,
                  fork_cache_keep_time=None,
                  component_thread_pool_workers=None,
-                 network_thread_pool_workers=None):
+                 network_thread_pool_workers=None,
+                 signature_thread_pool_workers=None):
 
         self._bind_network = bind_network
         self._bind_component = bind_component
@@ -307,6 +317,7 @@ class ValidatorConfig:
         self._fork_cache_keep_time = fork_cache_keep_time
         self._component_thread_pool_workers = component_thread_pool_workers
         self._network_thread_pool_workers = network_thread_pool_workers
+        self._signature_thread_pool_workers = signature_thread_pool_workers
 
     @property
     def bind_network(self):
@@ -396,6 +407,10 @@ class ValidatorConfig:
     def network_thread_pool_workers(self):
         return self._network_thread_pool_workers
 
+    @property
+    def signature_thread_pool_workers(self):
+        return self._signature_thread_pool_workers
+
     def __repr__(self):
         # not including  password for opentsdb
         return (
@@ -408,7 +423,8 @@ class ValidatorConfig:
             "state_pruning_block_depth={}, "
             "fork_cache_keep_time={})"
             "component_thread_pool_workers={}, "
-            "network_thread_pool_workers={})"
+            "network_thread_pool_workers={}, "
+            "signature_thread_pool_workers={})"
         ).format(
             self.__class__.__name__,
             repr(self._bind_network),
@@ -431,7 +447,8 @@ class ValidatorConfig:
             repr(self._state_pruning_block_depth),
             repr(self._fork_cache_keep_time),
             repr(self._component_thread_pool_workers),
-            repr(self._network_thread_pool_workers)
+            repr(self._network_thread_pool_workers),
+            repr(self._signature_thread_pool_workers)
         )
 
     def to_dict(self):
@@ -458,7 +475,9 @@ class ValidatorConfig:
             ('fork_cache_keep_time', self._fork_cache_keep_time),
             ('component_thread_pool_workers',
                 self._component_thread_pool_workers),
-            ('network_thread_pool_workers', self._network_thread_pool_workers)
+            ('network_thread_pool_workers', self._network_thread_pool_workers),
+            ('network_thread_pool_workers',
+                self._signature_thread_pool_workers)
         ])
 
     def to_toml_string(self):

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -258,6 +258,7 @@ def main(args):
 
     component_workers = validator_config.component_thread_pool_workers
     network_workers = validator_config.network_thread_pool_workers
+    sig_workers = validator_config.signature_thread_pool_workers
     validator = Validator(
         bind_network,
         bind_component,
@@ -279,7 +280,8 @@ def main(args):
         validator_config.network_private_key,
         roles=validator_config.roles,
         component_thread_pool_workers=component_workers,
-        network_thread_pool_workers=network_workers)
+        network_thread_pool_workers=network_workers,
+        signature_thread_pool_workers=sig_workers)
 
     # pylint: disable=broad-except
     try:

--- a/validator/sawtooth_validator/server/cli.py
+++ b/validator/sawtooth_validator/server/cli.py
@@ -256,6 +256,8 @@ def main(args):
         'Starting validator with %s scheduler',
         validator_config.scheduler)
 
+    component_workers = validator_config.component_thread_pool_workers
+    network_workers = validator_config.network_thread_pool_workers
     validator = Validator(
         bind_network,
         bind_component,
@@ -275,7 +277,9 @@ def main(args):
         validator_config.fork_cache_keep_time,
         validator_config.network_public_key,
         validator_config.network_private_key,
-        roles=validator_config.roles)
+        roles=validator_config.roles,
+        component_thread_pool_workers=component_workers,
+        network_thread_pool_workers=network_workers)
 
     # pylint: disable=broad-except
     try:

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -90,7 +90,9 @@ class Validator:
                  fork_cache_keep_time,
                  network_public_key=None,
                  network_private_key=None,
-                 roles=None):
+                 roles=None,
+                 component_thread_pool_workers=10,
+                 network_thread_pool_workers=10):
         """Constructs a validator instance.
 
         Args:
@@ -115,6 +117,10 @@ class Validator:
             config_dir (str): path to the config directory
             identity_signer (str): cryptographic signer the validator uses for
                 signing
+            component_thread_pool_workers (int): number of workers in the
+                component thread pool; defaults to 10.
+            network_thread_pool_workers (int): number of workers in the network
+                thread pool; defaults to 10.
         """
         # -- Setup Global State Database and Factory -- #
         global_state_db_filename = os.path.join(
@@ -153,10 +159,10 @@ class Validator:
 
         # -- Setup Thread Pools -- #
         component_thread_pool = InstrumentedThreadPoolExecutor(
-            max_workers=10,
+            max_workers=component_thread_pool_workers,
             name='Component')
         network_thread_pool = InstrumentedThreadPoolExecutor(
-            max_workers=10,
+            max_workers=network_thread_pool_workers,
             name='Network')
         client_thread_pool = InstrumentedThreadPoolExecutor(
             max_workers=5,

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -92,7 +92,8 @@ class Validator:
                  network_private_key=None,
                  roles=None,
                  component_thread_pool_workers=10,
-                 network_thread_pool_workers=10):
+                 network_thread_pool_workers=10,
+                 signature_thread_pool_workers=3):
         """Constructs a validator instance.
 
         Args:
@@ -121,6 +122,8 @@ class Validator:
                 component thread pool; defaults to 10.
             network_thread_pool_workers (int): number of workers in the network
                 thread pool; defaults to 10.
+            signature_thread_pool_workers (int): number of workers in the
+                signature thread pool; defaults to 3.
         """
         # -- Setup Global State Database and Factory -- #
         global_state_db_filename = os.path.join(
@@ -168,7 +171,7 @@ class Validator:
             max_workers=5,
             name='Client')
         sig_pool = InstrumentedThreadPoolExecutor(
-            max_workers=3,
+            max_workers=signature_thread_pool_workers,
             name='Signature')
 
         # -- Setup Dispatchers -- #


### PR DESCRIPTION
This PR adds configuration settings for the validator's network, component, and signature thread pool max workers.  This allows for easier tuning of these settings during performance testing, without having to run custom builds of the validator.

Note: These settings are config file only.