### PR TITLE
Retitle and move Architecture guide; add intro

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -14,11 +14,11 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("introduction") }}">{% trans %}Introduction{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Hyperledger Sawtooth{% endtrans %}</span></p>
 
-  <p class="biglink"><a class="biglink" href="{{ pathto("architecture") }}">{% trans %}Architecture{% endtrans %}</a><br/>
-    <span class="linkdescr">{% trans %}read high-level architecture and design topics{% endtrans %}</span></p>
-
   <p class="biglink"><a class="biglink" href="{{ pathto("app_developers_guide") }}">{% trans %}Application Developer's Guide{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}create applications using the Sawtooth platform{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("architecture") }}">{% trans %}Architecture Guide{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}read high-level architecture and design topics{% endtrans %}</span></p>
 
   <p class="biglink"><a class="biglink" href="{{ pathto("transaction_family_specifications") }}">{% trans %}Transaction Family Specifications{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}dive into the design of existing transaction families{% endtrans %}</span></p>

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -5,6 +5,15 @@ Architecture Guide
 
 The following diagram shows a high-level view of the Sawtooth architecture.
 
+This guide describes the design and architecture of Hyperledger Sawtooth,
+an enterprise blockchain platform for building distributed ledger applications
+and networks.
+
+This guide starts by explaining the important concepts of :term:`global state`
+and :term:`Sawtooth batches<Batch>`. Next, it describes key parts of the
+:term:`validator` and other core features, including the journal for block
+management, consensus, transaction scheduling, permissioning, and more.
+
 .. figure:: images/arch-sawtooth-overview.*
    :width: 100%
    :align: center

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -18,11 +18,11 @@ The following diagram shows a high-level view of the Sawtooth architecture.
    architecture/journal
    architecture/scheduling
    architecture/rest_api
-   architecture/poet
    architecture/validator_network
    architecture/permissioning_requirement
    architecture/injecting_batches_block_validation_rules
    architecture/events_and_transactions_receipts
+   architecture/poet
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -1,7 +1,7 @@
 
-************
-Architecture
-************
+******************
+Architecture Guide
+******************
 
 The following diagram shows a high-level view of the Sawtooth architecture.
 

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -5,8 +5,8 @@ Table of Contents
 .. toctree::
 
    introduction.rst
-   architecture.rst
    app_developers_guide.rst
+   architecture.rst
    transaction_family_specifications.rst
    sysadmin_guide.rst
    api_references.rst

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -270,7 +270,8 @@ Participating in Core Development
 Learn about Sawtooth Architecture
 ---------------------------------
 
-See :doc:`/architecture` for information on :term:`Sawtooth core` features such
+See the :doc:`/architecture` for information on :term:`Sawtooth core`
+features such
 as :term:`global state<Global state>`, transactions and :term:`batches<Batch>`
 (the atomic unit of state change in Sawtooth), permissioning, the validator
 network, the event system, and more.


### PR DESCRIPTION
- New title: Architecture Guide
- Move to after the Application Developer's Guide
- Add basic intro text (more in a later PR)
- Move the PoET architecture chapter to the end (for now; it may move elsewhere soon)