### PR TITLE
Integrate BlockManager in BlockPublisher

### DIFF
--- a/families/block_info/sawtooth_block_info/injector.py
+++ b/families/block_info/sawtooth_block_info/injector.py
@@ -21,6 +21,7 @@ from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
 from sawtooth_validator.protobuf.transaction_pb2 import Transaction
 from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 from sawtooth_validator.protobuf.batch_pb2 import Batch
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 
 from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfoTxn
 from sawtooth_block_info.protobuf.block_info_pb2 import BlockInfo
@@ -78,12 +79,15 @@ class BlockInfoInjector(BatchInjector):
         block. Can also return None if no batches should be injected.
 
         Args:
-            previous_block_id (str): The signature of the previous block.
+            previous_block (Block): The previous block.
 
         Returns:
             A list of batches to inject.
         """
-        previous_header = previous_block.header
+
+        previous_header_bytes = previous_block.header
+        previous_header = BlockHeader()
+        previous_header.ParseFromString(previous_header_bytes)
 
         block_info = BlockInfo(
             block_num=previous_header.block_num,

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -15,6 +15,7 @@ cbor-codec = "0.7"
 protobuf = "2.0"
 python3-sys = "0.2"
 rust-crypto = "0.2"
+uluru = "0.2.0"
 
 [dev-dependencies]
 rand = "0.4"

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -29,6 +29,7 @@ from sawtooth_validator.networking.dispatch import HandlerStatus
 
 from sawtooth_validator.journal.block_wrapper import BlockStatus
 
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.consensus_pb2 import ConsensusSettingsEntry
 from sawtooth_validator.protobuf.consensus_pb2 import ConsensusStateEntry
 
@@ -122,13 +123,18 @@ class ConsensusRegisterHandler(ConsensusServiceHandler):
         peers = [bytes.fromhex(peer_id) for peer_id in startup_info.peers]
         local_peer_info = startup_info.local_peer_info
 
-        response.chain_head.block_id = bytes.fromhex(chain_head.identifier)
+        block_header = BlockHeader()
+        block_header.ParseFromString(chain_head.header)
+
+        response.chain_head.block_id = bytes.fromhex(
+            chain_head.header_signature)
+
         response.chain_head.previous_id =\
-            bytes.fromhex(chain_head.previous_block_id)
+            bytes.fromhex(block_header.previous_block_id)
         response.chain_head.signer_id =\
-            bytes.fromhex(chain_head.signer_public_key)
-        response.chain_head.block_num = chain_head.block_num
-        response.chain_head.payload = chain_head.consensus
+            bytes.fromhex(block_header.signer_public_key)
+        response.chain_head.block_num = block_header.block_num
+        response.chain_head.payload = block_header.consensus
 
         response.peers.extend([
             consensus_pb2.ConsensusPeerInfo(peer_id=peer_id)
@@ -407,15 +413,18 @@ class ConsensusBlocksGetHandler(ConsensusServiceHandler):
 
     def handle_request(self, request, response):
         try:
-            response.blocks.extend([
-                consensus_pb2.ConsensusBlock(
-                    block_id=bytes.fromhex(block.identifier),
-                    previous_id=bytes.fromhex(block.previous_block_id),
-                    signer_id=bytes.fromhex(block.signer_public_key),
-                    block_num=block.block_num,
-                    payload=block.consensus)
-                for block in self._proxy.blocks_get(request.block_ids)
-            ])
+            blocks = []
+            for block in self._proxy.blocks_get(request.block_ids):
+                block_header = BlockHeader()
+                block_header.ParseFromString(block.header)
+
+                blocks.append(consensus_pb2.ConsensusBlock(
+                    block_id=bytes.fromhex(block.header_signature),
+                    previous_id=bytes.fromhex(block_header.previous_block_id),
+                    signer_id=bytes.fromhex(block_header.signer_public_key),
+                    block_num=block_header.block_num,
+                    payload=block_header.consensus))
+            response.blocks.extend(blocks)
         except UnknownBlock:
             response.status =\
                 consensus_pb2.ConsensusBlocksGetResponse.UNKNOWN_BLOCK
@@ -438,13 +447,18 @@ class ConsensusChainHeadGetHandler(ConsensusServiceHandler):
     def handle_request(self, request, response):
         try:
             chain_head = self._proxy.chain_head_get()
-            response.block.block_id = bytes.fromhex(chain_head.identifier)
+
+            block_header = BlockHeader()
+            block_header.ParseFromString(chain_head.header)
+
+            response.block.block_id = bytes.fromhex(
+                chain_head.header_signature)
             response.block.previous_id =\
-                bytes.fromhex(chain_head.previous_block_id)
+                bytes.fromhex(block_header.previous_block_id)
             response.block.signer_id =\
-                bytes.fromhex(chain_head.signer_public_key)
-            response.block.block_num = chain_head.block_num
-            response.block.payload = chain_head.consensus
+                bytes.fromhex(block_header.signer_public_key)
+            response.block.block_num = block_header.block_num
+            response.block.payload = block_header.consensus
         except UnknownBlock:
             response.status =\
                 consensus_pb2.ConsensusChainHeadGetResponse.NO_CHAIN_HEAD

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+
 from collections import namedtuple
+
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 
 
 class UnknownBlock(Exception):
@@ -29,10 +32,10 @@ class ConsensusProxy:
     """Receives requests from the consensus engine handlers and delegates them
     to the appropriate components."""
 
-    def __init__(self, block_cache, block_publisher,
+    def __init__(self, block_manager, block_publisher,
                  chain_controller, gossip, identity_signer,
                  settings_view_factory, state_view_factory):
-        self._block_cache = block_cache
+        self._block_manager = block_manager
         self._chain_controller = chain_controller
         self._block_publisher = block_publisher
         self._gossip = gossip
@@ -70,8 +73,9 @@ class ConsensusProxy:
     def initialize_block(self, previous_id):
         if previous_id:
             try:
-                previous_block = self._block_cache[previous_id.hex()]
-            except KeyError:
+                previous_block = next(
+                    self._block_manager.get([previous_id.hex()]))
+            except StopIteration:
                 raise UnknownBlock()
             self._block_publisher.initialize_block(previous_block)
         else:
@@ -90,7 +94,7 @@ class ConsensusProxy:
 
     def check_blocks(self, block_ids):
         for block_id in block_ids:
-            if block_id.hex() not in self._block_cache:
+            if block_id.hex() not in self._block_manager:
                 raise UnknownBlock(block_id.hex())
 
     def get_block_statuses(self, block_ids):
@@ -98,7 +102,9 @@ class ConsensusProxy:
         """
         try:
             return [
-                (block_id.hex(), self._block_cache[block_id.hex()].status)
+                (block_id.hex(),
+                 self._chain_controller.block_validation_result(
+                     block_id.hex()))
                 for block_id in block_ids
             ]
         except KeyError as key_error:
@@ -106,29 +112,29 @@ class ConsensusProxy:
 
     def commit_block(self, block_id):
         try:
-            block = self._block_cache[block_id.hex()]
-        except KeyError as key_error:
-            raise UnknownBlock(key_error.args[0])
+            block = next(self._block_manager.get([block_id.hex()]))
+        except StopIteration as stop_iteration:
+            raise UnknownBlock(stop_iteration.args[0])
         self._chain_controller.commit_block(block)
 
     def ignore_block(self, block_id):
         try:
-            block = self._block_cache[block_id.hex()]
-        except KeyError:
+            block = next(self._block_manager.get([block_id.hex()]))
+        except StopIteration:
             raise UnknownBlock()
         self._chain_controller.ignore_block(block)
 
     def fail_block(self, block_id):
         try:
-            block = self._block_cache[block_id.hex()]
-        except KeyError:
+            block = next(self._block_manager.get([block_id.hex()]))
+        except StopIteration:
             raise UnknownBlock()
         self._chain_controller.fail_block(block)
 
     # Using blockstore and state database
     def blocks_get(self, block_ids):
         '''Returns a list of blocks.'''
-        return self._get_blocks(block_ids)
+        return self._get_blocks([block_id.hex() for block_id in block_ids])
 
     def chain_head_get(self):
         '''Returns the chain head.'''
@@ -142,9 +148,14 @@ class ConsensusProxy:
 
     def settings_get(self, block_id, settings):
         '''Returns a list of key/value pairs (str, str).'''
-        settings_view = \
-            self._get_blocks([block_id])[0].get_settings_view(
-                self._settings_view_factory)
+
+        block = self._get_blocks([block_id.hex()])[0]
+
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+
+        settings_view = self._settings_view_factory.create_settings_view(
+            block_header.state_root_hash)
 
         result = []
         for setting in settings:
@@ -160,9 +171,12 @@ class ConsensusProxy:
 
     def state_get(self, block_id, addresses):
         '''Returns a list of address/data pairs (str, bytes)'''
-        state_view = \
-            self._get_blocks([block_id])[0].get_state_view(
-                self._state_view_factory)
+        block = self._get_blocks([block_id.hex()])[0]
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+
+        state_view = self._state_view_factory.create_view(
+            block_header.state_root_hash)
 
         result = []
 
@@ -187,10 +201,9 @@ class ConsensusProxy:
         return result
 
     def _get_blocks(self, block_ids):
-        try:
-            return [
-                self._block_cache[block_id.hex()]
-                for block_id in block_ids
-            ]
-        except KeyError:
-            raise UnknownBlock()
+        block_iter = self._block_manager.get(block_ids)
+        blocks = [b for b in block_iter]
+        if len(blocks) != len(block_ids):
+            return UnknownBlock()
+
+        return blocks

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -43,7 +43,7 @@ class BatchInjector(metaclass=abc.ABCMeta):
         block. Can also return None if no batches should be injected.
 
         Args:
-            previous_block_id (str): The signature of the previous block.
+            previous_block (Block): The previous block.
 
         Returns:
             A list of batches to inject.

--- a/validator/sawtooth_validator/journal/block_manager.py
+++ b/validator/sawtooth_validator/journal/block_manager.py
@@ -139,9 +139,9 @@ class _BlockIterator:
 
         block = ctypes.py_object()
 
-        _pylibexec("{}_next".format(self.name),
-                   self._c_iter_ptr,
-                   ctypes.byref(block))
+        _libexec("{}_next".format(self.name),
+                 self._c_iter_ptr,
+                 ctypes.byref(block))
 
         if block.value is None:
             raise StopIteration()

--- a/validator/sawtooth_validator/journal/block_manager.py
+++ b/validator/sawtooth_validator/journal/block_manager.py
@@ -68,6 +68,13 @@ class BlockManager(OwnedPointer):
                  self.pointer,
                  ctypes.py_object(branch))
 
+    def __contains__(self, item):
+        try:
+            next(self.get([item]))
+            return True
+        except StopIteration:
+            return False
+
     def get(self, block_ids):
         return _GetBlockIterator(self.pointer, block_ids)
 

--- a/validator/sawtooth_validator/journal/block_manager.py
+++ b/validator/sawtooth_validator/journal/block_manager.py
@@ -43,7 +43,7 @@ class ErrorCode(IntEnum):
     MissingPredecessorInBranch = 0x03
     MissingInput = 0x04
     UnknownBlock = 0x05
-    InvalidBlockStoreName = 0x06
+    InvalidInputString = 0x06
     Error = 0x07
     InvalidPythonObject = 0x0F
     StopIteration = 0x11
@@ -67,6 +67,12 @@ class BlockManager(OwnedPointer):
         _libexec("block_manager_put",
                  self.pointer,
                  ctypes.py_object(branch))
+
+    def persist(self, block_id, store_name):
+        _libexec("block_manager_persist",
+                 self.pointer,
+                 ctypes.c_char_p(block_id.encode()),
+                 ctypes.c_char_p(store_name.encode()))
 
     def __contains__(self, block_id):
         try:
@@ -112,7 +118,7 @@ def _exec(library, name, *args):
         raise MissingInput("Missing input to put method")
     elif res == ErrorCode.UnknownBlock:
         raise UnknownBlock("Block was unknown")
-    elif res == ErrorCode.InvalidBlockStoreName:
+    elif res == ErrorCode.InvalidInputString:
         raise TypeError("Invalid block store name provided")
     else:
         raise Exception("There was an unknown error: {}".format(res))

--- a/validator/sawtooth_validator/journal/block_manager.py
+++ b/validator/sawtooth_validator/journal/block_manager.py
@@ -68,9 +68,11 @@ class BlockManager(OwnedPointer):
                  self.pointer,
                  ctypes.py_object(branch))
 
-    def __contains__(self, item):
+    def __contains__(self, block_id):
         try:
-            next(self.get([item]))
+            # if StopIteration isn't raised the block
+            # associated with block_id is in the block_manager
+            next(self.get([block_id]))
             return True
         except StopIteration:
             return False

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -115,9 +115,13 @@ class BlockStore(MutableMapping):
         :return:
         None
         """
-        add_pairs = [(blkw.header_signature, blkw) for blkw in new_chain]
+
+        new_chain = [BlockWrapper.wrap(b) for b in new_chain]
         if old_chain:
-            del_keys = [blkw.header_signature for blkw in old_chain]
+            old_chain = [BlockWrapper.wrap(b) for b in old_chain]
+        add_pairs = [(blkw.identifier, blkw) for blkw in new_chain]
+        if old_chain:
+            del_keys = [blkw.identifier for blkw in old_chain]
         else:
             del_keys = []
 

--- a/validator/sawtooth_validator/journal/block_validator.py
+++ b/validator/sawtooth_validator/journal/block_validator.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# pylint: disable=inconsistent-return-statements
+
+import collections
 import logging
 from threading import RLock
 
@@ -30,6 +33,7 @@ from sawtooth_validator.journal.validation_rule_enforcer import \
 from sawtooth_validator.state.settings_view import SettingsViewFactory
 from sawtooth_validator import metrics
 
+from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 
 
@@ -70,13 +74,21 @@ def look_ahead(iterable):
     yield last, False
 
 
+BlockValidationResult = collections.namedtuple("BlockValidationResult",
+                                               ["execution_results",
+                                                "block_id",
+                                                "num_transactions",
+                                                "status"])
+
+
 class BlockValidator:
     """
     Responsible for validating a block.
     """
 
     def __init__(self,
-                 block_cache,
+                 block_manager,
+                 block_store,
                  state_view_factory,
                  transaction_executor,
                  identity_signer,
@@ -86,8 +98,8 @@ class BlockValidator:
                  thread_pool=None):
         """Initialize the BlockValidator
         Args:
-            block_cache: The cache of all recent blocks and the processing
-                state associated with them.
+            block_manager: The component that stores blocks and maintains
+                integrity of the predecessor relationship.
             state_view_factory: A factory that can be used to create read-
                 only views of state for a particular merkle root, in
                 particular the state as it existed when a particular block
@@ -106,7 +118,12 @@ class BlockValidator:
         Returns:
             None
         """
-        self._block_cache = block_cache
+
+        self._block_manager = block_manager
+        self._block_store = block_store
+        self._block_validity_fn = None
+        self._block_validity_cache = _Cache(100)
+        self._block_scheduler = BlockScheduler(self._block_validity_cache)
         self._state_view_factory = state_view_factory
         self._transaction_executor = transaction_executor
         self._identity_signer = identity_signer
@@ -119,18 +136,34 @@ class BlockValidator:
         self._thread_pool = InstrumentedThreadPoolExecutor(1) \
             if thread_pool is None else thread_pool
 
-        self._block_scheduler = BlockScheduler(block_cache)
-
     def stop(self):
         self._thread_pool.shutdown(wait=True)
 
-    def _get_previous_block_state_root(self, blkw):
-        if blkw.previous_block_id == NULL_BLOCK_IDENTIFIER:
+    def set_block_validity_fn(self, func):
+        self._block_validity_fn = func
+        self._block_scheduler.set_block_validity_fn(func=func)
+
+    def _block_validity(self, block_id):
+        validity = self._block_validity_cache.get(block_id)
+        return validity if validity else self._block_validity_fn(block_id)
+
+    def _get_previous_block_state_root(self, block):
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+
+        if block_header.previous_block_id == NULL_BLOCK_IDENTIFIER:
             return INIT_ROOT_KEY
+        try:
+            block = next(
+                self._block_manager.get(
+                    [block_header.previous_block_id]))
+        except StopIteration:
+            return None
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+        return block_header.state_root_hash
 
-        return self._block_cache[blkw.previous_block_id].state_root_hash
-
-    def _validate_batches_in_block(self, blkw, prev_state_root):
+    def _validate_batches_in_block(self, block, prev_state_root):
         """
         Validate all batches in the block. This includes:
             - Validating all transaction dependencies are met
@@ -139,7 +172,7 @@ class BlockValidator:
               correct state root hash
 
         Args:
-            blkw: the block of batches to validate
+            block: the block of batches to validate
             prev_state_root: the state root to execute transactions on top of
 
         Raises:
@@ -152,25 +185,28 @@ class BlockValidator:
             DuplicateBatch:
                 Validation failed because of a duplicate batch.
         """
-        if not blkw.block.batches:
+        if not block.batches:
             return
 
         scheduler = None
         try:
             while True:
                 try:
-                    chain_head = self._block_cache.block_store.chain_head
+                    chain_head = self._block_store.chain_head
+
+                    block_header = BlockHeader()
+                    block_header.ParseFromString(block.header)
 
                     chain_commit_state = ChainCommitState(
-                        blkw.previous_block_id,
-                        self._block_cache,
-                        self._block_cache.block_store)
+                        block_header.previous_block_id,
+                        self._block_manager,
+                        self._block_store)
 
                     chain_commit_state.check_for_duplicate_batches(
-                        blkw.block.batches)
+                        block.batches)
 
                     transactions = []
-                    for batch in blkw.block.batches:
+                    for batch in block.batches:
                         transactions.extend(batch.transactions)
 
                     chain_commit_state.check_for_duplicate_transactions(
@@ -179,24 +215,25 @@ class BlockValidator:
                     chain_commit_state.check_for_transaction_dependencies(
                         transactions)
 
-                    if not self._check_chain_head_updated(chain_head, blkw):
+                    if not self._check_chain_head_updated(chain_head, block):
                         break
 
                 except (DuplicateBatch,
                         DuplicateTransaction,
                         MissingDependency) as err:
-                    if not self._check_chain_head_updated(chain_head, blkw):
+                    if not self._check_chain_head_updated(chain_head, block):
                         raise BlockValidationFailure(
-                            "Block {} failed validation: {}".format(blkw, err))
+                            "Block {} failed validation: {}".format(
+                                block.header_signature, err))
 
             scheduler = self._transaction_executor.create_scheduler(
                 prev_state_root)
 
-            for batch, has_more in look_ahead(blkw.block.batches):
+            for batch, has_more in look_ahead(block.batches):
                 if has_more:
                     scheduler.add_batch(batch)
                 else:
-                    scheduler.add_batch(batch, blkw.state_root_hash)
+                    scheduler.add_batch(batch, block_header.state_root_hash)
 
         except Exception:
             if scheduler is not None:
@@ -207,26 +244,33 @@ class BlockValidator:
         scheduler.complete(block=True)
         state_hash = None
 
-        for batch in blkw.batches:
+        execution_results = []
+        num_transactions = 0
+
+        for batch in block.batches:
             batch_result = scheduler.get_batch_execution_result(
                 batch.header_signature)
             if batch_result is not None and batch_result.is_valid:
                 txn_results = \
                     scheduler.get_transaction_execution_results(
                         batch.header_signature)
-                blkw.execution_results.extend(txn_results)
+                execution_results.extend(txn_results)
                 state_hash = batch_result.state_hash
-                blkw.num_transactions += len(batch.transactions)
+                num_transactions += len(batch.transactions)
             else:
                 raise BlockValidationFailure(
                     "Block {} failed validation: Invalid batch "
-                    "{}".format(blkw, batch))
+                    "{}".format(block.header_signature, batch))
 
-        if blkw.state_root_hash != state_hash:
+        if block_header.state_root_hash != state_hash:
             raise BlockValidationFailure(
                 "Block {} failed state root hash validation. Expected {}"
                 " but got {}".format(
-                    blkw, blkw.state_root_hash, state_hash))
+                    block.header_signature,
+                    block_header.state_root_hash,
+                    state_hash))
+
+        return execution_results, num_transactions
 
     def _check_chain_head_updated(self, chain_head, block):
         # The validity of blocks depends partially on whether or not
@@ -240,8 +284,8 @@ class BlockValidator:
         if chain_head is None:
             return False
 
-        current_chain_head = self._block_cache.block_store.chain_head
-        if chain_head.identifier != current_chain_head.identifier:
+        current_chain_head = self._block_store.chain_head
+        if chain_head.header_signature != current_chain_head.header_signature:
             LOGGER.warning(
                 "Chain head updated from %s to %s while checking "
                 "duplicates and dependencies in block %s. "
@@ -251,83 +295,98 @@ class BlockValidator:
 
         return False
 
-    def _validate_permissions(self, blkw, prev_state_root):
+    def _validate_permissions(self, block, prev_state_root):
         """
         Validate that all of the batch signers and transaction signer for the
         batches in the block are permitted by the transactor permissioning
         roles stored in state as of the previous block. If a transactor is
         found to not be permitted, the block is invalid.
         """
-        if blkw.block_num != 0:
-            for batch in blkw.batches:
+
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+
+        if block_header.block_num != 0:
+            for batch in block.batches:
                 if not self._permission_verifier.is_batch_signer_authorized(
                         batch, prev_state_root, from_state=True):
                     return False
         return True
 
-    def _validate_on_chain_rules(self, blkw, prev_state_root):
+    def _validate_on_chain_rules(self, block, prev_state_root):
         """
         Validate that the block conforms to all validation rules stored in
         state. If the block breaks any of the stored rules, the block is
         invalid.
         """
-        if blkw.block_num != 0:
+
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
+
+        if block_header.block_num != 0:
             return enforce_validation_rules(
                 self._settings_view_factory.create_settings_view(
                     prev_state_root),
-                blkw.header.signer_public_key,
-                blkw.batches)
+                block_header.signer_public_key,
+                block.batches)
         return True
 
-    def validate_block(self, blkw):
-        if blkw.status == BlockStatus.Valid:
-            return
-        if blkw.status == BlockStatus.Invalid:
-            raise BlockValidationFailure(
-                'Block {} is already invalid'.format(blkw))
+    def validate_block(self, block):
+
+        block_header = BlockHeader()
+        block_header.ParseFromString(block.header)
 
         # pylint: disable=broad-except
         try:
             try:
-                prev_block = self._block_cache[blkw.previous_block_id]
-            except KeyError:
-                prev_block = None
+                prev_block = next(
+                    self._block_manager.get([block_header.previous_block_id]))
+            except StopIteration:
+                pass
             else:
-                if prev_block.status == BlockStatus.Invalid:
+                if self._block_validity(prev_block.header_signature) == \
+                        BlockStatus.Invalid:
                     raise BlockValidationFailure(
                         "Block {} rejected due to invalid predecessor"
-                        " {}".format(blkw, prev_block))
-                elif prev_block.status == BlockStatus.Unknown:
+                        " {}".format(block.header_signature,
+                                     prev_block.header_signature))
+                elif self._block_validity(prev_block.header_signature) == \
+                        BlockStatus.Unknown:
                     raise BlockValidationError(
                         "Attempted to validate block {} before its predecessor"
-                        " {}".format(blkw, prev_block))
+                        " {}".format(block.header_signature,
+                                     prev_block.header_signature))
 
             try:
-                prev_state_root = self._get_previous_block_state_root(blkw)
+                prev_state_root = self._get_previous_block_state_root(block)
             except KeyError:
                 raise BlockValidationError(
                     'Block {} rejected due to missing predecessor'.format(
-                        blkw))
+                        block.header_signature))
 
-            if not self._validate_permissions(blkw, prev_state_root):
+            if not self._validate_permissions(block, prev_state_root):
                 raise BlockValidationFailure(
-                    'Block {} failed permission validation'.format(blkw))
+                    'Block {} failed permission validation'.format(
+                        block.header_signature))
 
-            if not self._validate_on_chain_rules(blkw, prev_state_root):
+            if not self._validate_on_chain_rules(block, prev_state_root):
                 raise BlockValidationFailure(
                     'Block {} failed on-chain validation rules'.format(
-                        blkw))
+                        block))
 
-            self._validate_batches_in_block(blkw, prev_state_root)
+            execution_results, num_txns = \
+                self._validate_batches_in_block(block, prev_state_root)
 
-            blkw.status = BlockStatus.Valid
+            return BlockValidationResult(
+                execution_results=execution_results,
+                block_id=block.header_signature,
+                num_transactions=num_txns,
+                status=BlockStatus.Valid)
 
         except BlockValidationFailure as err:
-            blkw.status = BlockStatus.Invalid
             raise err
 
         except BlockValidationError as err:
-            blkw.status = BlockStatus.Unknown
             raise err
 
         except Exception as e:
@@ -336,10 +395,6 @@ class BlockValidator:
             raise e
 
     def submit_blocks_for_verification(self, blocks, callback):
-        # This is a work-around for the fact that the blocks passed to this
-        # function are both from the ChainController (in Rust) or itself.
-        # This ensures that the blocks being operated on come from the cache
-        blocks = [self._block_cache[b.identifier] for b in blocks]
         ready = self._block_scheduler.schedule(blocks)
         for block in ready:
             # Schedule the block for processing
@@ -352,37 +407,30 @@ class BlockValidator:
         in the process.
         """
         ready = []
-        if block.status == BlockStatus.Valid:
+        block_id = block.header_signature
+        if self._block_validity(block_id) == BlockStatus.Valid:
             ready.extend(self._block_scheduler.done(block))
 
-        elif block.status == BlockStatus.Invalid:
+        elif self._block_validity(block_id) == BlockStatus.Invalid:
             # Mark all pending blocks as invalid
             invalid = self._block_scheduler.done(block, and_descendants=True)
             for blk in invalid:
                 blk.status = BlockStatus.Invalid
-                LOGGER.debug('Marking descendant block invalid: %s', blk)
-
-        else:
-            # An error occured during validation, something is wrong internally
-            # and we need to abort validation of this block and all its
-            # children without marking them as invalid.
-            unknown = self._block_scheduler.done(block, and_descendants=True)
-            for blk in unknown:
                 LOGGER.debug(
-                    'Removing block from cache and pending due to error '
-                    'during validation: %s', block)
-                try:
-                    del self._block_cache[block.identifier]
-                except KeyError:
-                    LOGGER.exception(
-                        "Tried to delete a descendant pending block from the"
-                        " block cache because of an error, but the descendant"
-                        " was not in the cache.")
+                    'Marking descendant block invalid: %s',
+                    block.header_signature)
 
         return ready
 
     def has_block(self, block_id):
         return block_id in self._block_scheduler
+
+    def return_block_failure(self, block):
+        return BlockValidationResult(
+            execution_results=[],
+            num_transactions=0,
+            status=BlockStatus.Invalid,
+            block_id=block.header_signature)
 
     def process_block_verification(self, block, callback):
         """
@@ -391,21 +439,36 @@ class BlockValidator:
         be the new head block. Returns the results to the ChainController
         so that the change over can be made if necessary.
         """
+
+        result = None
+
         try:
-            self.validate_block(block)
+            result = self.validate_block(block)
             LOGGER.info(
-                'Block %s passed validation', block)
+                'Block %s passed validation', block.header_signature)
+            self._block_validity_cache.set(
+                block.header_signature,
+                BlockStatus.Valid)
         except BlockValidationFailure as err:
             LOGGER.warning(
-                'Block %s failed validation: %s', block, err)
+                'Block %s failed validation: %s', block.header_signature, err)
+            result = self.return_block_failure(block)
+            self._block_validity_cache.set(
+                block.header_signature,
+                BlockStatus.Invalid)
+
         except BlockValidationError as err:
             LOGGER.error(
-                'Encountered an error while validating %s: %s', block, err)
+                'Encountered an error while validating %s: %s',
+                block.header_signature, err)
+
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception(
-                "Block validation failed with unexpected error: %s", block)
-        else:
-            callback(block)
+                "Block validation failed with unexpected error: %s",
+                block.header_signature)
+
+        if result:
+            callback(result)
 
         try:
             blocks_now_ready = self._release_pending(block)
@@ -418,7 +481,7 @@ class BlockValidator:
 
 class BlockScheduler:
 
-    def __init__(self, block_cache):
+    def __init__(self, block_validity_cache):
         # Blocks that are currently being processed
         self._processing = set()
 
@@ -435,9 +498,17 @@ class BlockScheduler:
             'blocks_pending', instance=self)
         self._pending_gauge.set_value(0)
 
-        self._block_cache = block_cache
-
+        self._block_validity_cache = block_validity_cache
+        self._block_validity_fn = None
         self._lock = RLock()
+
+    def set_block_validity_fn(self, func):
+        self._block_validity_fn = func
+
+    def _block_validity(self, block_id):
+
+        validity = self._block_validity_cache.get(block_id)
+        return validity if validity else self._block_validity_fn(block_id)
 
     def schedule(self, blocks):
         """Add the blocks to the scheduler and return any blocks that are
@@ -447,21 +518,27 @@ class BlockScheduler:
         with self._lock:
             for block in blocks:
                 block_id = block.header_signature
-                prev_id = block.previous_block_id
+                block_header = BlockHeader()
+                block_header.ParseFromString(block.header)
+
+                prev_id = block_header.previous_block_id
 
                 if block_id in self._processing:
-                    LOGGER.debug("Block already in process: %s", block)
+                    LOGGER.debug("Block already in process: %s",
+                                 block.header_signature)
                     continue
 
                 if block_id in self._pending:
-                    LOGGER.debug("Block already pending: %s", block)
+                    LOGGER.debug("Block already pending: %s",
+                                 block.header_signature)
                     continue
 
                 if prev_id in self._processing:
                     LOGGER.debug(
                         "Previous block '%s' in process, adding '%s' to "
                         " pending",
-                        block.previous_block_id, block)
+                        block_header.previous_block_id,
+                        block.header_signature)
                     self._add_block_to_pending(block)
                     continue
 
@@ -469,35 +546,24 @@ class BlockScheduler:
                     LOGGER.debug(
                         "Previous block '%s' is pending, adding '%s' to "
                         " pending",
-                        block.previous_block_id, block)
+                        block_header.previous_block_id, block)
                     self._add_block_to_pending(block)
                     continue
 
-                try:
-                    prev_block = self._block_cache[block.previous_block_id]
-                except KeyError:
-                    LOGGER.error(
-                        "Block %s submitted for processing but predecessor %s"
-                        " is missing. Adding to pending.",
-                        block,
-                        block.previous_block_id)
+                if self._block_validity(prev_id) == BlockStatus.Unknown:
+                    LOGGER.warning(
+                        "Block %s submitted for processing but predecessor"
+                        " %s has not been validated and is not pending."
+                        " Adding to pending.", block, prev_id)
                     self._add_block_to_pending(block)
-                    continue
                 else:
-                    if prev_block.status == BlockStatus.Unknown:
-                        LOGGER.warning(
-                            "Block %s submitted for processing but predecessor"
-                            " %s has not been validated and is not pending."
-                            " Adding to pending.", block, prev_block)
-                        self._add_block_to_pending(block)
-                    else:
-                        LOGGER.debug(
-                            "Adding block %s for processing",
-                            block.identifier)
+                    LOGGER.debug(
+                        "Adding block %s for processing",
+                        block.header_signature)
 
-                        # Add the block to the set of blocks being processed
-                        self._processing.add(block.identifier)
-                        ready.append(block)
+                    # Add the block to the set of blocks being processed
+                    self._processing.add(block.header_signature)
+                    ready.append(block)
 
         self._update_gauges()
 
@@ -549,8 +615,10 @@ class BlockScheduler:
 
     def _add_block_to_pending(self, block):
         with self._lock:
-            self._pending.add(block.identifier)
-            previous = block.previous_block_id
+            self._pending.add(block.header_signature)
+            block_header = BlockHeader()
+            block_header.ParseFromString(block.header)
+            previous = block_header.previous_block_id
             if previous not in self._descendants:
                 self._descendants[previous] = [block]
             else:
@@ -560,3 +628,23 @@ class BlockScheduler:
     def _update_gauges(self):
         self._pending_gauge.set_value(len(self._pending))
         self._processing_gauge.set_value(len(self._processing))
+
+
+class _Cache:
+    def __init__(self, capacity):
+        self._capacity = capacity
+        self._cache = collections.OrderedDict()
+        self._lock = RLock()
+
+    def get(self, item):
+        with self._lock:
+            return self._cache.get(item)
+
+    def set(self, item, value):
+        with self._lock:
+            try:
+                self._cache.pop(item)
+            except KeyError:
+                if len(self._cache) >= self._capacity:
+                    self._cache.popitem(last=False)
+            self._cache[item] = value

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -56,8 +56,6 @@ class ChainController(OwnedPointer):
         if observers is None:
             observers = []
 
-        block_validator.set_chain_head_fn(self.chain_head_fn)
-
         _pylibexec(
             'chain_controller_new',
             ctypes.py_object(block_store),

--- a/validator/sawtooth_validator/journal/completer.py
+++ b/validator/sawtooth_validator/journal/completer.py
@@ -296,7 +296,7 @@ class Completer:
                         if self._complete_block(inc_block):
                             self._block_cache[inc_block.header_signature] = \
                                 inc_block
-                            self._on_block_received(inc_block)
+                            self._on_block_received(inc_block.block)
                             to_complete.append(inc_block.header_signature)
                     del self._incomplete_blocks[my_key]
 
@@ -315,7 +315,7 @@ class Completer:
             block = self._complete_block(blkw)
             if block is not None:
                 self._block_cache[block.header_signature] = blkw
-                self._on_block_received(blkw)
+                self._on_block_received(blkw.block)
                 self._process_incomplete_blocks(block.header_signature)
             self._incomplete_blocks_length.set_value(
                 len(self._incomplete_blocks))

--- a/validator/sawtooth_validator/journal/event_extractors.py
+++ b/validator/sawtooth_validator/journal/event_extractors.py
@@ -14,13 +14,16 @@
 # ------------------------------------------------------------------------------
 
 from sawtooth_validator.server.events.extractor import EventExtractor
+from sawtooth_validator.journal import block_wrapper
 from sawtooth_validator.protobuf.events_pb2 import Event
 from sawtooth_validator.protobuf.transaction_receipt_pb2 import StateChangeList
 
 
 class BlockEventExtractor(EventExtractor):
     def __init__(self, block):
-        self._block = block
+        self._block = block_wrapper.BlockWrapper.wrap(
+            block,
+            status=block_wrapper.BlockStatus.Valid)
 
     def _make_event(self):
         block = self._block

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -42,6 +42,7 @@ class GenesisController:
                  context_manager,
                  transaction_executor,
                  completer,
+                 block_manager,
                  block_store,
                  state_view_factory,
                  identity_signer,
@@ -71,6 +72,7 @@ class GenesisController:
         self._context_manager = context_manager
         self._transaction_executor = transaction_executor
         self._completer = completer
+        self._block_manager = block_manager
         self._block_store = block_store
         self._state_view_factory = state_view_factory
         self._identity_signer = identity_signer
@@ -202,6 +204,7 @@ class GenesisController:
 
         self._completer.add_block(block)
         self._block_store.update_chain([blkw])
+        self._block_manager.put([blkw.block])
 
         self._chain_id_manager.save_block_chain_id(block.header_signature)
 

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -203,8 +203,8 @@ class GenesisController:
         LOGGER.info('Genesis block created: %s', blkw)
 
         self._completer.add_block(block)
-        self._block_store.update_chain([blkw])
         self._block_manager.put([blkw.block])
+        self._block_manager.persist(blkw.identifier, "commit_store")
 
         self._chain_id_manager.save_block_chain_id(block.header_signature)
 

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -124,8 +124,8 @@ class BlockPublisher(OwnedPointer):
     """
 
     def __init__(self,
+                 block_manager,
                  transaction_executor,
-                 get_block,
                  batch_committed,
                  transaction_committed,
                  state_view_factory,
@@ -143,9 +143,9 @@ class BlockPublisher(OwnedPointer):
         Initialize the BlockPublisher object
 
         Args:
+            block_manager (:obj:`BlockManager`): A BlockManager instance
             transaction_executor (:obj:`TransactionExecutor`): A
                 TransactionExecutor instance.
-            get_block (fn(block_id) -> Block): A function for getting blocks
             batch_committed (fn(batch_id) -> bool): A function for checking if
                 a batch is committed.
             transaction_committed (fn(transaction_id) -> bool): A function for
@@ -169,8 +169,8 @@ class BlockPublisher(OwnedPointer):
 
         self._to_exception(PY_LIBRARY.call(
             'block_publisher_new',
+            block_manager.pointer,
             ctypes.py_object(transaction_executor),
-            ctypes.py_object(get_block),
             ctypes.py_object(batch_committed),
             ctypes.py_object(transaction_committed),
             ctypes.py_object(state_view_factory),

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -144,10 +144,6 @@ class Validator:
         # The cache keep time for the journal's block cache must be greater
         # than the cache keep time used by the completer.
         base_keep_time = 1200
-        block_cache = BlockCache(
-            block_store,
-            keep_time=int(base_keep_time * 9 / 8),
-            purge_frequency=30)
 
         block_manager = BlockManager()
 
@@ -302,8 +298,8 @@ class Validator:
             signer=identity_signer)
 
         block_publisher = BlockPublisher(
+            block_manager=block_manager,
             transaction_executor=transaction_executor,
-            get_block=lambda block: block_cache[block],
             transaction_committed=block_store.has_transaction,
             batch_committed=block_store.has_batch,
             state_view_factory=state_view_factory,

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -146,6 +146,7 @@ class Validator:
         base_keep_time = 1200
 
         block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         # -- Setup Thread Pools -- #
         component_thread_pool = InstrumentedThreadPoolExecutor(

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -338,7 +338,7 @@ impl BlockManagerState {
 /// The BlockManager maintains integrity of all the blocks it contains,
 /// such that for any Block within the BlockManager,
 /// that Block's predecessor is also within the BlockManager.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct BlockManager {
     state: Arc<RwLock<BlockManagerState>>,
 }

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -382,7 +382,7 @@ impl BlockManager {
         ))
     }
 
-    pub fn ref_block(&mut self, tip: &str) -> Result<(), BlockManagerError> {
+    pub fn ref_block(&self, tip: &str) -> Result<(), BlockManagerError> {
         let mut state = self.state
             .write()
             .expect("Unable to obtain write lock; it has been poisoned");
@@ -391,7 +391,7 @@ impl BlockManager {
 
     /// Starting at a tip block, if the tip block's ref-count drops to 0,
     /// remove all blocks until a ref-count of 1 is found.
-    pub fn unref_block(&mut self, tip: &str) -> Result<(), BlockManagerError> {
+    pub fn unref_block(&self, tip: &str) -> Result<(), BlockManagerError> {
         let mut state = self.state
             .write()
             .expect("Unable to obtain write lock; it has been poisoned");
@@ -399,7 +399,7 @@ impl BlockManager {
     }
 
     pub fn add_store(
-        &mut self,
+        &self,
         store_name: &str,
         store: Box<BlockStore>,
     ) -> Result<(), BlockManagerError> {

--- a/validator/src/journal/block_manager_ffi.rs
+++ b/validator/src/journal/block_manager_ffi.rs
@@ -86,10 +86,14 @@ pub unsafe extern "C" fn block_manager_add_store(
         Err(_) => return ErrorCode::InvalidInputString,
     };
 
-    (*(block_manager as *mut BlockManager))
-        .add_store(name, Box::new(py_block_store))
-        .map(|_| ErrorCode::Success)
-        .unwrap_or(ErrorCode::Error)
+    let block_manager = (*(block_manager as *mut BlockManager)).clone();
+
+    py.allow_threads(move || {
+        block_manager
+            .add_store(name, Box::new(py_block_store))
+            .map(|_| ErrorCode::Success)
+            .unwrap_or(ErrorCode::Error)
+    })
 }
 
 #[no_mangle]

--- a/validator/src/journal/block_manager_ffi.rs
+++ b/validator/src/journal/block_manager_ffi.rs
@@ -20,7 +20,9 @@ use std::marker::PhantomData;
 use std::os::raw::{c_char, c_void};
 use std::slice;
 
-use cpython::{FromPyObject, NoArgs, ObjectProtocol, PyList, PyObject, Python, ToPyObject};
+use cpython::{
+    FromPyObject, NoArgs, ObjectProtocol, PyClone, PyList, PyObject, Python, ToPyObject,
+};
 use py_ffi;
 use pylogger;
 
@@ -380,6 +382,16 @@ impl BlockStore for PyBlockStore {
     }
 }
 
+impl Clone for PyBlockStore {
+    fn clone(&self) -> Self {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        PyBlockStore {
+            py_block_store: self.py_block_store.clone_ref(py),
+        }
+    }
+}
+
 fn unwrap_block(py: Python, block_wrapper: PyObject) -> PyObject {
     block_wrapper
         .getattr(py, "block")
@@ -441,7 +453,7 @@ mod test {
     use journal::NULL_BLOCK_IDENTIFIER;
     use proto::block::BlockHeader;
 
-    use cpython::{NoArgs, ObjectProtocol, PyObject, Python};
+    use cpython::{NoArgs, ObjectProtocol, PyClone, PyObject, Python};
 
     use protobuf;
     use protobuf::Message;
@@ -459,7 +471,12 @@ mod test {
     #[test]
     fn py_block_store() {
         run_test(|db_path| {
-            let mut store = PyBlockStore::new(create_block_store(db_path));
+            let py_block_store = create_block_store(db_path);
+            let mut store = {
+                let gil_guard = Python::acquire_gil();
+                let py = gil_guard.python();
+                PyBlockStore::new(py_block_store.clone_ref(py))
+            };
 
             let block_a = create_block("A", 1, NULL_BLOCK_IDENTIFIER);
             let block_b = create_block("B", 2, "A");
@@ -479,7 +496,52 @@ mod test {
                 assert_eq!(iterator.next(), None);
             }
 
-            assert_eq!(store.delete(&["C"]).unwrap(), vec![block_c]);
+            assert_eq!(store.delete(&["C"]).unwrap(), vec![block_c.clone()]);
+
+            let chain_head = get_chain_head(&py_block_store);
+
+            assert_eq!(block_b, chain_head);
+        })
+    }
+
+    #[test]
+    fn persist_to_py_block_store() {
+        run_test(|db_path| {
+            let py_block_store = create_block_store(db_path);
+            let mut store = {
+                let gil_guard = Python::acquire_gil();
+                let py = gil_guard.python();
+                PyBlockStore::new(py_block_store.clone_ref(py))
+            };
+
+            let block_manager = BlockManager::new();
+            block_manager.add_store("commit_store", Box::new(store.clone()));
+
+            let block_a = create_block("A", 1, NULL_BLOCK_IDENTIFIER);
+            let block_b = create_block("B", 2, "A");
+            let block_c = create_block("C", 3, "B");
+
+            block_manager
+                .put(vec![block_a.clone(), block_b.clone(), block_c.clone()])
+                .unwrap();
+            block_manager
+                .persist(&block_c.header_signature, "commit_store")
+                .unwrap();
+
+            assert_eq!(store.get(&["A"]).unwrap().next().unwrap(), block_a);
+
+            {
+                let mut iterator = store.iter().unwrap();
+
+                assert_eq!(iterator.next().unwrap(), block_c);
+                assert_eq!(iterator.next().unwrap(), block_b);
+                assert_eq!(iterator.next().unwrap(), block_a);
+                assert_eq!(iterator.next(), None);
+            }
+
+            let chain_head = get_chain_head(&py_block_store);
+
+            assert_eq!(block_c, chain_head);
         })
     }
 
@@ -530,6 +592,19 @@ mod test {
             .unwrap();
 
         block_store.call(py, (db_instance,), None).unwrap()
+    }
+
+    fn get_chain_head(py_block_store: &PyObject) -> Block {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        py_block_store
+            .getattr(py, "chain_head")
+            .map_err(|py_err| py_err.print(py))
+            .unwrap()
+            .getattr(py, "block")
+            .unwrap()
+            .extract(py)
+            .unwrap()
     }
 
     fn run_test<T>(test: T) -> ()

--- a/validator/src/journal/block_store.rs
+++ b/validator/src/journal/block_store.rs
@@ -25,7 +25,7 @@ pub enum BlockStoreError {
     UnknownBlock,
 }
 
-pub trait BlockStore {
+pub trait BlockStore: Sync + Send {
     fn get<'a>(
         &'a self,
         block_ids: &[&str],

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -38,6 +38,8 @@ pub trait BlockValidator: Sync + Send + Clone {
         blocks: &[Block],
         response_sender: Sender<BlockValidationResult>,
     );
+
+    fn process_pending(&self, block: &Block, response_sender: Sender<BlockValidationResult>);
 }
 
 #[derive(Clone, Debug)]

--- a/validator/src/journal/block_wrapper_ffi.rs
+++ b/validator/src/journal/block_wrapper_ffi.rs
@@ -16,25 +16,20 @@
  */
 
 use cpython;
-use cpython::{FromPyObject, ObjectProtocol, PyClone, PyObject, Python, PythonObject, ToPyObject};
+use cpython::{FromPyObject, ObjectProtocol, PyClone, PyObject, Python, ToPyObject};
 
 use journal::block_wrapper::BlockStatus;
 use journal::block_wrapper::BlockWrapper;
 
 use batch::Batch;
-use block::Block;
 use transaction::Transaction;
 
 use protobuf;
-use protobuf::Message;
 
 use proto::batch::Batch as ProtoBatch;
 use proto::batch::BatchHeader;
-use proto::block::Block as ProtoBlock;
-use proto::block::BlockHeader;
 use proto::transaction::Transaction as ProtoTxn;
 use proto::transaction::TransactionHeader;
-use pylogger;
 
 lazy_static! {
     static ref PY_BLOCK_WRAPPER: PyObject = Python::acquire_gil()

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -26,9 +26,9 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha256;
 
 use batch::Batch;
+use block::Block;
 use transaction::Transaction;
 
-use journal::block_wrapper::BlockWrapper;
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::validation_rule_enforcer;
 
@@ -50,7 +50,7 @@ pub struct FinalizeBlockResult {
 }
 
 pub struct CandidateBlock {
-    previous_block: BlockWrapper,
+    previous_block: Block,
     batch_committed: cpython::PyObject,
     transaction_committed: cpython::PyObject,
     scheduler: Box<Scheduler>,
@@ -73,7 +73,7 @@ pub struct CandidateBlock {
 
 impl CandidateBlock {
     pub fn new(
-        previous_block: BlockWrapper,
+        previous_block: Block,
         batch_committed: cpython::PyObject,
         transaction_committed: cpython::PyObject,
         scheduler: Box<Scheduler>,
@@ -108,7 +108,7 @@ impl CandidateBlock {
     }
 
     pub fn previous_block_id(&self) -> String {
-        self.previous_block.header_signature().clone()
+        self.previous_block.header_signature.clone()
     }
 
     pub fn last_batch(&self) -> Option<&Batch> {

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -475,6 +475,11 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
         blocks_considered_count.inc();
 
         self.consensus_notifier.notify_block_new(block);
+
+        match self.notify_block_validation_results_received(&block) {
+            Ok(_) => (),
+            Err(err) => warn!("{:?}", err),
+        }
     }
 
     fn handle_block_commit(&mut self, block: &Block) -> Result<(), ChainControllerError> {
@@ -645,6 +650,19 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
 
         self.block_validator
             .submit_blocks_for_verification(blocks, sender);
+        Ok(())
+    }
+
+    fn notify_block_validation_results_received(
+        &self,
+        block: &Block,
+    ) -> Result<(), ChainControllerError> {
+        let sender = self.validation_result_sender
+            .as_ref()
+            .expect("Unable to ref validation_result_sender")
+            .clone();
+
+        self.block_validator.process_pending(block, sender);
         Ok(())
     }
 

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -122,14 +122,6 @@ pub trait ChainReader: Send + Sync {
     fn get_block_by_block_id(&self, block_id: &str) -> Result<Option<Block>, ChainReadError>;
 }
 
-pub trait ChainWriter: Send + Sync {
-    fn update_chain(
-        &mut self,
-        new_chain: &[Block],
-        old_chain: &[Block],
-    ) -> Result<(), ChainControllerError>;
-}
-
 pub trait ConsensusNotifier: Send + Sync {
     fn notify_block_new(&self, block: &Block);
     fn notify_block_valid(&self, block_id: &str);
@@ -161,7 +153,6 @@ type BlockValidationResultCache =
 struct ChainControllerState {
     block_manager: BlockManager,
     block_validation_results: BlockValidationResultCache,
-    chain_writer: Box<ChainWriter>,
     chain_reader: Box<ChainReader>,
     chain_head: Option<Block>,
     chain_id_manager: ChainIdManager,
@@ -298,7 +289,6 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
     pub fn new(
         block_manager: BlockManager,
         block_validator: BV,
-        chain_writer: Box<ChainWriter>,
         chain_reader: Box<ChainReader>,
         chain_head_lock: ChainHeadLock,
         consensus_notifier: Box<ConsensusNotifier>,
@@ -311,7 +301,6 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
             state: Arc::new(RwLock::new(ChainControllerState {
                 block_manager,
                 block_validation_results: BlockValidationResultCache::default(),
-                chain_writer,
                 chain_reader,
                 chain_id_manager: ChainIdManager::new(data_dir),
                 observers,

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -33,6 +33,7 @@ use std::thread;
 use std::time::Duration;
 
 use protobuf;
+use uluru;
 
 use batch::Batch;
 use block::Block;
@@ -49,6 +50,7 @@ use proto::transaction_receipt::TransactionReceipt;
 use scheduler::TxnExecutionResult;
 
 const RECV_TIMEOUT_MILLIS: u64 = 100;
+const BLOCK_VALIDATION_RESULT_CACHE_SIZE: usize = 512;
 
 lazy_static! {
     static ref COLLECTOR: metrics::MetricsCollectorHandle =
@@ -145,9 +147,12 @@ struct ForkResolutionResult<'a> {
 #[derive(Debug)]
 struct ForkResolutionError(String);
 
+type BlockValidationResultCache =
+    uluru::LRUCache<[uluru::Entry<BlockValidationResult>; BLOCK_VALIDATION_RESULT_CACHE_SIZE]>;
+
 struct ChainControllerState {
     block_manager: BlockManager,
-    block_validation_results: HashMap<String, BlockValidationResult>,
+    block_validation_results: BlockValidationResultCache,
     chain_writer: Box<ChainWriter>,
     chain_reader: Box<ChainReader>,
     chain_head: Option<Block>,
@@ -164,9 +169,9 @@ impl ChainControllerState {
         block_iter.next().map(|b| b.is_some()).unwrap_or(false)
     }
 
-    fn block_validation_result(&self, block_id: &str) -> Option<BlockValidationResult> {
+    fn block_validation_result(&mut self, block_id: &str) -> Option<BlockValidationResult> {
         self.block_validation_results
-            .get(block_id)
+            .find(|result| &result.block_id == block_id)
             .cloned()
             .or_else(|| {
                 if self.chain_reader
@@ -297,7 +302,7 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
         let mut chain_controller = ChainController {
             state: Arc::new(RwLock::new(ChainControllerState {
                 block_manager,
-                block_validation_results: HashMap::new(),
+                block_validation_results: BlockValidationResultCache::default(),
                 chain_writer,
                 chain_reader,
                 chain_id_manager: ChainIdManager::new(data_dir),
@@ -329,8 +334,8 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
     }
 
     pub fn block_validation_result(&self, block_id: &str) -> Option<BlockValidationResult> {
-        let state = self.state
-            .read()
+        let mut state = self.state
+            .write()
             .expect("No lock holder should have poisoned the lock");
         state.block_validation_result(block_id)
     }
@@ -430,16 +435,16 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
 
         state
             .block_validation_results
-            .get_mut(&block.header_signature)
+            .find(|result| &result.block_id == &block.header_signature)
             .map(|result| result.status = BlockStatus::Invalid);
     }
 
-    fn set_block_validation_result(&self, block_id: String, result: BlockValidationResult) {
+    fn set_block_validation_result(&self, result: BlockValidationResult) {
         let mut state = self.state
             .write()
             .expect("No lock holder should have poisoned the lock");
 
-        state.block_validation_results.insert(block_id, result);
+        state.block_validation_results.insert(result);
     }
 
     fn get_block_unchecked(&self, block_id: String) -> Block {
@@ -566,7 +571,7 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
                 for block in result.new_chain.iter().rev() {
                     let receipts: Vec<TransactionReceipt> = state
                         .block_validation_results
-                        .get(&block.header_signature)
+                        .find(|result| &block.header_signature == &result.block_id)
                         .expect("A block that has no validation results was committed")
                         .execution_results
                         .iter()
@@ -778,7 +783,6 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
 
                 if !result_thread_exit.load(Ordering::Relaxed) {
                     result_thread_controller.set_block_validation_result(
-                        block_validation_result.block_id.clone(),
                         block_validation_result.clone(),
                     );
                     let block = result_thread_controller

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -15,6 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
+use std::collections::HashMap;
 use std::io;
 use std::marker::Send;
 use std::marker::Sync;
@@ -34,9 +35,11 @@ use std::time::Duration;
 use protobuf;
 
 use batch::Batch;
+use block::Block;
 use journal;
-use journal::block_validator::{BlockValidator, ValidationError};
-use journal::block_wrapper::{BlockStatus, BlockWrapper};
+use journal::block_manager::BlockManager;
+use journal::block_validator::{BlockValidationResult, BlockValidator, ValidationError};
+use journal::block_wrapper::BlockStatus;
 use journal::chain_head_lock::ChainHeadLock;
 use journal::chain_id_manager::ChainIdManager;
 use metrics;
@@ -94,15 +97,7 @@ impl From<ForkResolutionError> for ChainControllerError {
 }
 
 pub trait ChainObserver: Send + Sync {
-    fn chain_update(&mut self, block: &BlockWrapper, receipts: &[&TransactionReceipt]);
-}
-
-pub trait BlockCache: Send + Sync {
-    fn contains(&self, block_id: &str) -> bool;
-
-    fn put(&mut self, block: BlockWrapper);
-
-    fn get(&self, block_id: &str) -> Option<BlockWrapper>;
+    fn chain_update(&mut self, block: &Block, receipts: &[&TransactionReceipt]);
 }
 
 #[derive(Debug)]
@@ -111,24 +106,22 @@ pub enum ChainReadError {
 }
 
 pub trait ChainReader: Send + Sync {
-    fn chain_head(&self) -> Result<Option<BlockWrapper>, ChainReadError>;
+    fn chain_head(&self) -> Result<Option<Block>, ChainReadError>;
     fn count_committed_transactions(&self) -> Result<usize, ChainReadError>;
-    fn get_block_by_block_num(
-        &self,
-        block_num: u64,
-    ) -> Result<Option<BlockWrapper>, ChainReadError>;
+    fn get_block_by_block_num(&self, block_num: u64) -> Result<Option<Block>, ChainReadError>;
+    fn get_block_by_block_id(&self, block_id: &str) -> Result<Option<Block>, ChainReadError>;
 }
 
 pub trait ChainWriter: Send + Sync {
     fn update_chain(
         &mut self,
-        new_chain: &[BlockWrapper],
-        old_chain: &[BlockWrapper],
+        new_chain: &[Block],
+        old_chain: &[Block],
     ) -> Result<(), ChainControllerError>;
 }
 
 pub trait ConsensusNotifier: Send + Sync {
-    fn notify_block_new(&self, block: &BlockWrapper);
+    fn notify_block_new(&self, block: &Block);
     fn notify_block_valid(&self, block_id: &str);
     fn notify_block_invalid(&self, block_id: &str);
     fn notify_block_commit(&self, block_id: &str);
@@ -136,11 +129,11 @@ pub trait ConsensusNotifier: Send + Sync {
 
 /// Holds the results of Block Validation.
 struct ForkResolutionResult<'a> {
-    pub block: &'a BlockWrapper,
-    pub chain_head: &'a Option<BlockWrapper>,
+    pub block: &'a Block,
+    pub chain_head: Option<&'a Block>,
 
-    pub new_chain: Vec<BlockWrapper>,
-    pub current_chain: Vec<BlockWrapper>,
+    pub new_chain: Vec<Block>,
+    pub current_chain: Vec<Block>,
 
     pub committed_batches: Vec<Batch>,
     pub uncommitted_batches: Vec<Batch>,
@@ -148,229 +141,114 @@ struct ForkResolutionResult<'a> {
     pub transaction_count: usize,
 }
 
-impl<'a> ForkResolutionResult<'a> {
-    fn new(block: &'a BlockWrapper) -> Self {
-        ForkResolutionResult {
-            block,
-            chain_head: &None,
-            new_chain: vec![],
-            current_chain: vec![],
-            committed_batches: vec![],
-            uncommitted_batches: vec![],
-            transaction_count: 0,
-        }
-    }
-}
-
 /// Indication that an error occured during fork resolution.
 #[derive(Debug)]
 struct ForkResolutionError(String);
 
-struct ChainControllerState<BC: BlockCache, BV: BlockValidator> {
-    block_cache: BC,
-    block_validator: BV,
+struct ChainControllerState {
+    block_manager: BlockManager,
+    block_validation_results: HashMap<String, BlockValidationResult>,
     chain_writer: Box<ChainWriter>,
     chain_reader: Box<ChainReader>,
-    chain_head: Option<BlockWrapper>,
+    chain_head: Option<Block>,
     chain_id_manager: ChainIdManager,
     observers: Vec<Box<ChainObserver>>,
     state_pruning_manager: StatePruningManager,
 }
 
-impl<BC: BlockCache, BV: BlockValidator> ChainControllerState<BC, BV> {
+impl ChainControllerState {
     fn has_block(&self, block_id: &str) -> bool {
-        self.block_cache.contains(block_id) || self.block_validator.has_block(block_id)
+        let block_ids = [block_id];
+
+        let mut block_iter = self.block_manager.get(&block_ids);
+        block_iter.next().map(|b| b.is_some()).unwrap_or(false)
     }
 
-    /// This is used by a non-genesis journal when it has received the
-    /// genesis block from the genesis validator
-    fn set_genesis(
-        &mut self,
-        lock: &ChainHeadLock,
-        block: BlockWrapper,
-    ) -> Result<(), ChainControllerError> {
-        if block.previous_block_id() == journal::NULL_BLOCK_IDENTIFIER {
-            let chain_id = self.chain_id_manager.get_block_chain_id()?;
-            if chain_id
-                .as_ref()
-                .map(|block_id| block_id != &block.header_signature())
-                .unwrap_or(false)
-            {
-                warn!(
-                    "Block id does not match block chain id {}. Ignoring initial chain head: {}",
-                    chain_id.unwrap(),
-                    block.header_signature()
-                );
-            } else {
-                self.block_validator.validate_block(block.clone())?;
-
-                if chain_id.is_none() {
-                    self.chain_id_manager
-                        .save_block_chain_id(&block.header_signature())?;
+    fn block_validation_result(&self, block_id: &str) -> Option<BlockValidationResult> {
+        self.block_validation_results
+            .get(block_id)
+            .cloned()
+            .or_else(|| {
+                if self.chain_reader
+                    .get_block_by_block_id(block_id)
+                    .expect("ChainReader errored reading from the database")
+                    .is_some()
+                {
+                    let result = BlockValidationResult {
+                        block_id: block_id.into(),
+                        execution_results: vec![],
+                        num_transactions: 0,
+                        status: BlockStatus::Valid,
+                    };
+                    return Some(result);
                 }
-
-                self.chain_writer.update_chain(&[block.clone()], &[])?;
-                self.chain_head = Some(block.clone());
-                let mut guard = lock.acquire();
-                guard.notify_on_chain_updated(block.clone(), vec![], vec![]);
-            }
-        }
-
-        Ok(())
+                None
+            })
     }
 
     fn build_fork<'a>(
         &mut self,
-        block: &'a BlockWrapper,
-        chain_head: &'a BlockWrapper,
+        block: &'a Block,
+        chain_head: &'a Block,
     ) -> Result<ForkResolutionResult<'a>, ChainControllerError> {
-        let mut result = ForkResolutionResult::new(block);
+        let new_block = block.clone();
 
-        let mut current_block = chain_head.clone();
-        let mut new_block = block.clone();
+        let new_chain = self.block_manager
+            .branch_diff(&new_block.header_signature, &chain_head.header_signature)
+            .collect::<Vec<Block>>();
+        let current_chain = self.block_manager
+            .branch_diff(&chain_head.header_signature, &new_block.header_signature)
+            .collect::<Vec<Block>>();
 
-        let chain_comparison = compare_chain_height(&current_block, &new_block);
-        let (compared_block, chain) = if chain_comparison {
-            self.build_fork_diff_to_common_height(&current_block, &new_block)?
-        } else {
-            self.build_fork_diff_to_common_height(&new_block, &current_block)?
+        let committed_batches: Vec<Batch> = new_chain.iter().fold(vec![], |mut batches, block| {
+            batches.append(&mut block.batches.clone());
+            batches
+        });
+        let uncommitted_batches: Vec<Batch> =
+            current_chain.iter().fold(vec![], |mut batches, block| {
+                batches.append(&mut block.batches.clone());
+                batches
+            });
+
+        let transaction_count = committed_batches.iter().fold(0, |mut txn_count, batch| {
+            txn_count += batch.transactions.len();
+            txn_count
+        });
+
+        let result = ForkResolutionResult {
+            block: block,
+            chain_head: Some(chain_head),
+            new_chain,
+            current_chain,
+            committed_batches,
+            uncommitted_batches,
+            transaction_count,
         };
-
-        if chain_comparison {
-            current_block = compared_block;
-            result.current_chain = chain;
-        } else {
-            new_block = compared_block;
-            result.new_chain = chain;
-        }
-
-        self.extend_fork_diff_to_common_anscestor(
-            &new_block,
-            &current_block,
-            &mut result.new_chain,
-            &mut result.current_chain,
-        )?;
-
-        result.transaction_count = result.new_chain.iter().map(|b| b.num_transactions()).sum();
 
         info!(
             "Comparing current chain head '{}' against new block '{}'",
-            &chain_head, &block
+            &chain_head, &new_block
         );
-
-        let (commit, uncommit) = get_batch_commit_changes(&result.new_chain, &result.current_chain);
-        result.committed_batches = commit;
-        result.uncommitted_batches = uncommit;
-
-        if result.new_chain[0].previous_block_id() != chain_head.header_signature() {
-            let mut moved_to_fork_count =
-                COLLECTOR.counter("ChainController.chain_head_moved_to_fork_count", None, None);
-            moved_to_fork_count.inc();
+        if let Some(prior_heads_successor) = result.new_chain.get(0) {
+            if prior_heads_successor.previous_block_id != chain_head.header_signature {
+                let mut moved_to_fork_count =
+                    COLLECTOR.counter("ChainController.chain_head_moved_to_fork_count", None, None);
+                moved_to_fork_count.inc();
+            }
         }
 
         Ok(result)
     }
 
-    fn build_fork_diff_to_common_height<'a>(
-        &self,
-        head_long: &BlockWrapper,
-        head_short: &BlockWrapper,
-    ) -> Result<(BlockWrapper, Vec<BlockWrapper>), ForkResolutionError> {
-        let mut fork_diff = vec![];
-
-        let last = head_short.block_num();
-        let mut block = head_long.clone();
-
-        loop {
-            if block.block_num() == last
-                || block.previous_block_id() == journal::NULL_BLOCK_IDENTIFIER
-            {
-                return Ok((block, fork_diff));
-            }
-
-            fork_diff.push(block.clone());
-
-            block = self.get_from_cache_strict(
-                &block.previous_block_id(),
-                "Failed to build fork diff",
-            )?;
-        }
-    }
-
-    /// Returns a block from the cache, or an error if it is not found
-    fn get_from_cache_strict(
-        &self,
-        block_id: &str,
-        error_msg_prefix: &'static str,
-    ) -> Result<BlockWrapper, ForkResolutionError> {
-        match self.block_cache.get(block_id) {
-            Some(block) => Ok(block),
-            None => {
-                return Err(ForkResolutionError(format!(
-                    "{}: block missing predecessor {}",
-                    error_msg_prefix, block_id
-                )))
-            }
-        }
-    }
-
-    /// Finds a common ancestor of the two chains. new_blkw and cur_blkw must be
-    /// at the same height, or this will always fail.
-    fn extend_fork_diff_to_common_anscestor(
-        &mut self,
-        new_block: &BlockWrapper,
-        cur_block: &BlockWrapper,
-        new_chain: &mut Vec<BlockWrapper>,
-        cur_chain: &mut Vec<BlockWrapper>,
-    ) -> Result<(), ForkResolutionError> {
-        let mut new = new_block.clone();
-        let mut current = cur_block.clone();
-
-        while current.header_signature() != new.header_signature() {
-            if current.previous_block_id() == journal::NULL_BLOCK_IDENTIFIER
-                || new.previous_block_id() == journal::NULL_BLOCK_IDENTIFIER
-            {
-                loop {
-                    match new_chain.pop() {
-                        Some(mut block) => {
-                            block.set_status(BlockStatus::Invalid);
-                            // need to put it back in the cache
-                            self.block_cache.put(block);
-                        }
-                        None => break,
-                    }
-                }
-
-                return Err(ForkResolutionError(format!(
-                    "Block {} rejected due to wrong genesis {}",
-                    current, new
-                )));
-            }
-
-            new_chain.push(new);
-            new = self.get_from_cache_strict(
-                &new_chain.last().unwrap().previous_block_id(),
-                "Failed to extend new chain",
-            )?;
-
-            cur_chain.push(current);
-            current = self.block_cache
-                .get(&cur_chain.last().unwrap().previous_block_id())
-                .expect("Could not find current chain predecessor in block cache");
-        }
-
-        Ok(())
-    }
-
     fn check_chain_head_updated(
         &self,
-        chain_head: &BlockWrapper,
-        block: &BlockWrapper,
+        chain_head: &Block,
+        block: &Block,
     ) -> Result<bool, ChainControllerError> {
         let current_chain_head = self.chain_reader.chain_head()?;
         if current_chain_head
             .as_ref()
-            .map(|block| block.header_signature() != chain_head.header_signature())
+            .map(|block| block.header_signature != chain_head.header_signature)
             .unwrap_or(false)
         {
             warn!(
@@ -387,54 +265,25 @@ impl<BC: BlockCache, BV: BlockValidator> ChainControllerState<BC, BV> {
     }
 }
 
-/// Returns true if head_a is taller, false if head_b is taller, and true if
-/// the heights are the same.
-fn compare_chain_height(block_a: &BlockWrapper, block_b: &BlockWrapper) -> bool {
-    block_a.block_num() >= block_b.block_num()
-}
-
-/// Get all the batches that should be committed from the new chain and
-/// all the batches that should be uncommitted from the current chain.
-fn get_batch_commit_changes(
-    new_chain: &[BlockWrapper],
-    cur_chain: &[BlockWrapper],
-) -> (Vec<Batch>, Vec<Batch>) {
-    let mut committed_batches = vec![];
-    for block in new_chain {
-        for batch in block.batches() {
-            committed_batches.push(batch.clone());
-        }
-    }
-
-    let mut uncommitted_batches = vec![];
-    for block in cur_chain {
-        for batch in block.batches() {
-            uncommitted_batches.push(batch.clone());
-        }
-    }
-
-    (committed_batches, uncommitted_batches)
-}
-
 #[derive(Clone)]
-pub struct ChainController<BC: BlockCache, BV: BlockValidator> {
-    state: Arc<RwLock<ChainControllerState<BC, BV>>>,
+pub struct ChainController<BV: BlockValidator> {
+    state: Arc<RwLock<ChainControllerState>>,
     stop_handle: Arc<Mutex<Option<ChainThreadStopHandle>>>,
 
     consensus_notifier: Arc<ConsensusNotifier>,
-
+    block_validator: BV,
     // Queues
-    block_queue_sender: Option<Sender<BlockWrapper>>,
-    commit_queue_sender: Option<Sender<BlockWrapper>>,
-    validation_result_sender: Option<Sender<BlockWrapper>>,
+    block_queue_sender: Option<Sender<Block>>,
+    commit_queue_sender: Option<Sender<Block>>,
+    validation_result_sender: Option<Sender<BlockValidationResult>>,
 
     state_pruning_block_depth: u32,
     chain_head_lock: ChainHeadLock,
 }
 
-impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC, BV> {
+impl<BV: BlockValidator + 'static> ChainController<BV> {
     pub fn new(
-        block_cache: BC,
+        block_manager: BlockManager,
         block_validator: BV,
         chain_writer: Box<ChainWriter>,
         chain_reader: Box<ChainReader>,
@@ -447,8 +296,8 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
     ) -> Self {
         let mut chain_controller = ChainController {
             state: Arc::new(RwLock::new(ChainControllerState {
-                block_cache,
-                block_validator,
+                block_manager,
+                block_validation_results: HashMap::new(),
                 chain_writer,
                 chain_reader,
                 chain_id_manager: ChainIdManager::new(data_dir),
@@ -456,6 +305,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                 chain_head: None,
                 state_pruning_manager,
             })),
+            block_validator,
             stop_handle: Arc::new(Mutex::new(None)),
             block_queue_sender: None,
             commit_queue_sender: None,
@@ -470,7 +320,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         chain_controller
     }
 
-    pub fn chain_head(&self) -> Option<BlockWrapper> {
+    pub fn chain_head(&self) -> Option<Block> {
         let state = self.state
             .read()
             .expect("No lock holder should have poisoned the lock");
@@ -478,27 +328,77 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         state.chain_head.clone()
     }
 
-    pub fn on_block_received(&mut self, block: BlockWrapper) -> Result<(), ChainControllerError> {
-        let mut state = self.state
-            .write()
+    pub fn block_validation_result(&self, block_id: &str) -> Option<BlockValidationResult> {
+        let state = self.state
+            .read()
             .expect("No lock holder should have poisoned the lock");
+        state.block_validation_result(block_id)
+    }
 
-        if state.has_block(&block.header_signature()) {
-            return Ok(());
-        }
-
-        if state.chain_head.is_none() {
-            if let Err(err) = state.set_genesis(&self.chain_head_lock, block.clone()) {
+    /// This is used by a non-genesis journal when it has received the
+    /// genesis block from the genesis validator
+    fn set_genesis(
+        &self,
+        state: &mut ChainControllerState,
+        lock: &ChainHeadLock,
+        block: Block,
+    ) -> Result<(), ChainControllerError> {
+        if block.previous_block_id == journal::NULL_BLOCK_IDENTIFIER {
+            let chain_id = state.chain_id_manager.get_block_chain_id()?;
+            if chain_id
+                .as_ref()
+                .map(|block_id| block_id != &block.header_signature)
+                .unwrap_or(false)
+            {
                 warn!(
-                    "Unable to set chain head; genesis block {} is not valid: {:?}",
-                    block.header_signature(),
-                    err
+                    "Block id does not match block chain id {}. Ignoring initial chain head: {}",
+                    chain_id.unwrap(),
+                    block.header_signature
                 );
+            } else {
+                self.block_validator.validate_block(block.clone())?;
+
+                if chain_id.is_none() {
+                    state
+                        .chain_id_manager
+                        .save_block_chain_id(&block.header_signature)?;
+                }
+
+                state.chain_writer.update_chain(&[block.clone()], &[])?;
+                state.chain_head = Some(block.clone());
+                let mut guard = lock.acquire();
+                guard.notify_on_chain_updated(block.clone(), vec![], vec![]);
             }
-            return Ok(());
         }
 
-        state.block_cache.put(block.clone());
+        Ok(())
+    }
+
+    pub fn on_block_received(&mut self, block: Block) -> Result<(), ChainControllerError> {
+        {
+            let mut state = self.state
+                .write()
+                .expect("No lock holder should have poisoned the lock");
+
+            if state.has_block(&block.header_signature) {
+                return Ok(());
+            }
+            match state.block_manager.put(vec![block.clone()]) {
+                Ok(_) => (),
+                Err(err) => warn!("During put to block manager in on_block_received {:?}", err),
+            }
+            if state.chain_head.is_none() {
+                if let Err(err) = self.set_genesis(&mut state, &self.chain_head_lock, block.clone())
+                {
+                    warn!(
+                        "Unable to set chain head; genesis block {} is not valid: {:?}",
+                        &block.header_signature, err
+                    );
+                }
+                return Ok(());
+            }
+        }
+
         let sender = self.validation_result_sender
             .as_ref()
             .expect(
@@ -506,8 +406,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             )
             .clone();
 
-        state
-            .block_validator
+        self.block_validator
             .submit_blocks_for_verification(&[block], sender);
 
         Ok(())
@@ -520,21 +419,44 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         state.has_block(block_id)
     }
 
-    pub fn ignore_block(&self, block: &BlockWrapper) {
+    pub fn ignore_block(&self, block: &Block) {
         info!("Ignoring block {}", block)
     }
 
-    pub fn fail_block(&self, block: &mut BlockWrapper) {
+    pub fn fail_block(&self, block: &mut Block) {
         let mut state = self.state
             .write()
             .expect("No lock holder should have poisoned the lock");
 
-        block.set_status(BlockStatus::Invalid);
-
-        state.block_cache.put(block.clone());
+        state
+            .block_validation_results
+            .get_mut(&block.header_signature)
+            .map(|result| result.status = BlockStatus::Invalid);
     }
 
-    pub fn commit_block(&self, block: BlockWrapper) {
+    fn set_block_validation_result(&self, block_id: String, result: BlockValidationResult) {
+        let mut state = self.state
+            .write()
+            .expect("No lock holder should have poisoned the lock");
+
+        state.block_validation_results.insert(block_id, result);
+    }
+
+    fn get_block_unchecked(&self, block_id: String) -> Block {
+        let state = self.state
+            .read()
+            .expect("No lock holder should have poisoned the lock");
+
+        let block_id = block_id.as_str();
+        let block_ids = [block_id];
+
+        let block = state.block_manager.get(&block_ids).next();
+        block
+            .expect("The caller must guarantee that the block is known to the block manager")
+            .expect("The caller must guarantee that the block is known to the block manager")
+    }
+
+    pub fn commit_block(&self, block: Block) {
         if let Some(sender) = self.commit_queue_sender.as_ref() {
             if let Err(err) = sender.send(block) {
                 error!("Unable to add block to block queue: {}", err);
@@ -547,7 +469,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         }
     }
 
-    fn on_block_validated(&self, block: &BlockWrapper) {
+    fn on_block_validated(&self, block: &Block) {
         let mut blocks_considered_count =
             COLLECTOR.counter("ChainController.blocks_considered_count", None, None);
         blocks_considered_count.inc();
@@ -555,7 +477,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         self.consensus_notifier.notify_block_new(block);
     }
 
-    fn handle_block_commit(&mut self, block: &BlockWrapper) -> Result<(), ChainControllerError> {
+    fn handle_block_commit(&mut self, block: &Block) -> Result<(), ChainControllerError> {
         {
             // only hold this lock as long as the loop is active.
             let mut state = self.state
@@ -578,12 +500,12 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                 let new_roots: Vec<String> = result
                     .new_chain
                     .iter()
-                    .map(|block| block.state_root_hash())
+                    .map(|block| block.state_root_hash.clone())
                     .collect();
                 let current_roots: Vec<(u64, String)> = result
                     .current_chain
                     .iter()
-                    .map(|block| (block.block_num(), block.state_root_hash()))
+                    .map(|block| (block.block_num, block.state_root_hash.clone()))
                     .collect();
                 state.state_pruning_manager.update_queue(
                     new_roots
@@ -609,14 +531,14 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
 
                 let mut chain_head_gauge =
                     COLLECTOR.gauge("ChainController.chain_head", None, None);
-                chain_head_gauge.set_value(&block.header_signature()[0..8]);
+                chain_head_gauge.set_value(&block.header_signature[0..8]);
 
                 let mut committed_transactions_count =
                     COLLECTOR.counter("ChainController.committed_transactions_count", None, None);
                 committed_transactions_count.inc_n(result.transaction_count);
 
                 let mut block_num_guage = COLLECTOR.gauge("ChainController.block_num", None, None);
-                block_num_guage.set_value(block.block_num());
+                block_num_guage.set_value(block.block_num);
 
                 let chain_head = state.chain_head.clone().unwrap();
                 chain_head_guard.notify_on_chain_updated(
@@ -626,7 +548,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                 );
 
                 state.chain_head.as_ref().map(|block| {
-                    block.batches().iter().for_each(|batch| {
+                    block.batches.iter().for_each(|batch| {
                         if batch.trace {
                             debug!(
                                 "TRACE: {}: ChainController.on_block_validated",
@@ -637,8 +559,11 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                 });
 
                 for block in result.new_chain.iter().rev() {
-                    let receipts: Vec<TransactionReceipt> = block
-                        .execution_results()
+                    let receipts: Vec<TransactionReceipt> = state
+                        .block_validation_results
+                        .get(&block.header_signature)
+                        .expect("A block that has no validation results was committed")
+                        .execution_results
                         .iter()
                         .map(TransactionReceipt::from)
                         .collect();
@@ -661,13 +586,13 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                     COLLECTOR.gauge("ChainController.committed_transactions_gauge", None, None);
                 committed_transactions_gauge.set_value(total_committed_txns);
 
-                let chain_head_block_num = state.chain_head.as_ref().unwrap().block_num();
+                let chain_head_block_num = state.chain_head.as_ref().unwrap().block_num;
                 if chain_head_block_num + 1 > self.state_pruning_block_depth as u64 {
                     let prune_at = chain_head_block_num - (self.state_pruning_block_depth as u64);
                     match state.chain_reader.get_block_by_block_num(prune_at) {
                         Ok(Some(block)) => state
                             .state_pruning_manager
-                            .add_to_queue(block.block_num(), &block.state_root_hash()),
+                            .add_to_queue(block.block_num, &block.state_root_hash),
                         Ok(None) => warn!("No block at block height {}; ignoring...", prune_at),
                         Err(err) => {
                             error!("Unable to fetch block at height {}: {:?}", prune_at, err)
@@ -684,7 +609,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         }
 
         self.consensus_notifier
-            .notify_block_commit(&block.header_signature());
+            .notify_block_commit(&block.header_signature);
 
         Ok(())
     }
@@ -697,6 +622,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             // This instance doesn't share the stop handle: it's not a
             // publicly accessible instance
             stop_handle: Arc::new(Mutex::new(None)),
+            block_validator: self.block_validator.clone(),
             block_queue_sender: self.block_queue_sender.clone(),
             commit_queue_sender: self.commit_queue_sender.clone(),
             validation_result_sender: self.validation_result_sender.clone(),
@@ -708,7 +634,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
 
     pub fn submit_blocks_for_verification(
         &self,
-        blocks: &[BlockWrapper],
+        blocks: &[Block],
     ) -> Result<(), ChainControllerError> {
         let sender = self.validation_result_sender
             .as_ref()
@@ -717,15 +643,12 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             )
             .clone();
 
-        self.state
-            .write()
-            .expect("No lock holder should have poisoned the lock")
-            .block_validator
+        self.block_validator
             .submit_blocks_for_verification(blocks, sender);
         Ok(())
     }
 
-    pub fn queue_block(&self, block: BlockWrapper) {
+    pub fn queue_block(&self, block: Block) {
         if self.block_queue_sender.is_some() {
             let sender = self.block_queue_sender.clone();
             if let Err(err) = sender.as_ref().unwrap().send(block) {
@@ -759,11 +682,12 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
             let notify_block = chain_head.clone().unwrap();
             state.chain_head = chain_head;
             let mut gauge = COLLECTOR.gauge("ChainController.chain_head", None, None);
-            gauge.set_value(&notify_block.header_signature()[0..8]);
+            gauge.set_value(&notify_block.header_signature[0..8]);
 
             let mut block_num_guage = COLLECTOR.gauge("ChainController.block_num", None, None);
-            block_num_guage.set_value(&notify_block.block_num());
+            block_num_guage.set_value(&notify_block.block_num);
             let mut guard = self.chain_head_lock.acquire();
+
             guard.notify_on_chain_updated(notify_block, vec![], vec![]);
         }
     }
@@ -809,7 +733,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
     fn start_validation_result_thread(
         &self,
         result_thread_exit: Arc<AtomicBool>,
-        validation_result_receiver: Receiver<BlockWrapper>,
+        validation_result_receiver: Receiver<BlockValidationResult>,
     ) {
         // Setup the ValidationResult thread
         let result_thread_builder =
@@ -817,7 +741,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
         let result_thread_controller = self.light_clone();
         result_thread_builder
             .spawn(move || loop {
-                let block = match validation_result_receiver
+                let block_validation_result = match validation_result_receiver
                     .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
                 {
                     Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -835,6 +759,12 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
                 };
 
                 if !result_thread_exit.load(Ordering::Relaxed) {
+                    result_thread_controller.set_block_validation_result(
+                        block_validation_result.block_id.clone(),
+                        block_validation_result.clone(),
+                    );
+                    let block = result_thread_controller
+                        .get_block_unchecked(block_validation_result.block_id);
                     result_thread_controller.on_block_validated(&block);
                 } else {
                     break;
@@ -846,7 +776,7 @@ impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainController<BC,
     fn start_commit_queue_thread(
         &self,
         commit_thread_exit: Arc<AtomicBool>,
-        commit_queue_receiver: Receiver<BlockWrapper>,
+        commit_queue_receiver: Receiver<Block>,
     ) {
         // Setup the Commit thread:
         let commit_thread_builder =
@@ -911,9 +841,9 @@ impl<'a> From<&'a TxnExecutionResult> for TransactionReceipt {
     }
 }
 
-struct ChainThread<BC: BlockCache, BV: BlockValidator> {
-    chain_controller: ChainController<BC, BV>,
-    block_queue: Receiver<BlockWrapper>,
+struct ChainThread<BV: BlockValidator> {
+    chain_controller: ChainController<BV>,
+    block_queue: Receiver<Block>,
     exit: Arc<AtomicBool>,
 }
 
@@ -921,10 +851,10 @@ trait StopHandle: Clone {
     fn stop(&self);
 }
 
-impl<BC: BlockCache + 'static, BV: BlockValidator + 'static> ChainThread<BC, BV> {
+impl<BV: BlockValidator + 'static> ChainThread<BV> {
     fn new(
-        chain_controller: ChainController<BC, BV>,
-        block_queue: Receiver<BlockWrapper>,
+        chain_controller: ChainController<BV>,
+        block_queue: Receiver<Block>,
         exit_flag: Arc<AtomicBool>,
     ) -> Self {
         ChainThread {

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -38,7 +38,7 @@ use uluru;
 use batch::Batch;
 use block::Block;
 use journal;
-use journal::block_manager::BlockManager;
+use journal::block_manager::{BlockManager, BlockManagerError};
 use journal::block_validator::{BlockValidationResult, BlockValidator, ValidationError};
 use journal::block_wrapper::BlockStatus;
 use journal::chain_head_lock::ChainHeadLock;
@@ -51,6 +51,8 @@ use scheduler::TxnExecutionResult;
 
 const RECV_TIMEOUT_MILLIS: u64 = 100;
 const BLOCK_VALIDATION_RESULT_CACHE_SIZE: usize = 512;
+
+const COMMIT_STORE: &str = "commit_store";
 
 lazy_static! {
     static ref COLLECTOR: metrics::MetricsCollectorHandle =
@@ -95,6 +97,12 @@ impl From<ChainReadError> for ChainControllerError {
 impl From<ForkResolutionError> for ChainControllerError {
     fn from(err: ForkResolutionError) -> Self {
         ChainControllerError::ForkResolutionError(err.0)
+    }
+}
+
+impl From<BlockManagerError> for ChainControllerError {
+    fn from(err: BlockManagerError) -> Self {
+        ChainControllerError::ChainUpdateError(format!("{:?}", err))
     }
 }
 
@@ -369,12 +377,13 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
                         .save_block_chain_id(&block.header_signature)?;
                 }
 
-                state.chain_writer.update_chain(&[block.clone()], &[])?;
+                state.block_manager.persist(&block.header_signature, COMMIT_STORE)?;
                 state.chain_head = Some(block.clone());
                 let mut guard = lock.acquire();
                 guard.notify_on_chain_updated(block.clone(), vec![], vec![]);
             }
         }
+
 
         Ok(())
     }
@@ -530,9 +539,10 @@ impl<BV: BlockValidator + 'static> ChainController<BV> {
                         .as_slice(),
                 );
 
-                state
-                    .chain_writer
-                    .update_chain(&result.new_chain, &result.current_chain)?;
+                state.block_manager.persist(
+                    &state.chain_head.as_ref().unwrap().header_signature,
+                    COMMIT_STORE,
+                )?;
 
                 info!(
                     "Chain head updated to {}",

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -88,7 +88,6 @@ pub extern "C" fn chain_controller_new(
     let py = unsafe { Python::assume_gil_acquired() };
 
     let py_block_store_reader = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
-    let py_block_store_writer = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
     let py_block_validator = unsafe { PyObject::from_borrowed_ptr(py, block_validator) };
     let py_observers = unsafe { PyObject::from_borrowed_ptr(py, observers) };
     let chain_head_lock_ref =
@@ -113,7 +112,6 @@ pub extern "C" fn chain_controller_new(
     let chain_controller = ChainController::new(
         block_manager,
         PyBlockValidator::new(py_block_validator),
-        Box::new(PyBlockStore::new(py_block_store_writer)),
         Box::new(PyBlockStore::new(py_block_store_reader)),
         chain_head_lock_ref.clone(),
         Box::new(PyConsensusNotifier::new(py_consensus_notifier)),
@@ -590,27 +588,6 @@ struct PyBlockStore {
 impl PyBlockStore {
     fn new(py_block_store: PyObject) -> Self {
         PyBlockStore { py_block_store }
-    }
-}
-
-impl ChainWriter for PyBlockStore {
-    fn update_chain(
-        &mut self,
-        new_chain: &[Block],
-        old_chain: &[Block],
-    ) -> Result<(), ChainControllerError> {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        self.py_block_store
-            .call_method(py, "update_chain", (new_chain, old_chain), None)
-            .map(|_| ())
-            .map_err(|py_err| {
-                ChainControllerError::ChainUpdateError(format!(
-                    "An error occurred while executing update_chain: {}",
-                    py_err.get_type(py).name(py)
-                ))
-            })
     }
 }
 

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -14,11 +14,14 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+
+use block::Block;
 use cpython;
 use cpython::{ObjectProtocol, PyClone, PyList, PyObject, Python, PythonObject, ToPyObject};
 use database::lmdb::LmdbDatabase;
-use journal::block_validator::{BlockValidator, ValidationError};
-use journal::block_wrapper::BlockWrapper;
+use journal::block_manager::BlockManager;
+use journal::block_validator::{BlockValidationResult, BlockValidator, ValidationError};
+use journal::block_wrapper::{BlockStatus, BlockWrapper};
 use journal::chain::*;
 use journal::chain_head_lock::ChainHeadLock;
 use py_ffi;
@@ -54,7 +57,7 @@ macro_rules! check_null {
 #[no_mangle]
 pub extern "C" fn chain_controller_new(
     block_store: *mut py_ffi::PyObject,
-    block_cache: *mut py_ffi::PyObject,
+    block_manager: *const c_void,
     block_validator: *mut py_ffi::PyObject,
     state_database: *const c_void,
     chain_head_lock: *const c_void,
@@ -66,7 +69,7 @@ pub extern "C" fn chain_controller_new(
 ) -> ErrorCode {
     check_null!(
         block_store,
-        block_cache,
+        block_manager,
         block_validator,
         state_database,
         chain_head_lock,
@@ -86,7 +89,6 @@ pub extern "C" fn chain_controller_new(
 
     let py_block_store_reader = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
     let py_block_store_writer = unsafe { PyObject::from_borrowed_ptr(py, block_store) };
-    let py_block_cache = unsafe { PyObject::from_borrowed_ptr(py, block_cache) };
     let py_block_validator = unsafe { PyObject::from_borrowed_ptr(py, block_validator) };
     let py_observers = unsafe { PyObject::from_borrowed_ptr(py, observers) };
     let chain_head_lock_ref =
@@ -103,12 +105,13 @@ pub extern "C" fn chain_controller_new(
         return ErrorCode::InvalidPythonObject;
     };
 
+    let block_manager = unsafe { (*(block_manager as *const BlockManager)).clone() };
     let state_database = unsafe { (*(state_database as *const LmdbDatabase)).clone() };
 
     let state_pruning_manager = StatePruningManager::new(state_database);
 
     let chain_controller = ChainController::new(
-        PyBlockCache::new(py_block_cache),
+        block_manager,
         PyBlockValidator::new(py_block_validator),
         Box::new(PyBlockStore::new(py_block_store_writer)),
         Box::new(PyBlockStore::new(py_block_store_reader)),
@@ -131,9 +134,7 @@ pub extern "C" fn chain_controller_new(
 pub extern "C" fn chain_controller_drop(chain_controller: *mut c_void) -> ErrorCode {
     check_null!(chain_controller);
 
-    unsafe {
-        Box::from_raw(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator>)
-    };
+    unsafe { Box::from_raw(chain_controller as *mut ChainController<PyBlockValidator>) };
     ErrorCode::Success
 }
 
@@ -142,9 +143,33 @@ pub extern "C" fn chain_controller_start(chain_controller: *mut c_void) -> Error
     check_null!(chain_controller);
 
     unsafe {
-        (*(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator>)).start();
+        (*(chain_controller as *mut ChainController<PyBlockValidator>)).start();
     }
 
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn chain_controller_block_validation_result(
+    chain_controller: *mut c_void,
+    block_id: *const c_char,
+    result: *mut *const py_ffi::PyObject,
+) -> ErrorCode {
+    let block_id = match CStr::from_ptr(block_id).to_str() {
+        Ok(s) => s,
+        Err(_) => return ErrorCode::InvalidBlockId,
+    };
+
+    let status = match (*(chain_controller as *mut ChainController<PyBlockValidator>))
+        .block_validation_result(block_id)
+    {
+        Some(r) => r.status,
+        None => BlockStatus::Unknown,
+    };
+    let gil = cpython::Python::acquire_gil();
+    let py = gil.python();
+    let py_status = status.to_py_object(py);
+    *result = py_status.steal_ptr();
     ErrorCode::Success
 }
 
@@ -153,7 +178,7 @@ pub extern "C" fn chain_controller_stop(chain_controller: *mut c_void) -> ErrorC
     check_null!(chain_controller);
 
     unsafe {
-        (*(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator>)).stop();
+        (*(chain_controller as *mut ChainController<PyBlockValidator>)).stop();
     }
     ErrorCode::Success
 }
@@ -174,8 +199,8 @@ pub extern "C" fn chain_controller_has_block(
     };
 
     unsafe {
-        *result = (*(chain_controller as *mut ChainController<PyBlockCache, PyBlockValidator>))
-            .has_block(block_id);
+        *result =
+            (*(chain_controller as *mut ChainController<PyBlockValidator>)).has_block(block_id);
     }
 
     ErrorCode::Success
@@ -193,7 +218,7 @@ macro_rules! chain_controller_block_ffi {
             let gil_guard = Python::acquire_gil();
             let py = gil_guard.python();
 
-            let mut $block: BlockWrapper = unsafe {
+            let mut $block: Block = unsafe {
                 match PyObject::from_borrowed_ptr(py, block).extract(py) {
                     Ok(val) => val,
                     Err(py_err) => {
@@ -209,7 +234,7 @@ macro_rules! chain_controller_block_ffi {
 
             unsafe {
                 let controller = (*(chain_controller
-                    as *mut ChainController<PyBlockCache, PyBlockValidator>))
+                    as *mut ChainController<PyBlockValidator>))
                     .light_clone();
 
                 py.allow_threads(move || {
@@ -236,7 +261,7 @@ pub extern "C" fn chain_controller_queue_block(
     let gil_guard = Python::acquire_gil();
     let py = gil_guard.python();
 
-    let block: BlockWrapper = unsafe {
+    let block: Block = unsafe {
         match PyObject::from_borrowed_ptr(py, block).extract(py) {
             Ok(val) => val,
             Err(py_err) => {
@@ -250,9 +275,8 @@ pub extern "C" fn chain_controller_queue_block(
         }
     };
     unsafe {
-        let controller = (*(chain_controller
-            as *mut ChainController<PyBlockCache, PyBlockValidator>))
-            .light_clone();
+        let controller =
+            (*(chain_controller as *mut ChainController<PyBlockValidator>)).light_clone();
 
         py.allow_threads(move || {
             let builder = thread::Builder::new().name("ChainController.queue_block".into());
@@ -279,7 +303,7 @@ pub extern "C" fn chain_controller_submit_blocks_for_verification(
     let gil_guard = Python::acquire_gil();
     let py = gil_guard.python();
 
-    let blocks: Vec<BlockWrapper> = unsafe {
+    let blocks: Vec<Block> = unsafe {
         match PyObject::from_borrowed_ptr(py, blocks).extract(py) {
             Ok(val) => val,
             Err(py_err) => {
@@ -293,9 +317,8 @@ pub extern "C" fn chain_controller_submit_blocks_for_verification(
         }
     };
     unsafe {
-        let controller = (*(chain_controller
-            as *mut ChainController<PyBlockCache, PyBlockValidator>))
-            .light_clone();
+        let controller =
+            (*(chain_controller as *mut ChainController<PyBlockValidator>)).light_clone();
 
         py.allow_threads(move || {
             // A thread has to be spawned here, otherwise, any subsequent attempt to
@@ -331,7 +354,7 @@ pub extern "C" fn chain_controller_on_block_received(
     let gil_guard = Python::acquire_gil();
     let py = gil_guard.python();
 
-    let block: BlockWrapper = unsafe {
+    let block: Block = unsafe {
         match PyObject::from_borrowed_ptr(py, block).extract(py) {
             Ok(val) => val,
             Err(py_err) => {
@@ -345,9 +368,8 @@ pub extern "C" fn chain_controller_on_block_received(
         }
     };
     unsafe {
-        let mut controller = (*(chain_controller
-            as *mut ChainController<PyBlockCache, PyBlockValidator>))
-            .light_clone();
+        let mut controller =
+            (*(chain_controller as *mut ChainController<PyBlockValidator>)).light_clone();
 
         py.allow_threads(move || {
             // A thread has to be spawned here, otherwise, any subsequent attempt to
@@ -378,17 +400,12 @@ pub extern "C" fn chain_controller_chain_head(
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
-        let controller = (*(chain_controller
-            as *mut ChainController<PyBlockCache, PyBlockValidator>))
-            .light_clone();
+        let controller =
+            (*(chain_controller as *mut ChainController<PyBlockValidator>)).light_clone();
 
         let chain_head = py.allow_threads(move || controller.chain_head());
 
-        // This is relying on the BlockWrapper being backed by a PyObject and `into_py_object()`
-        // not incrementing the reference count on the PyObject when passing up to Python. If these
-        // changes are invalidated, memory leaks may occur to BlockWrappers with incorrect
-        // reference counts never being cleaned up.
-        *block = chain_head.into_py_object(py).as_ptr();
+        *block = chain_head.into_py_object(py).steal_ptr();
     }
     ErrorCode::Success
 }
@@ -403,81 +420,27 @@ pub extern "C" fn sender_drop(sender: *const c_void) -> ErrorCode {
 }
 
 #[no_mangle]
-pub extern "C" fn sender_send(sender: *const c_void, block: *mut py_ffi::PyObject) -> ErrorCode {
-    check_null!(sender, block);
+pub extern "C" fn sender_send(
+    sender: *const c_void,
+    validation_result: *mut py_ffi::PyObject,
+) -> ErrorCode {
+    check_null!(sender, validation_result);
 
     let gil_guard = Python::acquire_gil();
     let py = gil_guard.python();
 
-    let py_block_wrapper = unsafe { PyObject::from_borrowed_ptr(py, block) };
-    let block: BlockWrapper = py_block_wrapper
-        .extract(py)
-        .expect("Unable to extract block");
+    let py_result = unsafe { PyObject::from_borrowed_ptr(py, validation_result) };
+    let result: BlockValidationResult = py_result.extract(py).expect("Unable to extract block");
 
     unsafe {
-        let sender = (*(sender as *mut Sender<BlockWrapper>)).clone();
-        py.allow_threads(move || match sender.send(block) {
+        let sender = (*(sender as *mut Sender<BlockValidationResult>)).clone();
+        py.allow_threads(move || match sender.send(result) {
             Ok(_) => ErrorCode::Success,
             Err(err) => {
                 error!("Unable to send validation result: {:?}", err);
                 ErrorCode::Unknown
             }
         })
-    }
-}
-
-struct PyBlockCache {
-    py_block_cache: PyObject,
-}
-
-impl PyBlockCache {
-    fn new(py_block_cache: PyObject) -> Self {
-        PyBlockCache { py_block_cache }
-    }
-}
-
-impl BlockCache for PyBlockCache {
-    fn contains(&self, block_id: &str) -> bool {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        match self.py_block_cache
-            .call_method(py, "__contains__", (block_id,), None)
-        {
-            Err(py_err) => {
-                pylogger::exception(py, "Unable to call __contains__ on BlockCache", py_err);
-                false
-            }
-            Ok(py_bool) => py_bool.extract(py).expect("Unable to extract boolean"),
-        }
-    }
-
-    fn put(&mut self, block: BlockWrapper) {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        match self.py_block_cache
-            .set_item(py, block.header_signature(), &block)
-        {
-            Err(py_err) => {
-                pylogger::exception(py, "Unable to call __setitem__ on BlockCache", py_err);
-                ()
-            }
-            Ok(_) => (),
-        }
-    }
-
-    fn get(&self, block_id: &str) -> Option<BlockWrapper> {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        match self.py_block_cache.get_item(py, block_id) {
-            Err(_) => {
-                // This is probably a key error, so we can return none
-                None
-            }
-            Ok(res) => Some(res.extract(py).expect("Unable to extract block")),
-        }
     }
 }
 
@@ -536,7 +499,7 @@ impl BlockValidator for PyBlockValidator {
         }
     }
 
-    fn validate_block(&self, block: BlockWrapper) -> Result<(), ValidationError> {
+    fn validate_block(&self, block: Block) -> Result<(), ValidationError> {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
@@ -550,8 +513,8 @@ impl BlockValidator for PyBlockValidator {
 
     fn submit_blocks_for_verification(
         &self,
-        blocks: &[BlockWrapper],
-        response_sender: Sender<BlockWrapper>,
+        blocks: &[Block],
+        response_sender: Sender<BlockValidationResult>,
     ) {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
@@ -599,8 +562,8 @@ impl PyBlockStore {
 impl ChainWriter for PyBlockStore {
     fn update_chain(
         &mut self,
-        new_chain: &[BlockWrapper],
-        old_chain: &[BlockWrapper],
+        new_chain: &[Block],
+        old_chain: &[Block],
     ) -> Result<(), ChainControllerError> {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
@@ -618,29 +581,67 @@ impl ChainWriter for PyBlockStore {
 }
 
 impl ChainReader for PyBlockStore {
-    fn chain_head(&self) -> Result<Option<BlockWrapper>, ChainReadError> {
+    fn chain_head(&self) -> Result<Option<Block>, ChainReadError> {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
         self.py_block_store
             .getattr(py, "chain_head")
             .and_then(|result| result.extract(py))
+            .map(|bw: Option<BlockWrapper>| {
+                if let Some(bw) = bw {
+                    Some(bw.block())
+                } else {
+                    None
+                }
+            })
             .map_err(|py_err| {
                 pylogger::exception(py, "Unable to call block_store.chain_head", py_err);
                 ChainReadError::GeneralReadError("Unable to read from python block store".into())
             })
     }
 
-    fn get_block_by_block_num(
-        &self,
-        block_num: u64,
-    ) -> Result<Option<BlockWrapper>, ChainReadError> {
+    fn get_block_by_block_id(&self, block_id: &str) -> Result<Option<Block>, ChainReadError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_block_store
+            .get_item(py, block_id)
+            .and_then(|result| result.extract(py))
+            .map(|bw: Option<BlockWrapper>| {
+                if let Some(bw) = bw {
+                    Some(bw.block())
+                } else {
+                    None
+                }
+            })
+            .or_else(|py_err| {
+                if py_err.get_type(py).name(py) == "KeyError" {
+                    Ok(None)
+                } else {
+                    Err(py_err)
+                }
+            })
+            .map_err(|py_err| {
+                pylogger::exception(py, "Unable to call block_store.chain_head", py_err);
+                ChainReadError::GeneralReadError("Unable to read from python block store".into())
+            })
+    }
+
+    fn get_block_by_block_num(&self, block_num: u64) -> Result<Option<Block>, ChainReadError> {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
         self.py_block_store
             .call_method(py, "get_block_by_number", (block_num,), None)
             .and_then(|result| result.extract(py))
+            .map(|bw: Option<BlockWrapper>| {
+                if let Some(bw) = bw {
+                    Some(bw.block())
+                } else {
+                    None
+                }
+            })
             .or_else(|py_err| {
                 if py_err.get_type(py).name(py) == "KeyError" {
                     Ok(None)
@@ -679,7 +680,7 @@ impl PyChainObserver {
 }
 
 impl ChainObserver for PyChainObserver {
-    fn chain_update(&mut self, block: &BlockWrapper, receipts: &[&TransactionReceipt]) {
+    fn chain_update(&mut self, block: &Block, receipts: &[&TransactionReceipt]) {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
@@ -718,7 +719,7 @@ impl Clone for PyConsensusNotifier {
 }
 
 impl ConsensusNotifier for PyConsensusNotifier {
-    fn notify_block_new(&self, block: &BlockWrapper) {
+    fn notify_block_new(&self, block: &Block) {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -483,6 +483,14 @@ impl PyBlockValidator {
     }
 }
 
+impl Clone for PyBlockValidator {
+    fn clone(&self) -> Self {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        PyBlockValidator::new(self.py_block_validator.clone_ref(py))
+    }
+}
+
 impl BlockValidator for PyBlockValidator {
     fn has_block(&self, block_id: &str) -> bool {
         let gil_guard = Python::acquire_gil();

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -555,6 +555,32 @@ impl BlockValidator for PyBlockValidator {
             })
             .unwrap_or(());
     }
+
+    fn process_pending(&self, block: &Block, response_sender: Sender<BlockValidationResult>) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let sender_ptr = Box::into_raw(Box::new(response_sender)) as u64;
+
+        let sender_c_void = self.ctypes_c_void
+            .call(py, (sender_ptr,), None)
+            .expect("unable to create ctypes.c_void_p");
+
+        let py_sender = self.py_validation_response_sender
+            .call(py, (sender_c_void,), None)
+            .expect("unable to create ValidationResponseSender");
+
+        let py_callback = self.py_callback_maker
+            .call(py, (py_sender,), None)
+            .expect("Unable to create py_callback");
+
+        match self.py_block_validator
+            .call_method(py, "process_pending", (block, py_callback), None)
+        {
+            Ok(_) => (),
+            Err(py_err) => warn!("During call to process_pending: {:?}", py_err),
+        }
+    }
 }
 
 struct PyBlockStore {

--- a/validator/src/journal/chain_head_lock.rs
+++ b/validator/src/journal/chain_head_lock.rs
@@ -1,8 +1,10 @@
-use std::sync::RwLockWriteGuard;
-
 use batch::Batch;
+use block::Block;
+use cpython;
+use cpython::ToPyObject;
 use journal::block_wrapper::BlockWrapper;
 use journal::publisher::{BlockPublisherState, SyncBlockPublisher};
+use std::sync::RwLockWriteGuard;
 
 /// Abstracts acquiring the lock used by the BlockPublisher without exposing access to the
 /// publisher itself.
@@ -33,7 +35,7 @@ pub struct ChainHeadGuard<'a> {
 impl<'a> ChainHeadGuard<'a> {
     pub fn notify_on_chain_updated(
         &mut self,
-        chain_head: BlockWrapper,
+        chain_head: Block,
         committed_batches: Vec<Batch>,
         uncommitted_batches: Vec<Batch>,
     ) {

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -171,7 +171,7 @@ impl SyncBlockPublisher {
         if self.is_building_block(state) {
             previous_block = state
                 .get_previous_block_id()
-                .map(|block_id| self.get_block_checked(block_id.as_str()).ok())
+                .map(|block_id| self.get_block(block_id.as_str()).ok())
                 .unwrap_or(None);
             self.cancel_block(state);
         }
@@ -357,7 +357,7 @@ impl SyncBlockPublisher {
         }
     }
 
-    fn get_block_checked(&self, block_id: &str) -> Result<Block, BlockPublisherError> {
+    fn get_block(&self, block_id: &str) -> Result<Block, BlockPublisherError> {
         self.block_manager
             .get(&[block_id])
             .next()
@@ -365,19 +365,22 @@ impl SyncBlockPublisher {
             .ok_or_else(|| BlockPublisherError::UnknownBlock(block_id.to_string()))
     }
 
-    fn get_block(&self, block_id: &str) -> Block {
-        self.get_block_checked(block_id)
-            .expect("Unable to extract BlockWrapper")
-    }
-
     fn restart_block(&self, state: &mut BlockPublisherState) {
-        if let Some(previous_block) = state
+        match state
             .get_previous_block_id()
             .map(|previous_block_id| self.get_block(previous_block_id.as_str()))
         {
-            state.candidate_block = None;
-            self.initialize_block(state, &previous_block)
-                .expect("Initialization failed unexpectedly");
+            Some(Ok(previous_block)) => {
+                self.cancel_block(state);
+
+                if let Err(err) = self.initialize_block(state, &previous_block) {
+                    error!("Initialization failed unexpectedly: {:?}", err);
+                }
+            }
+            Some(Err(err)) => {
+                error!("Unable to read previous block on restart: {:?}", err);
+            }
+            None => (),
         }
     }
 

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -67,7 +67,7 @@ pub enum StartError {
 
 pub struct BlockPublisherState {
     pub transaction_executor: Box<ExecutionPlatform>,
-    pub chain_head: Option<BlockWrapper>,
+    pub chain_head: Option<Block>,
     pub candidate_block: Option<CandidateBlock>,
     pub pending_batches: PendingBatchesPool,
 }
@@ -75,7 +75,7 @@ pub struct BlockPublisherState {
 impl BlockPublisherState {
     pub fn new(
         transaction_executor: Box<ExecutionPlatform>,
-        chain_head: Option<BlockWrapper>,
+        chain_head: Option<Block>,
         candidate_block: Option<CandidateBlock>,
         pending_batches: PendingBatchesPool,
     ) -> Self {
@@ -156,16 +156,16 @@ impl SyncBlockPublisher {
     pub fn on_chain_updated(
         &self,
         state: &mut BlockPublisherState,
-        chain_head: BlockWrapper,
+        chain_head: Block,
         committed_batches: Vec<Batch>,
         uncommitted_batches: Vec<Batch>,
     ) {
         info!("Now building on top of block, {}", chain_head);
-        let batches_len = chain_head.block().batches.len();
+        let batches_len = chain_head.batches.len();
         state.chain_head = Some(chain_head);
-        let mut previous_block_id = None;
+        let mut previous_block = None;
         if self.is_building_block(state) {
-            previous_block_id = state
+            previous_block = state
                 .get_previous_block_id()
                 .map(|block_id| self.get_block_checked(block_id.as_str()).ok())
                 .unwrap_or(None);
@@ -177,15 +177,15 @@ impl SyncBlockPublisher {
             .pending_batches
             .rebuild(Some(committed_batches), Some(uncommitted_batches));
 
-        if let Some(block_id) = previous_block_id {
-            self.initialize_block(state, &block_id)
+        if let Some(prev) = previous_block {
+            self.initialize_block(state, &prev.block())
                 .expect("Unable to initialize block after canceling");
         }
     }
 
     pub fn on_chain_updated_internal(
         &mut self,
-        chain_head: BlockWrapper,
+        chain_head: Block,
         committed_batches: Vec<Batch>,
         uncommitted_batches: Vec<Batch>,
     ) {
@@ -200,14 +200,9 @@ impl SyncBlockPublisher {
         );
     }
 
-    fn get_state_view(&self, py: Python, previous_block: &BlockWrapper) -> PyObject {
-        self.block_wrapper_class
-            .call_method(
-                py,
-                "state_view_for_block",
-                (previous_block, &self.state_view_factory),
-                None,
-            )
+    fn get_state_view(&self, py: Python, previous_block: &Block) -> PyObject {
+        self.state_view_factory
+            .call_method(py, "create_view", (&previous_block.state_root_hash,), None)
             .expect("BlockWrapper, unable to call state_view_for_block")
     }
 
@@ -224,7 +219,7 @@ impl SyncBlockPublisher {
     fn initialize_block(
         &self,
         state: &mut BlockPublisherState,
-        previous_block: &BlockWrapper,
+        previous_block: &Block,
     ) -> Result<(), InitializeBlockError> {
         if state.candidate_block.is_some() {
             warn!("Tried to initialize block but block already initialized");
@@ -242,7 +237,7 @@ impl SyncBlockPublisher {
                     "get_setting",
                     (
                         "sawtooth.publisher.max_batches_per_block",
-                        previous_block.block().state_root_hash.clone(),
+                        &previous_block.state_root_hash,
                     ),
                     Some(&kwargs),
                 )
@@ -252,18 +247,14 @@ impl SyncBlockPublisher {
 
             let state_view = self.get_state_view(py, previous_block);
             let public_key = self.get_public_key(py);
-            let batch_injectors = self.load_injectors(py, &previous_block.state_root_hash());
+            let batch_injectors = self.load_injectors(py, &previous_block.state_root_hash);
 
             let kwargs = PyDict::new(py);
             kwargs
-                .set_item(py, "block_num", previous_block.block().block_num + 1)
+                .set_item(py, "block_num", previous_block.block_num + 1)
                 .unwrap();
             kwargs
-                .set_item(
-                    py,
-                    "previous_block_id",
-                    &previous_block.block().header_signature,
-                )
+                .set_item(py, "previous_block_id", &previous_block.header_signature)
                 .unwrap();
             kwargs
                 .set_item(py, "signer_public_key", &public_key)
@@ -278,11 +269,11 @@ impl SyncBlockPublisher {
 
             let scheduler = state
                 .transaction_executor
-                .create_scheduler(&previous_block.block().state_root_hash)
+                .create_scheduler(&previous_block.state_root_hash)
                 .expect("Failed to create new scheduler");
 
-            let committed_txn_cache = TransactionCommitCache::new(
-                self.transaction_committed.clone_ref(py));
+            let committed_txn_cache =
+                TransactionCommitCache::new(self.transaction_committed.clone_ref(py));
 
             let settings_view = self.settings_view_class
                 .call(py, (state_view,), None)
@@ -371,7 +362,7 @@ impl SyncBlockPublisher {
             .map(|previous_block_id| self.get_block(previous_block_id.as_str()))
         {
             state.candidate_block = None;
-            self.initialize_block(state, &previous_block)
+            self.initialize_block(state, &previous_block.block())
                 .expect("Initialization failed unexpectedly");
         }
     }
@@ -505,7 +496,7 @@ impl BlockPublisher {
 
         let state = Arc::new(RwLock::new(BlockPublisherState::new(
             tep,
-            chain_head,
+            chain_head.map(|bw| bw.block()),
             None,
             PendingBatchesPool::new(NUM_PUBLISH_COUNT_SAMPLES, INITIAL_PUBLISH_COUNT),
         )));
@@ -582,10 +573,7 @@ impl BlockPublisher {
         ChainHeadLock::new(self.publisher.clone())
     }
 
-    pub fn initialize_block(
-        &self,
-        previous_block: BlockWrapper,
-    ) -> Result<(), InitializeBlockError> {
+    pub fn initialize_block(&self, previous_block: Block) -> Result<(), InitializeBlockError> {
         let mut state = self.publisher.state.write().expect("RwLock was poisoned");
         self.publisher.initialize_block(&mut state, &previous_block)
     }

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -18,7 +18,7 @@
 use batch::Batch;
 use block::Block;
 
-use cpython::{NoArgs, ObjectProtocol, PyClone, PyDict, PyErr, PyList, PyObject, Python};
+use cpython::{NoArgs, ObjectProtocol, PyClone, PyDict, PyList, PyObject, Python};
 use std::collections::{HashSet, VecDeque};
 use std::mem;
 use std::slice::Iter;
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use execution::execution_platform::ExecutionPlatform;
 use execution::py_executor::PyExecutor;
-use journal::block_wrapper::BlockWrapper;
+use journal::block_manager::BlockManager;
 use journal::candidate_block::{CandidateBlock, CandidateBlockError};
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::chain_head_lock::ChainHeadLock;
@@ -65,6 +65,11 @@ pub enum StartError {
     Disconnected,
 }
 
+#[derive(Debug)]
+pub enum BlockPublisherError{
+    UnknownBlock(String),
+}
+
 pub struct BlockPublisherState {
     pub transaction_executor: Box<ExecutionPlatform>,
     pub chain_head: Option<Block>,
@@ -97,13 +102,12 @@ impl BlockPublisherState {
 pub struct SyncBlockPublisher {
     pub state: Arc<RwLock<BlockPublisherState>>,
 
+    block_manager: BlockManager,
     batch_observers: Vec<PyObject>,
     batch_injector_factory: PyObject,
-    block_wrapper_class: PyObject,
     block_header_class: PyObject,
     block_builder_class: PyObject,
     settings_view_class: PyObject,
-    block_getter: PyObject,
     batch_committed: PyObject,
     transaction_committed: PyObject,
     state_view_factory: PyObject,
@@ -127,16 +131,15 @@ impl Clone for SyncBlockPublisher {
 
         SyncBlockPublisher {
             state,
+            block_manager: self.block_manager.clone(),
             batch_observers: self.batch_observers
                 .iter()
                 .map(|i| i.clone_ref(py))
                 .collect(),
             batch_injector_factory: self.batch_injector_factory.clone_ref(py),
-            block_wrapper_class: self.block_wrapper_class.clone_ref(py),
             block_header_class: self.block_header_class.clone_ref(py),
             block_builder_class: self.block_builder_class.clone_ref(py),
             settings_view_class: self.settings_view_class.clone_ref(py),
-            block_getter: self.block_getter.clone_ref(py),
             batch_committed: self.batch_committed.clone_ref(py),
             transaction_committed: self.transaction_committed.clone_ref(py),
             state_view_factory: self.state_view_factory.clone_ref(py),
@@ -178,7 +181,7 @@ impl SyncBlockPublisher {
             .rebuild(Some(committed_batches), Some(uncommitted_batches));
 
         if let Some(prev) = previous_block {
-            self.initialize_block(state, &prev.block())
+            self.initialize_block(state, &prev)
                 .expect("Unable to initialize block after canceling");
         }
     }
@@ -344,14 +347,13 @@ impl SyncBlockPublisher {
         }
     }
 
-    fn get_block_checked(&self, block_id: &str) -> Result<BlockWrapper, PyErr> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let res = self.block_getter.call(py, (block_id,), None);
-        res.map(|i| i.extract::<BlockWrapper>(py))?
+    fn get_block_checked(&self, block_id: &str) -> Result<Block, BlockPublisherError> {
+        self.block_manager.get(&[block_id]).next()
+            .expect("Did not return any Results, even not found blocks")
+            .ok_or_else(|| BlockPublisherError::UnknownBlock(block_id.to_string()))
     }
 
-    fn get_block(&self, block_id: &str) -> BlockWrapper {
+    fn get_block(&self, block_id: &str) -> Block {
         self.get_block_checked(block_id)
             .expect("Unable to extract BlockWrapper")
     }
@@ -362,7 +364,7 @@ impl SyncBlockPublisher {
             .map(|previous_block_id| self.get_block(previous_block_id.as_str()))
         {
             state.candidate_block = None;
-            self.initialize_block(state, &previous_block.block())
+            self.initialize_block(state, &previous_block)
                 .expect("Initialization failed unexpectedly");
         }
     }
@@ -472,22 +474,21 @@ pub struct BlockPublisher {
 
 impl BlockPublisher {
     pub fn new(
+        block_manager: BlockManager,
         transaction_executor: PyObject,
-        block_getter: PyObject,
         batch_committed: PyObject,
         transaction_committed: PyObject,
         state_view_factory: PyObject,
         settings_cache: PyObject,
         block_sender: PyObject,
         batch_publisher: PyObject,
-        chain_head: Option<BlockWrapper>,
+        chain_head: Option<Block>,
         identity_signer: PyObject,
         data_dir: PyObject,
         config_dir: PyObject,
         permission_verifier: PyObject,
         batch_observers: Vec<PyObject>,
         batch_injector_factory: PyObject,
-        block_wrapper_class: PyObject,
         block_header_class: PyObject,
         block_builder_class: PyObject,
         settings_view_class: PyObject,
@@ -496,14 +497,14 @@ impl BlockPublisher {
 
         let state = Arc::new(RwLock::new(BlockPublisherState::new(
             tep,
-            chain_head.map(|bw| bw.block()),
+            chain_head,
             None,
             PendingBatchesPool::new(NUM_PUBLISH_COUNT_SAMPLES, INITIAL_PUBLISH_COUNT),
         )));
 
         let publisher = SyncBlockPublisher {
             state,
-            block_getter,
+            block_manager,
             batch_committed,
             transaction_committed,
             state_view_factory,
@@ -516,7 +517,6 @@ impl BlockPublisher {
             permission_verifier,
             batch_observers,
             batch_injector_factory,
-            block_wrapper_class,
             block_header_class,
             block_builder_class,
             settings_view_class,

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -39,6 +39,7 @@ pub enum ErrorCode {
     BlockNotInitialized = 0x04,
     BlockEmpty = 0x05,
     BlockNotInProgress = 0x06,
+    MissingPredecessor = 0x07,
 }
 
 macro_rules! check_null {
@@ -262,6 +263,7 @@ pub extern "C" fn block_publisher_initialize_block(
     let publisher = unsafe { (*(publisher as *mut BlockPublisher)).clone() };
     py.allow_threads(move || match publisher.initialize_block(block) {
         Err(InitializeBlockError::BlockInProgress) => ErrorCode::BlockInProgress,
+        Err(InitializeBlockError::MissingPredecessor) => ErrorCode::MissingPredecessor,
         Ok(_) => ErrorCode::Success,
     })
 }

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -23,6 +23,7 @@ use std::slice;
 use cpython::{PyClone, PyList, PyObject, Python};
 
 use batch::Batch;
+use block::Block;
 use journal::block_wrapper::BlockWrapper;
 use journal::publisher::{
     BlockPublisher, FinalizeBlockError, IncomingBatchSender, InitializeBlockError,
@@ -262,7 +263,7 @@ pub extern "C" fn block_publisher_initialize_block(
     let py = gil.python();
     let block = unsafe {
         PyObject::from_borrowed_ptr(py, previous_block)
-            .extract::<BlockWrapper>(py)
+            .extract::<Block>(py)
             .unwrap()
     };
 
@@ -388,7 +389,7 @@ pub extern "C" fn block_publisher_on_chain_updated(
     let mut publisher = unsafe { (*(publisher as *mut BlockPublisher)).clone() };
     py.allow_threads(move || {
         publisher.publisher.on_chain_updated_internal(
-            chain_head,
+            chain_head.block(),
             committed_batches,
             uncommitted_batches,
         )

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -24,7 +24,7 @@ use cpython::{PyClone, PyList, PyObject, Python};
 
 use batch::Batch;
 use block::Block;
-use journal::block_wrapper::BlockWrapper;
+use journal::block_manager::BlockManager;
 use journal::publisher::{
     BlockPublisher, FinalizeBlockError, IncomingBatchSender, InitializeBlockError,
 };
@@ -49,8 +49,8 @@ macro_rules! check_null {
 
 #[no_mangle]
 pub extern "C" fn block_publisher_new(
+    block_manager_ptr: *const c_void,
     transaction_executor_ptr: *mut py_ffi::PyObject,
-    get_block_ptr: *mut py_ffi::PyObject,
     batch_committed_ptr: *mut py_ffi::PyObject,
     transaction_committed_ptr: *mut py_ffi::PyObject,
     state_view_factory_ptr: *mut py_ffi::PyObject,
@@ -67,8 +67,8 @@ pub extern "C" fn block_publisher_new(
     block_publisher_ptr: *mut *const c_void,
 ) -> ErrorCode {
     check_null!(
+        block_manager_ptr,
         transaction_executor_ptr,
-        get_block_ptr,
         batch_committed_ptr,
         transaction_committed_ptr,
         state_view_factory_ptr,
@@ -86,8 +86,8 @@ pub extern "C" fn block_publisher_new(
 
     let py = unsafe { Python::assume_gil_acquired() };
 
+    let block_manager = unsafe { (*(block_manager_ptr as *mut BlockManager)).clone() };
     let transaction_executor = unsafe { PyObject::from_borrowed_ptr(py, transaction_executor_ptr) };
-    let get_block = unsafe { PyObject::from_borrowed_ptr(py, get_block_ptr) };
     let batch_committed = unsafe { PyObject::from_borrowed_ptr(py, batch_committed_ptr) };
     let transaction_committed = unsafe { PyObject::from_borrowed_ptr(py, transaction_committed_ptr) };
     let state_view_factory = unsafe { PyObject::from_borrowed_ptr(py, state_view_factory_ptr) };
@@ -127,13 +127,6 @@ pub extern "C" fn block_publisher_new(
         )
         .expect("Unable to create BatchPublisher");
 
-    let block_wrapper_mod = py.import("sawtooth_validator.journal.block_wrapper")
-        .expect("Unable to import 'sawtooth_validator.journal.block_wrapper'");
-
-    let block_wrapper_class = block_wrapper_mod
-        .get(py, "BlockWrapper")
-        .expect("Unable to import BlockWrapper from 'sawtooth_validator.journal.block_wrapper'");
-
     let block_header_class = py.import("sawtooth_validator.protobuf.block_pb2")
         .expect("Unable to import 'sawtooth_validator.protobuf.block_pb2'")
         .get(py, "BlockHeader")
@@ -150,8 +143,8 @@ pub extern "C" fn block_publisher_new(
         .expect("Unable to import SettingsView from 'sawtooth_validator.state.settings_view'");
 
     let publisher = BlockPublisher::new(
+        block_manager,
         transaction_executor,
-        get_block,
         batch_committed,
         transaction_committed,
         state_view_factory,
@@ -165,7 +158,6 @@ pub extern "C" fn block_publisher_new(
         permission_verifier,
         batch_observers,
         batch_injector_factory,
-        block_wrapper_class,
         block_header_class,
         block_builder_class,
         settings_view_class,
@@ -328,7 +320,7 @@ pub fn convert_on_chain_updated_args(
     chain_head_ptr: *mut py_ffi::PyObject,
     committed_batches_ptr: *mut py_ffi::PyObject,
     uncommitted_batches_ptr: *mut py_ffi::PyObject,
-) -> (BlockWrapper, Vec<Batch>, Vec<Batch>) {
+) -> (Block, Vec<Batch>, Vec<Batch>) {
     let chain_head = unsafe { PyObject::from_borrowed_ptr(py, chain_head_ptr) };
     let py_committed_batches = unsafe { PyObject::from_borrowed_ptr(py, committed_batches_ptr) };
     let committed_batches: Vec<Batch> = if py_committed_batches == Python::None(py) {
@@ -389,7 +381,7 @@ pub extern "C" fn block_publisher_on_chain_updated(
     let mut publisher = unsafe { (*(publisher as *mut BlockPublisher)).clone() };
     py.allow_threads(move || {
         publisher.publisher.on_chain_updated_internal(
-            chain_head.block(),
+            chain_head,
             committed_batches,
             uncommitted_batches,
         )

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -29,6 +29,7 @@ extern crate lazy_static;
 extern crate log;
 #[cfg(test)]
 extern crate rand;
+extern crate uluru;
 
 // exported modules
 pub mod database;

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -29,6 +29,7 @@ from sawtooth_validator.database.dict_database import DictDatabase
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.genesis_pb2 import GenesisData
+from sawtooth_validator.journal.block_manager import BlockManager
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.block_wrapper import BlockWrapper
@@ -65,12 +66,13 @@ class TestGenesisController(unittest.TestCase):
         self._with_empty_batch_file()
 
         genesis_ctrl = GenesisController(
-            Mock('context_manager'),
-            Mock('txn_executor'),
-            Mock('completer'),
-            self.make_block_store(),  # Empty block store
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=self.make_block_store(),  # Empty block store
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -85,12 +87,13 @@ class TestGenesisController(unittest.TestCase):
         })
 
         genesis_ctrl = GenesisController(
-            Mock('context_manager'),
-            Mock('txn_executor'),
-            Mock('completer'),
-            block_store,
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=block_store,
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -104,12 +107,13 @@ class TestGenesisController(unittest.TestCase):
         block_store = self.make_block_store()
 
         genesis_ctrl = GenesisController(
-            Mock('context_manager'),
-            Mock('txn_executor'),
-            Mock('completer'),
-            block_store,
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=block_store,
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -128,12 +132,13 @@ class TestGenesisController(unittest.TestCase):
         block_store = self.make_block_store()
 
         genesis_ctrl = GenesisController(
-            Mock(name='context_manager'),
-            Mock(name='txn_executor'),
-            Mock('completer'),
-            block_store,
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=block_store,
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -155,12 +160,13 @@ class TestGenesisController(unittest.TestCase):
         block_store = self.make_block_store({block.header_signature: block})
 
         genesis_ctrl = GenesisController(
-            Mock('context_manager'),
-            Mock('txn_executor'),
-            Mock('completer'),
-            block_store,
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=block_store,
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -183,12 +189,13 @@ class TestGenesisController(unittest.TestCase):
         block_store = self.make_block_store()
 
         genesis_ctrl = GenesisController(
-            Mock('context_manager'),
-            Mock('txn_executor'),
-            Mock('completer'),
-            block_store,
-            Mock('StateViewFactory'),
-            self._signer,
+            context_manager=Mock('context_manager'),
+            transaction_executor=Mock('txn_executor'),
+            completer=Mock('completer'),
+            block_store=block_store,
+            state_view_factory=Mock('StateViewFactory'),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -227,12 +234,13 @@ class TestGenesisController(unittest.TestCase):
         completer.add_block = Mock('add_block')
 
         genesis_ctrl = GenesisController(
-            ctx_mgr,
-            txn_executor,
-            completer,
-            block_store,
-            StateViewFactory(state_database),
-            self._signer,
+            context_manager=ctx_mgr,
+            transaction_executor=txn_executor,
+            completer=completer,
+            block_store=block_store,
+            state_view_factory=StateViewFactory(state_database),
+            identity_signer=self._signer,
+            block_manager=BlockManager(),
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -65,14 +65,18 @@ class TestGenesisController(unittest.TestCase):
     def test_requires_genesis(self):
         self._with_empty_batch_file()
 
+        block_store = self.make_block_store()
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
+
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
             transaction_executor=Mock('txn_executor'),
             completer=Mock('completer'),
-            block_store=self.make_block_store(),  # Empty block store
+            block_store=block_store,  # Empty block store
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -85,6 +89,8 @@ class TestGenesisController(unittest.TestCase):
         block_store = self.make_block_store({
             block.header_signature: block
         })
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
@@ -93,7 +99,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -105,6 +111,8 @@ class TestGenesisController(unittest.TestCase):
         self._with_network_name('some_network_name')
 
         block_store = self.make_block_store()
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
@@ -113,7 +121,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -130,6 +138,8 @@ class TestGenesisController(unittest.TestCase):
         the the GenesisController should not require genesis.
         """
         block_store = self.make_block_store()
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
@@ -138,7 +148,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -158,6 +168,8 @@ class TestGenesisController(unittest.TestCase):
 
         block = self._create_block()
         block_store = self.make_block_store({block.header_signature: block})
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
@@ -166,7 +178,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -187,6 +199,8 @@ class TestGenesisController(unittest.TestCase):
         self._with_network_name('some_block_chain_id')
 
         block_store = self.make_block_store()
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         genesis_ctrl = GenesisController(
             context_manager=Mock('context_manager'),
@@ -195,7 +209,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=Mock('StateViewFactory'),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
@@ -218,6 +232,8 @@ class TestGenesisController(unittest.TestCase):
         """
         genesis_file = self._with_empty_batch_file()
         block_store = self.make_block_store()
+        block_manager = BlockManager()
+        block_manager.add_store("commit_store", block_store)
 
         state_database = NativeLmdbDatabase(
             os.path.join(self._temp_dir, 'test_genesis.lmdb'),
@@ -240,7 +256,7 @@ class TestGenesisController(unittest.TestCase):
             block_store=block_store,
             state_view_factory=StateViewFactory(state_database),
             identity_signer=self._signer,
-            block_manager=BlockManager(),
+            block_manager=block_manager,
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -102,6 +102,7 @@ class BlockTreeManager:
         self.state_db = {}
 
         self.block_manager = BlockManager()
+        self.block_manager.add_store("commit_store", self.block_store)
 
         # add the mock reference to the consensus
         consensus_setting_addr = SettingsView.setting_address(

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -29,6 +29,7 @@ from sawtooth_validator.database.dict_database import DictDatabase
 
 from sawtooth_validator.journal.block_builder import BlockBuilder
 from sawtooth_validator.journal.block_cache import BlockCache
+from sawtooth_validator.journal.block_manager import BlockManager
 from sawtooth_validator.journal.block_store import BlockStore
 from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
 from sawtooth_validator.journal.block_wrapper import BlockStatus
@@ -100,6 +101,8 @@ class BlockTreeManager:
         self.block_cache = BlockCache(self.block_store)
         self.state_db = {}
 
+        self.block_manager = BlockManager()
+
         # add the mock reference to the consensus
         consensus_setting_addr = SettingsView.setting_address(
             'sawtooth.consensus.algorithm')
@@ -121,8 +124,8 @@ class BlockTreeManager:
             chain_head = self.genesis_block
 
         self.block_publisher = BlockPublisher(
+            block_manager=self.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_cache[block],
             transaction_committed=self.block_store.has_transaction,
             batch_committed=self.block_store.has_batch,
             state_view_factory=self.state_view_factory,
@@ -131,7 +134,7 @@ class BlockTreeManager:
             ),
             block_sender=self.block_sender,
             batch_sender=self.block_sender,
-            chain_head=chain_head,
+            chain_head=chain_head.block,
             identity_signer=self.identity_signer,
             data_dir=None,
             config_dir=None,

--- a/validator/tests/test_journal/mock.py
+++ b/validator/tests/test_journal/mock.py
@@ -327,7 +327,8 @@ class MockBatchInjector(BatchInjector):
 
 class MockBlockValidator(BlockValidator):
     def __init__(self,
-                 block_cache,
+                 block_manager,
+                 block_store,
                  state_view_factory,
                  transaction_executor,
                  identity_signer,
@@ -339,14 +340,15 @@ class MockBlockValidator(BlockValidator):
         self._submitted_blocks = None
         self._has_block = has_block
         super().__init__(
-            block_cache,
-            state_view_factory,
-            transaction_executor,
-            identity_signer,
-            data_dir,
-            config_dir,
-            permission_verifier,
-            thread_pool)
+            block_manager=block_manager,
+            state_view_factory=state_view_factory,
+            transaction_executor=transaction_executor,
+            identity_signer=identity_signer,
+            data_dir=data_dir,
+            config_dir=config_dir,
+            permission_verifier=permission_verifier,
+            thread_pool=thread_pool,
+            block_store=block_store)
 
     def has_block(self, block_id):
         return self._has_block

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -159,8 +159,8 @@ class TestBlockPublisher(unittest.TestCase):
         self.permission_verifier = MockPermissionVerifier()
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -172,7 +172,7 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -335,9 +335,9 @@ class TestBlockPublisher(unittest.TestCase):
 
         mock_batch_injector_factory.create_injectors.return_value = []
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(
                 batch_execution_result=False),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -349,7 +349,7 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -381,8 +381,8 @@ class TestBlockPublisher(unittest.TestCase):
             {addr: value})
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -394,7 +394,7 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -442,8 +442,8 @@ class TestBlockPublisher(unittest.TestCase):
         injected_batch = self.make_batch()
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -455,7 +455,7 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -494,8 +494,8 @@ class TestBlockPublisher(unittest.TestCase):
         batch2 = self.make_batch(txn_count=1)
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -507,7 +507,7 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -1000,8 +1000,8 @@ class TestChainController(unittest.TestCase):
             thread_pool=self.executor)
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -1013,7 +1013,7 @@ class TestChainController(unittest.TestCase):
             ),
             block_sender=MockBlockSender(),
             batch_sender=MockBatchSender(),
-            chain_head=self.block_tree_manager.chain_head,
+            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -1171,8 +1171,8 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
         self.consensus_notifier = MockConsensusNotifier()
 
         self.publisher = BlockPublisher(
+            block_manager=self.block_tree_manager.block_manager,
             transaction_executor=self.txn_executor,
-            get_block=lambda block: self.block_tree_manager.block_cache[block],
             transaction_committed=(
                 self.block_tree_manager.block_store.has_transaction
             ),
@@ -1185,7 +1185,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
             ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.block_store.chain_head,
+            chain_head=self.block_tree_manager.block_store.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -1314,8 +1314,8 @@ class TestJournal(unittest.TestCase):
         chain_controller = None
         try:
             block_publisher = BlockPublisher(
+                block_manager=block_manager,
                 transaction_executor=self.txn_executor,
-                get_block=lambda block: btm.block_cache[block],
                 transaction_committed=btm.block_store.has_transaction,
                 batch_committed=btm.block_store.has_batch,
                 state_view_factory=MockStateViewFactory(btm.state_db),
@@ -1325,7 +1325,7 @@ class TestJournal(unittest.TestCase):
                 ),
                 block_sender=self.block_sender,
                 batch_sender=self.batch_sender,
-                chain_head=btm.block_store.chain_head,
+                chain_head=btm.block_store.chain_head.block,
                 identity_signer=btm.identity_signer,
                 data_dir=None,
                 config_dir=None,


### PR DESCRIPTION
Replaces the use of the block cache in the BlockPublisher with the BlockManager.  Additionally, it refs the previous block when it initializes a block, and unref's the same when the block is canceled.

This is based on #1806 
