### PR TITLE
Add SettingsViewFactory in Rust

### DIFF
--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -21,6 +21,9 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha256;
 use protobuf;
 
+use database::lmdb::LmdbDatabase;
+
+use state::merkle::MerkleDatabase;
 use state::StateDatabaseError;
 use state::StateReader;
 
@@ -55,6 +58,24 @@ impl From<protobuf::ProtobufError> for SettingsViewError {
 impl From<ParseIntError> for SettingsViewError {
     fn from(err: ParseIntError) -> Self {
         SettingsViewError::ParseIntError(err)
+    }
+}
+
+pub struct SettingsViewFactory {
+    state_db: LmdbDatabase,
+}
+
+impl SettingsViewFactory {
+    pub fn new(state_db: LmdbDatabase) -> Self {
+        SettingsViewFactory { state_db }
+    }
+
+    pub fn create_settings_view<S: Into<String>>(
+        &mut self,
+        merkle_root: S,
+    ) -> Result<SettingsView<MerkleDatabase>, StateDatabaseError> {
+        let merkle_db = MerkleDatabase::new(self.state_db.clone(), Some(&merkle_root.into()))?;
+        Ok(SettingsView::new(merkle_db))
     }
 }
 


### PR DESCRIPTION
The SettingsViewFactory produces SettingsView<MerkleDatabase> instances
with a particular merkle root.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>