### PR TITLE
Use Rust SettingsView in BlockPublisher

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -130,7 +130,6 @@ class BlockPublisher(OwnedPointer):
                  batch_committed,
                  transaction_committed,
                  state_view_factory,
-                 settings_cache,
                  block_sender,
                  batch_sender,
                  chain_head,
@@ -151,8 +150,8 @@ class BlockPublisher(OwnedPointer):
                 a batch is committed.
             transaction_committed (fn(transaction_id) -> bool): A function for
                 checking if a transaction is committed.
-            state_view_factory (:obj:`StateViewFactory`): StateViewFactory for
-                read-only state views.
+            state_view_factory (:obj:`NativeStateViewFactory`):
+                NativeStateViewFactory for read-only state views.
             block_sender (:obj:`BlockSender`): The BlockSender instance.
             batch_sender (:obj:`BatchSender`): The BatchSender instance.
             chain_head (:obj:`BlockWrapper`): The initial chain head.
@@ -180,8 +179,7 @@ class BlockPublisher(OwnedPointer):
             ctypes.py_object(transaction_executor),
             ctypes.py_object(batch_committed),
             ctypes.py_object(transaction_committed),
-            ctypes.py_object(state_view_factory),
-            ctypes.py_object(settings_cache),
+            state_view_factory.pointer,
             ctypes.py_object(block_sender),
             ctypes.py_object(batch_sender),
             ctypes.py_object(chain_head_block),

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -50,6 +50,7 @@ from sawtooth_validator.state.settings_cache import SettingsObserver
 from sawtooth_validator.state.settings_cache import SettingsCache
 from sawtooth_validator.state.identity_view import IdentityViewFactory
 from sawtooth_validator.state.state_view import StateViewFactory
+from sawtooth_validator.state.state_view import NativeStateViewFactory
 from sawtooth_validator.gossip.permission_verifier import PermissionVerifier
 from sawtooth_validator.gossip.permission_verifier import IdentityCache
 from sawtooth_validator.gossip.identity_observer import IdentityObserver
@@ -122,6 +123,7 @@ class Validator:
             global_state_db_filename,
             indexes=MerkleDatabase.create_index_configuration())
         state_view_factory = StateViewFactory(global_state_db)
+        native_state_view_factory = NativeStateViewFactory(global_state_db)
 
         # -- Setup Receipt Store -- #
         receipt_db_filename = os.path.join(
@@ -300,8 +302,7 @@ class Validator:
             transaction_executor=transaction_executor,
             transaction_committed=block_store.has_transaction,
             batch_committed=block_store.has_batch,
-            state_view_factory=state_view_factory,
-            settings_cache=settings_cache,
+            state_view_factory=native_state_view_factory,
             block_sender=block_sender,
             batch_sender=batch_sender,
             chain_head=block_store.chain_head,

--- a/validator/sawtooth_validator/state/state_view.py
+++ b/validator/sawtooth_validator/state/state_view.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
+import ctypes
 
 from sawtooth_validator.state.merkle import MerkleDatabase
 from sawtooth_validator.state.merkle import INIT_ROOT_KEY
+
+from sawtooth_validator import ffi
 
 
 class StateViewFactory:
@@ -51,6 +54,16 @@ class StateViewFactory:
                                    merkle_root=state_root_hash)
 
         return StateView(merkle_db)
+
+
+class NativeStateViewFactory(ffi.OwnedPointer):
+    """A StateViewFactory, which wraps a native Rust instance, which can be
+    passed to other rust objects."""
+    def __init__(self, database):
+        super(NativeStateViewFactory, self).__init__('state_view_factory_drop')
+        ffi.LIBRARY.call('state_view_factory_new',
+                         database.pointer,
+                         ctypes.byref(self.pointer))
 
 
 class StateView:

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -31,6 +31,7 @@ use transaction::Transaction;
 
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::validation_rule_enforcer;
+use state::settings_view::SettingsView;
 
 use pylogger;
 
@@ -58,7 +59,7 @@ pub struct CandidateBlock {
     block_builder: cpython::PyObject,
     batch_injectors: Vec<cpython::PyObject>,
     identity_signer: cpython::PyObject,
-    settings_view: cpython::PyObject,
+    settings_view: SettingsView,
 
     summary: Option<Vec<u8>>,
     /// Batches remaining after the summary has been computed
@@ -82,7 +83,7 @@ impl CandidateBlock {
         max_batches: usize,
         batch_injectors: Vec<cpython::PyObject>,
         identity_signer: cpython::PyObject,
-        settings_view: cpython::PyObject,
+        settings_view: SettingsView,
     ) -> Self {
         CandidateBlock {
             previous_block,

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -35,6 +35,8 @@ use journal::candidate_block::{CandidateBlock, CandidateBlockError};
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::chain_head_lock::ChainHeadLock;
 use metrics;
+use state::settings_view::SettingsView;
+use state::state_view_factory::StateViewFactory;
 
 const NUM_PUBLISH_COUNT_SAMPLES: usize = 5;
 const INITIAL_PUBLISH_COUNT: usize = 30;
@@ -108,11 +110,9 @@ pub struct SyncBlockPublisher {
     batch_injector_factory: PyObject,
     block_header_class: PyObject,
     block_builder_class: PyObject,
-    settings_view_class: PyObject,
     batch_committed: PyObject,
     transaction_committed: PyObject,
-    state_view_factory: PyObject,
-    settings_cache: PyObject,
+    state_view_factory: StateViewFactory,
     block_sender: PyObject,
     batch_publisher: PyObject,
     identity_signer: PyObject,
@@ -141,11 +141,9 @@ impl Clone for SyncBlockPublisher {
             batch_injector_factory: self.batch_injector_factory.clone_ref(py),
             block_header_class: self.block_header_class.clone_ref(py),
             block_builder_class: self.block_builder_class.clone_ref(py),
-            settings_view_class: self.settings_view_class.clone_ref(py),
             batch_committed: self.batch_committed.clone_ref(py),
             transaction_committed: self.transaction_committed.clone_ref(py),
-            state_view_factory: self.state_view_factory.clone_ref(py),
-            settings_cache: self.settings_cache.clone_ref(py),
+            state_view_factory: self.state_view_factory.clone(),
             block_sender: self.block_sender.clone_ref(py),
             batch_publisher: self.batch_publisher.clone_ref(py),
             identity_signer: self.identity_signer.clone_ref(py),
@@ -204,12 +202,6 @@ impl SyncBlockPublisher {
         );
     }
 
-    fn get_state_view(&self, py: Python, previous_block: &Block) -> PyObject {
-        self.state_view_factory
-            .call_method(py, "create_view", (&previous_block.state_root_hash,), None)
-            .expect("BlockWrapper, unable to call state_view_for_block")
-    }
-
     fn load_injectors(&self, py: Python, state_root: &str) -> Vec<PyObject> {
         self.batch_injector_factory
             .call_method(py, "create_injectors", (state_root,), None)
@@ -243,27 +235,19 @@ impl SyncBlockPublisher {
                 })?;
         }
         let mut candidate_block = {
+            let settings_view: SettingsView = self
+                .state_view_factory
+                .create_view(&previous_block.state_root_hash)
+                .expect("Failed to get state view for previous block");
+
+            let max_batches = settings_view
+                .get_setting_u32("sawtooth.publisher.max_batches_per_block", Some(0u32))
+                .expect("Unable to get value from settings view")
+                .expect("Failed to return expected default") as usize;
+
             let gil = Python::acquire_gil();
             let py = gil.python();
 
-            let kwargs = PyDict::new(py);
-            kwargs.set_item(py, "default_value", 0).unwrap();
-            let max_batches = self
-                .settings_cache
-                .call_method(
-                    py,
-                    "get_setting",
-                    (
-                        "sawtooth.publisher.max_batches_per_block",
-                        &previous_block.state_root_hash,
-                    ),
-                    Some(&kwargs),
-                )
-                .expect("settings_cache has no method get_setting")
-                .extract::<usize>(py)
-                .unwrap();
-
-            let state_view = self.get_state_view(py, previous_block);
             let public_key = self.get_public_key(py);
             let batch_injectors = self.load_injectors(py, &previous_block.state_root_hash);
 
@@ -294,11 +278,6 @@ impl SyncBlockPublisher {
 
             let committed_txn_cache =
                 TransactionCommitCache::new(self.transaction_committed.clone_ref(py));
-
-            let settings_view = self
-                .settings_view_class
-                .call(py, (state_view,), None)
-                .expect("SettingsView could not be constructed");
 
             CandidateBlock::new(
                 previous_block.clone(),
@@ -526,8 +505,7 @@ impl BlockPublisher {
         transaction_executor: PyObject,
         batch_committed: PyObject,
         transaction_committed: PyObject,
-        state_view_factory: PyObject,
-        settings_cache: PyObject,
+        state_view_factory: StateViewFactory,
         block_sender: PyObject,
         batch_publisher: PyObject,
         chain_head: Option<Block>,
@@ -539,7 +517,6 @@ impl BlockPublisher {
         batch_injector_factory: PyObject,
         block_header_class: PyObject,
         block_builder_class: PyObject,
-        settings_view_class: PyObject,
     ) -> Self {
         let tep = Box::new(PyExecutor::new(transaction_executor).unwrap());
 
@@ -556,7 +533,6 @@ impl BlockPublisher {
             batch_committed,
             transaction_committed,
             state_view_factory,
-            settings_cache,
             block_sender,
             batch_publisher,
             identity_signer,
@@ -567,7 +543,6 @@ impl BlockPublisher {
             batch_injector_factory,
             block_header_class,
             block_builder_class,
-            settings_view_class,
             exit: Arc::new(Exit::new()),
         };
 

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -29,6 +29,8 @@ use journal::publisher::{
     BlockPublisher, FinalizeBlockError, IncomingBatchSender, InitializeBlockError,
 };
 
+use state::state_view_factory::StateViewFactory;
+
 #[repr(u32)]
 #[derive(Debug)]
 pub enum ErrorCode {
@@ -54,8 +56,7 @@ pub unsafe extern "C" fn block_publisher_new(
     transaction_executor_ptr: *mut py_ffi::PyObject,
     batch_committed_ptr: *mut py_ffi::PyObject,
     transaction_committed_ptr: *mut py_ffi::PyObject,
-    state_view_factory_ptr: *mut py_ffi::PyObject,
-    settings_cache_ptr: *mut py_ffi::PyObject,
+    state_view_factory_ptr: *const c_void,
     block_sender_ptr: *mut py_ffi::PyObject,
     batch_sender_ptr: *mut py_ffi::PyObject,
     chain_head_ptr: *mut py_ffi::PyObject,
@@ -73,7 +74,6 @@ pub unsafe extern "C" fn block_publisher_new(
         batch_committed_ptr,
         transaction_committed_ptr,
         state_view_factory_ptr,
-        settings_cache_ptr,
         block_sender_ptr,
         batch_sender_ptr,
         chain_head_ptr,
@@ -91,8 +91,9 @@ pub unsafe extern "C" fn block_publisher_new(
     let transaction_executor = PyObject::from_borrowed_ptr(py, transaction_executor_ptr);
     let batch_committed = PyObject::from_borrowed_ptr(py, batch_committed_ptr);
     let transaction_committed = PyObject::from_borrowed_ptr(py, transaction_committed_ptr);
-    let state_view_factory = PyObject::from_borrowed_ptr(py, state_view_factory_ptr);
-    let settings_cache = PyObject::from_borrowed_ptr(py, settings_cache_ptr);
+    let state_view_factory = (state_view_factory_ptr as *const StateViewFactory)
+        .as_ref()
+        .unwrap();
     let block_sender = PyObject::from_borrowed_ptr(py, block_sender_ptr);
     let batch_sender = PyObject::from_borrowed_ptr(py, batch_sender_ptr);
     let chain_head = PyObject::from_borrowed_ptr(py, chain_head_ptr);
@@ -140,19 +141,12 @@ pub unsafe extern "C" fn block_publisher_new(
         .get(py, "BlockBuilder")
         .expect("Unable to import BlockBuilder from 'sawtooth_validator.journal.block_builder'");
 
-    let settings_view_class = py
-        .import("sawtooth_validator.state.settings_view")
-        .expect("Unable to import 'sawtooth_validator.state.settings_view'")
-        .get(py, "SettingsView")
-        .expect("Unable to import SettingsView from 'sawtooth_validator.state.settings_view'");
-
     let publisher = BlockPublisher::new(
         block_manager,
         transaction_executor,
         batch_committed,
         transaction_committed,
-        state_view_factory,
-        settings_cache,
+        state_view_factory.clone(),
         block_sender,
         batch_publisher,
         chain_head,
@@ -164,7 +158,6 @@ pub unsafe extern "C" fn block_publisher_new(
         batch_injector_factory,
         block_header_class,
         block_builder_class,
-        settings_view_class,
     );
 
     *block_publisher_ptr = Box::into_raw(Box::new(publisher)) as *const c_void;

--- a/validator/src/state/identity_view.rs
+++ b/validator/src/state/identity_view.rs
@@ -57,19 +57,13 @@ impl From<protobuf::ProtobufError> for IdentityViewError {
 /// Provides a view into global state which translates Role and Policy names
 /// into the corresponding addresses, and returns the deserialized values from
 /// state.
-pub struct IdentityView<R>
-where
-    R: StateReader,
-{
-    state_reader: R,
+pub struct IdentityView {
+    state_reader: Box<StateReader>,
 }
 
-impl<R> IdentityView<R>
-where
-    R: StateReader,
-{
+impl IdentityView {
     /// Creates an IdentityView from a given StateReader.
-    pub fn new(state_reader: R) -> Self {
+    pub fn new(state_reader: Box<StateReader>) -> Self {
         IdentityView { state_reader }
     }
 
@@ -241,7 +235,7 @@ mod tests {
     #[test]
     fn no_roles() {
         let mock_reader = MockStateReader::new(vec![]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(None, identity_view.get_role("my_role").unwrap());
         let expect_empty: Vec<Role> = vec![];
@@ -254,7 +248,7 @@ mod tests {
             role_entry("role1", "some_policy"),
             role_entry("role2", "some_other_policy"),
         ]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(
             Some(role("role2", "some_other_policy")),
@@ -268,7 +262,7 @@ mod tests {
             role_entry("role1", "some_policy"),
             role_entry("role2", "some_other_policy"),
         ]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(
             vec![
@@ -282,7 +276,7 @@ mod tests {
     #[test]
     fn no_policies() {
         let mock_reader = MockStateReader::new(vec![]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(None, identity_view.get_policy("my_policy").unwrap());
         let expect_empty: Vec<Policy> = vec![];
@@ -295,7 +289,7 @@ mod tests {
             policy_entry("policy1", &["some_pubkey"]),
             policy_entry("policy2", &["some_other_pubkey"]),
         ]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(
             Some(policy("policy2", &["some_other_pubkey"])),
@@ -309,7 +303,7 @@ mod tests {
             policy_entry("policy1", &["some_pubkey"]),
             policy_entry("policy2", &["some_other_pubkey"]),
         ]);
-        let identity_view = IdentityView::new(mock_reader);
+        let identity_view = IdentityView::new(Box::new(mock_reader));
 
         assert_eq!(
             vec![

--- a/validator/src/state/identity_view.rs
+++ b/validator/src/state/identity_view.rs
@@ -141,6 +141,12 @@ impl IdentityView {
     }
 }
 
+impl From<Box<StateReader>> for IdentityView {
+    fn from(state_reader: Box<StateReader>) -> Self {
+        IdentityView::new(state_reader)
+    }
+}
+
 trait ProtobufList<T>: protobuf::Message {
     fn values(&self) -> &[T];
 }

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -21,6 +21,7 @@ pub mod merkle;
 pub mod merkle_ffi;
 pub mod settings_view;
 pub mod state_pruning_manager;
+pub mod state_view_factory;
 
 use state::error::StateDatabaseError;
 

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -22,6 +22,7 @@ pub mod merkle_ffi;
 pub mod settings_view;
 pub mod state_pruning_manager;
 pub mod state_view_factory;
+pub mod state_view_ffi;
 
 use state::error::StateDatabaseError;
 

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -26,7 +26,7 @@ pub mod state_view_ffi;
 
 use state::error::StateDatabaseError;
 
-pub trait StateReader {
+pub trait StateReader: Send + Sync {
     /// Returns true if the given address exists in State; false, otherwise.
     ///
     /// Will return a StateDatabaseError if any errors occur while querying for

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -62,6 +62,11 @@ pub struct SettingsView {
     state_reader: Box<StateReader>,
 }
 
+// Given that this is not threadsafe, but can be members of objects that can
+// be moved between threads (themselves guarded by mutexes/rwlocks), we can
+// safely implement sync.
+unsafe impl Sync for SettingsView {}
+
 impl SettingsView {
     /// Creates a new SettingsView with a given StateReader
     pub fn new(state_reader: Box<StateReader>) -> Self {

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -140,6 +140,12 @@ impl SettingsView {
     }
 }
 
+impl From<Box<StateReader>> for SettingsView {
+    fn from(state_reader: Box<StateReader>) -> Self {
+        SettingsView { state_reader }
+    }
+}
+
 fn setting_address(key: &str) -> String {
     let mut address = String::new();
     address.push_str(CONFIG_STATE_NAMESPACE);

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -79,19 +79,13 @@ impl SettingsViewFactory {
     }
 }
 
-pub struct SettingsView<R>
-where
-    R: StateReader,
-{
-    state_reader: R,
+pub struct SettingsView {
+    state_reader: Box<StateReader>,
 }
 
-impl<R> SettingsView<R>
-where
-    R: StateReader,
-{
+impl SettingsView {
     /// Creates a new SettingsView with a given StateReader
-    pub fn new(state_reader: R) -> Self {
+    pub fn new(state_reader: Box<StateReader>) -> Self {
         SettingsView { state_reader }
     }
 
@@ -203,7 +197,7 @@ mod tests {
             setting_entry("my.other.list", "13;14;15"),
         ]);
 
-        let settings_view = SettingsView::new(mock_reader);
+        let settings_view = SettingsView::new(Box::new(mock_reader));
 
         // Test not founds
         assert_eq!(

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -21,9 +21,6 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha256;
 use protobuf;
 
-use database::lmdb::LmdbDatabase;
-
-use state::merkle::MerkleDatabase;
 use state::StateDatabaseError;
 use state::StateReader;
 
@@ -58,24 +55,6 @@ impl From<protobuf::ProtobufError> for SettingsViewError {
 impl From<ParseIntError> for SettingsViewError {
     fn from(err: ParseIntError) -> Self {
         SettingsViewError::ParseIntError(err)
-    }
-}
-
-pub struct SettingsViewFactory {
-    state_db: LmdbDatabase,
-}
-
-impl SettingsViewFactory {
-    pub fn new(state_db: LmdbDatabase) -> Self {
-        SettingsViewFactory { state_db }
-    }
-
-    pub fn create_settings_view<S: Into<String>>(
-        &mut self,
-        merkle_root: S,
-    ) -> Result<SettingsView<MerkleDatabase>, StateDatabaseError> {
-        let merkle_db = MerkleDatabase::new(self.state_db.clone(), Some(&merkle_root.into()))?;
-        Ok(SettingsView::new(merkle_db))
     }
 }
 

--- a/validator/src/state/state_view_factory.rs
+++ b/validator/src/state/state_view_factory.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Bitwise IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use database::lmdb::LmdbDatabase;
+use state::error::StateDatabaseError;
+use state::merkle::MerkleDatabase;
+use state::StateReader;
+
+/// The StateViewFactory produces StateViews for a particular merkle root.
+///
+/// This factory produces read-only views of a merkle tree. For a given
+/// database, these views are considered immutable.
+#[derive(Clone)]
+pub struct StateViewFactory {
+    state_database: LmdbDatabase,
+}
+
+impl StateViewFactory {
+    pub fn new(state_database: LmdbDatabase) -> Self {
+        StateViewFactory { state_database }
+    }
+
+    /// Creates a state view for a given state root hash.
+    pub fn create_view<V: From<Box<StateReader>>>(
+        &self,
+        state_root_hash: &str,
+    ) -> Result<V, StateDatabaseError> {
+        let merkle_db = MerkleDatabase::new(self.state_database.clone(), Some(state_root_hash))?;
+        Ok(V::from(Box::new(merkle_db)))
+    }
+}

--- a/validator/src/state/state_view_ffi.rs
+++ b/validator/src/state/state_view_ffi.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Bitwise IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+use std::os::raw::c_void;
+
+use database::lmdb::LmdbDatabase;
+use state::state_view_factory::StateViewFactory;
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum ErrorCode {
+    Success = 0,
+    NullPointerProvided = 1,
+    Unknown = 0xFF,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn state_view_factory_new(
+    database: *const c_void,
+    state_view_factory: *mut *const c_void,
+) -> ErrorCode {
+    if database.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    let db_ref = (database as *const LmdbDatabase).as_ref().unwrap();
+
+    *state_view_factory =
+        Box::into_raw(Box::new(StateViewFactory::new(db_ref.clone()))) as *const c_void;
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn state_view_factory_drop(state_view_factory: *mut c_void) -> ErrorCode {
+    if state_view_factory.is_null() {
+        return ErrorCode::NullPointerProvided;
+    }
+
+    Box::from_raw(state_view_factory as *mut StateViewFactory);
+    ErrorCode::Success
+}

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -74,8 +74,7 @@ from sawtooth_validator.protobuf.events_pb2 import Event
 from sawtooth_validator.protobuf.events_pb2 import EventFilter
 
 from sawtooth_validator.state.merkle import MerkleDatabase
-from sawtooth_validator.state.settings_view import SettingsViewFactory
-from sawtooth_validator.state.settings_cache import SettingsCache
+from sawtooth_validator.state.state_view import NativeStateViewFactory
 
 from test_journal.block_tree_manager import BlockTreeManager
 
@@ -166,10 +165,6 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.block_tree_manager.state_view_factory),
-            ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.chain_head.block,
@@ -343,10 +338,6 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.block_tree_manager.state_view_factory),
-            ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.chain_head.block,
@@ -388,10 +379,6 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.state_view_factory),
-            ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.chain_head.block,
@@ -449,10 +436,6 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.block_tree_manager.state_view_factory),
-            ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.chain_head.block,
@@ -501,10 +484,6 @@ class TestBlockPublisher(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.state_view_factory),
-            ),
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.chain_head.block,
@@ -977,10 +956,11 @@ class TestChainController(unittest.TestCase):
             indexes=MerkleDatabase.create_index_configuration(),
             _size=120 * 1024 * 1024)
 
+        self.state_view_factory = NativeStateViewFactory(self.state_database)
+
         self.block_tree_manager = BlockTreeManager()
         self.permission_verifier = MockPermissionVerifier()
-        self.state_view_factory = MockStateViewFactory(
-            self.block_tree_manager.state_db)
+
         self.transaction_executor = MockTransactionExecutor(
             batch_execution_result=None)
         self.executor = SynchronousExecutor()
@@ -1007,10 +987,6 @@ class TestChainController(unittest.TestCase):
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.block_tree_manager.state_view_factory),
-            ),
             block_sender=MockBlockSender(),
             batch_sender=MockBatchSender(),
             chain_head=self.block_tree_manager.chain_head.block,
@@ -1175,6 +1151,10 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
             os.path.join(self.dir, 'merkle.lmdb'),
             indexes=MerkleDatabase.create_index_configuration(),
             _size=120 * 1024 * 1024)
+
+        self.native_state_view_factory = NativeStateViewFactory(
+            self.state_database)
+
         self.block_sender = MockBlockSender()
         self.batch_sender = MockBatchSender()
         self.consensus_notifier = MockConsensusNotifier()
@@ -1186,12 +1166,7 @@ class TestChainControllerGenesisPeer(unittest.TestCase):
                 self.block_tree_manager.block_store.has_transaction
             ),
             batch_committed=self.block_tree_manager.block_store.has_batch,
-            state_view_factory=MockStateViewFactory(
-                self.block_tree_manager.state_db),
-            settings_cache=SettingsCache(
-                SettingsViewFactory(
-                    self.block_tree_manager.state_view_factory),
-            ),
+            state_view_factory=self.native_state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
             chain_head=self.block_tree_manager.block_store.chain_head.block,
@@ -1326,10 +1301,6 @@ class TestJournal(unittest.TestCase):
                 transaction_committed=btm.block_store.has_transaction,
                 batch_committed=btm.block_store.has_batch,
                 state_view_factory=MockStateViewFactory(btm.state_db),
-                settings_cache=SettingsCache(
-                    SettingsViewFactory(
-                        btm.state_view_factory),
-                ),
                 block_sender=self.block_sender,
                 batch_sender=self.batch_sender,
                 chain_head=btm.block_store.chain_head.block,


### PR DESCRIPTION
This finalizes the implementation of the SettingsView in Rust, by providing the similar functionality to the python implementation of instance-level memoization.  Additionally, it creates a generic version of the StateViewFactory, which will return any item that implements `From<Box<StateReader>>` (useful for forthcoming work on the IdentityView).  As a result, the existing SettingsViewFactory is removed.