### PR TITLE
Add block validation checks in Rust

### DIFF
--- a/validator/src/gossip/mod.rs
+++ b/validator/src/gossip/mod.rs
@@ -15,37 +15,4 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate cbor;
-extern crate cpython;
-extern crate crypto;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
-extern crate python3_sys as py_ffi;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate rand;
-extern crate uluru;
-
-// exported modules
-pub mod database;
-pub mod execution;
-pub mod gossip;
-pub mod journal;
-mod metrics;
-pub mod proto;
-pub mod pylogger;
-pub mod scheduler;
-pub mod state;
-
-pub mod batch;
-mod batch_ffi;
-pub mod block;
-mod block_ffi;
-pub mod transaction;
-
-pub mod ffi;
+pub mod permission_verifier;

--- a/validator/src/gossip/permission_verifier.rs
+++ b/validator/src/gossip/permission_verifier.rs
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cpython::{self, ObjectProtocol};
+
+use batch::Batch;
+use transaction::Transaction;
+
+pub trait PermissionVerifier {
+    fn is_batch_signer_authorized(&self, batch: &Batch, state_root: &str, from_state: bool)
+        -> bool;
+}
+
+pub struct PyPermissionVerifier {
+    verifier: cpython::PyObject,
+}
+
+impl PyPermissionVerifier {
+    pub fn new(verifier: cpython::PyObject) -> Self {
+        PyPermissionVerifier { verifier }
+    }
+}
+
+impl PermissionVerifier for PyPermissionVerifier {
+    fn is_batch_signer_authorized(
+        &self,
+        batch: &Batch,
+        state_root: &str,
+        from_state: bool,
+    ) -> bool {
+        let gil = cpython::Python::acquire_gil();
+        let py = gil.python();
+
+        self.verifier
+            .call_method(
+                py,
+                "is_batch_signer_authorized",
+                (batch, state_root, from_state),
+                None,
+            )
+            .expect("PermissionVerifier has no method `is_batch_signer_authorized`")
+            .extract(py)
+            .expect("Unable to extract bool from `is_batch_signer_authorized`")
+    }
+}

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -19,13 +19,15 @@ use cpython;
 use cpython::{FromPyObject, ObjectProtocol, PyObject, Python};
 
 use block::Block;
-use journal::block_wrapper::BlockStatus;
+use journal::{block_manager::BlockManager, block_store::BlockStore, block_wrapper::BlockStatus};
 use scheduler::TxnExecutionResult;
 use std::sync::mpsc::Sender;
 
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ValidationError {
     BlockValidationFailure(String),
+    BlockValidationError(String),
+    BlockStoreUpdated,
 }
 
 pub trait BlockValidator: Sync + Send + Clone {
@@ -68,5 +70,122 @@ impl<'source> FromPyObject<'source> for BlockValidationResult {
             num_transactions,
             status,
         })
+    }
+}
+
+/// A generic block validation. Returns a ValidationError::BlockValidationFailure on
+/// validation failure. It is a dependent validation if it can return
+/// ValidationError::BlockStoreUpdated and is an independent validation otherwise
+trait BlockValidation {
+    type ReturnValue;
+
+    fn validate_block(
+        &self,
+        block: &Block,
+        previous_state_root: Option<&String>,
+    ) -> Result<Self::ReturnValue, ValidationError>;
+}
+
+/// A check that determines if the Dependent checks are honored. If this check
+/// returns false, the dependent checks are honored.
+trait BlockStoreUpdatedCheck {
+    fn check_chain_head_updated(
+        &self,
+        expected_chain_head_id: Option<&String>,
+    ) -> Result<bool, ValidationError>;
+}
+
+struct BlockValidationProcessor<
+    BS: BlockStore,
+    SBV: BlockValidation<ReturnValue = BlockValidationResult>,
+    C: BlockStoreUpdatedCheck,
+> {
+    block_store: BS,
+    block_manager: BlockManager,
+    dependent_validations: Vec<Box<BlockValidation<ReturnValue = ()>>>,
+    independent_validations: Vec<Box<BlockValidation<ReturnValue = ()>>>,
+    state_validation: SBV,
+    check: C,
+}
+
+impl<
+        BS: BlockStore,
+        SBV: BlockValidation<ReturnValue = BlockValidationResult>,
+        C: BlockStoreUpdatedCheck,
+    > BlockValidationProcessor<BS, SBV, C>
+{
+    fn new(
+        block_store: BS,
+        block_manager: BlockManager,
+        dependent_validations: Vec<Box<BlockValidation<ReturnValue = ()>>>,
+        independent_validations: Vec<Box<BlockValidation<ReturnValue = ()>>>,
+        state_validation: SBV,
+        check: C,
+    ) -> Self {
+        BlockValidationProcessor {
+            block_store,
+            block_manager,
+            dependent_validations,
+            independent_validations,
+            state_validation,
+            check,
+        }
+    }
+
+    fn validate_block(&self, block: &Block) -> Result<BlockValidationResult, ValidationError> {
+        let previous_blocks_state_hash = self
+            .block_manager
+            .get(&[&block.previous_block_id])
+            .next()
+            .unwrap_or(None)
+            .map(|b| b.state_root_hash.clone());
+
+        let checks = 'outer: loop {
+            let chain_head_option = self
+                .block_store
+                .iter()
+                .map_err(|err| {
+                    ValidationError::BlockValidationError(format!(
+                        "There was an error reading from the BlockStore: {:?}",
+                        err
+                    ))
+                })?
+                .next()
+                .map(|b| b.header_signature.clone());
+            let mut dependent_checks = vec![];
+            for validation in &self.dependent_validations {
+                match validation.validate_block(&block, previous_blocks_state_hash.as_ref()) {
+                    Ok(()) => (),
+                    Err(ValidationError::BlockStoreUpdated) => {
+                        warn!(
+                            "Blockstore updated during validation of block {}, retrying checks",
+                            &block.header_signature
+                        );
+                        continue 'outer;
+                    }
+                    Err(err) => dependent_checks.push(Err(err)),
+                }
+            }
+
+            if !self
+                .check
+                .check_chain_head_updated(chain_head_option.as_ref())?
+            {
+                break dependent_checks;
+            }
+        };
+        for check in checks {
+            check?;
+        }
+
+        for validation in &self.independent_validations {
+            match validation.validate_block(&block, previous_blocks_state_hash.as_ref()) {
+                Ok(()) => (),
+                Err(err) => return Err(err),
+            }
+        }
+
+        self.state_validation
+            .validate_block(&block, previous_blocks_state_hash.as_ref())
     }
 }


### PR DESCRIPTION
This PR adds code to validate the batches and state produced, on chain rules, permissions, and duplicates and dependencies.

~~This PR is built on #1827~~