### PR TITLE
Remove mut requirement for MessageSender

### DIFF
--- a/sdk/rust/src/messaging/stream.rs
+++ b/sdk/rust/src/messaging/stream.rs
@@ -27,14 +27,14 @@ use std::time::Duration;
 /// A message
 pub trait MessageSender {
     fn send(
-        &mut self,
+        &self,
         destination: Message_MessageType,
         correlation_id: &str,
         contents: &[u8],
     ) -> Result<MessageFuture, SendError>;
 
     fn reply(
-        &mut self,
+        &self,
         destination: Message_MessageType,
         correlation_id: &str,
         contents: &[u8],

--- a/sdk/rust/src/messaging/zmq_stream.rs
+++ b/sdk/rust/src/messaging/zmq_stream.rs
@@ -103,7 +103,7 @@ impl ZmqMessageSender {
 
 impl MessageSender for ZmqMessageSender {
     fn send(
-        &mut self,
+        &self,
         destination: Message_MessageType,
         correlation_id: &str,
         contents: &[u8],
@@ -129,7 +129,7 @@ impl MessageSender for ZmqMessageSender {
     }
 
     fn reply(
-        &mut self,
+        &self,
         destination: Message_MessageType,
         correlation_id: &str,
         contents: &[u8],
@@ -199,7 +199,7 @@ impl InboundRouter {
         }
     }
 
-    fn expect_reply(&mut self, correlation_id: String) -> Receiver<MessageResult> {
+    fn expect_reply(&self, correlation_id: String) -> Receiver<MessageResult> {
         let (expect_tx, expect_rx) = channel();
         let mut expected_replies = self.expected_replies.lock().unwrap();
         expected_replies.insert(correlation_id, expect_tx);

--- a/sdk/rust/src/processor/mod.rs
+++ b/sdk/rust/src/processor/mod.rs
@@ -83,7 +83,7 @@ impl<'a> TransactionProcessor<'a> {
         self.handlers.push(handler);
     }
 
-    fn register(&mut self, mut sender: ZmqMessageSender, unregister: &Arc<AtomicBool>) -> bool {
+    fn register(&mut self, sender: ZmqMessageSender, unregister: &Arc<AtomicBool>) -> bool {
         for handler in &self.handlers {
             for version in handler.family_versions() {
                 let mut request = TpRegisterRequest::new();
@@ -134,7 +134,7 @@ impl<'a> TransactionProcessor<'a> {
         true
     }
 
-    fn unregister(&mut self, mut sender: ZmqMessageSender) {
+    fn unregister(&mut self, sender: ZmqMessageSender) {
         let request = TpUnregisterRequest::new();
         info!("sending TpUnregisterRequest");
         let serialized = match request.write_to_bytes() {


### PR DESCRIPTION
The `rust-zmq` library doesn't actually require mutability for sending and replying, even though our `MessageSender` trait requires it. This PR removes the `mut` requirement on both the trait and the `ZmqMessageSender` struct, and updates a few function arguments to remove the `mut` requirement as well.

As an example of where this is useful, [Seth's ValidatorClient](https://github.com/hyperledger/sawtooth-seth/blob/master/rpc/src/client.rs#L163) currently requires `&mut self` for nearly all of it's methods simply because it has a `MessageSender` in it. Without this PR, turning those into `&self` references would require wrapping it's `sender` in `Arc<Mutex<...>>` unnecessarily, and with this PR those references can simply be switched to `&self` without any further changes.

This could impact future `MessageSender` implementations, if they required mutability for sending or replying, however that could then be solved by adding `Arc<Mutex<...>>`'s as necessary.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>