### PR TITLE
Remove encoding from SDK tutorials + TF specs; fix errors

### DIFF
--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -137,7 +137,7 @@ helper functions.
 
     class XOHandler extends TransactionHandler {
       constructor () {
-        super(XO_FAMILY, '1.0', 'csv-utf8', [XO_NAMESPACE])
+        super(XO_FAMILY, '1.0', [XO_NAMESPACE])
       }
 
       apply (transactionProcessRequest, stateStore) {
@@ -241,10 +241,6 @@ XoTransactionHandler``, which is where most of the handler's work is done.
         @property
         def family_versions(self):
             return ['1.0']
-
-        @property
-        def encodings(self):
-            return ['csv-utf8']
 
         @property
         def namespaces(self):

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -140,7 +140,7 @@ helper functions.
         super(XO_FAMILY, ['1.0'], [XO_NAMESPACE])
       }
 
-      apply (transactionProcessRequest, stateStore) {
+      apply (transactionProcessRequest, context) {
         //
 
 Note that the ``XOHandler`` class extends the ``TransactionHandler`` class defined in the

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -137,7 +137,7 @@ helper functions.
 
     class XOHandler extends TransactionHandler {
       constructor () {
-        super(XO_FAMILY, '1.0', [XO_NAMESPACE])
+        super(XO_FAMILY, ['1.0'], [XO_NAMESPACE])
       }
 
       apply (transactionProcessRequest, stateStore) {

--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -146,6 +146,13 @@ Dependencies
 ------------
 None.
 
+Family
+------
+
+- family_name: "block_info"
+- family_version: "1.0"
+
+
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -146,10 +146,6 @@ Dependencies
 ------------
 None.
 
-Encoding
---------
-The encoding field must be set to 'application/protobuf'
-
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/identity_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/identity_transaction_family.rst
@@ -182,11 +182,6 @@ Family
 - family_name: "sawtooth_identity"
 - family_version: "1.0"
 
-Encoding
---------
-
-The encoding field must be set to "application/protobuf".
-
 Execution
 =========
 Initially, the transaction processor gets the current values of

--- a/docs/source/transaction_family_specifications/integerkey_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/integerkey_transaction_family.rst
@@ -101,19 +101,6 @@ Family
 - family_name: "intkey"
 - family_version: "1.0"
 
-Encoding
---------
-- payload_encoding: "application/cbor"
-
-.. note:: The CBOR encoding map used by IntegerKey is a definite map. For example, a transaction payload is encoded as follows:
-
-    .. code-block:: pycon
-
-        >>> cbor.dumps({'Verb':'verb', 'Name':'name', 'Value':1234})
-        b'\xa3dVerbdverbdNamednameeValue\x19\x04\xd2'
-
-    CBOR Specification: `RFC 7049 - Concise Binary Object Representation (CBOR) <https://tools.ietf.org/html/rfc7049>`_
-
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/settings_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/settings_transaction_family.rst
@@ -253,12 +253,6 @@ Family
 - family_name: "sawtooth_settings"
 - family_version: "1.0"
 
-Encoding
---------
-
-The encoding field must be set to "application/protobuf".
-
-
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/smallbank_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/smallbank_transaction_family.rst
@@ -216,10 +216,6 @@ Family
 - family_name: "smallbank"
 - family_version: "1.0"
 
-Encoding
---------
-- payload_encoding: "application/protobuf"
-
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -133,7 +133,7 @@ set like this:
   '6a43722aee5b550a3cbd1595f4de10049ee805bc035b5e232dfacfc31cc6275170b30d'
 
 The map of the current registered validator_id should be stored at the
- following address:
+following address:
 
 
 .. code-block:: pycon

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -198,12 +198,6 @@ Family
 - family_version: "1.0"
 
 
-Encoding
---------
-
-The encoding field must be set to "application/protobuf".
-
-
 Execution
 =========
 

--- a/docs/source/transaction_family_specifications/xo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/xo_transaction_family.rst
@@ -88,11 +88,6 @@ Family
 * family_version: "1.0"
 
 
-Encoding
---------
-
-* payload_encoding: "csv-utf8"
-
 .. _xo-execution-label:
 
 Execution


### PR DESCRIPTION
Fix the problems reported in STL-1165 and more: 

- Correct JS version number argument (array, not string) for XOHandler example (in SDK tutorial)

- Correct the JavaScript argument for apply, as shown in XOHandler example (in SDK tutorial)

- In SDK tutorials, delete the encoding argument from the JS & Python examples

- In Transaction Family Specifications, remove  the "Encoding" subsection from the "Transaction Header" section

- Add missing "Family" subsection to BlockInfo transaction family specification

- Fix a format error in the Validator Registry txn family spec
