### PR TITLE
validator.toml.example is missing a comma

### DIFF
--- a/validator/packaging/validator.toml.example
+++ b/validator/packaging/validator.toml.example
@@ -28,7 +28,7 @@
 # network and component.
 bind = [
   "network:tcp://127.0.0.1:8800",
-  "component:tcp://127.0.0.1:4004"
+  "component:tcp://127.0.0.1:4004",
   "consensus:tcp://127.0.0.1:5050"
 ]
 


### PR DESCRIPTION
There needs to be a comma between the options in the bind section.

Signed-off-by: Richard Berg <rberg@bitwise.io>