### PR TITLE
Fix SDK repo links in "Available SDKs" & SDK tutorials

### DIFF
--- a/docs/source/_templates/sdk_overview_tutorial.rst
+++ b/docs/source/_templates/sdk_overview_tutorial.rst
@@ -53,17 +53,42 @@ to create transactions and submit them as :term:`Sawtooth batches<Batch>`.
 
 {% endif %}
 
-
 .. note::
 
    This tutorial demonstrates the relevant concepts for a Sawtooth transaction
    processor and client, but does not create a complete implementation.
 
-   * For a full implementation of the tic-tac-toe transaction family, see
-     ``/project/sawtooth-core/sdk/examples/xo_{{ lowercase_lang }}/``.
 
-   * For full implementations in other languages, see
-     ``https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples``.
+{% if language == 'Rust' %}
+
+   For a full Rust implementation of the XO transaction family, see
+   ``/{project}/sawtooth-core/sdk/examples/xo_{{ lowercase_lang }}/``.
+
+{% elif language == 'Go' %}
+
+   For a full Go implementation of the XO transaction family, see
+   `https://github.com/hyperledger/sawtooth-sdk-go/tree/master/examples/xo_go
+   <https://github.com/hyperledger/sawtooth-sdk-go/tree/master/examples/xo_go>`_.
+
+{% elif language == 'Java' %}
+
+   For a full Java implementation of the XO transaction family, see
+   `https://github.com/hyperledger/sawtooth-sdk-java/tree/master/examples/xo_java
+   <https://github.com/hyperledger/sawtooth-sdk-java/tree/master/examples/xo_java>`_.
+
+{% elif language == 'JavaScript' %}
+
+   For a full JavaScript implementation of the XO transaction family, see
+   `https://github.com/hyperledger/sawtooth-sdk-javascript/tree/master/examples/xo
+   <https://github.com/hyperledger/sawtooth-sdk-javascript/tree/master/examples/xo>`_.
+
+{% else %}
+
+   For a full Python implementation of the XO transaction family, see
+   ``/{project}/sawtooth-core/sdk/examples/xo_{{ lowercase_lang }}/``.
+
+{% endif %}
+
 
 Prerequisites
 =============

--- a/docs/source/app_developers_guide/sdk_table.rst
+++ b/docs/source/app_developers_guide/sdk_table.rst
@@ -34,8 +34,31 @@ The Maturity column shows the general maturity level of each feature:
   2.  Community support only
   3.  Experimental: Might have known issues and future API changes
 
-The available SDKs are in
-https://github.com/hyperledger/sawtooth-core/tree/master/sdk.
+The available SDKs are in the following repositories:
+
+* Python:
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python>`_
+
+* Rust:
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust>`_
+
+* Go:
+  `https://github.com/hyperledger/sawtooth-sdk-go
+  <https://github.com/hyperledger/sawtooth-sdk-go>`_
+
+* JavaScript:
+  `https://github.com/hyperledger/sawtooth-sdk-javascript
+  <https://github.com/hyperledger/sawtooth-sdk-javascript>`_
+
+* Java:
+  `https://github.com/hyperledger/sawtooth-sdk-java
+  <https://github.com/hyperledger/sawtooth-sdk-java>`_
+
+* C++:
+  `https://github.com/hyperledger/sawtooth-sdk-cxx
+  <https://github.com/hyperledger/sawtooth-sdk-cxx>`_
 
 .. |yes| unicode:: U+2713 .. checkmark
 


### PR DESCRIPTION
Several SDKs moved into separate repositories (Go, Java, JS, and C++)

Signed-off-by: Anne Chenette <chenette@bitwise.io>