### PR TITLE
Move SDK table to SDK section of App Dev guide

### DIFF
--- a/docs/source/app_developers_guide.rst
+++ b/docs/source/app_developers_guide.rst
@@ -21,7 +21,6 @@ Python SDKs.
    :maxdepth: 2
 
    app_developers_guide/overview
-   app_developers_guide/sdk_table
    app_developers_guide/installing_sawtooth
    app_developers_guide/creating_sawtooth_network.rst
    app_developers_guide/intro_xo_transaction_family

--- a/docs/source/app_developers_guide/using_the_sdks.rst
+++ b/docs/source/app_developers_guide/using_the_sdks.rst
@@ -8,6 +8,7 @@ development.
 .. toctree::
    :maxdepth: 2
 
+   sdk_table.rst
    go_sdk
    javascript_sdk
    python_sdk


### PR DESCRIPTION
The "Available SDKs" topic was at the beginning of the App Dev Guide. 
The doc flow seems better when this topic is under "Using the SDKs".

Signed-off-by: Anne Chenette <chenette@bitwise.io>