### PR TITLE
Fix App Dev guide's SDK section; reorg & separate prereqs

### DIFF
--- a/docs/source/_templates/sdk_overview_tutorial.rst
+++ b/docs/source/_templates/sdk_overview_tutorial.rst
@@ -16,8 +16,11 @@
     {% set lowercase_lang = 'rust' %}
 {% endif %}
 
-This tutorial describes how to develop a Sawtooth application with an example
-transaction family, using the Sawtooth {{ language }} SDK.
+Overview
+========
+
+This tutorial shows how to use the Sawtooth {{ language }} SDK to develop a
+simple application (also called a transaction family).
 
 A transaction family includes these components:
 

--- a/docs/source/_templates/sdk_overview_tutorial.rst
+++ b/docs/source/_templates/sdk_overview_tutorial.rst
@@ -21,17 +21,16 @@ Overview
 
 This tutorial shows how to use the Sawtooth {{ language }} SDK to develop a
 simple application (also called a transaction family).
-
 A transaction family includes these components:
 
-* A transaction processor to define the business logic for your application.
+* A **transaction processor** to define the business logic for your application.
   The transaction processor is responsible for registering with the validator,
   handling transaction payloads and associated metadata, and getting/setting
   state as needed.
 
-* A data model to record and store data
+* A **data model** to record and store data.
 
-* A client to handle the client logic for your application.
+* A **client** to handle the client logic for your application.
   The client is responsible for creating and signing transactions, combining
   those transactions into batches, and submitting them to the validator. The
   client can post batches through the REST API or connect directly to the

--- a/docs/source/_templates/sdk_overview_tutorial.rst
+++ b/docs/source/_templates/sdk_overview_tutorial.rst
@@ -65,18 +65,6 @@ to create transactions and submit them as :term:`Sawtooth batches<Batch>`.
    * For full implementations in other languages, see
      ``https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples``.
 
-Prerequisites
-=============
-
- * A working Sawtooth development environment, as described in
-   :doc:`/app_developers_guide/installing_sawtooth`
-
- * Familiarity with the basic Sawtooth concepts introduced in
-   :doc:`/app_developers_guide/installing_sawtooth`
-
- * Understanding of the Sawtooth transaction and batch data structures as
-   described in :doc:`/architecture/transactions_and_batches`
-
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/go_sdk.rst
+++ b/docs/source/app_developers_guide/go_sdk.rst
@@ -6,6 +6,7 @@ Using the Go SDK
    :maxdepth: 2
 
    ../_autogen/sdk_overview_tutorial_go
+   sdk_prerequisites
    ../_autogen/sdk_TP_tutorial_go
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/app_developers_guide/go_sdk.rst
+++ b/docs/source/app_developers_guide/go_sdk.rst
@@ -2,6 +2,9 @@
 Using the Go SDK
 **************************
 
+This tutorial describes how to develop a Sawtooth application with an example
+transaction family, XO, using the Sawtooth Go SDK.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/app_developers_guide/javascript_sdk.rst
+++ b/docs/source/app_developers_guide/javascript_sdk.rst
@@ -6,6 +6,7 @@ Using the JavaScript SDK
    :maxdepth: 2
 
    ../_autogen/sdk_overview_tutorial_js
+   sdk_prerequisites
    ../_autogen/sdk_TP_tutorial_js
    ../_autogen/sdk_submit_tutorial_js
 

--- a/docs/source/app_developers_guide/javascript_sdk.rst
+++ b/docs/source/app_developers_guide/javascript_sdk.rst
@@ -2,6 +2,9 @@
 Using the JavaScript SDK
 **********************************
 
+This tutorial describes how to develop a Sawtooth application with an example
+transaction family, XO, using the Sawtooth JavaScript SDK.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/app_developers_guide/python_sdk.rst
+++ b/docs/source/app_developers_guide/python_sdk.rst
@@ -2,6 +2,9 @@
 Using the Python SDK
 ******************************
 
+This tutorial describes how to develop a Sawtooth application with an example
+transaction family, XO, using the Sawtooth Python SDK.
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/source/app_developers_guide/python_sdk.rst
+++ b/docs/source/app_developers_guide/python_sdk.rst
@@ -6,6 +6,7 @@ Using the Python SDK
    :maxdepth: 2
 
    ../_autogen/sdk_overview_tutorial_python
+   sdk_prerequisites
    python_sdk_install.rst
    ../_autogen/sdk_TP_tutorial_python
    ../_autogen/sdk_submit_tutorial_python

--- a/docs/source/app_developers_guide/rust_sdk.rst
+++ b/docs/source/app_developers_guide/rust_sdk.rst
@@ -6,6 +6,7 @@ Using the Rust SDK
     :maxdepth: 2
 
     ../_autogen/sdk_overview_tutorial_rust
+    sdk_prerequisites
     ./rust_sdk_import.rst
     ../_autogen/sdk_TP_tutorial_rust
 

--- a/docs/source/app_developers_guide/rust_sdk.rst
+++ b/docs/source/app_developers_guide/rust_sdk.rst
@@ -2,6 +2,9 @@
 Using the Rust SDK
 ******************************
 
+This tutorial describes how to develop a Sawtooth application with an example
+transaction family, XO, using the Sawtooth Rust SDK.
+
 .. toctree::
     :maxdepth: 2
 

--- a/docs/source/app_developers_guide/sdk_prerequisites.rst
+++ b/docs/source/app_developers_guide/sdk_prerequisites.rst
@@ -1,0 +1,18 @@
+Prerequisites
+=============
+
+This tutorial requires:
+
+ * A working Sawtooth development environment, as described in
+   :doc:`/app_developers_guide/installing_sawtooth` or
+   :doc:`/app_developers_guide/creating_sawtooth_network`
+
+ * Familiarity with the basic Sawtooth concepts that are introduced in
+   :doc:`/app_developers_guide/installing_sawtooth`
+
+ * Understanding of the Sawtooth transaction and batch data structures, as
+   described in :doc:`/architecture/transactions_and_batches`
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
- Move the SDK tutorial's prerequisites to a separate topic (not part of the Overview)

- Add an intro sentence to the *_sdk.rst topics

- Make minor wording and format changes for clarity
