### PR TITLE
Jenkins skip whitelist check when building 1-1 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ node ('master') {
                 sh 'git fetch --tag'
             }
 
-            if (!(env.BRANCH_NAME == 'master' && env.JOB_BASE_NAME == 'master')) {
+            if (!(env.BRANCH_NAME == '1-1' && env.JOB_BASE_NAME == '1-1') && !(env.BRANCH_NAME ==~ /1-1-staging-\d{2}/ && env.JOB_BASE_NAME ==~ /1-1-staging-\d{2}/)) {
                 stage("Check Whitelist") {
                     readTrusted 'bin/whitelist'
                     sh './bin/whitelist "$CHANGE_AUTHOR" /etc/jenkins-authorized-builders'


### PR DESCRIPTION
Signed-off-by: Richard Berg <rberg@bitwise.io>