### PR TITLE
Fix typos & misc errors in App Dev multi-node proc

### DIFF
--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -99,7 +99,7 @@ processing and static peering. However, it has the following differences:
   Software Guard Extensions (SGX) to implement a leader-election lottery system.
   PoET simulator provides the same consensus algorithm on an SGX simulator.
 
-* An additional transaction processor, Validator Registry, which handles PoET
+* An additional transaction processor, PoET Validator Registry, handles PoET
   settings for a multiple-node network.
 
 Prerequisites
@@ -371,7 +371,7 @@ processing and static peering. However, it has the following differences:
   Software Guard Extensions (SGX) to implement a leader-election lottery system.
   PoET simulator provides the same consensus algorithm on an SGX simulator.
 
-* An additional transaction processor, Validator Registry, which handles PoET
+* An additional transaction processor, PoET Validator Registry, handles PoET
   settings for a multiple-node network.
 
 .. _prereqs-multi-ubuntu-label:
@@ -524,7 +524,7 @@ in :doc:`ubuntu`.
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
 
-#. Create a batch to register the first validator with the PoET Validator
+#. Create a batch to register the first validator with the Validator
    Registry. Without this command, the validator would not be able to publish
    any blocks.
 
@@ -627,7 +627,9 @@ in :doc:`ubuntu`.
 
    .. note::
 
-      This network requires ``settings-tp`` and ``poet-validator-registry-tp``.
+      This network requires the Settings transaction processor, ``settings-tp``,
+      and the PoET Validator Registry transaction processor,
+      ``poet-validator-registry-tp``.
       The other transaction processors (``intkey-tp-python`` and
       ``xo-tp-python``) are not required, but are used for the other tutorials
       in this guide. Note that each node in the network must run the same
@@ -960,7 +962,7 @@ This example environment includes the following transaction processors:
    handles Sawtooth's on-chain settings. The ``sawtooth-settings-tp``
    transaction processor is required for this environment.
 
- * :doc:`Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
+ * :doc:`PoET Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
    configures PoET consensus and handles a network with multiple validators.
 
  * :doc:`IntegerKey <../transaction_family_specifications/integerkey_transaction_family>`
@@ -1264,7 +1266,7 @@ Step 5: Confirm Network and Blockchain Functionality
    available in the kubeconfig file or on a pod's page on the Kubernetes
    dashboard.
 
-   The following example connects to pod 3's Validator Registry container
+   The following example connects to pod 3's PoET Validator Registry container
    (``sawtooth-poet-validator-registry-tp``), then displays the list of running
    process.
 

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -23,8 +23,9 @@ environment on one of the following platforms:
 
 .. note::
 
-   The guides in this chapter set up an environment with five Sawtooth validator
-   nodes. For a single-node environment, see :doc:`installing_sawtooth`.
+   The guides in this chapter set up an environment with multiple Sawtooth
+   validator nodes. For a single-node environment, see
+   :doc:`installing_sawtooth`.
 
 To get started, choose the guide for the platform of your choice:
 

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -120,7 +120,7 @@ following command from your host system:
 For more information, see :ref:`stop-sawtooth-docker-label`.
 
 
-Step 1: Download the Docker Compose file
+Step 1: Download the Docker Compose File
 ----------------------------------------
 
 Download the Docker Compose file for a multiple-node network,
@@ -168,7 +168,7 @@ Step 2: Start the Sawtooth Network
 Step 3: Verify Connectivity
 ---------------------------
 
-You can connect to Docker container, such as
+You can connect to a Docker container, such as
 ``sawtooth-poet-validator-registry-tp-0``, then use the following ``ps``
 command to verify that the component is running.
 
@@ -209,8 +209,8 @@ Step 4: Confirm Network Functionality
         }
 
 #. (Optional) You can also connect to a validator container, such as
-    ``sawtooth-validator-default-0``, and run the following Sawtooth commands to
-    show the other nodes on the network.
+   ``sawtooth-validator-default-0``, and run the following Sawtooth commands to
+   show the other nodes on the network.
 
    a. Run ``sawtooth peer list`` to show the peers of a particular node.
 
@@ -1231,7 +1231,7 @@ Step 5: Confirm Network and Blockchain Functionality
         $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-N/{print $1}') --container sawtooth-shell -- bash
 
 #. (Optional) You can also connect to the shell container of any pod, and
-    run the following Sawtooth commands to show the other nodes on the network.
+   run the following Sawtooth commands to show the other nodes on the network.
 
    a. Run ``sawtooth peer list`` to show the peers of a particular node.
 
@@ -1261,7 +1261,7 @@ Step 5: Confirm Network and Blockchain Functionality
            root@sawtooth-1# intkey show MyKey
            MyKey: 999
 
-#. You can can check whether a Sawtooth component is running by connecting to a
+#. You can check whether a Sawtooth component is running by connecting to a
    different container, then running the ``ps`` command. The container names are
    available in the kubeconfig file or on a pod's page on the Kubernetes
    dashboard.
@@ -1386,7 +1386,7 @@ Use the following steps to create and submit a batch containing the new setting.
 
 .. _stop-sawtooth-kube2-label:
 
-Step 7: Stop the Sawtooth Kubernetes Cluster
+Step 6: Stop the Sawtooth Kubernetes Cluster
 --------------------------------------------
 
 Use the following commands to stop and reset the Sawtooth network.

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -1280,18 +1280,10 @@ At this point, your environment is ready for experimenting with Sawtooth.
 For more ways to test basic functionality, see the Kubernetes section of
 "Setting Up a Sawtooth Application Development Environment".
 
-.. REVIEWERS: THE FOLLOWING LINKS WON'T WORK UNTIL PR 1822 HAS BEEN MERGED.
-.. I WILL ACTIVATE THESE LINKS (AND REMOVE THE COMMENTS) WHEN THE SINGLE-NODE
-.. KUBERNETES PROCEDURE IS AVAILABLE.
-
 * To use Sawtooth client commands to view block information and check state
-  data, see xxx.
+  data, see :ref:`sawtooth-client-kube-label`.
 
-.. :ref:`sawtooth-client-kube-label`.
-
-* For information on the Sawtooth logs, see xxx.
-
-.. :ref:`examine-logs-kube-label`.
+* For information on the Sawtooth logs, see :ref:`examine-logs-kube-label`.
 
 
 .. _configure-txn-procs-kube-label:

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -959,8 +959,8 @@ to view pod status, container names, Sawtooth log files, and more.
 This example environment includes the following transaction processors:
 
  * :doc:`Settings <../transaction_family_specifications/settings_transaction_family>`
-   handles Sawtooth's on-chain settings. The ``sawtooth-settings-tp``
-   transaction processor is required for this environment.
+   handles Sawtooth's on-chain settings. The Settings transaction processor,
+   ``settings-tp``, is required for this environment.
 
  * :doc:`PoET Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
    configures PoET consensus and handles a network with multiple validators.

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -495,7 +495,7 @@ in :doc:`ubuntu`.
    .. code-block:: console
 
       $ ls ~/.sawtooth/keys/
-      yourname.priv    yourname.pub
+      {yourname}.priv    {yourname}.pub
 
       $ ls /etc/sawtooth/keys/
       validator.priv   validator.pub
@@ -650,8 +650,8 @@ Step 2: Set Up the Second Validator Node
    .. code-block:: console
 
       $ sawtooth keygen
-      writing file: /home/yourname/.sawtooth/keys/yourname.priv
-      writing file: /home/yourname/.sawtooth/keys/yourname.pub
+      writing file: /home/{yourname}/.sawtooth/keys/{yourname}.priv
+      writing file: /home/{yourname}/.sawtooth/keys/{yourname}.pub
 
 #. Create the root key for the validator:
 

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -14,7 +14,7 @@ environment on one of the following platforms:
   `Docker <https://www.docker.com/>`_ containers.
 
 * Ubuntu: Install Sawtooth natively using
-  `Ubuntu 16.04 <https://www.ubuntu.com/>`_. You will add a node to the existing
+  `Ubuntu 16.04 <https://www.ubuntu.com/>`_. You will add a node to an existing
   application development environment that is described in :doc:`ubuntu`, but
   you will delete all existing blockchain data, including the genesis block.
 
@@ -344,8 +344,8 @@ command from your host system:
 Ubuntu: Add a Node to the Single-Node Environment
 =================================================
 
-This procedure describes how to add a second validator node to a single-node
-application development environment, as described in :doc:`ubuntu`.
+This procedure describes how to add a second validator node to an existing
+single-node application development environment, as described in :doc:`ubuntu`.
 You will stop the Sawtooth components on the first node and delete the
 existing blockchain data, then create a new genesis block that specifies PoET
 simulator consensus and related settings. All nodes on the network will run four


### PR DESCRIPTION
Correct intro description of the multi-node environment: Change "five nodes"  
to "multiple nodes" (because the Ubuntu proc creates two nodes)  

Make Settings and Validator Registry terms consistent with the rest of the doc 

Clarify that the Ubuntu multi-node procedure starts with an existing  single-node environment                                                       

In Ubuntu proc, add curly braces to "yourname" in the user key path & file name, 
to clarify it's not a literal 

Replace placeholder "xxx" text with links to the single-node K8s proc 

Fix format problems, a bad step number (K8s proc), and several typos          
          