### PR TITLE
Modify Duplicates and Dependencies check to decrease time that persist lock must be held

### DIFF
--- a/validator/src/journal/block_store.rs
+++ b/validator/src/journal/block_store.rs
@@ -52,6 +52,8 @@ pub trait TransactionIndex: Sync + Send {
     fn get_block_by_id(&self, id: &str) -> Result<Option<Block>, BlockStoreError>;
 }
 
+pub trait IndexedBlockStore: BlockStore + TransactionIndex + BatchIndex {}
+
 #[derive(Clone, Default)]
 pub struct InMemoryBlockStore {
     state: Arc<Mutex<InMemoryBlockStoreState>>,
@@ -70,6 +72,8 @@ impl InMemoryBlockStore {
             .cloned()
     }
 }
+
+impl IndexedBlockStore for InMemoryBlockStore {}
 
 impl BlockStore for InMemoryBlockStore {
     fn get<'a>(

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -653,22 +653,26 @@ impl BlockValidation for DuplicatesAndDependenciesValidation {
     type ReturnValue = ();
 
     fn validate_block(&self, block: &Block, _: Option<&String>) -> Result<(), ValidationError> {
-        let batch_ids = block
-            .batches
-            .iter()
-            .map(|b| b.header_signature.clone())
-            .collect();
+        let batch_ids: Vec<&String> = block.batches.iter().map(|b| &b.header_signature).collect();
 
-        validate_no_duplicate_batches(&self.block_manager, &block.previous_block_id, batch_ids)?;
+        validate_no_duplicate_batches(
+            &self.block_manager,
+            &block.previous_block_id,
+            batch_ids.as_slice(),
+        )?;
 
         let txn_ids = block.batches.iter().fold(vec![], |mut arr, b| {
             for txn in &b.transactions {
-                arr.push(txn.header_signature.clone());
+                arr.push(&txn.header_signature);
             }
             arr
         });
 
-        validate_no_duplicate_transactions(&self.block_manager, &block.previous_block_id, txn_ids)?;
+        validate_no_duplicate_transactions(
+            &self.block_manager,
+            &block.previous_block_id,
+            txn_ids.as_slice(),
+        )?;
 
         let transactions = block.batches.iter().fold(vec![], |mut arr, b| {
             for txn in &b.transactions {

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -514,15 +514,15 @@ impl BlockStore for PyBlockStore {
         let py = gil_guard.python();
         let mut deleted_blocks = Vec::new();
         for block_id in block_ids {
-            let block: Block = self.py_block_store
+            let block: Block = self
+                .py_block_store
                 .call_method(py, "get", (block_id,), None)
                 // Unwrap the block wrapper
                 .and_then(|blkw| blkw.getattr(py, "block"))
                 .map_err(|py_err| {
                     pylogger::exception(py, "Unable to call block_store.get_blocks", py_err);
                     BlockStoreError::Error("Unable to get blocks".into())
-                })?
-                .extract(py)
+                })?.extract(py)
                 .expect("Unable to convert block from python");
 
             self.py_block_store
@@ -660,18 +660,23 @@ impl BatchIndex for PyBlockStore {
         let py = gil_guard.python();
         self.py_block_store
             .call_method(py, "get_block_by_batch_id", (id,), None)
-            .map_err(|py_err| {
-                BlockStoreError::Error(format!(
-                    "Error calling get_block_by_id on the block store: {:?}",
-                    py_err
-                ))
-            })?.extract(py)
-            .map_err(|py_err| {
-                BlockStoreError::Error(format!(
-                    "Error extracting Option<BlockWrapper>: {:?}",
-                    py_err
-                ))
-            }).and_then(|b: Option<BlockWrapper>| Ok(b.map(|b| b.block())))
+            .and_then(|r| r.extract(py))
+            .map(|bw: Option<BlockWrapper>| {
+                if let Some(bw) = bw {
+                    Some(bw.block())
+                } else {
+                    None
+                }
+            }).or_else(|py_err| {
+                if py_err.get_type(py).name(py) == "ValueError" {
+                    Ok(None)
+                } else {
+                    Err(BlockStoreError::Error(format!(
+                        "Error calling get_block_by_batch_id: {:?}",
+                        py_err
+                    )))
+                }
+            })
     }
 }
 
@@ -697,18 +702,23 @@ impl TransactionIndex for PyBlockStore {
         let py = gil_guard.python();
         self.py_block_store
             .call_method(py, "get_block_by_transaction_id", (id,), None)
-            .map_err(|py_err| {
-                BlockStoreError::Error(format!(
-                    "Error calling get_block_transaction_id on the block store: {:?}",
-                    py_err
-                ))
-            })?.extract(py)
-            .map_err(|py_err| {
-                BlockStoreError::Error(format!(
-                    "Error extracting Option<BlockWrapper>: {:?}",
-                    py_err
-                ))
-            }).and_then(|b: Option<BlockWrapper>| Ok(b.map(|b| b.block())))
+            .and_then(|r| r.extract(py))
+            .map(|bw: Option<BlockWrapper>| {
+                if let Some(bw) = bw {
+                    Some(bw.block())
+                } else {
+                    None
+                }
+            }).or_else(|py_err| {
+                if py_err.get_type(py).name(py) == "ValueError" {
+                    Ok(None)
+                } else {
+                    Err(BlockStoreError::Error(format!(
+                        "Error calling get_block_by_transaction_id: {:?}",
+                        py_err
+                    )))
+                }
+            })
     }
 }
 

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -26,7 +26,9 @@ use database::lmdb::LmdbDatabase;
 use execution::py_executor::PyExecutor;
 use gossip::permission_verifier::PyPermissionVerifier;
 use journal::block_manager::BlockManager;
-use journal::block_store::{BatchIndex, BlockStore, BlockStoreError, TransactionIndex};
+use journal::block_store::{
+    BatchIndex, BlockStore, BlockStoreError, IndexedBlockStore, TransactionIndex,
+};
 use journal::block_validator::{BlockValidationResult, BlockValidationResultStore, BlockValidator};
 use journal::block_wrapper::{BlockStatus, BlockWrapper};
 use journal::chain::*;
@@ -721,6 +723,8 @@ impl TransactionIndex for PyBlockStore {
             })
     }
 }
+
+impl IndexedBlockStore for PyBlockStore {}
 
 impl Clone for PyBlockStore {
     fn clone(&self) -> Self {


### PR DESCRIPTION
This PR does 2 main things
- uses a lock to guarantee that the block store stays stable during duplicates and dependencies check that relies on the block store
- simplifies the code that was in ChainCommitState, bringing in some of that functionality to the block manager - in particular `contains_any_transactions(branch_head_id, transaction_ids)` and the corresponding batch id function.