### PR TITLE
Fix nonetype is not callable error when consensus engine disconnect happens

### DIFF
--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -238,7 +238,6 @@ class Validator:
             secured=False,
             heartbeat=False,
             max_incoming_connections=20,
-            monitor=True,
             max_future_callback_workers=10)
 
         consensus_notifier = ConsensusNotifier(consensus_service)


### PR DESCRIPTION
It is required that to monitor disconnects, a check_connections callback
is passed to the Interconnect instance (component, consensus, ...).

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>