### PR TITLE
Update non-SGX install/config/run proc in Sys Admin Guide

### DIFF
--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -1,17 +1,32 @@
-
 ****************************
 System Administrator's Guide
 ****************************
+
+This guide explains how to install, configure, and run Hyperledger Sawtooth
+on a Ubuntu system for proof-of-concept or production use in a Sawtooth network.
+
+It includes steps to configure a consensus mechanism, using PoET simulator
+consensus as an example, and to start the Sawtooth components as services.
+
+It also includes optional procedures to change the user, client, and validator
+permissions; set up a proxy for the REST API; and configure Grafana to display
+Sawtooth metrics.
+
+.. note::
+
+   The instructions in this guide have been tested on Ubuntu 16.04 only.
+
 
 .. toctree::
    :maxdepth: 2
 
    sysadmin_guide/setting_up_sawtooth_poet-sim
-   sysadmin_guide/configuring_sawtooth
    sysadmin_guide/rest_auth_proxy
    sysadmin_guide/configuring_permissions
-   sysadmin_guide/configure_sgx
    sysadmin_guide/grafana_configuration
+   sysadmin_guide/configure_sgx
+   sysadmin_guide/configuring_sawtooth
+
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -6,8 +6,7 @@ System Administrator's Guide
 .. toctree::
    :maxdepth: 2
 
-   sysadmin_guide/installation
-   sysadmin_guide/systemd
+   sysadmin_guide/setting_up_sawtooth_poet-sim
    sysadmin_guide/configuring_sawtooth
    sysadmin_guide/rest_auth_proxy
    sysadmin_guide/configuring_permissions

--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -1,0 +1,145 @@
+**************************
+Creating the Genesis Block
+**************************
+
+.. important::
+
+   Use this procedure **only** for the first validator node on a Sawtooth
+   network. Skip this procedure if you are creating a node that will join an
+   existing Sawtooth network.
+
+The first node in a new Sawtooth network must create the genesis block to
+initialize the Settings transaction processor and specify the consensus
+mechanism. The settings in the genesis block enable other nodes to join the
+network and use these on-chain settings.
+
+Before you start the first Sawtooth node, use this procedure to create and
+submit the genesis block.
+
+.. note::
+
+   This procedure uses the same validator key for all commands that require a
+   key. In theory, some of these commands could use a different key, but
+   configuring multiple keys is a complicated process. Describing how to use
+   multiple keys to create the genesis block is outside the scope of this guide.
+
+1. Ensure that the required user and validator keys exist:
+
+   .. code-block:: console
+
+      $ ls ~/.sawtooth/keys/
+      {yourname}.priv    {yourname}.pub
+
+      $ ls /etc/sawtooth/keys/
+      validator.priv   validator.pub
+
+   If these key files do not exist, create them as described in
+   :doc:`generating_keys`.
+
+#. Become the ``sawtooth`` user. In the following commands, the prompt
+   ``[sawtooth@system]`` shows the commands that must be executed as
+   ``sawtooth``.
+
+   .. code-block:: console
+
+      $ sudo -u sawtooth -s
+      [sawtooth@system]$ cd /tmp
+
+#. Create a batch to initialize the Settings transaction family in the genesis
+   block.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ sawset genesis --key /etc/sawtooth/keys/validator.priv -o config-genesis.batch
+
+   This command authorizes this key (the validator key on this node) to change
+   Sawtooth settings. You must use the same key for the following commands in
+   this procedure. Also, any later commands to change on-chain Sawtooth settings
+   must specify this key.
+
+#. Create and submit a proposal to initialize the PoET consensus settings. This
+   command sets the consensus algorithm to PoET simulator, and then applies the
+   required settings.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+      -o config.batch \
+      sawtooth.consensus.algorithm=poet \
+      sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
+      sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
+      sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
+
+   This is a complicated command. Here's an explanation of the options:
+
+   ``--key /etc/sawtooth/keys/validator.priv``
+    Signs the proposal with this node's validator key. Only this key can be
+    used to change on-chain settings. For more information, see
+    :doc:`configuring_permissions`.
+
+   ``-o config.batch``
+    Wraps the proposal transaction in a batch named ``config.batch``.
+
+   ``sawtooth.consensus.algorithm=poet``
+    Changes the consensus algorithm to PoET.
+
+   ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)"``
+    Adds the public key for the PoET Validator Registry transaction
+    processor to use for the PoET simulator consensus.
+
+   ``sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement)``
+    Adds a simulated enclave measurement to the blockchain. The
+    PoET Validator Registry transaction processor uses this value to check
+    signup information.
+
+   ``sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)``
+    Adds a simulated enclave basename to the blockchain. The PoET
+    Validator Registry uses this value to check signup information.
+
+#. Create a batch to register the first Sawtooth node with the PoET Validator
+   Registry transaction processor. Without this command, the validator would not
+   be able to publish any blocks.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ poet registration create --key /etc/sawtooth/keys/validator.priv -o poet.batch
+
+#. (Optional) Create a batch to configure other PoET settings. This example
+   shows the default settings.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+      -o poet-settings.batch \
+      sawtooth.poet.target_wait_time=5 \
+      sawtooth.poet.initial_wait_time=25 \
+      sawtooth.publisher.max_batches_per_block=100
+
+#. Combine the previously created batches into a single genesis batch that will
+   be committed in the genesis block.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ sawadm genesis config-genesis.batch config.batch poet.batch poet-settings.batch
+
+   You’ll see some output indicating success:
+
+   .. code-block:: console
+
+       Processing config-genesis.batch...
+       Processing config.batch...
+       Processing poet.batch...
+       Processing poet-settings.batch...
+       Generating /var/lib/sawtooth/genesis.batch
+
+#. When this command finishes, genesis configuration is complete. Log out of the
+   ``sawtooth`` account.
+
+   .. code-block:: console
+
+      [sawtooth@system]$ exit
+      $
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/generating_keys.rst
+++ b/docs/source/sysadmin_guide/generating_keys.rst
@@ -1,0 +1,33 @@
+**********************************
+Generating User and Validator Keys
+**********************************
+
+1.  Generate your user key for Sawtooth.
+
+    .. code-block:: console
+
+       $ sawtooth keygen
+
+    This command stores user keys in ``$HOME/.sawtooth/keys/{yourname}.priv``
+    and ``$HOME/.sawtooth/keys/{yourname}.pub``.
+
+#. Generate the key for the validator, which runs as root.
+
+   .. code-block:: console
+
+       $ sudo sawadm keygen
+
+   By default, this command stores the validator key files in
+   ``/etc/sawtooth/keys/validator.priv`` and
+   ``/etc/sawtooth/keys/validator.pub``.
+   However, settings in the path configuration file could change this location;
+   see :doc:`configuring_sawtooth/path_configuration_file`.
+
+Sawtooth also includes a network key pair that is used to encrypt communication
+between the validators in a Sawtooth network. The network keys are described in
+a later procedure.
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/
+

--- a/docs/source/sysadmin_guide/installation.rst
+++ b/docs/source/sysadmin_guide/installation.rst
@@ -2,40 +2,44 @@
 Installing Hyperledger Sawtooth
 *******************************
 
-The easiest way to install Hyperledger Sawtooth is with apt-get.
+This procedure describes how to install Hyperledger Sawtooth on a Ubuntu system
+for proof-of-concept or production use in a Sawtooth network.
 
-.. note::
+1. Choose whether you want the stable version (recommended) or most recent
+   nightly build (for testing purposes only).
 
-  These instructions have been tested on Ubuntu 16.04 only.
+   * (Release 1.1 and later) To add the stable repository, run these commands in
+     a terminal window on your host system.
 
-Stable Builds:
+     .. code-block:: console
 
-To add the stable repository, run these commands in a terminal window on your
-host system:
+        $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
+        $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe'
 
-.. code-block:: console
+     .. note::
 
-  $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
-  $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe'
+        The ``bumper`` metapackage includes the Sawtooth core software and
+        associated items such as separate consensus software.
 
-Nightly Builds:
+   * The latest version of Sawtooth is available in a repository of nightly
+     builds. These builds may incorporate undocumented features and should be
+     used for testing purposes only.
 
-If you'd like the latest version of Sawtooth, we also provide a repository of
-nightly builds. These builds may incorporate undocumented features and should
-be used for testing purposes only. To use the nightly repository, run the
-following commands in a terminal window on your host system:
+     To use the nightly repository, run the following commands in a terminal
+     window on your host system.
 
-.. code-block:: console
+     .. code-block:: console
 
-  $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
-  $ sudo apt-add-repository "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe"
+        $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
+        $ sudo apt-add-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe'
 
-Update your package lists and install Sawtooth:
+#. Update your package lists, then install Sawtooth.
 
-.. code-block:: console
+   .. code-block:: console
 
-  $ sudo apt-get update
-  $ sudo apt-get install -y sawtooth
+      $ sudo apt-get update
+      $ sudo apt-get install -y sawtooth python3-sawtooth-poet-engine
+
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
+++ b/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
@@ -1,0 +1,54 @@
+**************************
+Setting Up a Sawtooth Node
+**************************
+
+This section describes how to install, configure, and run Hyperledger Sawtooth
+on a Ubuntu system for proof-of-concept or production use in a Sawtooth network.
+
+Use this set of procedures to create the first Sawtooth node in a network or to
+add a node to an existing network.  Note that certain steps are performed only
+on the first node.
+
+.. important::
+
+   These procedures use PoET simulator consensus, which is recommended for a
+   system without a Trusted Execution Environment (TEE). To configure Sawtooth
+   with PoET SGX consensus on a system with |Intel (R)| Software Guard
+   Extensions (SGX), see :doc:`configure_sgx`.
+
+.. |Intel (R)| unicode:: Intel U+00AE .. registered copyright symbol
+
+Each node in this Sawtooth network runs a validator, a REST API, and the
+following transaction processors:
+
+* :doc:`Settings <../transaction_family_specifications/settings_transaction_family>`
+  (``settings-tp``)
+* :doc:`Identity <../transaction_family_specifications/identity_transaction_family>`
+  (``identity-tp``)
+* :doc:`PoET Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
+  (``poet-validator-registry-tp``)
+* :doc:`IntegerKey <../transaction_family_specifications/integerkey_transaction_family>`
+  (``intkey-tp-python``) -- optional, but used to test basic Sawtooth
+  functionality
+
+Each node in a Sawtooth network must run the same set of transaction
+processors. If this node will join an existing Sawtooth network, make sure
+that you know the full list of required transaction processors, and that you
+install any custom transaction processors.
+
+.. note::
+
+    These instructions have been tested on Ubuntu 16.04 only.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   installation.rst
+   generating_keys.rst
+   creating_genesis_block.rst
+   systemd.rst
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
+++ b/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
@@ -48,6 +48,7 @@ install any custom transaction processors.
    generating_keys.rst
    creating_genesis_block.rst
    systemd.rst
+   testing_sawtooth.rst
 
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/sysadmin_guide/systemd.rst
+++ b/docs/source/sysadmin_guide/systemd.rst
@@ -2,87 +2,119 @@
 Running Sawtooth as a Service
 *****************************
 
-When installing Sawtooth using apt-get, *systemd* units are added for the
-following components. These can then be started, stopped, and restarted using
-the *systemctl* command:
+When you installed Sawtooth with ``apt-get``, ``systemd`` units were added for
+the Sawtooth components (validator, REST API, transaction processors, and
+consensus engines). This procedure describes how to use the ``systemctl``
+command to start, stop, and restart Sawtooth components as ``systemd`` services.
 
-* validator
-* transaction processors
-* rest_api
+To learn more about ``systemd`` and the ``systemctl`` command, see the `Digital
+Ocean systemctl guide`_.
 
-To learn more about *systemd* and the *systemctl* command, check out `this
-guide`_:
-
-.. _this guide: https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units
-
-
-Viewing Console Output
-----------------------
-
-To view the console output that you would see if you ran the components
-manually, run the following command:
-
-.. code-block:: console
-
-  $ sudo journalctl -f \
-      -u sawtooth-validator \
-      -u sawtooth-settings-tp \
-      -u sawtooth-poet-validator-registry-tp \
-      -u sawtooth-rest-api
-
-Validator Start-up Process
-==========================
-
-Create Genesis Block
---------------------
-
-The first validator created in a new network must load a genesis block on
-creation to enable other validators to join the network. Prior to starting the
-first validator, run the following commands to generate a genesis block that
-the first validator can load:
-
-.. code-block:: console
-
-  $ sawtooth keygen --key-dir ~/sawtooth
-  $ sawset genesis --key ~/sawtooth.priv
-  $ sawadm genesis config-genesis.batch
-
-Running Sawtooth
-----------------
+.. _Digital Ocean systemctl guide: https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units
 
 .. note::
-  Before starting the ``validator`` component you may need to generate
-  the validator keypairs using the following command:
+
+   Each node in the Sawtooth network must run the same set of transaction
+   processors. If this node will join an existing Sawtooth network, make sure
+   that you know the full list of required transaction processors, and have
+   installed any custom transaction processors.
+
+   If necessary, add the additional transaction processors to all ``systemctl``
+   commands in this procedure.
+
+
+Start the Sawtooth Services
+===========================
+
+Use these commands to start each Sawtooth component as a service:
+
+.. code-block:: console
+
+    $ sudo systemctl start sawtooth-rest-api.service
+    $ sudo systemctl start sawtooth-poet-validator-registry-tp.service
+    $ sudo systemctl start sawtooth-validator.service
+    $ sudo systemctl start sawtooth-settings-tp.service
+    $ sudo systemctl start sawtooth-intkey-tp-python.service
+    $ sudo systemctl start sawtooth-identity-tp.service
+    $ sudo systemctl start sawtooth-poet-engine.service
+
+This command starts the required transaction processors:
+PoET Validator Registry (`sawtooth-poet-validator-registry-tp`),
+Settings (`sawtooth-settings-tp.service), and
+Identity (`sawtooth-identity-tp.service`).  It also starts the IntegerKey
+transaction processor (``sawtooth-intkey-tp-python``), which is used in a
+later procedure to test basic Sawtooth functionality.
+
+
+Check Service Status
+====================
+
+Run this command to verify that the Sawtooth services are running:
+
+.. code-block:: console
+
+    $ sudo systemctl status sawtooth-rest-api.service
+    $ sudo systemctl status sawtooth-poet-validator-registry-tp.service
+    $ sudo systemctl status sawtooth-validator.service
+    $ sudo systemctl status sawtooth-settings-tp.service
+    $ sudo systemctl status sawtooth-intkey-tp-python.service
+    $ sudo systemctl status sawtooth-identity-tp.service
+    $ sudo systemctl status sawtooth-poet-engine.service
+
+
+View Sawtooth Logs
+==================
+
+Use the following command to view the log output.
+
+.. code-block:: console
+
+    $ sudo journalctl -f \
+    -u sawtooth-validator \
+    -u sawtooth-settings-tp \
+    -u sawtooth-poet-validator-registry-tp \
+    -u sawtooth-rest-api \
+    -u sawtooth-intkey-tp-python \
+    -u sawtooth-identity-tp.service \
+    -u sawtooth-poet-engine.service
+
+This command shows the output that would have been displayed on the console
+if you ran the components manually.
+
+Additional logging output can be found in ``/var/log/sawtooth/``. For more
+information, see :doc:`log_configuration`.
+
+
+Stop or Restart the Sawtooth Services
+=====================================
+
+If you need to stop or restart the Sawtooth services for any reason, use the
+following commands:
+
+* Stop Sawtooth services:
 
   .. code-block:: console
 
-    $ sudo sawadm keygen
+     $ sudo systemctl stop sawtooth-rest-api.service
+     $ sudo systemctl stop sawtooth-poet-validator-registry-tp.service
+     $ sudo systemctl stop sawtooth-validator.service
+     $ sudo systemctl stop sawtooth-settings-tp.service
+     $ sudo systemctl stop sawtooth-intkey-tp-python.service
+     $ sudo systemctl stop sawtooth-identity-tp.service
+     $ sudo systemctl stop sawtooth-poet-engine.service
 
+* Restart Sawtooth services:
 
-To start a component using *systemd*, run the following command where
-`COMPONENT` is one of:
+  .. code-block:: console
 
-  * validator
-  * rest-api
-  * intkey-tp-python
-  * settings-tp
-  * xo-tp-python
+     $ sudo systemctl restart sawtooth-rest-api.service
+     $ sudo systemctl restart sawtooth-poet-validator-registry-tp.service
+     $ sudo systemctl restart sawtooth-validator.service
+     $ sudo systemctl restart sawtooth-settings-tp.service
+     $ sudo systemctl restart sawtooth-intkey-tp-python.service
+     $ sudo systemctl restart sawtooth-identity-tp.service
+     $ sudo systemctl restart sawtooth-poet-engine.service
 
-.. code-block:: console
-
-  $ sudo systemctl start sawtooth-COMPONENT
-
-To see the status of a component run:
-
-.. code-block:: console
-
-  $ sudo systemctl status sawtooth-COMPONENT
-
-Likewise, to stop a component run:
-
-.. code-block:: console
-
-  $ sudo systemctl stop sawtooth-COMPONENT
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/testing_sawtooth.rst
+++ b/docs/source/sysadmin_guide/testing_sawtooth.rst
@@ -1,0 +1,109 @@
+Testing Sawtooth Functionality
+==============================
+
+After :doc:`starting Sawtooth services <systemd>`, you can use this procedure
+to test basic Sawtooth functionality.
+
+#. Confirm that the REST API is reachable.
+
+   .. code-block:: console
+
+      $ curl http://localhost:8008/blocks
+
+   .. note::
+
+      The Sawtooth environment described this guide runs a local REST API on
+      each validator node. For a node that is not running a local REST API,
+      replace ``localhost:8008`` with the externally advertised IP address and
+      port.
+
+   You should see a JSON response that is similar to this example:
+
+   .. code-block:: console
+
+      {
+        "data": [
+          {
+            "batches": [
+              {
+                "header": {
+                  "signer_public_key": . . .
+
+   If not, check the status of the REST API service and restart it, if
+   necessary; see :doc:`systemd`.
+
+#. Check the list of blocks on the blockchain.
+
+   .. code-block:: console
+
+      $ sawtooth block list
+
+   For the first node on a network, this list will contain only a few blocks.
+   If this node has joined an existing network, the block list could be quite
+   long. In both cases, the list should end with output that resembles this
+   example:
+
+   .. code-block:: console
+
+      NUM  BLOCK_ID                                                                                                                          BATS  TXNS  SIGNER
+      .
+      .
+      .
+      2    f40b90d06b4a9074af2ab09e0187223da7466be75ec0f472f2edd5f22960d76e402e6c07c90b7816374891d698310dd25d9b88dce7dbcba8219d9f7c9cae1861  3     3     02e56e...
+      1    4d7b3a2e6411e5462d94208a5bb83b6c7652fa6f4c2ada1aa98cabb0be34af9d28cf3da0f8ccf414aac2230179becade7cdabbd0976c4846990f29e1f96000d6  1     1     034aad...
+      0    0fb3ebf6fdc5eef8af600eccc8d1aeb3d2488992e17c124b03083f3202e3e6b9182e78fef696f5a368844da2a81845df7c3ba4ad940cee5ca328e38a0f0e7aa0  3     11    034aad...
+
+   Block 0 is the :term:`genesis block`. The other two blocks contain the
+   initial transactions for on-chain settings, such as setting PoET consensus.
+
+#. Make sure that new blocks of transactions are added to the blockchain.
+
+   #. Use the IntegerKey transaction processor to submit a test transaction.
+      The following command uses ``intkey`` (the command-line client for
+      IntegerKey) to set a key named ``MyKey`` to the value 999.
+
+      .. code-block:: console
+
+         $ intkey set MyKey 999
+
+   #. Next, check that this transaction appears on the blockchain.
+
+      .. code-block:: console
+
+         $ intkey show MyKey
+         MyKey: 999
+
+   #. Repeat the ``block list`` command to verify that there is now one more
+      block on the blockchain, as in this example:
+
+      .. code-block:: console
+
+         $ sawtooth block list
+
+         NUM  BLOCK_ID                                                                                                                          BATS  TXNS  SIGNER
+         N    1b7f121a82e73ba0e7f73de3e8b46137a2e47b9a2d2e6566275b5ee45e00ee5a06395e11c8aef76ff0230cbac0c0f162bb7be626df38681b5b1064f9c18c76e5  3     3     02d87a...
+         .
+         .
+         .
+         2    f40b90d06b4a9074af2ab09e0187223da7466be75ec0f472f2edd5f22960d76e402e6c07c90b7816374891d698310dd25d9b88dce7dbcba8219d9f7c9cae1861  3     3     02e56e...
+         1    4d7b3a2e6411e5462d94208a5bb83b6c7652fa6f4c2ada1aa98cabb0be34af9d28cf3da0f8ccf414aac2230179becade7cdabbd0976c4846990f29e1f96000d6  1     1     034aad...
+         0    0fb3ebf6fdc5eef8af600eccc8d1aeb3d2488992e17c124b03083f3202e3e6b9182e78fef696f5a368844da2a81845df7c3ba4ad940cee5ca328e38a0f0e7aa0  3     11    034aad...
+
+   If there is a problem, examine the logs for the validator, REST API, and
+   transaction processors for possible clues. For more information, see
+   :doc:`log_configuration`.
+
+.. tip::
+
+   For more help with problems, see the `Unofficial Hyperledger Sawtooth FAQ
+   <https://github.com/danintel/sawtooth-faq/blob/master/installation.rst>`__
+   or ask a question on the Hyperledger Chat `#sawtooth channel
+   <https://chat.hyperledger.org/channel/sawtooth>`__.
+
+After verifying that Sawtooth is running correctly, you can continue with
+the optional configuration and customization steps that are described in the
+following procedures.
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Update and correct existing procedures; add missing steps and procedures; clarify and expand the explanatory text.  

- Group the non-SGX procedures in a new section so that you can tell what's non-SGX vs SGX
- Clarify and format the install procedure
- Expand the "Starting Sawtooth" procedure to show the actual service commands and add the PoET simulator service
- Move the key-generation steps into their own procedure ; add more info to clarify user vs validator keys and key file location
- Create a new genesis block procedure with the correct steps for a system with PoET simulator consensus
- Reorganize the non-SGX sections to be in the correct order

Also:
- Add an overview/intro to the Sys Admin Guide
- Reorganize other sections: Move SGX section after the "generic" sections (for non-SGX and SGX systems), put consensus section at the end because it's reference doc

