### PR TITLE
Fix bug in rust sdk at TransactionContext add_event

### DIFF
--- a/sdk/rust/src/processor/handler.rs
+++ b/sdk/rust/src/processor/handler.rs
@@ -393,7 +393,7 @@ impl TransactionContext {
         let x: &[u8] = &serialized;
 
         let mut future = self.sender.send(
-            Message_MessageType::TP_RECEIPT_ADD_DATA_REQUEST,
+            Message_MessageType::TP_EVENT_ADD_REQUEST,
             &generate_correlation_id(),
             x,
         )?;


### PR DESCRIPTION
This PR changes the message type sent with the add event request from `TP_RECEIPT_ADD_DATA_REQUEST` to `TP_EVENT_ADD_REQUEST`.
The wrong message prevented new event types from being added successfully.

Signed-off-by: Eloá Franca Verona <eloafran@bitwise.io>