### PR TITLE
Fix info on policy entries in Identity txn fam spec

### DIFF
--- a/docs/source/transaction_family_specifications/identity_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/identity_transaction_family.rst
@@ -44,8 +44,8 @@ State
 Policies
 --------
 A policy will have a name and a list of entries. Each policy entry will have a
-type and a key list. The type will be either PERMIT_KEY or DENY_KEY and the key
-list will be a list of public keys.
+list of type/key pairs. The type will be either PERMIT_KEY or DENY_KEY.
+Each key in a type/key pair will be a public key.
 
 .. code-block:: protobuf
 
@@ -55,22 +55,25 @@ list will be a list of public keys.
   }
 
   message Policy {
-    enum Type {
-      PERMIT_KEY = 0;
-      DENY_KEY = 1;
+
+    enum EntryType {
+      ENTRY_TYPE_UNSET = 0;
+      PERMIT_KEY = 1;
+      DENY_KEY = 2;
     }
 
     message Entry {
       // Whether this is a PERMIT_KEY or DENY_KEY entry
-      Type type = 1;
-      // This should be a public key or * to refer to all participants.
-      string key = 2;
+      EntryType type = 1;
 
+      // This should a public key or * to refer to all participants.
+      string key = 2;
     }
 
     // name of the policy, this should be unique.
     string name = 1;
 
+    // list of Entries
     // The entries will be processed in order from first to last.
     repeated Entry entries = 2;
   }


### PR DESCRIPTION
Each policy is a list of type/key pairs (not a type and key list)

Also corrected the proto code in the doc to match the contents of protos/identity.proto

Signed-off-by: Anne Chenette <chenette@bitwise.io>