### PR TITLE
Fix incorrect comment in identity proto

### DIFF
--- a/protos/identity.proto
+++ b/protos/identity.proto
@@ -30,8 +30,7 @@ message Policy {
     // Whether this is a Permit_KEY or Deny_KEY entry
     EntryType type = 1;
 
-    // This should be a list of public keys or * to refer to all participants.
-    // If using *, it should be the only key in the list.
+    // This should be a public key or * to refer to all participants.
     string  key = 2;
   }
 


### PR DESCRIPTION
The previous comment mistakenly said that the key was a
list of public keys, when it is in fact onlyi one key or
* per entry.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>