### PR TITLE
Block Publisher FFI Cleanup

### DIFF
--- a/validator/src/ffi.rs
+++ b/validator/src/ffi.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+use cpython::{PyObject, Python};
+
 #[no_mangle]
 pub unsafe extern "C" fn ffi_reclaim_string(s_ptr: *mut u8, s_len: usize, s_cap: usize) -> isize {
     String::from_raw_parts(s_ptr, s_len, s_cap);
@@ -31,4 +33,14 @@ pub unsafe extern "C" fn ffi_reclaim_vec(
     Vec::from_raw_parts(vec_ptr, vec_len, vec_cap);
 
     0
+}
+
+pub fn py_import_class(module: &str, class: &str) -> PyObject {
+    let gil = Python::acquire_gil();
+    let python = gil.python();
+    python
+        .import(module)
+        .expect(&format!("Unable to import '{}'", module))
+        .get(python, class)
+        .expect(&format!("Unable to import {} from '{}'", class, module))
 }

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -31,7 +31,6 @@ use std::thread;
 use std::time::Duration;
 
 use execution::execution_platform::ExecutionPlatform;
-use execution::py_executor::PyExecutor;
 use ffi::py_import_class;
 use journal::block_manager::BlockManager;
 use journal::candidate_block::{CandidateBlock, CandidateBlockError};
@@ -505,7 +504,7 @@ impl BlockPublisher {
     #![allow(too_many_arguments)]
     pub fn new(
         block_manager: BlockManager,
-        transaction_executor: PyObject,
+        transaction_executor: Box<ExecutionPlatform>,
         batch_committed: PyObject,
         transaction_committed: PyObject,
         state_view_factory: StateViewFactory,
@@ -519,10 +518,8 @@ impl BlockPublisher {
         batch_observers: Vec<PyObject>,
         batch_injector_factory: PyObject,
     ) -> Self {
-        let tep = Box::new(PyExecutor::new(transaction_executor).unwrap());
-
         let state = Arc::new(RwLock::new(BlockPublisherState::new(
-            tep,
+            transaction_executor,
             chain_head,
             None,
             PendingBatchesPool::new(NUM_PUBLISH_COUNT_SAMPLES, INITIAL_PUBLISH_COUNT),

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -24,6 +24,7 @@ use cpython::{ObjectProtocol, PyClone, PyList, PyObject, Python};
 
 use batch::Batch;
 use block::Block;
+use execution::py_executor::PyExecutor;
 use ffi::py_import_class;
 use journal::block_manager::BlockManager;
 use journal::publisher::{
@@ -130,7 +131,10 @@ pub unsafe extern "C" fn block_publisher_new(
 
     let publisher = BlockPublisher::new(
         block_manager,
-        transaction_executor,
+        Box::new(
+            PyExecutor::new(transaction_executor)
+                .expect("Failed to create python transaction executor"),
+        ),
         batch_committed,
         transaction_committed,
         state_view_factory.clone(),


### PR DESCRIPTION
This is the first of (I hope) a few PRs to cleanup some of the FFI and concurrency code in the BlockPublisher and validator in general.