### PR TITLE
Fix build.rs script for breaking protoc-rust change

### DIFF
--- a/families/smallbank/smallbank_rust/build.rs
+++ b/families/smallbank/smallbank_rust/build.rs
@@ -41,9 +41,7 @@ fn main() {
             .map(|proto_file| proto_file.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["../protos"],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("Error generating rust files from smallbank protos");
 
     // Create mod.rs accordingly

--- a/perf/smallbank_workload/build.rs
+++ b/perf/smallbank_workload/build.rs
@@ -41,9 +41,7 @@ fn main() {
             .map(|proto_file| proto_file.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["../../families/smallbank/protos"],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("Error generating rust files from smallbank protos");
 
     // Create mod.rs accordingly

--- a/sdk/rust/build.rs
+++ b/sdk/rust/build.rs
@@ -62,9 +62,7 @@ fn main() {
             .map(|a| a.as_ref())
             .collect::<Vec<&str>>(),
         includes: &["src", "../../protos"],
-        customize: Customize {
-            ..Default::default()
-        },
+        customize: Customize::default(),
     }).expect("unable to run protoc");
 }
 

--- a/validator/build.rs
+++ b/validator/build.rs
@@ -74,9 +74,7 @@ fn main() {
                 .map(|proto_file| proto_file.file_path.as_ref())
                 .collect::<Vec<&str>>(),
             includes: &["src", PROTO_FILES_DIR],
-            customize: Customize {
-                ..Default::default()
-            },
+            customize: Customize::default(),
         }).expect("unable to run protoc");
 
         let mod_file_name = format!("{}/mod.rs", &dest_path.to_str().unwrap());


### PR DESCRIPTION
..Default::default() causes a private attribute to be accessed, while
Customize::default() is clearer.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>