### PR TITLE
Adding optional serde support for consensus structs

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -23,6 +23,7 @@ build = "build.rs"
 default = ["pem"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
+with-serde = ["serde", "serde_derive"]
 
 [dependencies]
 hex = "0.3"
@@ -36,6 +37,8 @@ log = "0.3"
 libc = "0.2"
 ctrlc = { version = "3.0", features = ["termination"] }
 openssl = { version = "0.10", optional = true }
+serde = { version = "1.0", optional = true }
+serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -38,6 +38,7 @@ pub enum Update {
 }
 
 #[derive(Clone, Default, Eq, Hash, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub struct BlockId(Vec<u8>);
 impl Deref for BlockId {
     type Target = Vec<u8>;
@@ -93,6 +94,7 @@ impl fmt::Debug for Block {
 }
 
 #[derive(Clone, Default, PartialEq, Eq, Hash, PartialOrd)]
+#[cfg_attr(feature = "with-serde", derive(Serialize, Deserialize))]
 pub struct PeerId(Vec<u8>);
 impl Deref for PeerId {
     type Target = Vec<u8>;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -25,6 +25,11 @@ extern crate openssl;
 extern crate protobuf;
 extern crate rand;
 extern crate secp256k1;
+#[cfg(feature = "with-serde")]
+extern crate serde;
+#[macro_use]
+#[cfg(feature = "with-serde")]
+extern crate serde_derive;
 extern crate uuid;
 extern crate zmq;
 


### PR DESCRIPTION
The Pbft consensus engine introduced state management via Serde, which relies on a few structs in the core consensus code having Serde support. This PR adds Serde support to the necessary structs.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>