### PR TITLE
Convert consensus ID newtypes to type aliases

### DIFF
--- a/sdk/examples/devmode_rust/src/engine.rs
+++ b/sdk/examples/devmode_rust/src/engine.rs
@@ -58,7 +58,7 @@ impl DevmodeService {
         self.service
             .get_blocks(vec![block_id.clone()])
             .expect("Failed to get block")
-            .remove(&block_id)
+            .remove(block_id)
             .unwrap()
     }
 

--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -17,7 +17,6 @@
 
 use std::error;
 use std::fmt;
-use std::ops::Deref;
 use std::sync::mpsc::Receiver;
 
 use hex;
@@ -37,35 +36,7 @@ pub enum Update {
     Shutdown,
 }
 
-#[derive(Clone, Default, Eq, Hash, PartialEq, PartialOrd)]
-pub struct BlockId(Vec<u8>);
-impl Deref for BlockId {
-    type Target = Vec<u8>;
-
-    fn deref(&self) -> &Vec<u8> {
-        &self.0
-    }
-}
-impl From<BlockId> for Vec<u8> {
-    fn from(id: BlockId) -> Vec<u8> {
-        id.0
-    }
-}
-impl From<Vec<u8>> for BlockId {
-    fn from(v: Vec<u8>) -> BlockId {
-        BlockId(v)
-    }
-}
-impl AsRef<[u8]> for BlockId {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-impl fmt::Debug for BlockId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
-    }
-}
+pub type BlockId = Vec<u8>;
 
 /// All information about a block that is relevant to consensus
 #[derive(Clone, Default)]
@@ -92,35 +63,7 @@ impl fmt::Debug for Block {
     }
 }
 
-#[derive(Clone, Default, PartialEq, Eq, Hash, PartialOrd)]
-pub struct PeerId(Vec<u8>);
-impl Deref for PeerId {
-    type Target = Vec<u8>;
-
-    fn deref(&self) -> &Vec<u8> {
-        &self.0
-    }
-}
-impl From<PeerId> for Vec<u8> {
-    fn from(id: PeerId) -> Vec<u8> {
-        id.0
-    }
-}
-impl From<Vec<u8>> for PeerId {
-    fn from(v: Vec<u8>) -> PeerId {
-        PeerId(v)
-    }
-}
-impl AsRef<[u8]> for PeerId {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-impl fmt::Debug for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", hex::encode(&self.0))
-    }
-}
+pub type PeerId = Vec<u8>;
 
 /// Information about a peer that is relevant to consensus
 #[derive(Default, Debug)]


### PR DESCRIPTION
As newtypes, they require extra machinery to play nicely with serde, and switching them to type aliases means they get serde support for free.

Signed-off-by: Kenneth Koski <knkski@bitwise.io>