### PR TITLE
Derive Clone for PeerMessage

### DIFF
--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -72,7 +72,7 @@ pub struct PeerInfo {
 }
 
 /// A consensus-related message sent between peers
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct PeerMessage {
     pub message_type: String,
     pub content: Vec<u8>,


### PR DESCRIPTION
This will allow PBFT and other consensus code to avoid cloning by writing `PeerMessage { ... }`.

See https://github.com/hyperledger/sawtooth-pbft/blob/master/src/node.rs#L271 for an example where we could improve things

Signed-off-by: Kenneth Koski <knkski@bitwise.io>