### PR TITLE
Fix xo smoke test so it passes in go sdk repo

### DIFF
--- a/integration/sawtooth_integration/tests/test_xo_smoke.py
+++ b/integration/sawtooth_integration/tests/test_xo_smoke.py
@@ -148,6 +148,10 @@ def _send_cmd(cmd_str):
 
 
 def _tp_supports_delete():
-    supported_langs = 'python'
+    supported_langs = ['python', 'go']
 
-    return os.getenv('TP_LANG', None) in supported_langs
+    lang = os.getenv('TP_LANG', None)
+    if lang is not None:
+        return lang in supported_langs
+
+    return False


### PR DESCRIPTION
A change in commit e8c3dbab causes the xo smoke test to fail when
run from the Go SDK repo. This commit fixes this behavior and changes
'supported_langs' to an array to prevent unintentional breakage in
the future.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>