### PR TITLE
Safe rm in Makefile for docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -73,7 +73,7 @@ RUSTSDKDIR := $(HTMLDIR)/rust_sdk
 rust:
 	mkdir -p $(RUSTSDKDIR)/
 	cd $(SAWTOOTH)/sdk/rust/; cargo doc --no-deps --lib;
-	rm $(SAWTOOTH)/sdk/rust/target/doc/.lock
+	rm -f $(SAWTOOTH)/sdk/rust/target/doc/.lock
 	cp -r $(SAWTOOTH)/sdk/rust/target/doc/ $(RUSTSDKDIR)/doc
 
 html: templates cli python rust


### PR DESCRIPTION
Scenario: make process interrupted after cargo doc generation.
Upon again performing make, build won't continue because .lock
file is now deleted and cargo won't generate doc again.

'rm -f' would not fail make process if file is not found, but
will delete the file if there is one.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>