### PR TITLE
Document Go SDK client usage

### DIFF
--- a/docs/source/_templates/partials/encoding_your_payload.rst
+++ b/docs/source/_templates/partials/encoding_your_payload.rst
@@ -23,6 +23,22 @@ Transaction Processor uses a payload of three key/value pairs encoded as
 
     const payloadBytes = cbor.encode(payload)
 
+{% elif language == 'Go' %}
+
+.. code-block:: go
+
+    import (
+        cbor "github.com/brianolson/cbor_go"
+    )
+
+    payloadData := make(map[string]interface{})
+    payloadData["Verb"] = "set"
+    payloadData["Name"] = "foo"
+    payloadData["Value"] = 42
+
+    // check if err is nil before continuing
+    payloadBytes, err := cbor.Dumps(payloadData)
+
 {% else %}
 
 .. code-block:: python

--- a/docs/source/_templates/partials/submitting_to_validator.rst
+++ b/docs/source/_templates/partials/submitting_to_validator.rst
@@ -27,6 +27,22 @@ prepared the BatchList:
         console.log(response.body)
     })
 
+{% elif language == 'Go' %}
+
+.. code-block:: go
+
+    import (
+        "bytes"
+        "net/http"
+    )
+
+    // Check if err is nil before continuing
+    response, err := http.Post(
+        "http://rest.api.domain/batches",
+        "application/octet-stream",
+        bytes.NewBuffer(batchListBytes)
+    )
+
 {% else %}
 
 .. code-block:: python
@@ -60,6 +76,17 @@ sent it from the command line with ``curl``:
     const fileStream = fs.createWriteStream('intkey.batches')
     fileStream.write(batchListBytes)
     fileStream.end()
+
+{% elif language == 'Go' %}
+
+.. code-block:: go
+
+    import (
+        "io/ioutil"
+    )
+
+    // Check if err is nil before continuing
+    err = ioutil.WriteFile("intkey.batches", batchListBytes, 0644)
 
 {% else %}
 

--- a/docs/source/_templates/sdk_TP_tutorial.rst
+++ b/docs/source/_templates/sdk_TP_tutorial.rst
@@ -1813,7 +1813,7 @@ Addressing is implemented as follows:
 .. code-block:: go
 
     func makeAddress(name string) string {
-	    return Namespace + hexdigest(name)[:64]
+        return Namespace + hexdigest(name)[:64]
     }
 
 {% elif language == 'Rust' %}

--- a/docs/source/_templates/template_config.yaml
+++ b/docs/source/_templates/template_config.yaml
@@ -21,6 +21,11 @@ targets:
     args:
       language: Python 3
 
+  sdk_submit_tutorial_go:
+    template: sdk_submit_tutorial.rst
+    args:
+      language: Go
+
   sdk_TP_tutorial_python:
     template: sdk_TP_tutorial.rst
     args:

--- a/docs/source/app_developers_guide/go_sdk.rst
+++ b/docs/source/app_developers_guide/go_sdk.rst
@@ -10,7 +10,9 @@ transaction family, XO, using the Sawtooth Go SDK.
 
    ../_autogen/sdk_overview_tutorial_go
    sdk_prerequisites
+   go_sdk_import.rst
    ../_autogen/sdk_TP_tutorial_go
+   ../_autogen/sdk_submit_tutorial_go
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/go_sdk_import.rst
+++ b/docs/source/app_developers_guide/go_sdk_import.rst
@@ -1,0 +1,59 @@
+********************
+Importing the Go SDK
+********************
+
+.. note::
+   The Sawtooth Go SDK assumes that you have the latest version of Go,
+   more information on installing and configuring can be found at `go
+   <https://github.com/golang/go>`_.
+
+Once you've got a working version of Sawtooth, there are a few additional
+steps you'll need to take to get started developing for Sawtooth in Go.
+
+1. Get Go SDK located at `Sawtooth Go SDK repository
+   <https://github.com/hyperledger/sawtooth-sdk-go>`_.
+
+.. code-block:: ini
+    :caption: Run following command for downloading Go SDK
+
+    $ go get github.com/hyperledger/sawtooth-sdk-go
+
+2. Import the SDK into your Go files. You need to specify packages from SDK
+   which are needed.
+
+.. code-block:: ini
+    :caption: Sample header for a Go file
+
+    import (
+        // to use signing package from SDK
+        "github.com/hyperledger/sawtooth-sdk-go/signing"
+    )
+
+    // --snip--
+
+3. Generate protobuf files for use, go to location
+   ``$GOPATH/src/github.com/hyperledger/sawtooth-sdk-go`` and run ``go generate``
+
+.. code-block:: ini
+    :caption: Run following command for generating Go protobuf files
+
+    $ go generate
+
+4. Root location of generated protobuf is
+   ``github.com/hyperledger/sawtooth-sdk-go/protobuf/``, notice that you may
+   need ``"github.com/golang/protobuf/proto"`` for encoding / decoding.
+   For example:
+
+.. code-block:: go
+    :caption: Sample header for a Go file using protobuf
+
+    import (
+        "github.com/golang/protobuf/proto"
+        // For transaction protobuf structs
+        "github.com/hyperledger/sawtooth-sdk-go/protobuf/transaction_pb2"
+    )
+
+    // --snip--
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/go_sdk_import.rst
+++ b/docs/source/app_developers_guide/go_sdk_import.rst
@@ -3,26 +3,28 @@ Importing the Go SDK
 ********************
 
 .. note::
-   The Sawtooth Go SDK assumes that you have the latest version of Go,
-   more information on installing and configuring can be found at `go
-   <https://github.com/golang/go>`_.
+   The Sawtooth Go SDK assumes that you have the latest version of Go.
+   More information on installing and configuring go can be found in the
+   `golang/go repository <https://github.com/golang/go>`__.
 
 Once you've got a working version of Sawtooth, there are a few additional
 steps you'll need to take to get started developing for Sawtooth in Go.
 
 1. Get Go SDK located at `Sawtooth Go SDK repository
-   <https://github.com/hyperledger/sawtooth-sdk-go>`_.
+   <https://github.com/hyperledger/sawtooth-sdk-go>`__.
 
-.. code-block:: ini
-    :caption: Run following command for downloading Go SDK
+   Note that $GOPATH is a list of directories, the Go SDK is downloaded
+   to the first directory entry present in it. We will assume that $GOPATH has
+   been set to single directory for the rest of this document.
+
+.. code-block:: console
 
     $ go get github.com/hyperledger/sawtooth-sdk-go
 
-2. Import the SDK into your Go files. You need to specify packages from SDK
-   which are needed.
+2. Import the SDK into your Go files. You need to specify which packages
+   from the SDK are needed as in this example:
 
-.. code-block:: ini
-    :caption: Sample header for a Go file
+.. code-block:: go
 
     import (
         // to use signing package from SDK
@@ -31,21 +33,20 @@ steps you'll need to take to get started developing for Sawtooth in Go.
 
     // --snip--
 
-3. Generate protobuf files for use, go to location
-   ``$GOPATH/src/github.com/hyperledger/sawtooth-sdk-go`` and run ``go generate``
+3. Generate the protobuf files.
 
-.. code-block:: ini
-    :caption: Run following command for generating Go protobuf files
+.. code-block:: console
 
+    $ cd $GOPATH/src/github.com/hyperledger/sawtooth-sdk-go
     $ go generate
 
-4. Root location of generated protobuf is
-   ``github.com/hyperledger/sawtooth-sdk-go/protobuf/``, notice that you may
-   need ``"github.com/golang/protobuf/proto"`` for encoding / decoding.
+4. The Root location of the generated protobuf is
+   ``github.com/hyperledger/sawtooth-sdk-go/protobuf/``.
+   Notice that you may need ``"github.com/golang/protobuf/proto"`` for
+   encoding / decoding.
    For example:
 
 .. code-block:: go
-    :caption: Sample header for a Go file using protobuf
 
     import (
         "github.com/golang/protobuf/proto"


### PR DESCRIPTION
1. Add information on Go SDK installation
  => Also include information on generating go protobuf files
2. Add information on Go SDK usage for constructing a client
  => Used intkey as an example to demonstrate client application
     development, this is in sync with document on other
     languages
3. Add information on Go SDK for submitting a request to validator
4. [minor] Change from tab to space for Go TP doc section

A Pull Request is raised on sawtooth-sdk-go repository to add intkey client application in Go.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>