### PR TITLE
Rewrite consensus notifier in Rust and run in background thread

### DIFF
--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -75,7 +75,7 @@ class ChainController(OwnedPointer):
             state_database.pointer,
             chain_head_lock.pointer,
             block_status_store.pointer,
-            ctypes.py_object(consensus_notifier),
+            consensus_notifier.pointer,
             ctypes.py_object(observers),
             ctypes.c_long(state_pruning_block_depth),
             ctypes.c_long(fork_cache_keep_time),

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -404,6 +404,7 @@ class Validator:
 
         self._block_status_store = block_status_store
 
+        self._consensus_notifier = consensus_notifier
         self._consensus_dispatcher = consensus_dispatcher
         self._consensus_service = consensus_service
         self._consensus_thread_pool = consensus_thread_pool

--- a/validator/src/consensus/mod.rs
+++ b/validator/src/consensus/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Intel Corporation
+ * Copyright 2018 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,39 +15,5 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate cbor;
-extern crate cpython;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
-extern crate python3_sys as py_ffi;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-extern crate openssl;
-#[cfg(test)]
-extern crate rand;
-extern crate uluru;
-
-// exported modules
-pub mod consensus;
-pub mod database;
-pub mod execution;
-pub mod gossip;
-pub mod hashlib;
-pub mod journal;
-mod metrics;
-pub mod proto;
-pub mod pylogger;
-pub mod scheduler;
-pub mod state;
-
-pub mod batch;
-mod batch_ffi;
-pub mod block;
-mod block_ffi;
-pub mod transaction;
-
-pub mod ffi;
+pub mod notifier;
+pub mod notifier_ffi;

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -17,9 +17,133 @@
 
 use block::Block;
 
+use hashlib::sha256_digest_strs;
+use hex;
+use protobuf::Message;
+
+use proto::consensus::{
+    ConsensusBlock, ConsensusNotifyBlockCommit, ConsensusNotifyBlockInvalid,
+    ConsensusNotifyBlockNew, ConsensusNotifyBlockValid, ConsensusNotifyPeerConnected,
+    ConsensusNotifyPeerDisconnected, ConsensusNotifyPeerMessage, ConsensusPeerInfo,
+    ConsensusPeerMessage,
+};
+use proto::validator::Message_MessageType as MessageType;
+
 pub trait ConsensusNotifier: Send + Sync {
+    fn notify_peer_connected(&self, peer_id: &str);
+    fn notify_peer_disconnected(&self, peer_id: &str);
+    fn notify_peer_message(&self, message: ConsensusPeerMessage, sender_id: &[u8]);
+
     fn notify_block_new(&self, block: &Block);
     fn notify_block_valid(&self, block_id: &str);
     fn notify_block_invalid(&self, block_id: &str);
     fn notify_block_commit(&self, block_id: &str);
+}
+
+#[derive(Debug)]
+pub struct NotifierServiceError(pub String);
+
+pub trait NotifierService: Sync + Send {
+    fn notify<T: Message>(
+        &self,
+        message_type: MessageType,
+        message: T,
+    ) -> Result<(), NotifierServiceError>;
+}
+
+impl<T: NotifierService> ConsensusNotifier for T {
+    fn notify_peer_connected(&self, peer_id: &str) {
+        let mut peer_info = ConsensusPeerInfo::new();
+        peer_info.set_peer_id(from_hex(peer_id, "peer_id"));
+
+        let mut notification = ConsensusNotifyPeerConnected::new();
+        notification.set_peer_info(peer_info);
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_PEER_CONNECTED, notification)
+            .expect("Failed to send peer connected notification");
+    }
+
+    fn notify_peer_disconnected(&self, peer_id: &str) {
+        let mut notification = ConsensusNotifyPeerDisconnected::new();
+        notification.set_peer_id(from_hex(peer_id, "peer_id"));
+
+        self.notify(
+            MessageType::CONSENSUS_NOTIFY_PEER_DISCONNECTED,
+            notification,
+        ).expect("Failed to send peer disconnected notification");
+    }
+
+    fn notify_peer_message(&self, message: ConsensusPeerMessage, sender_id: &[u8]) {
+        let mut notification = ConsensusNotifyPeerMessage::new();
+        notification.set_message(message);
+        notification.set_sender_id(sender_id.into());
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_PEER_MESSAGE, notification)
+            .expect("Failed to send peer message notification");
+    }
+
+    fn notify_block_new(&self, block: &Block) {
+        let summary = summarize(block);
+
+        let mut consensus_block = ConsensusBlock::new();
+        consensus_block.set_block_id(from_hex(&block.header_signature, "block.header_signature"));
+        consensus_block.set_previous_id(from_hex(
+            &block.previous_block_id,
+            "block.previous_block_id",
+        ));
+        consensus_block.set_signer_id(from_hex(
+            &block.signer_public_key,
+            "block.signer_public_key",
+        ));
+        consensus_block.set_block_num(block.block_num);
+        consensus_block.set_payload(block.consensus.clone());
+        consensus_block.set_summary(summary);
+
+        let mut notification = ConsensusNotifyBlockNew::new();
+        notification.set_block(consensus_block);
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_BLOCK_NEW, notification)
+            .expect("Failed to send block new notification");
+    }
+
+    fn notify_block_valid(&self, block_id: &str) {
+        let mut notification = ConsensusNotifyBlockValid::new();
+        notification.set_block_id(from_hex(block_id, "block_id"));
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_BLOCK_VALID, notification)
+            .expect("Failed to send block valid notification");
+    }
+
+    fn notify_block_invalid(&self, block_id: &str) {
+        let mut notification = ConsensusNotifyBlockInvalid::new();
+        notification.set_block_id(from_hex(block_id, "block_id"));
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_BLOCK_INVALID, notification)
+            .expect("Failed to send block invalid notification");
+    }
+
+    fn notify_block_commit(&self, block_id: &str) {
+        let mut notification = ConsensusNotifyBlockCommit::new();
+        notification.set_block_id(from_hex(block_id, "block_id"));
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_BLOCK_COMMIT, notification)
+            .expect("Failed to send block commit notification");
+    }
+}
+
+fn summarize(block: &Block) -> Vec<u8> {
+    let batch_ids: Vec<&str> = block
+        .batches
+        .iter()
+        .map(|batch| batch.header_signature.as_str())
+        .collect();
+
+    sha256_digest_strs(batch_ids.as_slice())
+}
+
+fn from_hex<T: AsRef<str>>(hex_string: T, id_name: &str) -> Vec<u8> {
+    match hex::decode(hex_string.as_ref()) {
+        Ok(d) => d,
+        Err(err) => panic!("{} is invalid hex: {:?}", id_name, err),
+    }
 }

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -15,6 +15,10 @@
  * ------------------------------------------------------------------------------
  */
 
+use std::sync::mpsc::{channel, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
 use block::Block;
 
 use hashlib::sha256_digest_strs;
@@ -145,5 +149,96 @@ fn from_hex<T: AsRef<str>>(hex_string: T, id_name: &str) -> Vec<u8> {
     match hex::decode(hex_string.as_ref()) {
         Ok(d) => d,
         Err(err) => panic!("{} is invalid hex: {:?}", id_name, err),
+    }
+}
+
+#[derive(Debug)]
+enum ConsensusNotification {
+    PeerConnected(String),
+    PeerDisconnected(String),
+    PeerMessage((ConsensusPeerMessage, Vec<u8>)),
+    BlockNew(Block),
+    BlockValid(String),
+    BlockInvalid(String),
+    BlockCommit(String),
+}
+
+#[derive(Clone)]
+pub struct BackgroundConsensusNotifier {
+    tx: Arc<Mutex<Sender<ConsensusNotification>>>,
+}
+
+impl BackgroundConsensusNotifier {
+    pub fn new<T: ConsensusNotifier + 'static>(notifier: T) -> Self {
+        let (tx, rx) = channel();
+        let thread_builder = thread::Builder::new().name("BackgroundConsensusNotifier".into());
+        thread_builder
+            .spawn(move || loop {
+                if let Ok(notification) = rx.recv() {
+                    handle_notification(&notifier, notification);
+                } else {
+                    break;
+                }
+            }).expect("Failed to spawn BackgroundConsensusNotifier thread");
+        BackgroundConsensusNotifier {
+            tx: Arc::new(Mutex::new(tx)),
+        }
+    }
+
+    fn send_notification(&self, notification: ConsensusNotification) {
+        self.tx
+            .lock()
+            .expect("Lock poisoned")
+            .send(notification)
+            .expect("Failed to send notification to background thread");
+    }
+}
+
+impl ConsensusNotifier for BackgroundConsensusNotifier {
+    fn notify_peer_connected(&self, peer_id: &str) {
+        self.send_notification(ConsensusNotification::PeerConnected(peer_id.into()))
+    }
+
+    fn notify_peer_disconnected(&self, peer_id: &str) {
+        self.send_notification(ConsensusNotification::PeerDisconnected(peer_id.into()))
+    }
+
+    fn notify_peer_message(&self, message: ConsensusPeerMessage, sender_id: &[u8]) {
+        self.send_notification(ConsensusNotification::PeerMessage((
+            message,
+            sender_id.into(),
+        )))
+    }
+
+    fn notify_block_new(&self, block: &Block) {
+        self.send_notification(ConsensusNotification::BlockNew(block.clone()))
+    }
+
+    fn notify_block_valid(&self, block_id: &str) {
+        self.send_notification(ConsensusNotification::BlockValid(block_id.into()))
+    }
+
+    fn notify_block_invalid(&self, block_id: &str) {
+        self.send_notification(ConsensusNotification::BlockInvalid(block_id.into()))
+    }
+
+    fn notify_block_commit(&self, block_id: &str) {
+        self.send_notification(ConsensusNotification::BlockCommit(block_id.into()))
+    }
+}
+
+fn handle_notification<T: ConsensusNotifier>(notifier: &T, notification: ConsensusNotification) {
+    match notification {
+        ConsensusNotification::PeerConnected(peer_id) => notifier.notify_peer_connected(&peer_id),
+        ConsensusNotification::PeerDisconnected(peer_id) => {
+            notifier.notify_peer_disconnected(&peer_id)
+        }
+        ConsensusNotification::PeerMessage((msg, sender_id)) => {
+            notifier.notify_peer_message(msg, &sender_id)
+        }
+        ConsensusNotification::BlockNew(block) => notifier.notify_block_new(&block),
+        ConsensusNotification::BlockValid(block_id) => notifier.notify_block_valid(&block_id),
+        ConsensusNotification::BlockInvalid(block_id) => notifier.notify_block_invalid(&block_id),
+        ConsensusNotification::BlockCommit(block_id) => notifier.notify_block_commit(&block_id),
     }
 }

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Intel Corporation
+ * Copyright 2018 Cargill Incorporated
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,39 +15,11 @@
  * ------------------------------------------------------------------------------
  */
 
-extern crate cbor;
-extern crate cpython;
-extern crate hex;
-extern crate libc;
-extern crate lmdb_zero;
-extern crate protobuf;
-extern crate python3_sys as py_ffi;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate log;
-extern crate openssl;
-#[cfg(test)]
-extern crate rand;
-extern crate uluru;
+use block::Block;
 
-// exported modules
-pub mod consensus;
-pub mod database;
-pub mod execution;
-pub mod gossip;
-pub mod hashlib;
-pub mod journal;
-mod metrics;
-pub mod proto;
-pub mod pylogger;
-pub mod scheduler;
-pub mod state;
-
-pub mod batch;
-mod batch_ffi;
-pub mod block;
-mod block_ffi;
-pub mod transaction;
-
-pub mod ffi;
+pub trait ConsensusNotifier: Send + Sync {
+    fn notify_block_new(&self, block: &Block);
+    fn notify_block_valid(&self, block_id: &str);
+    fn notify_block_invalid(&self, block_id: &str);
+    fn notify_block_commit(&self, block_id: &str);
+}

--- a/validator/src/consensus/notifier_ffi.rs
+++ b/validator/src/consensus/notifier_ffi.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cpython::{ObjectProtocol, PyClone, PyObject, Python, ToPyObject};
+
+use block::Block;
+use consensus::notifier::ConsensusNotifier;
+use pylogger;
+
+pub struct PyConsensusNotifier {
+    py_consensus_notifier: PyObject,
+}
+
+impl PyConsensusNotifier {
+    pub fn new(py_consensus_notifier: PyObject) -> Self {
+        PyConsensusNotifier {
+            py_consensus_notifier,
+        }
+    }
+
+    fn call_py_fn<T: ToPyObject>(&self, py_fn_name: &str, obj: T) {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_consensus_notifier
+            .call_method(py, py_fn_name, (obj,), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    &format!("Unable to call consensus_notifier.{}", py_fn_name),
+                    py_err,
+                );
+                ()
+            }).unwrap_or(())
+    }
+}
+
+impl Clone for PyConsensusNotifier {
+    fn clone(&self) -> Self {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        PyConsensusNotifier {
+            py_consensus_notifier: self.py_consensus_notifier.clone_ref(py),
+        }
+    }
+}
+
+impl ConsensusNotifier for PyConsensusNotifier {
+    fn notify_block_new(&self, block: &Block) {
+        self.call_py_fn("notify_block_new", block)
+    }
+
+    fn notify_block_valid(&self, block_id: &str) {
+        self.call_py_fn("notify_block_valid", block_id)
+    }
+
+    fn notify_block_invalid(&self, block_id: &str) {
+        self.call_py_fn("notify_block_invalid", block_id)
+    }
+
+    fn notify_block_commit(&self, block_id: &str) {
+        self.call_py_fn("notify_block_commit", block_id)
+    }
+}

--- a/validator/src/consensus/notifier_ffi.rs
+++ b/validator/src/consensus/notifier_ffi.rs
@@ -24,7 +24,9 @@ use protobuf::{self, Message, ProtobufEnum};
 use py_ffi;
 
 use block::Block;
-use consensus::notifier::{ConsensusNotifier, NotifierService, NotifierServiceError};
+use consensus::notifier::{
+    BackgroundConsensusNotifier, ConsensusNotifier, NotifierService, NotifierServiceError,
+};
 use proto::validator::Message_MessageType as MessageType;
 use proto::{self, consensus::ConsensusPeerMessage};
 use pylogger;
@@ -101,8 +103,8 @@ pub unsafe extern "C" fn consensus_notifier_new(
     let py = Python::assume_gil_acquired();
     let py_notifier_service = PyObject::from_borrowed_ptr(py, py_notifier_service_ptr);
 
-    *consensus_notifier_ptr = Box::into_raw(Box::new(PyNotifierService::new(
-        py_notifier_service
+    *consensus_notifier_ptr = Box::into_raw(Box::new(BackgroundConsensusNotifier::new(
+        PyNotifierService::new(py_notifier_service),
     ))) as *const c_void;
 
     ErrorCode::Success
@@ -111,7 +113,7 @@ pub unsafe extern "C" fn consensus_notifier_new(
 #[no_mangle]
 pub unsafe extern "C" fn consensus_notifier_drop(notifier: *mut c_void) -> ErrorCode {
     check_null!(notifier);
-    Box::from_raw(notifier as *mut PyNotifierService);
+    Box::from_raw(notifier as *mut BackgroundConsensusNotifier);
     ErrorCode::Success
 }
 
@@ -124,7 +126,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_peer_connected(
 
     match deref_cstr(peer_id) {
         Ok(peer_id) => {
-            (*(notifier as *mut PyNotifierService)).notify_peer_connected(peer_id);
+            (*(notifier as *mut BackgroundConsensusNotifier)).notify_peer_connected(peer_id);
             ErrorCode::Success
         }
         Err(err) => err,
@@ -140,7 +142,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_peer_disconnected(
 
     match deref_cstr(peer_id) {
         Ok(peer_id) => {
-            (*(notifier as *mut PyNotifierService)).notify_peer_disconnected(peer_id);
+            (*(notifier as *mut BackgroundConsensusNotifier)).notify_peer_disconnected(peer_id);
             ErrorCode::Success
         }
         Err(err) => err,
@@ -167,7 +169,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_peer_message(
     };
 
     let sender_id = slice::from_raw_parts(sender_id_bytes, sender_id_len);
-    (*(notifier as *mut PyNotifierService)).notify_peer_message(message, &sender_id);
+    (*(notifier as *mut BackgroundConsensusNotifier)).notify_peer_message(message, &sender_id);
 
     ErrorCode::Success
 }
@@ -192,7 +194,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_block_new(
         proto_block.into()
     };
 
-    (*(notifier as *mut PyNotifierService)).notify_block_new(&block);
+    (*(notifier as *mut BackgroundConsensusNotifier)).notify_block_new(&block);
 
     ErrorCode::Success
 }
@@ -206,7 +208,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_block_valid(
 
     match deref_cstr(block_id) {
         Ok(block_id) => {
-            (*(notifier as *mut PyNotifierService)).notify_block_valid(block_id);
+            (*(notifier as *mut BackgroundConsensusNotifier)).notify_block_valid(block_id);
             ErrorCode::Success
         }
         Err(err) => err,
@@ -222,7 +224,7 @@ pub unsafe extern "C" fn consensus_notifier_notify_block_invalid(
 
     match deref_cstr(block_id) {
         Ok(block_id) => {
-            (*(notifier as *mut PyNotifierService)).notify_block_invalid(block_id);
+            (*(notifier as *mut BackgroundConsensusNotifier)).notify_block_invalid(block_id);
             ErrorCode::Success
         }
         Err(err) => err,

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -37,6 +37,7 @@ use protobuf;
 
 use batch::Batch;
 use block::Block;
+use consensus::notifier::ConsensusNotifier;
 use execution::execution_platform::ExecutionPlatform;
 use gossip::permission_verifier::PermissionVerifier;
 use journal;
@@ -124,13 +125,6 @@ pub trait ChainReader: Send + Sync {
     fn count_committed_transactions(&self) -> Result<usize, ChainReadError>;
     fn get_block_by_block_num(&self, block_num: u64) -> Result<Option<Block>, ChainReadError>;
     fn get_block_by_block_id(&self, block_id: &str) -> Result<Option<Block>, ChainReadError>;
-}
-
-pub trait ConsensusNotifier: Send + Sync {
-    fn notify_block_new(&self, block: &Block);
-    fn notify_block_valid(&self, block_id: &str);
-    fn notify_block_invalid(&self, block_id: &str);
-    fn notify_block_commit(&self, block_id: &str);
 }
 
 /// Holds the results of Block Validation.

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -18,7 +18,7 @@
 #![allow(unknown_lints)]
 
 use block::Block;
-use consensus::notifier_ffi::PyNotifierService;
+use consensus::notifier::BackgroundConsensusNotifier;
 use cpython::{self, ObjectProtocol, PyList, PyObject, Python, PythonObject, ToPyObject};
 use database::lmdb::LmdbDatabase;
 use execution::py_executor::PyExecutor;
@@ -101,7 +101,8 @@ pub unsafe extern "C" fn chain_controller_new(
 
     let py_observers = PyObject::from_borrowed_ptr(py, observers);
     let chain_head_lock_ref = (chain_head_lock as *const ChainHeadLock).as_ref().unwrap();
-    let consensus_notifier_service = Box::from_raw(consensus_notifier_service as *mut PyNotifierService);
+    let consensus_notifier_service =
+        Box::from_raw(consensus_notifier_service as *mut BackgroundConsensusNotifier);
 
     let observer_wrappers = if let Ok(py_list) = py_observers.extract::<PyList>(py) {
         let mut res: Vec<Box<ChainObserver>> = Vec::with_capacity(py_list.len(py));

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -18,7 +18,8 @@
 #![allow(unknown_lints)]
 
 use block::Block;
-use cpython::{self, ObjectProtocol, PyClone, PyList, PyObject, Python, PythonObject, ToPyObject};
+use consensus::notifier_ffi::PyConsensusNotifier;
+use cpython::{self, ObjectProtocol, PyList, PyObject, Python, PythonObject, ToPyObject};
 use database::lmdb::LmdbDatabase;
 use execution::py_executor::PyExecutor;
 use gossip::permission_verifier::PyPermissionVerifier;
@@ -391,99 +392,6 @@ impl ChainObserver for PyChainObserver {
             .map(|_| ())
             .map_err(|py_err| {
                 pylogger::exception(py, "Unable to call observer.chain_update", py_err);
-                ()
-            }).unwrap_or(())
-    }
-}
-
-struct PyConsensusNotifier {
-    py_consensus_notifier: PyObject,
-}
-
-impl PyConsensusNotifier {
-    fn new(py_consensus_notifier: PyObject) -> Self {
-        PyConsensusNotifier {
-            py_consensus_notifier,
-        }
-    }
-}
-
-impl Clone for PyConsensusNotifier {
-    fn clone(&self) -> Self {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        PyConsensusNotifier {
-            py_consensus_notifier: self.py_consensus_notifier.clone_ref(py),
-        }
-    }
-}
-
-impl ConsensusNotifier for PyConsensusNotifier {
-    fn notify_block_new(&self, block: &Block) {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        self.py_consensus_notifier
-            .call_method(py, "notify_block_new", (block,), None)
-            .map(|_| ())
-            .map_err(|py_err| {
-                pylogger::exception(
-                    py,
-                    "Unable to call consensus_notifier.notify_block_new",
-                    py_err,
-                );
-                ()
-            }).unwrap_or(())
-    }
-
-    fn notify_block_valid(&self, block_id: &str) {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        self.py_consensus_notifier
-            .call_method(py, "notify_block_valid", (block_id,), None)
-            .map(|_| ())
-            .map_err(|py_err| {
-                pylogger::exception(
-                    py,
-                    "Unable to call consensus_notifier.notify_block_valid",
-                    py_err,
-                );
-                ()
-            }).unwrap_or(())
-    }
-
-    fn notify_block_invalid(&self, block_id: &str) {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        self.py_consensus_notifier
-            .call_method(py, "notify_block_invalid", (block_id,), None)
-            .map(|_| ())
-            .map_err(|py_err| {
-                pylogger::exception(
-                    py,
-                    "Unable to call consensus_notifier.notify_block_invalid",
-                    py_err,
-                );
-                ()
-            }).unwrap_or(())
-    }
-
-    fn notify_block_commit(&self, block_id: &str) {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
-
-        self.py_consensus_notifier
-            .call_method(py, "notify_block_commit", (block_id,), None)
-            .map(|_| ())
-            .map_err(|py_err| {
-                pylogger::exception(
-                    py,
-                    "Unable to call consensus_notifier.notify_block_commit",
-                    py_err,
-                );
                 ()
             }).unwrap_or(())
     }


### PR DESCRIPTION
This removes an inefficiency in the core validator, where it must wait for a network ack from the engine whenever it sends it a notification.