### PR TITLE
Enforce consensus settings

### DIFF
--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -77,7 +77,12 @@ services:
         sawadm keygen && \
         sawtooth keygen my_key && \
         sawset genesis -k /root/.sawtooth/keys/my_key.priv && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /root/.sawtooth/keys/my_key.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,7 +143,15 @@ services:
         cp ./target/release/sawtooth-validator bin/sawtooth-validator
         cp ./target/release/libsawtooth_validator.so lib/libsawtooth_validator.so
         sawadm keygen
-        sawadm genesis
+        sawset genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -vv \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/docker/compose/sawtooth-default-poet.yaml
+++ b/docker/compose/sawtooth-default-poet.yaml
@@ -49,7 +49,8 @@ services:
           -o config-genesis.batch && \
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.consensus.algorithm=poet \
+          sawtooth.consensus.algorithm.name=PoET \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.poet.report_public_key_pem=\
           \\\"$$(cat /poet-shared/simulator_rk_pub.pem)\\\" \
           sawtooth.poet.valid_enclave_measurements=$$(cat /poet-shared/poet-enclave-measurement) \

--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -50,7 +50,12 @@ services:
         sawadm keygen && \
         sawtooth keygen my_key && \
         sawset genesis -k /root/.sawtooth/keys/my_key.priv && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /root/.sawtooth/keys/my_key.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -vv \
           --endpoint tcp://validator:8800 \
           --bind component:tcp://eth0:4004 \

--- a/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml
+++ b/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml
@@ -122,7 +122,8 @@ items:
                  if [ ! -e config.batch ]; then \
                    sawset proposal create \
                      -k /etc/sawtooth/keys/validator.priv \
-                     sawtooth.consensus.algorithm=poet \
+                     sawtooth.consensus.algorithm.name=PoET \
+                     sawtooth.consensus.algorithm.version=0.1 \
                      sawtooth.poet.report_public_key_pem=\"$(cat /poet-shared/simulator_rk_pub.pem)\" \
                      sawtooth.poet.valid_enclave_measurements=$(cat /poet-shared/poet-enclave-measurement) \
                      sawtooth.poet.valid_enclave_basenames=$(cat /poet-shared/poet-enclave-basename) \

--- a/docker/kubernetes/sawtooth-kubernetes-default.yaml
+++ b/docker/kubernetes/sawtooth-kubernetes-default.yaml
@@ -64,7 +64,12 @@ items:
               - "sawadm keygen \
               && sawtooth keygen my_key \
               && sawset genesis -k /root/.sawtooth/keys/my_key.priv \
-              && sawadm genesis config-genesis.batch \
+              && sawset proposal create \
+                -k /etc/sawtooth/keys/validator.priv \
+                sawtooth.consensus.algorithm.name=Devmode \
+                sawtooth.consensus.algorithm.version=0.1 \
+                -o config.batch \
+              && sawadm genesis config-genesis.batch config.batch \
               && sawtooth-validator -vv \
                   --endpoint tcp://$SAWTOOTH_0_SERVICE_HOST:8800 \
                   --bind component:tcp://eth0:4004 \
@@ -115,4 +120,3 @@ items:
         protocol: TCP
         port: 8800
         targetPort: 8800
-

--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -60,8 +60,8 @@ A Sawtooth network has the following requirements:
   ``trust`` authorization.
 
 * The genesis block is created for the first validator node only. It includes
-  on-chain configuration settings, such as the consensus type, that will be
-  available to the new validator nodes once they join the network.
+  on-chain configuration settings that will be available to the new validator
+  nodes once they join the network.
 
 .. note::
 
@@ -314,7 +314,8 @@ setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
@@ -519,7 +520,8 @@ in :doc:`ubuntu`.
 
       $ sawset proposal create -k /etc/sawtooth/keys/validator.priv \
       -o config.batch \
-      sawtooth.consensus.algorithm=poet \
+      sawtooth.consensus.algorithm.name=PoET \
+      sawtooth.consensus.algorithm.version=0.1 \
       sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
@@ -885,7 +887,9 @@ setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
@@ -1371,7 +1375,8 @@ Use the following steps to create and submit a batch containing the new setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...

--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -246,7 +246,8 @@ a ``GenesisData`` list of batches for the genesis block.
         $ sawset proposal create \
           -k <signing-key-file> \
           -o sawset.batch \
-          sawtooth.consensus.algorithm=poet \
+          sawtooth.consensus.algorithm.name=PoET \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.poet.initial_wait_timer={value} \
           sawtooth.poet.target_wait_time={value} \
           sawtooth.poet.population_estimate_sample_size={value}
@@ -310,8 +311,7 @@ If any transactions in the genesis block set or change settings, Sawtooth
 requires the `Sawtooth Settings transaction processor <../cli/settings-tp>`_
 or an equivalent implementation.
 For example, if the genesis block configures PoET consensus, this transaction
-processor is handles the transactions with PoET settings. (If no
-consensus is specified, Sawtooth uses dev mode consensus.)
+processor is handles the transactions with PoET settings.
 
 When the genesis block is committed, the consensus settings are stored in
 state. All subsequent blocks are processed with the configured consensus

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -239,7 +239,8 @@ Create and submit a proposal:
 .. code-block:: console
 
     [sawtooth@system]$ sawset proposal create -k /etc/sawtooth/keys/validator.priv \
-    sawtooth.consensus.algorithm=poet \
+    sawtooth.consensus.algorithm.name=PoET \
+    sawtooth.consensus.algorithm.version=0.1 \
     sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)" \
     sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement) \
     sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename) \
@@ -259,8 +260,11 @@ lines of output showing that the SGX enclave has been initialized:
     There’s quite a bit going on in the previous ``sawset proposal`` command, so
     let’s take a closer look at what it accomplishes:
 
-    ``sawtooth.consensus.algorithm=poet``
+    ``sawtooth.consensus.algorithm.name=PoET``
       Changes the consensus algorithm to PoET.
+
+    ``sawtooth.consensus.algorithm.version=0.1``
+      Changes the version of the consensus algorithm to 0.1.
 
     ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)"``
       Adds the public key that the validator registry transaction processor uses

--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -65,7 +65,8 @@ submit the genesis block.
 
       [sawtooth@system]$ sawset proposal create --key /etc/sawtooth/keys/validator.priv \
       -o config.batch \
-      sawtooth.consensus.algorithm=poet \
+      sawtooth.consensus.algorithm.name=PoET \
+      sawtooth.consensus.algorithm.version=0.1 \
       sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
@@ -80,8 +81,11 @@ submit the genesis block.
    ``-o config.batch``
     Wraps the proposal transaction in a batch named ``config.batch``.
 
-   ``sawtooth.consensus.algorithm=poet``
+   ``sawtooth.consensus.algorithm.name=PoET``
     Changes the consensus algorithm to PoET.
+
+    ``sawtooth.consensus.algorithm.version=0.1``
+     Changes the version of the consensus algorithm to 0.1.
 
    ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)"``
     Adds the public key for the PoET Validator Registry transaction

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -51,7 +51,8 @@ PoET Validator Registry transaction processors.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
@@ -76,5 +77,3 @@ PoET Validator Registry transaction processors.
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/
-
-

--- a/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
@@ -54,7 +54,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_block_info_injector.yaml
+++ b/integration/sawtooth_integration/docker/test_block_info_injector.yaml
@@ -93,6 +93,8 @@ services:
           -o config-genesis.batch && \
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.validator.batch_injectors=block_info \
           'sawtooth.validator.block_validation_rules=NofX:1,block_info;XatY:block_info,0;local:0' \
           -o config.batch && \

--- a/integration/sawtooth_integration/docker/test_config_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_config_smoke.yaml
@@ -53,7 +53,12 @@ services:
         echo 2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088 > /tmp/test.priv && \
         sawadm keygen && \
         sawset genesis -k /tmp/test.priv -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch  && \
+        sawset proposal create \
+          -k /tmp/test.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator -v --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_devmode_engine_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_devmode_engine_liveness.yaml
@@ -163,7 +163,8 @@ services:
           -o config-genesis.batch && \
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
-          sawtooth.consensus.algorithm=None \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.consensus.min_wait_time=2 \
           sawtooth.consensus.max_wait_time=4 \
           -o config.batch && \

--- a/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
+++ b/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
@@ -72,7 +72,12 @@ services:
         sawadm keygen && \
         sawtooth keygen my_key && \
         sawset genesis -k /root/.sawtooth/keys/my_key.priv && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /root/.sawtooth/keys/my_key.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_intkey_cli.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_cli.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_namespace_restriction.yaml
+++ b/integration/sawtooth_integration/docker/test_namespace_restriction.yaml
@@ -123,6 +123,8 @@ services:
           -o config_transaction_families.batch && \
         sawset proposal create \
           -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.validator.batch_injectors=block_info \
           'sawtooth.validator.block_validation_rules=NofX:1,block_info;XatY:block_info,0;local:0' \
           -o config.batch && \

--- a/integration/sawtooth_integration/docker/test_peer_list.yaml
+++ b/integration/sawtooth_integration/docker/test_peer_list.yaml
@@ -36,7 +36,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -vv \
             --endpoint tcp://validator-0:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_permission.yaml
+++ b/integration/sawtooth_integration/docker/test_permission.yaml
@@ -53,6 +53,13 @@ services:
         echo 2f1e7b7a130d7ba9da0068b3bb0ba1d79e7e77110302c9f746c3c2a63fe40088 > test.priv && \
         sawadm keygen && \
         sawset genesis -k test.priv -o setting-genesis.batch && \
+        sawset proposal create \
+            -k test.priv \
+            sawtooth.consensus.algorithm.name=Devmode \
+            sawtooth.consensus.algorithm.version=0.1 \
+            -o config.batch && \
+        sawadm genesis \
+            config-genesis.batch config.batch && \
         sawadm genesis setting-genesis.batch  && \
         sawtooth-validator -v --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:40000 \

--- a/integration/sawtooth_integration/docker/test_track_and_trade.yaml
+++ b/integration/sawtooth_integration/docker/test_track_and_trade.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawadm genesis && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \

--- a/integration/sawtooth_integration/docker/test_two_families.yaml
+++ b/integration/sawtooth_integration/docker/test_two_families.yaml
@@ -90,7 +90,12 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config-genesis.batch config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -vv \
             --bind component:tcp://eth0:4004 \
             --bind consensus:tcp://eth0:5005 \

--- a/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
+++ b/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
@@ -67,7 +67,12 @@ services:
     # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawadm keygen && \
-        sawadm genesis && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/docker/test_workload.yaml
+++ b/integration/sawtooth_integration/docker/test_workload.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator -v \
             --endpoint tcp://validator:8800 \
             --bind component:tcp://eth0:4004 \

--- a/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
@@ -72,7 +72,13 @@ services:
         sawset genesis \
           -k /etc/sawtooth/keys/validator.priv \
           -o config-genesis.batch && \
-        sawadm genesis config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/tests/scripts_for_permissioning_tests/test_transactor_permissioning.sh
+++ b/integration/sawtooth_integration/tests/scripts_for_permissioning_tests/test_transactor_permissioning.sh
@@ -53,4 +53,8 @@ transactor = "allow_dave_walter_deny_chuck_mallory"
 "transactor.batch_signer" = "deny_dave_from_sending_batches"
 EOM
 
-sawset proposal create -k /root/.sawtooth/keys/walter.priv sawtooth.identity.allowed_keys=$(cat /root/.sawtooth/keys/walter.pub) -o config.batch
+sawset proposal create -k /root/.sawtooth/keys/walter.priv \
+  sawtooth.identity.allowed_keys=$(cat /root/.sawtooth/keys/walter.pub) \
+  sawtooth.consensus.algorithm.name=Devmode \
+  sawtooth.consensus.algorithm.version=0.1 \
+  -o config.batch

--- a/integration/sawtooth_integration/tests/test_config_smoke.py
+++ b/integration/sawtooth_integration/tests/test_config_smoke.py
@@ -104,6 +104,8 @@ class TestConfigSmoke(unittest.TestCase):
         settings = self._read_from_stdout(command, args).split('\n')
 
         _expected_output = [
+            'sawtooth.consensus.algorithm.name: Devmode',
+            'sawtooth.consensus.algorithm.version: 0.1',
             'sawtooth.settings.vote.authorized_keys: {:15}'.format(
                 TEST_PUBKEY),
             'x: 1',

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -334,6 +334,8 @@ class BatchSubmitter:
         self.imf = IntkeyMessageFactory()
         self.timeout = timeout
 
+        wait_for_rest_apis(['rest-api:8008'])
+
     def _post_batch(self, batch):
         headers = {'Content-Type': 'application/octet-stream'}
         response = self._query_rest_api(

--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -170,6 +170,8 @@ message ConsensusNotifyAck {}
 //    NOT_READY
 //        The validator is not accepting requests, usually because it is still
 //        starting up
+//    NOT_ACTIVE_ENGINE
+//        The consensus engine making the request is not the active engine
 //
 // Additionally, messages may have the following additional return statuses:
 //
@@ -206,6 +208,8 @@ message ConsensusSendToResponse {
     NOT_READY = 4;
 
     UNKNOWN_PEER = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
   Status status = 1;
 }
@@ -229,6 +233,7 @@ message ConsensusBroadcastResponse {
     BAD_REQUEST = 2;
     SERVICE_ERROR = 3;
     NOT_READY = 4;
+    NOT_ACTIVE_ENGINE = 5;
   }
   Status status = 1;
 }
@@ -252,6 +257,8 @@ message ConsensusInitializeBlockResponse {
 
     INVALID_STATE = 5;
     UNKNOWN_BLOCK = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
   }
   Status status = 1;
 }
@@ -270,6 +277,8 @@ message ConsensusSummarizeBlockResponse {
 
     INVALID_STATE = 5;
     BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
   }
   Status status = 1;
 
@@ -294,6 +303,8 @@ message ConsensusFinalizeBlockResponse {
 
     INVALID_STATE = 5;
     BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
   }
   Status status = 1;
 
@@ -313,6 +324,8 @@ message ConsensusCancelBlockResponse {
     NOT_READY = 4;
 
     INVALID_STATE = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -343,6 +356,8 @@ message ConsensusCheckBlocksResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -367,6 +382,8 @@ message ConsensusCommitBlockResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -387,6 +404,8 @@ message ConsensusIgnoreBlockResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -406,6 +425,8 @@ message ConsensusFailBlockResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -428,6 +449,8 @@ message ConsensusBlocksGetResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -446,6 +469,8 @@ message ConsensusChainHeadGetResponse {
     NOT_READY = 4;
 
     NO_CHAIN_HEAD = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -469,6 +494,8 @@ message ConsensusSettingsGetResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;
@@ -492,6 +519,8 @@ message ConsensusStateGetResponse {
     NOT_READY = 4;
 
     UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
   }
 
   Status status = 1;

--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -149,6 +149,17 @@ message ConsensusNotifyBlockCommit {
   bytes block_id = 1;
 }
 
+// The engine has been activated
+message ConsensusNotifyEngineActivated {
+  // Startup Info
+  ConsensusBlock chain_head = 1;
+  repeated ConsensusPeerInfo peers = 2;
+  ConsensusPeerInfo local_peer_info = 3;
+}
+
+// The engine has been deactivated
+message ConsensusNotifyEngineDeactivated {}
+
 // Confirm that the notification was received. The validator message
 // correlation id is used to determine which notification this is an ack for.
 message ConsensusNotifyAck {}

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -201,6 +201,9 @@ message Message {
         CONSENSUS_NOTIFY_BLOCK_INVALID = 905;
         CONSENSUS_NOTIFY_BLOCK_COMMIT = 906;
 
+        CONSENSUS_NOTIFY_ENGINE_ACTIVATED = 907;
+        CONSENSUS_NOTIFY_ENGINE_DEACTIVATED = 908;
+
         CONSENSUS_NOTIFY_ACK = 999;
     }
     // The type of message, used to determine how to 'route' the message

--- a/sdk/python/tests/test_zmq_driver.py
+++ b/sdk/python/tests/test_zmq_driver.py
@@ -135,6 +135,10 @@ class TestDriver(unittest.TestCase):
         self.assertEqual(request.version, 'test-version')
 
         self.send_req_rep(
+            consensus_pb2.ConsensusNotifyEngineActivated(),
+            Message.CONSENSUS_NOTIFY_ENGINE_ACTIVATED)
+
+        self.send_req_rep(
             consensus_pb2.ConsensusNotifyPeerConnected(),
             Message.CONSENSUS_NOTIFY_PEER_CONNECTED)
 

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -115,36 +115,7 @@ class ConsensusRegisterHandler(ConsensusServiceHandler):
         self._proxy = proxy
 
     def handle_request(self, request, response, connection_id):
-        startup_info = self._proxy.register(
-            request.name, request.version, connection_id)
-
-        if startup_info is None:
-            response.status = consensus_pb2.ConsensusRegisterResponse.NOT_READY
-            return HandlerStatus.RETURN
-
-        chain_head = startup_info.chain_head
-        peers = [bytes.fromhex(peer_id) for peer_id in startup_info.peers]
-        local_peer_info = startup_info.local_peer_info
-
-        block_header = BlockHeader()
-        block_header.ParseFromString(chain_head.header)
-
-        response.chain_head.block_id = bytes.fromhex(
-            chain_head.header_signature)
-
-        response.chain_head.previous_id =\
-            bytes.fromhex(block_header.previous_block_id)
-        response.chain_head.signer_id =\
-            bytes.fromhex(block_header.signer_public_key)
-        response.chain_head.block_num = block_header.block_num
-        response.chain_head.payload = block_header.consensus
-
-        response.peers.extend([
-            consensus_pb2.ConsensusPeerInfo(peer_id=peer_id)
-            for peer_id in peers
-        ])
-
-        response.local_peer_info.peer_id = local_peer_info
+        self._proxy.register(request.name, request.version, connection_id)
 
         LOGGER.info(
             "Consensus engine registered: %s %s",

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -47,7 +47,7 @@ class ConsensusServiceHandler(Handler):
         request_class,
         request_type,
         response_class,
-        response_type,
+        response_type
     ):
         self._request_class = request_class
         self._request_type = request_type
@@ -77,6 +77,17 @@ class ConsensusServiceHandler(Handler):
         request = self._request_class()
         response = self._response_class()
         response.status = response.OK
+
+        if not (
+            self._request_type
+                == validator_pb2.Message.CONSENSUS_REGISTER_REQUEST
+                or self._proxy.is_active_engine_id(connection_id)
+        ):
+            response.status = response.NOT_ACTIVE_ENGINE
+            return HandlerResult(
+                status=HandlerStatus.RETURN,
+                message_out=response,
+                message_type=self._response_type)
 
         try:
             request.ParseFromString(message_content)
@@ -355,6 +366,8 @@ class ConsensusCheckBlocksNotifier(Handler):
         return self._request_type
 
     def handle(self, connection_id, message_content):
+        # No need to verify this is a valid consensus engine; previous handler
+        # ConsensusCheckBlocksHandler has already verifified
         request = consensus_pb2.ConsensusCheckBlocksRequest()
 
         try:

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -147,10 +147,11 @@ class ConsensusRegisterBlockNewSyncHandler(Handler):
     def __init__(self, proxy, consensus_notifier):
         self._proxy = proxy
         self._consensus_notifier = consensus_notifier
+        self._request_type = validator_pb2.Message.CONSENSUS_REGISTER_REQUEST
 
     @property
     def request_type(self):
-        return validator_pb2.Message.CONSENSUS_REGISTER_REQUEST
+        return self._request_type
 
     def handle(self, connection_id, message_content):
         forks = self._proxy.forks()
@@ -343,11 +344,15 @@ class ConsensusCheckBlocksHandler(ConsensusServiceHandler):
 
 
 class ConsensusCheckBlocksNotifier(Handler):
-    request_type = validator_pb2.Message.CONSENSUS_CHECK_BLOCKS_REQUEST
-
     def __init__(self, proxy, consensus_notifier):
         self._proxy = proxy
         self._consensus_notifier = consensus_notifier
+        self._request_type = \
+            validator_pb2.Message.CONSENSUS_CHECK_BLOCKS_REQUEST
+
+    @property
+    def request_type(self):
+        return self._request_type
 
     def handle(self, connection_id, message_content):
         request = consensus_pb2.ConsensusCheckBlocksRequest()

--- a/validator/sawtooth_validator/consensus/notifier.py
+++ b/validator/sawtooth_validator/consensus/notifier.py
@@ -32,13 +32,13 @@ class _NotifierService:
         self._consensus_registry = consensus_registry
 
     def notify(self, message_type, message):
-        if self._consensus_registry:
-            message_bytes = bytes(message)
-            futures = self._service.send_all(
+        active_engine = self._consensus_registry.get_active_engine_info()
+        if active_engine is not None:
+            self._service.send(
                 message_type,
-                message_bytes)
-            for future in futures:
-                future.result()
+                bytes(message),
+                active_engine.connection_id
+            ).result()
 
 
 class ErrorCode(IntEnum):

--- a/validator/sawtooth_validator/consensus/notifier.py
+++ b/validator/sawtooth_validator/consensus/notifier.py
@@ -40,6 +40,13 @@ class _NotifierService:
                 active_engine.connection_id
             ).result()
 
+    def notify_id(self, message_type, message, connection_id):
+        self._service.send(
+            message_type,
+            bytes(message),
+            connection_id
+        ).result()
+
 
 class ErrorCode(IntEnum):
     Success = CommonErrorCode.Success

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -226,7 +226,7 @@ class ConsensusProxy:
         return blocks
 
     def _wrap_consensus_message(self, content, message_type, connection_id):
-        _, name, version = self._consensus_registry.get_engine_info()
+        _, name, version = self._consensus_registry.get_active_engine_info()
         header = ConsensusPeerMessageHeader(
             signer_id=self._public_key,
             content_sha512=hashlib.sha512(content).digest(),

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -66,6 +66,9 @@ class ConsensusProxy:
             ],
             local_peer_info=self._public_key)
 
+    def is_active_engine_id(self, connection_id):
+        return self._consensus_registry.is_active_engine_id(connection_id)
+
     # Using network service
     def send_to(self, peer_id, message_type, content, connection_id):
         message = self._wrap_consensus_message(

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -16,8 +16,6 @@
 import hashlib
 import logging
 
-from collections import namedtuple
-
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.consensus_pb2 import ConsensusPeerMessage
 from sawtooth_validator.protobuf.consensus_pb2 import \
@@ -31,11 +29,6 @@ class UnknownBlock(Exception):
     """The given block could not be found."""
 
 
-StartupInfo = namedtuple(
-    'SignupInfo',
-    ['chain_head', 'peers', 'local_peer_info'])
-
-
 class ConsensusProxy:
     """Receives requests from the consensus engine handlers and delegates them
     to the appropriate components."""
@@ -43,7 +36,7 @@ class ConsensusProxy:
     def __init__(self, block_manager, block_publisher,
                  chain_controller, gossip, identity_signer,
                  settings_view_factory, state_view_factory,
-                 consensus_registry):
+                 consensus_registry, consensus_notifier):
         self._block_manager = block_manager
         self._chain_controller = chain_controller
         self._block_publisher = block_publisher
@@ -81,6 +74,7 @@ class ConsensusProxy:
         if engine_name == conf_name and engine_version == conf_version:
             self._consensus_registry.activate_engine(
                 engine_name, engine_version)
+            self._consensus_notifier.notify_engine_activated(chain_head)
 
             LOGGER.info(
                 "Consensus engine activated: %s %s",

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -201,6 +201,13 @@ class Gossip:
         with self._lock:
             return self._network.connection_id_to_public_key(peer)
 
+    def get_peers_public_keys(self):
+        """Returns the list of public keys for all peers."""
+        with self._lock:
+            return [
+                self._network.connection_id_to_public_key(peer)
+                for peer in copy.copy(self._peers)]
+
     @property
     def endpoint(self):
         """Returns the validator's public endpoint.

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -54,6 +54,7 @@ class ChainController(OwnedPointer):
         chain_head_lock,
         block_status_store,
         consensus_notifier,
+        consensus_registry,
         state_pruning_block_depth=1000,
         fork_cache_keep_time=300,  # seconds
         data_dir=None,
@@ -80,7 +81,8 @@ class ChainController(OwnedPointer):
             ctypes.c_long(state_pruning_block_depth),
             ctypes.c_long(fork_cache_keep_time),
             ctypes.c_char_p(data_dir.encode()),
-            ctypes.byref(self.pointer))
+            ctypes.byref(self.pointer),
+            ctypes.py_object(consensus_registry))
 
     def start(self):
         _libexec('chain_controller_start', self.pointer)

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -20,7 +20,7 @@ def add(
         dispatcher,
         thread_pool,
         consensus_proxy,
-        consensus_notifier,
+        consensus_notifier
 ):
 
     handler = handlers.ConsensusRegisterHandler(consensus_proxy)

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -26,6 +26,9 @@ def add(
     handler = handlers.ConsensusRegisterHandler(consensus_proxy)
     dispatcher.add_handler(handler.request_type, handler, thread_pool)
 
+    handler = handlers.ConsensusRegisterActivateHandler(consensus_proxy)
+    dispatcher.add_handler(handler.request_type, handler, thread_pool)
+
     handler = handlers.ConsensusRegisterBlockNewSyncHandler(
         consensus_proxy, consensus_notifier)
     dispatcher.add_handler(handler.request_type, handler, thread_pool)

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -331,6 +331,7 @@ class Validator:
             chain_head_lock=block_publisher.chain_head_lock,
             block_status_store=block_status_store,
             consensus_notifier=consensus_notifier,
+            consensus_registry=consensus_registry,
             state_pruning_block_depth=state_pruning_block_depth,
             fork_cache_keep_time=fork_cache_keep_time,
             data_dir=data_dir,
@@ -409,6 +410,7 @@ class Validator:
         self._consensus_dispatcher = consensus_dispatcher
         self._consensus_service = consensus_service
         self._consensus_thread_pool = consensus_thread_pool
+        self._consensus_registry = consensus_registry
 
         self._client_thread_pool = client_thread_pool
         self._sig_pool = sig_pool

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -239,8 +239,10 @@ class Validator:
 
         consensus_registry = ConsensusRegistry()
 
-        consensus_notifier = ConsensusNotifier(consensus_service,
-                                               consensus_registry)
+        consensus_notifier = ConsensusNotifier(
+            consensus_service,
+            consensus_registry,
+            identity_signer.get_public_key().as_hex())
 
         # -- Setup P2P Networking -- #
         gossip = Gossip(
@@ -257,6 +259,8 @@ class Validator:
             maximum_peer_connectivity=maximum_peer_connectivity,
             topology_check_frequency=1
         )
+
+        consensus_notifier.set_gossip(gossip)
 
         completer = Completer(
             block_manager=block_manager,
@@ -396,7 +400,8 @@ class Validator:
             identity_signer=identity_signer,
             settings_view_factory=SettingsViewFactory(state_view_factory),
             state_view_factory=state_view_factory,
-            consensus_registry=consensus_registry)
+            consensus_registry=consensus_registry,
+            consensus_notifier=consensus_notifier)
 
         consensus_handlers.add(
             consensus_dispatcher,

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -53,6 +53,13 @@ pub trait NotifierService: Sync + Send {
         message_type: MessageType,
         message: T,
     ) -> Result<(), NotifierServiceError>;
+
+    fn notify_id<T: Message>(
+        &self,
+        message_type: MessageType,
+        message: T,
+        connection_id: String,
+    ) -> Result<(), NotifierServiceError>;
 }
 
 impl<T: NotifierService> ConsensusNotifier for T {

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -23,11 +23,12 @@ use block::Block;
 
 use hashlib::sha256_digest_strs;
 use hex;
-use protobuf::Message;
+use protobuf::{Message, RepeatedField};
 
 use proto::consensus::{
     ConsensusBlock, ConsensusNotifyBlockCommit, ConsensusNotifyBlockInvalid,
-    ConsensusNotifyBlockNew, ConsensusNotifyBlockValid, ConsensusNotifyPeerConnected,
+    ConsensusNotifyBlockNew, ConsensusNotifyBlockValid, ConsensusNotifyEngineActivated,
+    ConsensusNotifyEngineDeactivated, ConsensusNotifyPeerConnected,
     ConsensusNotifyPeerDisconnected, ConsensusNotifyPeerMessage, ConsensusPeerInfo,
     ConsensusPeerMessage,
 };
@@ -42,6 +43,8 @@ pub trait ConsensusNotifier: Send + Sync {
     fn notify_block_valid(&self, block_id: &str);
     fn notify_block_invalid(&self, block_id: &str);
     fn notify_block_commit(&self, block_id: &str);
+    fn notify_engine_activated(&self, block: &Block);
+    fn notify_engine_deactivated(&self, connection_id: String);
 }
 
 #[derive(Debug)]
@@ -60,6 +63,10 @@ pub trait NotifierService: Sync + Send {
         message: T,
         connection_id: String,
     ) -> Result<(), NotifierServiceError>;
+
+    fn get_peers_public_keys(&self) -> Result<Vec<String>, NotifierServiceError>;
+
+    fn get_public_key(&self) -> Result<String, NotifierServiceError>;
 }
 
 impl<T: NotifierService> ConsensusNotifier for T {
@@ -126,6 +133,45 @@ impl<T: NotifierService> ConsensusNotifier for T {
         self.notify(MessageType::CONSENSUS_NOTIFY_BLOCK_COMMIT, notification)
             .expect("Failed to send block commit notification");
     }
+
+    fn notify_engine_activated(&self, block: &Block) {
+        let chain_head = get_consensus_block(block);
+
+        let peers = RepeatedField::from_vec(
+            self.get_peers_public_keys()
+                .expect("Failed to get list of peers")
+                .iter()
+                .map(|peer_id| {
+                    let mut peer_info = ConsensusPeerInfo::new();
+                    peer_info.set_peer_id(from_hex(peer_id, "peer_id"));
+                    peer_info
+                }).collect(),
+        );
+
+        let mut local_peer_info = ConsensusPeerInfo::new();
+        local_peer_info.set_peer_id(from_hex(
+            self.get_public_key().expect("Failed to get public key"),
+            "pub_key",
+        ));
+
+        let mut notification = ConsensusNotifyEngineActivated::new();
+        notification.set_chain_head(chain_head);
+        notification.set_peers(peers);
+        notification.set_local_peer_info(local_peer_info);
+
+        self.notify(MessageType::CONSENSUS_NOTIFY_ENGINE_ACTIVATED, notification)
+            .expect("Failed to send engine activation notification");
+    }
+
+    fn notify_engine_deactivated(&self, connection_id: String) {
+        let notification = ConsensusNotifyEngineDeactivated::new();
+
+        self.notify_id(
+            MessageType::CONSENSUS_NOTIFY_ENGINE_DEACTIVATED,
+            notification,
+            connection_id,
+        ).expect("Failed to send engine deactivation notification");
+    }
 }
 
 fn get_consensus_block(block: &Block) -> ConsensusBlock {
@@ -170,6 +216,8 @@ enum ConsensusNotification {
     BlockValid(String),
     BlockInvalid(String),
     BlockCommit(String),
+    EngineActivated(Block),
+    EngineDeactivated(String),
 }
 
 #[derive(Clone)]
@@ -234,6 +282,14 @@ impl ConsensusNotifier for BackgroundConsensusNotifier {
     fn notify_block_commit(&self, block_id: &str) {
         self.send_notification(ConsensusNotification::BlockCommit(block_id.into()))
     }
+
+    fn notify_engine_activated(&self, block: &Block) {
+        self.send_notification(ConsensusNotification::EngineActivated(block.clone()))
+    }
+
+    fn notify_engine_deactivated(&self, connection_id: String) {
+        self.send_notification(ConsensusNotification::EngineDeactivated(connection_id))
+    }
 }
 
 fn handle_notification<T: ConsensusNotifier>(notifier: &T, notification: ConsensusNotification) {
@@ -249,5 +305,9 @@ fn handle_notification<T: ConsensusNotifier>(notifier: &T, notification: Consens
         ConsensusNotification::BlockValid(block_id) => notifier.notify_block_valid(&block_id),
         ConsensusNotification::BlockInvalid(block_id) => notifier.notify_block_invalid(&block_id),
         ConsensusNotification::BlockCommit(block_id) => notifier.notify_block_commit(&block_id),
+        ConsensusNotification::EngineActivated(block) => notifier.notify_engine_activated(&block),
+        ConsensusNotification::EngineDeactivated(connection_id) => {
+            notifier.notify_engine_deactivated(connection_id)
+        }
     }
 }

--- a/validator/src/consensus/notifier_ffi.rs
+++ b/validator/src/consensus/notifier_ffi.rs
@@ -19,7 +19,7 @@ use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::slice;
 
-use cpython::{ObjectProtocol, PyClone, PyObject, Python};
+use cpython::{NoArgs, ObjectProtocol, PyClone, PyObject, Python};
 use protobuf::{self, Message, ProtobufEnum};
 use py_ffi;
 
@@ -89,6 +89,65 @@ impl NotifierService for PyNotifierService {
                 pylogger::exception(py, "Unable to notify consensus", py_err);
                 NotifierServiceError("FFI error notifying consensus".into())
             })
+    }
+
+    fn get_peers_public_keys(&self) -> Result<Vec<String>, NotifierServiceError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let res = self
+            .py_notifier_service
+            .call_method(py, "get_peers_public_keys", NoArgs, None)
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    "Unable to call py_notifier_service.get_peers_public_keys",
+                    py_err,
+                );
+                NotifierServiceError(
+                    "FFI error calling py_notifier_service.get_peers_public_keys".into(),
+                )
+            })?;
+
+        res.extract::<Vec<String>>(py).map_err(|py_err| {
+            pylogger::exception(
+                py,
+                "py_notifier_service.get_peers_public_keys did not return a valid string list",
+                py_err,
+            );
+            NotifierServiceError(
+                "py_notifier_service.get_peers_public_keys did not return a valid string list"
+                    .into(),
+            )
+        })
+    }
+
+    fn get_public_key(&self) -> Result<String, NotifierServiceError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let res = self
+            .py_notifier_service
+            .call_method(py, "get_public_key", NoArgs, None)
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    "Unable to call py_notifier_service.get_public_key",
+                    py_err,
+                );
+                NotifierServiceError("FFI error calling py_notifier_service.get_public_key".into())
+            })?;
+
+        res.extract::<String>(py).map_err(|py_err| {
+            pylogger::exception(
+                py,
+                "py_notifier_service.get_public_key did not return a valid string",
+                py_err,
+            );
+            NotifierServiceError(
+                "py_notifier_service.get_public_key did not return a valid string".into(),
+            )
+        })
     }
 }
 
@@ -251,6 +310,47 @@ pub unsafe extern "C" fn consensus_notifier_notify_block_invalid(
     match deref_cstr(block_id) {
         Ok(block_id) => {
             (*(notifier as *mut BackgroundConsensusNotifier)).notify_block_invalid(block_id);
+            ErrorCode::Success
+        }
+        Err(err) => err,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn consensus_notifier_notify_engine_activated(
+    notifier: *mut c_void,
+    block_bytes: *const u8,
+    block_bytes_len: usize,
+) -> ErrorCode {
+    check_null!(notifier, block_bytes);
+
+    let block: Block = {
+        let data = slice::from_raw_parts(block_bytes, block_bytes_len);
+        let proto_block: proto::block::Block = match protobuf::parse_from_bytes(&data) {
+            Ok(block) => block,
+            Err(err) => {
+                error!("Failed to parse block bytes: {:?}", err);
+                return ErrorCode::InvalidArgument;
+            }
+        };
+        proto_block.into()
+    };
+
+    (*(notifier as *mut BackgroundConsensusNotifier)).notify_engine_activated(&block);
+    ErrorCode::Success
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn consensus_notifier_notify_engine_deactivated(
+    notifier: *mut c_void,
+    connection_id: *const c_char,
+) -> ErrorCode {
+    check_null!(notifier, connection_id);
+
+    match deref_cstr(connection_id) {
+        Ok(connection_id) => {
+            (*(notifier as *mut BackgroundConsensusNotifier))
+                .notify_engine_deactivated(connection_id.to_string());
             ErrorCode::Success
         }
         Err(err) => err,

--- a/validator/src/consensus/registry.rs
+++ b/validator/src/consensus/registry.rs
@@ -18,8 +18,15 @@
 #[derive(Debug)]
 pub struct ConsensusRegistryError(pub String);
 
+pub struct EngineInfo {
+    pub connection_id: String,
+    pub name: String,
+    pub version: String,
+}
+
 pub trait ConsensusRegistry: Send + Sync {
     fn activate_engine(&self, name: &str, version: &str) -> Result<(), ConsensusRegistryError>;
+    fn get_active_engine_info(&self) -> Result<Option<EngineInfo>, ConsensusRegistryError>;
     fn is_active_engine_name_version(
         &self,
         name: &str,

--- a/validator/src/consensus/registry.rs
+++ b/validator/src/consensus/registry.rs
@@ -15,7 +15,14 @@
  * ------------------------------------------------------------------------------
  */
 
-pub mod notifier;
-pub mod notifier_ffi;
-pub mod registry;
-pub mod registry_ffi;
+#[derive(Debug)]
+pub struct ConsensusRegistryError(pub String);
+
+pub trait ConsensusRegistry: Send + Sync {
+    fn activate_engine(&self, name: &str, version: &str) -> Result<(), ConsensusRegistryError>;
+    fn is_active_engine_name_version(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<bool, ConsensusRegistryError>;
+}

--- a/validator/src/consensus/registry_ffi.rs
+++ b/validator/src/consensus/registry_ffi.rs
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cpython::{NoArgs, ObjectProtocol, PyClone, PyObject, Python};
+
+use consensus::registry::{ConsensusRegistry, ConsensusRegistryError, EngineInfo};
+use pylogger;
+
+pub struct PyConsensusRegistry {
+    py_consensus_registry: PyObject,
+}
+
+impl PyConsensusRegistry {
+    pub fn new(py_consensus_registry: PyObject) -> Self {
+        PyConsensusRegistry {
+            py_consensus_registry,
+        }
+    }
+}
+
+impl Clone for PyConsensusRegistry {
+    fn clone(&self) -> Self {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        PyConsensusRegistry {
+            py_consensus_registry: self.py_consensus_registry.clone_ref(py),
+        }
+    }
+}
+
+impl ConsensusRegistry for PyConsensusRegistry {
+    fn activate_engine(&self, name: &str, version: &str) -> Result<(), ConsensusRegistryError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        self.py_consensus_registry
+            .call_method(py, "activate_engine", (name, version), None)
+            .map(|_| ())
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    "Unable to call consensus_registry.activate_engine",
+                    py_err,
+                );
+                ConsensusRegistryError(
+                    "FFI error calling consensus_registry.activate_engine".into(),
+                )
+            })
+    }
+
+    fn is_active_engine_name_version(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<bool, ConsensusRegistryError> {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+
+        let res = self
+            .py_consensus_registry
+            .call_method(py, "is_active_engine_name_version", (name, version), None)
+            .map_err(|py_err| {
+                pylogger::exception(
+                    py,
+                    "Unable to call consensus_registry.is_active_engine_name_version",
+                    py_err,
+                );
+                ConsensusRegistryError(
+                    "FFI error calling consensus_registry.is_active_engine_name_version".into(),
+                )
+            })?;
+
+        res.extract::<bool>(py).map_err(|py_err| {
+            pylogger::exception(
+                py,
+                "consensus_registry.is_active_engine_name_version did not return a valid bool",
+                py_err,
+            );
+            ConsensusRegistryError(
+                "consensus_registry.is_active_engine_name_version did not return a valid bool"
+                    .into(),
+            )
+        })
+    }
+}

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -38,6 +38,7 @@ use protobuf;
 use batch::Batch;
 use block::Block;
 use consensus::notifier::ConsensusNotifier;
+use consensus::registry::ConsensusRegistry;
 use execution::execution_platform::ExecutionPlatform;
 use gossip::permission_verifier::PermissionVerifier;
 use journal;
@@ -50,7 +51,9 @@ use journal::chain_head_lock::ChainHeadLock;
 use journal::chain_id_manager::ChainIdManager;
 use journal::fork_cache::ForkCache;
 use metrics;
+use state::settings_view::SettingsView;
 use state::state_pruning_manager::StatePruningManager;
+use state::state_view_factory::StateViewFactory;
 
 use proto::transaction_receipt::TransactionReceipt;
 use scheduler::TxnExecutionResult;
@@ -73,6 +76,7 @@ pub enum ChainControllerError {
     ForkResolutionError(String),
     BlockValidationError(ValidationError),
     BrokenQueue,
+    ConsensusError(String),
 }
 
 impl From<RecvError> for ChainControllerError {
@@ -244,6 +248,8 @@ pub struct ChainController<TEP: ExecutionPlatform + Clone, PV: PermissionVerifie
     stop_handle: Arc<Mutex<Option<ChainThreadStopHandle>>>,
 
     consensus_notifier: Arc<ConsensusNotifier>,
+    consensus_registry: Arc<ConsensusRegistry>,
+    state_view_factory: StateViewFactory,
     block_validator: BlockValidator<TEP, PV>,
     block_validation_results: BlockValidationResultStore,
 
@@ -267,6 +273,8 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
         chain_head_lock: ChainHeadLock,
         block_validation_results: BlockValidationResultStore,
         consensus_notifier: Box<ConsensusNotifier>,
+        consensus_registry: Box<ConsensusRegistry>,
+        state_view_factory: StateViewFactory,
         data_dir: String,
         state_pruning_block_depth: u32,
         observers: Vec<Box<ChainObserver>>,
@@ -292,6 +300,8 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
             state_pruning_block_depth,
             chain_head_lock,
             consensus_notifier: Arc::from(consensus_notifier),
+            consensus_registry: Arc::from(consensus_registry),
+            state_view_factory,
         };
 
         chain_controller.initialize_chain_head();
@@ -809,6 +819,58 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
         self.consensus_notifier
             .notify_block_commit(&block.header_signature);
 
+        // Check if active consensus engine needs to be updated
+        let settings_view: SettingsView = self
+            .state_view_factory
+            .create_view(&block.state_root_hash)
+            .map_err(|db_err| {
+                let err_str = format!(
+                    "Failed to get state view for block {:?}: {:?}",
+                    block, db_err
+                );
+                warn!("{}", err_str);
+                ChainControllerError::ConsensusError(err_str)
+            })?;
+        let name = settings_view
+            .get_setting_str("sawtooth.consensus.algorithm.name", None)
+            .map_err(|settings_err| {
+                let err_str = format!(
+                    "Error getting sawtooth.consensus.algorithm.name from settings view: {:?}",
+                    settings_err
+                );
+                warn!("{}", err_str);
+                ChainControllerError::ConsensusError(err_str)
+            })?.unwrap_or_else(|| String::from(""));
+        let version = settings_view
+            .get_setting_str("sawtooth.consensus.algorithm.version", None)
+            .map_err(|settings_err| {
+                let err_str = format!(
+                    "Error getting sawtooth.consensus.algorithm.version from settings view: {:?}",
+                    settings_err
+                );
+                warn!("{}", err_str);
+                ChainControllerError::ConsensusError(err_str)
+            })?.unwrap_or_else(|| String::from(""));
+
+        let is_active_engine = self
+            .consensus_registry
+            .is_active_engine_name_version(&name, &version)
+            .map_err(|reg_err| {
+                let err_str = format!("Error verifying active engine: {:?}", reg_err);
+                warn!("{}", err_str);
+                ChainControllerError::ConsensusError(err_str)
+            })?;
+
+        if !is_active_engine {
+            self.consensus_registry
+                .activate_engine(&name, &version)
+                .map_err(|reg_err| {
+                    let err_str = format!("Error activating consensus engine: {:?}", reg_err);
+                    warn!("{}", err_str);
+                    ChainControllerError::ConsensusError(err_str)
+                })?;
+        }
+
         Ok(())
     }
 
@@ -828,6 +890,8 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
             state_pruning_block_depth: self.state_pruning_block_depth,
             chain_head_lock: self.chain_head_lock.clone(),
             consensus_notifier: self.consensus_notifier.clone(),
+            consensus_registry: self.consensus_registry.clone(),
+            state_view_factory: self.state_view_factory.clone(),
         }
     }
 

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -22,6 +22,7 @@ class TestHandlers(unittest.TestCase):
     def setUp(self):
         self.mock_proxy = Mock()
         self.mock_consensus_notifier = Mock()
+        self.mock_consensus_registry = MockConsensusRegistry()
 
     def test_consensus_register_handler(self):
         header = BlockHeader(
@@ -42,16 +43,16 @@ class TestHandlers(unittest.TestCase):
         handler = handlers.ConsensusRegisterHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.assertEqual(response.chain_head.block_id, bytes.fromhex("dead"))
         self.assertEqual(response.peers[0].peer_id, bytes.fromhex("dead"))
         self.assertEqual(response.local_peer_info.peer_id, b'abc')
-        self.mock_proxy.register.assert_called_with('', '', None)
+        self.mock_proxy.register.assert_called_with('', '', 'mock-id')
 
     def test_consensus_send_to_handler(self):
-        handler = handlers.ConsensusSendToHandler(self.mock_proxy)
+        handler = handlers.ConsensusSendToHandler(self.mock_proxy, self.mock_consensus_registry)
         request_class = handler.request_class
         request = request_class()
         request.receiver_id = b"test"
@@ -83,7 +84,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.previous_id = b"test"
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.initialize_block.assert_called_with(
@@ -94,7 +95,7 @@ class TestHandlers(unittest.TestCase):
         handler = handlers.ConsensusSummarizeBlockHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.summarize_block.assert_called_with()
@@ -105,7 +106,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.data = b"test"
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.finalize_block.assert_called_with(
@@ -115,7 +116,7 @@ class TestHandlers(unittest.TestCase):
         handler = handlers.ConsensusCancelBlockHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.cancel_block.assert_called_with()
@@ -125,7 +126,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.block_ids.extend([b"test"])
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.check_blocks.assert_called_with(
@@ -136,7 +137,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.block_id = b"test"
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.commit_block.assert_called_with(
@@ -147,7 +148,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.block_id = b"test"
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.ignore_block.assert_called_with(
@@ -158,7 +159,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.block_id = b"test"
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.fail_block.assert_called_with(
@@ -179,7 +180,7 @@ class TestHandlers(unittest.TestCase):
         request_class = handler.request_class
         request = request_class()
         request.block_ids.extend([b"test"])
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.blocks_get.assert_called_with(
@@ -198,7 +199,7 @@ class TestHandlers(unittest.TestCase):
         handler = handlers.ConsensusChainHeadGetHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.chain_head_get.assert_called_with()
@@ -210,7 +211,7 @@ class TestHandlers(unittest.TestCase):
         request = request_class()
         request.block_id = b"test"
         request.keys.extend(["test"])
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.settings_get.assert_called_with(
@@ -223,7 +224,7 @@ class TestHandlers(unittest.TestCase):
         request = request_class()
         request.block_id = b"test"
         request.addresses.extend(["test"])
-        result = handler.handle(None, request.SerializeToString())
+        result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.state_get.assert_called_with(
@@ -430,6 +431,9 @@ class MockBlockManager:
 class MockConsensusRegistry(Mock):
     def get_active_engine_info(self):
         return EngineInfo('mock-id', 'mock-name', 'mock-version')
+
+    def is_active_engine_id(self, engine_id):
+        return True
 
 
 class MockGossip(Mock):

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -428,7 +428,7 @@ class MockBlockManager:
 
 
 class MockConsensusRegistry(Mock):
-    def get_engine_info(self):
+    def get_active_engine_info(self):
         return EngineInfo('mock-id', 'mock-name', 'mock-version')
 
 


### PR DESCRIPTION
Updates the validator to:
1. Register any engine that requests
2. Set the active engine based on the value of the on-chain settings `sawtooth.consensus.algorithm.name` and `sawtooth.consensus.algorithm.version`
3. Check all consensus messages and only accept a message if it is a registration request OR it is from the registered consensus engine
4. Send `EngineActivated` and `EngineDeactivated` updates to a consensus engine when it is activated/deactivated