### PR TITLE
Fix spelling of hexadecimal in openapi.yaml

### DIFF
--- a/rest_api/openapi.yaml
+++ b/rest_api/openapi.yaml
@@ -202,7 +202,7 @@ paths:
         characters specified.
 
         Note that the partial address in `address` parameter should have even 
-        number of hecadeximal characters (i.e., complete bytes).
+        number of hexadecimal characters (i.e., complete bytes).
         
       parameters:
         - $ref: "#/parameters/head"


### PR DESCRIPTION
It was spelled as hecadeximal instead of hexadecimal.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>