### PR TITLE
Stabilize Consensus P2P messaging API

### DIFF
--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -17,37 +17,31 @@ syntax = "proto3";
 
 // --== Data Structures ==--
 
-// A consensus-related message sent between peers
-message ConsensusPeerMessage {
-  // Interpretation is left to the consensus engine implementation
-  string message_type = 1;
-
-  // The opaque payload to send to other nodes
-  bytes content = 2;
-}
-
 message ConsensusPeerMessageHeader {
   // Public key for the component internal to the validator that
   // signed the message
-  bytes signer_public_key = 1;
+  bytes signer_id = 1;
 
   // The sha512 hash of the encoded message
-  bytes message_sha512 = 2;
+  bytes content_sha512 = 2;
+  // Interpretation is left to the consensus engine implementation
+  string message_type = 5;
 
   // Used to identify the consensus engine that produced this message
   string name = 3;
   string version = 4;
 }
 
-message ConsensusPeerMessageEnvelope {
+// A consensus-related message sent between peers
+message ConsensusPeerMessage {
   // The serialized version of the ConsensusPeerMessageHeader
   bytes header = 1;
 
   // The signature derived from signing the header
   bytes header_signature = 3;
 
-  // The serialized version of the ConsensusPeerMessage
-  bytes message = 2;
+  // The opaque payload to send to other nodes
+  bytes content = 2;
 }
 
 // All information about a block that is relevant to consensus
@@ -127,7 +121,9 @@ message ConsensusNotifyPeerDisconnected {
 
 // A new message was received from a peer
 message ConsensusNotifyPeerMessage {
+  // The message sent
   ConsensusPeerMessage message = 1;
+  // The node that sent the message, not necessarily the node that created it
   bytes sender_id = 2;
 }
 
@@ -188,8 +184,17 @@ message ConsensusNotifyAck {}
 
 // Send a consensus message to a specific, connected peer
 message ConsensusSendToRequest {
-  ConsensusPeerMessage message = 1;
-  bytes peer_id = 2;
+  // Payload to send to peer
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 3;
+
+  // Peer that this message is destined for
+  bytes receiver_id = 2;
 }
 
 message ConsensusSendToResponse {
@@ -207,7 +212,14 @@ message ConsensusSendToResponse {
 
 // Broadcast a consensus message to all peers
 message ConsensusBroadcastRequest {
-  ConsensusPeerMessage message = 1;
+  // Payload to broadcast peers
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 2;
 }
 
 message ConsensusBroadcastResponse {

--- a/sdk/examples/devmode_rust/src/engine.rs
+++ b/sdk/examples/devmode_rust/src/engine.rs
@@ -309,7 +309,7 @@ impl Engine for DevmodeEngine {
                         }
 
                         Update::PeerMessage(message, sender_id) => {
-                            match DevmodeMessage::from_str(message.message_type.as_ref()).unwrap() {
+                            match DevmodeMessage::from_str(message.header.message_type.as_ref()).unwrap() {
                                 DevmodeMessage::Published => {
                                     let block_id = BlockId::from(message.content);
                                     info!(

--- a/sdk/python/sawtooth_sdk/consensus/engine.py
+++ b/sdk/python/sawtooth_sdk/consensus/engine.py
@@ -22,6 +22,11 @@ StartupState = namedtuple(
     ['chain_head', 'peers', 'local_peer_info'])
 
 
+PeerMessage = namedtuple(
+    'PeerMessage',
+    ['header', 'header_bytes', 'header_signature', 'content'])
+
+
 class Engine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def start(self, updates, service, startup_state):

--- a/sdk/python/sawtooth_sdk/consensus/service.py
+++ b/sdk/python/sawtooth_sdk/consensus/service.py
@@ -33,11 +33,11 @@ class Service(metaclass=abc.ABCMeta):
     # -- P2P --
 
     @abc.abstractmethod
-    def send_to(self, peer_id, message_type, payload):
+    def send_to(self, receiver_id, message_type, payload):
         '''Send a consensus message to a specific connected peer.
 
         Args:
-            peer_id (bytes)
+            receiver_id (bytes)
             message_type (str)
             payload (bytes)
         '''

--- a/sdk/python/sawtooth_sdk/consensus/zmq_driver.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_driver.py
@@ -20,6 +20,7 @@ from threading import Thread
 
 from sawtooth_sdk.consensus.driver import Driver
 from sawtooth_sdk.consensus.engine import StartupState
+from sawtooth_sdk.consensus.engine import PeerMessage
 from sawtooth_sdk.consensus.zmq_service import ZmqService
 from sawtooth_sdk.consensus import exceptions
 from sawtooth_sdk.messaging.stream import Stream
@@ -138,7 +139,16 @@ class ZmqDriver(Driver):
             notification = consensus_pb2.ConsensusNotifyPeerMessage()
             notification.ParseFromString(message.content)
 
-            data = notification.message, notification.sender_id
+            header = consensus_pb2.ConsensusPeerMessageHeader()
+            header.ParseFromString(notification.message.header)
+
+            peer_message = PeerMessage(
+                header=header,
+                header_bytes=notification.message.header,
+                header_signature=notification.message.header_signature,
+                content=notification.message.content)
+
+            data = peer_message, notification.sender_id
 
         elif type_tag == Message.CONSENSUS_NOTIFY_BLOCK_NEW:
             notification = consensus_pb2.ConsensusNotifyBlockNew()

--- a/sdk/python/sawtooth_sdk/consensus/zmq_service.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_service.py
@@ -38,14 +38,11 @@ class ZmqService(Service):
 
     # -- P2P --
 
-    def send_to(self, peer_id, message_type, payload):
-        message = consensus_pb2.ConsensusPeerMessage(
-            message_type=message_type,
-            content=payload)
-
+    def send_to(self, receiver_id, message_type, payload):
         request = consensus_pb2.ConsensusSendToRequest(
-            message=message,
-            peer_id=peer_id)
+            message_type=message_type,
+            content=payload,
+            receiver_id=receiver_id)
 
         response = self._send(
             request=request,
@@ -57,11 +54,9 @@ class ZmqService(Service):
                 'Failed with status {}'.format(response.status))
 
     def broadcast(self, message_type, payload):
-        message = consensus_pb2.ConsensusPeerMessage(
+        request = consensus_pb2.ConsensusBroadcastRequest(
             message_type=message_type,
             content=payload)
-
-        request = consensus_pb2.ConsensusBroadcastRequest(message=message)
 
         response = self._send(
             request=request,

--- a/sdk/python/tests/test_zmq_service.py
+++ b/sdk/python/tests/test_zmq_service.py
@@ -44,17 +44,16 @@ class TestService(unittest.TestCase):
             ).SerializeToString())
 
         self.service.send_to(
-            peer_id=b'peer_id',
+            receiver_id=b'receiver_id',
             message_type='message_type',
             payload=b'payload')
 
         self.mock_stream.send.assert_called_with(
             message_type=Message.CONSENSUS_SEND_TO_REQUEST,
             content=consensus_pb2.ConsensusSendToRequest(
-                message=consensus_pb2.ConsensusPeerMessage(
-                    message_type='message_type',
-                    content=b'payload'),
-                peer_id=b'peer_id').SerializeToString())
+                message_type='message_type',
+                content=b'payload',
+                receiver_id=b'receiver_id').SerializeToString())
 
     def test_broadcast(self):
         self.mock_stream.send.return_value = self._make_future(
@@ -70,9 +69,8 @@ class TestService(unittest.TestCase):
         self.mock_stream.send.assert_called_with(
             message_type=Message.CONSENSUS_BROADCAST_REQUEST,
             content=consensus_pb2.ConsensusBroadcastRequest(
-                message=consensus_pb2.ConsensusPeerMessage(
-                    message_type='message_type',
-                    content=b'payload')).SerializeToString())
+                message_type='message_type',
+                content=b'payload').SerializeToString())
 
     def test_initialize_block(self):
         self.mock_stream.send.return_value = self._make_future(

--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -74,8 +74,24 @@ pub struct PeerInfo {
 /// A consensus-related message sent between peers
 #[derive(Default, Debug, Clone)]
 pub struct PeerMessage {
-    pub message_type: String,
+    pub header: PeerMessageHeader,
+    pub header_bytes: Vec<u8>,
+    pub header_signature: Vec<u8>,
     pub content: Vec<u8>,
+}
+
+/// A header associated with a consensus-related message sent from a peer, can be used to verify
+/// the origin of the message
+#[derive(Default, Debug, Clone)]
+pub struct PeerMessageHeader {
+    /// The public key of the validator where this message originated
+    ///
+    /// NOTE: This may not be the validator that sent the message
+    pub signer_id: Vec<u8>,
+    pub content_sha512: Vec<u8>,
+    pub message_type: String,
+    pub name: String,
+    pub version: String,
 }
 
 /// Engine is the only trait that needs to be implemented when adding a new consensus engine.

--- a/sdk/rust/src/consensus/zmq_service.rs
+++ b/sdk/rust/src/consensus/zmq_service.rs
@@ -95,13 +95,10 @@ impl Service for ZmqService {
         message_type: &str,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
-        let mut message = ConsensusPeerMessage::new();
-        message.set_message_type(message_type.into());
-        message.set_content(payload);
-
         let mut request = ConsensusSendToRequest::new();
-        request.set_message(message);
-        request.set_peer_id((*peer).clone().into());
+        request.set_content(payload);
+        request.set_message_type(message_type.into());
+        request.set_receiver_id((*peer).clone().into());
 
         let response: ConsensusSendToResponse = self.rpc(
             &request,
@@ -113,12 +110,9 @@ impl Service for ZmqService {
     }
 
     fn broadcast(&mut self, message_type: &str, payload: Vec<u8>) -> Result<(), Error> {
-        let mut message = ConsensusPeerMessage::new();
-        message.set_message_type(message_type.into());
-        message.set_content(payload);
-
         let mut request = ConsensusBroadcastRequest::new();
-        request.set_message(message);
+        request.set_content(payload);
+        request.set_message_type(message_type.into());
 
         let response: ConsensusBroadcastResponse = self.rpc(
             &request,

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -176,8 +176,9 @@ class ConsensusSendToHandler(ConsensusServiceHandler):
     def handle_request(self, request, response, connection_id):
         try:
             self._proxy.send_to(
-                request.peer_id,
-                request.message.SerializeToString(),
+                request.receiver_id,
+                request.message_type,
+                request.content,
                 connection_id)
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception("ConsensusSendTo")
@@ -200,7 +201,8 @@ class ConsensusBroadcastHandler(ConsensusServiceHandler):
     def handle_request(self, request, response, connection_id):
         try:
             self._proxy.broadcast(
-                request.message.SerializeToString(),
+                request.message_type,
+                request.content,
                 connection_id)
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception("ConsensusBroadcast")

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -330,22 +330,22 @@ class Gossip:
             batch_request,
             validator_pb2.Message.GOSSIP_BATCH_BY_BATCH_ID_REQUEST)
 
-    def send_consensus_message(self, peer_id, message_envelope):
+    def send_consensus_message(self, peer_id, message):
         connection_id = self._network.public_key_to_connection_id(peer_id)
 
         self.send(
             validator_pb2.Message.GOSSIP_MESSAGE,
             GossipMessage(
                 content_type=GossipMessage.CONSENSUS,
-                content=message_envelope.SerializeToString(),
+                content=message.SerializeToString(),
                 time_to_live=self.get_time_to_live()).SerializeToString(),
             connection_id)
 
-    def broadcast_consensus_message(self, message_envelope):
+    def broadcast_consensus_message(self, message):
         self.broadcast(
             GossipMessage(
                 content_type=GossipMessage.CONSENSUS,
-                content=message_envelope.SerializeToString(),
+                content=message.SerializeToString(),
                 time_to_live=self.get_time_to_live()),
             validator_pb2.Message.GOSSIP_MESSAGE)
 

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -22,8 +22,6 @@ from sawtooth_validator.protobuf import validator_pb2
 from sawtooth_validator.protobuf.batch_pb2 import Batch
 from sawtooth_validator.protobuf.block_pb2 import Block
 from sawtooth_validator.protobuf.consensus_pb2 import ConsensusPeerMessage
-from sawtooth_validator.protobuf.consensus_pb2 import \
-    ConsensusPeerMessageEnvelope
 from sawtooth_validator.protobuf.network_pb2 import GossipMessage
 from sawtooth_validator.protobuf.network_pb2 import GossipBlockResponse
 from sawtooth_validator.protobuf.network_pb2 import GossipBatchResponse
@@ -248,11 +246,8 @@ class GossipBroadcastHandler(Handler):
             if not self._completer.get_block(obj.header_signature):
                 self._gossip.broadcast_block(obj, exclude, time_to_live=ttl)
         elif tag == GossipMessage.CONSENSUS:
-            peer_message = ConsensusPeerMessage()
-            peer_message.ParseFromString(obj.message)
-
             self._notifier.notify_peer_message(
-                message=peer_message,
+                message=obj,
                 sender_id=bytes.fromhex(
                     self._gossip.peer_to_public_key(connection_id)))
         else:
@@ -273,7 +268,7 @@ def gossip_message_preprocessor(message_content_bytes):
         obj = Batch()
         obj.ParseFromString(gossip_message.content)
     elif tag == GossipMessage.CONSENSUS:
-        obj = ConsensusPeerMessageEnvelope()
+        obj = ConsensusPeerMessage()
         obj.ParseFromString(gossip_message.content)
 
     content = obj, tag, gossip_message.time_to_live

--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -115,25 +115,25 @@ def is_valid_transaction(txn):
     return True
 
 
-def is_valid_consensus_message(message_envelope):
+def is_valid_consensus_message(message):
     # validate consensus message signature
     header = ConsensusPeerMessageHeader()
-    header.ParseFromString(message_envelope.header)
+    header.ParseFromString(message.header)
 
     context = create_context('secp256k1')
-    public_key = Secp256k1PublicKey.from_bytes(header.signer_public_key)
-    if not context.verify(message_envelope.header_signature,
-                          message_envelope.header,
+    public_key = Secp256k1PublicKey.from_bytes(header.signer_id)
+    if not context.verify(message.header_signature,
+                          message.content,
                           public_key):
         LOGGER.debug("message signature invalid for message: %s",
-                     message_envelope.header_signature)
+                     message.header_signature)
         return False
 
     # verify the message field matches the header
-    message_sha512 = hashlib.sha512(message_envelope.message).digest()
-    if message_sha512 != header.message_sha512:
-        LOGGER.debug("message doesn't match message_sha512 of the header for"
-                     "message envelope: %s", message_envelope.header_signature)
+    content_sha512 = hashlib.sha512(message.content).digest()
+    if content_sha512 != header.content_sha512:
+        LOGGER.debug("message doesn't match content_sha512 of the header for"
+                     "message envelope: %s", message.header_signature)
         return False
 
     return True

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -54,28 +54,29 @@ class TestHandlers(unittest.TestCase):
         handler = handlers.ConsensusSendToHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        request.peer_id = b"test"
-        request.message.message_type = "test"
-        request.message.content = b"test"
+        request.receiver_id = b"test"
+        request.message_type = "test"
+        request.content = b"test"
         result = handler.handle(None, request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.send_to.assert_called_with(
-            request.peer_id,
-            request.message.SerializeToString(),
+            request.receiver_id,
+            request.message_type,
+            request.content,
             None)
 
     def test_consensus_broadcast_handler(self):
         handler = handlers.ConsensusBroadcastHandler(self.mock_proxy)
         request_class = handler.request_class
         request = request_class()
-        request.message.message_type = "test"
-        request.message.content = b"test"
+        request.message_type = "test"
+        request.content = b"test"
         result = handler.handle(None, request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
         self.mock_proxy.broadcast.assert_called_with(
-            request.message.SerializeToString(), None)
+            request.message_type, request.content, None)
 
     def test_consensus_initialize_block_handler(self):
         handler = handlers.ConsensusInitializeBlockHandler(self.mock_proxy)
@@ -252,10 +253,16 @@ class TestProxy(unittest.TestCase):
 
     def test_send_to(self):
         self._proxy.send_to(
-            peer_id=b'peer_id', message=b'message', connection_id=b'')
+            peer_id=b'peer_id',
+            content=b'message',
+            message_type='message_type',
+            connection_id=b'')
 
     def test_broadcast(self):
-        self._proxy.broadcast(message=b'message', connection_id=b'')
+        self._proxy.broadcast(
+            content=b'message',
+            message_type='message_type',
+            connection_id=b'')
 
     # Using block publisher
     def test_initialize_block(self):


### PR DESCRIPTION
This makes one more change to the p2p messaging API, which allows consensus
engines to save messages with their signatures and enables validation of
message signatures after the fact by an engine or observer.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>