### PR TITLE
Allow subscribers to connect when no Genesis Block

### DIFF
--- a/validator/sawtooth_validator/server/events/broadcaster.py
+++ b/validator/sawtooth_validator/server/events/broadcaster.py
@@ -113,7 +113,8 @@ class EventBroadcaster(ChainObserver):
         '''
         # If latest known block is not the current chain head, catch up
         catchup_up_blocks = []
-        if last_known_block_id != self._block_store.chain_head.identifier:
+        chain_head = self._block_store.chain_head
+        if chain_head and last_known_block_id != chain_head.identifier:
             # Start from the chain head and get blocks until we reach the
             # known block
             for block in self._block_store.get_predecessor_iter():

--- a/validator/tests/test_events/tests.py
+++ b/validator/tests/test_events/tests.py
@@ -19,6 +19,7 @@ import os
 import tempfile
 import unittest
 from unittest.mock import Mock
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from sawtooth_validator.database.dict_database import DictDatabase
@@ -393,6 +394,41 @@ class EventBroadcasterTest(unittest.TestCase):
         event_broadcaster.enable_subscriber("test_conn_id")
         event_broadcaster.chain_update(block, [])
 
+        event_list = events_pb2.EventList(
+            events=BlockEventExtractor(block).extract(
+                [create_block_commit_subscription()])).SerializeToString()
+        mock_service.send.assert_called_with(
+            validator_pb2.Message.CLIENT_EVENTS,
+            event_list, connection_id="test_conn_id", one_way=True)
+
+    def test_catchup_subscriber(self):
+        """Test that catch subscriber handles the case of:
+        - no blocks (i.e. the genesis block has not been produced or received
+        - a block that has some receipts exists and sends results
+        """
+        mock_service = Mock()
+        mock_block_store = MagicMock()
+        mock_block_store.chain_head = None
+        mock_block_store.get_predecessor_iter.return_value = []
+        mock_receipt_store = Mock()
+
+        event_broadcaster = EventBroadcaster(mock_service,
+                                             mock_block_store,
+                                             mock_receipt_store)
+
+        event_broadcaster.add_subscriber(
+            "test_conn_id", [create_block_commit_subscription()], [])
+
+        event_broadcaster.catchup_subscriber("test_conn_id")
+
+        mock_service.send.assert_not_called()
+
+        block = create_block()
+        mock_block_store.chain_head = block
+        mock_block_store.get_predecessor_iter.return_value = [block]
+        mock_block_store.__getitem__.return_value = block
+
+        event_broadcaster.catchup_subscriber("test_conn_id")
         event_list = events_pb2.EventList(
             events=BlockEventExtractor(block).extract(
                 [create_block_commit_subscription()])).SerializeToString()


### PR DESCRIPTION
This change handles the case when an event subscriber connects to the validator before it has either generated or received the genesis block.

In that instance, chain head is `None`, and an exception is raised, then the subscriber is left in an invalid state. This fix mitigates that issue.

Fixes [STL-952](https://jira.hyperledger.org/browse/STL-952)

Note, this should be back-ported to the 1-1 and 1-0 branches.