### PR TITLE
Add get_block_by_id convenience function to Rust and Python SDKs

### DIFF
--- a/sdk/python/sawtooth_sdk/consensus/service.py
+++ b/sdk/python/sawtooth_sdk/consensus/service.py
@@ -137,6 +137,17 @@ class Service(metaclass=abc.ABCMeta):
         '''
 
     @abc.abstractmethod
+    def get_block_by_id(self, block_id):
+        '''Retrieve consensus-related information about a particular block.
+
+        Args:
+            block_id (bytes)
+
+        Return:
+            block
+        '''
+
+    @abc.abstractmethod
     def get_chain_head(self):
         '''Retrieve consensus-related information about the chain head.
 

--- a/sdk/python/sawtooth_sdk/consensus/service.py
+++ b/sdk/python/sawtooth_sdk/consensus/service.py
@@ -127,7 +127,7 @@ class Service(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_blocks(self, block_ids):
-        '''Retrive consensus-related information about blocks.
+        '''Retrieve consensus-related information about blocks.
 
         Args:
             block_ids (list[bytes])

--- a/sdk/python/sawtooth_sdk/consensus/zmq_service.py
+++ b/sdk/python/sawtooth_sdk/consensus/zmq_service.py
@@ -273,6 +273,9 @@ class ZmqService(Service):
             for block in response.blocks
         }
 
+    def get_block_by_id(self, block_id):
+        return self.get_blocks([block_id])[block_id]
+
     def get_chain_head(self):
         request = consensus_pb2.ConsensusChainHeadGetRequest()
 

--- a/sdk/python/tests/test_zmq_service.py
+++ b/sdk/python/tests/test_zmq_service.py
@@ -229,6 +229,34 @@ class TestService(unittest.TestCase):
             b'block2': (b'block1', b'signer2', 2, b'test2'),
         })
 
+    def test_get_block_by_id(self):
+        block_1 = consensus_pb2.ConsensusBlock(
+            block_id=b'id1',
+            previous_id=b'block0',
+            signer_id=b'signer1',
+            block_num=1,
+            payload=b'test1')
+
+        self.mock_stream.send.return_value = self._make_future(
+            message_type=Message.CONSENSUS_BLOCKS_GET_RESPONSE,
+            content=consensus_pb2.ConsensusBlocksGetResponse(
+                status=consensus_pb2.ConsensusBlocksGetResponse.OK,
+                blocks=[block_1]).SerializeToString())
+
+        block = self.service.get_block_by_id(block_id=b'id1')
+
+        self.mock_stream.send.assert_called_with(
+            message_type=Message.CONSENSUS_BLOCKS_GET_REQUEST,
+            content=consensus_pb2.ConsensusBlocksGetRequest(
+                block_ids=[b'id1']).SerializeToString())
+
+        self.assertEqual((
+            block.previous_id,
+            block.signer_id,
+            block.block_num,
+            block.payload
+        ), (b'block0', b'signer1', 1, b'test1'))
+
     def test_get_chain_head(self):
         block = consensus_pb2.ConsensusBlock(
             block_id=b'block',

--- a/sdk/rust/src/consensus/service.rs
+++ b/sdk/rust/src/consensus/service.rs
@@ -66,6 +66,9 @@ pub trait Service {
     /// Retrieve consensus-related information about blocks
     fn get_blocks(&mut self, block_ids: Vec<BlockId>) -> Result<HashMap<BlockId, Block>, Error>;
 
+    /// Retrieve consensus-related information about a particular block
+    fn get_block_by_id(&mut self, block_id: BlockId) -> Result<Block, Error>;
+
     /// Get the chain head block.
     fn get_chain_head(&mut self) -> Result<Block, Error>;
 
@@ -131,6 +134,9 @@ pub mod tests {
             &mut self,
             _block_ids: Vec<BlockId>,
         ) -> Result<HashMap<BlockId, Block>, Error> {
+            Ok(Default::default())
+        }
+        fn get_block_by_id(&mut self, _block_id: BlockId) -> Result<Block, Error> {
             Ok(Default::default())
         }
         fn get_chain_head(&mut self) -> Result<Block, Error> {

--- a/sdk/rust/src/consensus/zmq_service.rs
+++ b/sdk/rust/src/consensus/zmq_service.rs
@@ -302,6 +302,13 @@ impl Service for ZmqService {
             .collect())
     }
 
+    fn get_block_by_id(&mut self, block_id: BlockId) -> Result<Block, Error> {
+        self.get_blocks(vec![block_id.clone()])?
+            .get(&block_id)
+            .map(|b| b.clone())
+            .ok_or_else(|| Error::UnknownBlock("Block not found".into()))
+    }
+
     fn get_chain_head(&mut self) -> Result<Block, Error> {
         let request = ConsensusChainHeadGetRequest::new();
 


### PR DESCRIPTION
Adds a `get_block_by_id` convenience method to the Rust and Python SDKs that builds on top of their respective `get_block` methods.

Motivating example: https://github.com/hyperledger/sawtooth-pbft/blob/master/src/handlers.rs#L468