### PR TITLE
Clarify Sawtooth help-wanted link (must log into JIRA)

### DIFF
--- a/docs/source/community/issue_tracking.rst
+++ b/docs/source/community/issue_tracking.rst
@@ -16,7 +16,10 @@ Hyperledger Sawtooth uses JIRA as our issue tracking system:
 https://jira.hyperledger.org/projects/STL
 
 If you want to contribute to Hyperledger Sawtooth quickly, we have a list of
-issues that will help you get involved right away. See the open Sawtooth issues:
+issues that will help you get involved right away. Log into
+`jira.hyperledger.org <https://jira.hyperledger.org>`_ (requires a
+`Linux Foundation Account <https://identity.linuxfoundation.org/>`_)
+and see the Sawtooth "help-wanted" list:
 
 https://jira.hyperledger.org/issues/?filter=10612
 


### PR DESCRIPTION
Add text in Community/Tracking Issues/Using JIRA to make it clear that:
- The Sawtooth issues link shows "help-wanted" issues
- You must log into JIRA to view this list (because the filter permissions
  restrict viewing to logged-in users)

Signed-off-by: Anne Chenette <chenette@bitwise.io>