### PR TITLE
Fix SDK location in SDK table page

### DIFF
--- a/docs/source/app_developers_guide/sdk_table.rst
+++ b/docs/source/app_developers_guide/sdk_table.rst
@@ -37,12 +37,12 @@ The Maturity column shows the general maturity level of each feature:
 The available SDKs are in the following repositories:
 
 * Python:
-  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python
-  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python>`_
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/python
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/python>`_
 
 * Rust:
-  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust
-  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust>`_
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/rust
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/rust>`_
 
 * Go:
   `https://github.com/hyperledger/sawtooth-sdk-go


### PR DESCRIPTION
SDK maturity table / overview page had link of XO TP example code
for Python and Rust, whereas it pointed to SDK repository for
other languages.
The header also tells that links mentioned are for SDK, thus changed
the link in document from XO example to respective SDK code.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>