### PR TITLE
Update ci dockerfiles to pull from bumper/nightly

### DIFF
--- a/ci/nightly/sawtooth-block-info-tp
+++ b/ci/nightly/sawtooth-block-info-tp
@@ -1,0 +1,43 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth block-info package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-block-info-tp -t sawtooth-block-info-tp
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-block-info-tp
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-block-info \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["block-info-tp", "-C", "tcp://validator:4004"]

--- a/ci/nightly/sawtooth-devmode-engine
+++ b/ci/nightly/sawtooth-devmode-engine
@@ -1,0 +1,42 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Devmode Engine package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-devmode-engine -t sawtooth-devmode-engine
+#
+# Run:
+#   $ cd sawtooth-ci
+#   $ docker run sawtooth-devmode-engine
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-devmode-rust \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+
+CMD ["devmode-rust", "-C", "tcp://validator:5050"]

--- a/ci/nightly/sawtooth-identity-tp
+++ b/ci/nightly/sawtooth-identity-tp
@@ -1,0 +1,36 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Identity TP package installed from
+#   the Sawtooth Package Repository.
+#
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-identity \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["identity-tp", "-vv"]

--- a/ci/nightly/sawtooth-intkey-tp-go
+++ b/ci/nightly/sawtooth-intkey-tp-go
@@ -1,0 +1,41 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth TP Intkey package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-intkey-tp-go -t sawtooth-intkey-tp-go
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-intkey-tp-go
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-intkey-tp-go \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["intkey-tp-go", "-vv"]

--- a/ci/nightly/sawtooth-intkey-tp-python
+++ b/ci/nightly/sawtooth-intkey-tp-python
@@ -1,0 +1,43 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth TP Intkey package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-intkey-tp-python -t sawtooth-intkey-tp-python
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-intkey-tp-python
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-intkey \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["intkey-tp-python", "-vv"]

--- a/ci/nightly/sawtooth-rest-api
+++ b/ci/nightly/sawtooth-rest-api
@@ -1,0 +1,44 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Rest API package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-rest-api -t sawtooth-rest-api
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-rest-api
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-rest-api \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+EXPOSE 8008
+
+CMD ["sawtooth-rest-api"]

--- a/ci/nightly/sawtooth-settings-tp
+++ b/ci/nightly/sawtooth-settings-tp
@@ -1,0 +1,43 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Rest API package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-rest_api -t sawtooth-rest_api
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-rest_api
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-settings \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["settings-tp", "-vv"]

--- a/ci/nightly/sawtooth-shell
+++ b/ci/nightly/sawtooth-shell
@@ -1,0 +1,50 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with all the python3 Sawtooth packages installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-shell -t sawtooth-shell
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -it sawtooth-shell bash
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    curl \
+    python3-sawtooth-cli \
+    python3-sawtooth-intkey \
+    python3-sawtooth-poet-cli \
+    python3-sawtooth-sdk \
+    python3-sawtooth-settings \
+    python3-sawtooth-xo \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+EXPOSE 8008
+
+# Entrypoint is left up to user

--- a/ci/nightly/sawtooth-smallbank-tp-go
+++ b/ci/nightly/sawtooth-smallbank-tp-go
@@ -1,0 +1,41 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth TP Smallbank package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-smallbank-tp-go -t sawtooth-smallbank-tp-go
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-smallbank-tp-go
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-smallbank-tp-go \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["smallbank-tp-go", "-vv"]

--- a/ci/nightly/sawtooth-validator
+++ b/ci/nightly/sawtooth-validator
@@ -1,0 +1,45 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth Validator and CLI packages installed
+#   from the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-validator -t sawtooth-validator
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-validator
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-block-info \
+    python3-sawtooth-cli \
+    python3-sawtooth-validator \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["sawtooth-validator", "-vv"]

--- a/ci/nightly/sawtooth-xo-tp-go
+++ b/ci/nightly/sawtooth-xo-tp-go
@@ -1,0 +1,41 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth TP xo package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-xo-tp-go -t sawtooth-xo-tp-go
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-xo-tp-go
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-xo-tp-go \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["xo-tp-go", "-vv"]

--- a/ci/nightly/sawtooth-xo-tp-python
+++ b/ci/nightly/sawtooth-xo-tp-python
@@ -1,0 +1,43 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with the Sawtooth TP XO package installed from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci/nightly
+#   $ docker build . -f sawtooth-xo-tp-python -t sawtooth-xo-tp-python
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run sawtooth-xo-tp-python
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-xo \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 4004/tcp
+
+CMD ["xo-tp-python", "-vv"]


### PR DESCRIPTION
This change enables us to publish nightly docker images from the bumper
branch for use in testing.

Signed-off-by: Richard Berg <rberg@bitwise.io>