### PR TITLE
Make JS links consistent in SDK doc cover page

### DIFF
--- a/docs/source/sdks.rst
+++ b/docs/source/sdks.rst
@@ -24,8 +24,11 @@ Go
 Javascript
 ----------
 
-- `Transaction Processor and Signing
-  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/>`__
+- `Transaction Processor
+  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/module-processor.html>`__
+
+- `Signing
+  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/module-signing.html>`__
 
 Rust
 ----


### PR DESCRIPTION
Split the single JavaScript link into two links to match the
other SDKs on this page. (This fix is now possible because
the JavaScript SDK docs are being published correctly.)

Signed-off-by: Anne Chenette <chenette@bitwise.io>