### PR TITLE
Rename sawtooth-devmode-rust to sawtooth-devmode-engine-rust

### DIFF
--- a/bin/devmode-engine-rust
+++ b/bin/devmode-engine-rust
@@ -15,7 +15,7 @@
 # limitations under the License.
 # -----------------------------------------------------------------------------
 top_dir=$(cd $(dirname $(dirname $0)) && pwd)
-bin=$top_dir/sdk/examples/devmode_rust/bin/devmode-rust
+bin=$top_dir/sdk/examples/devmode_rust/bin/devmode-engine-rust
 
 if [ -e $bin ]
 then

--- a/docker-compose-installed.yaml
+++ b/docker-compose-installed.yaml
@@ -290,8 +290,8 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: sawtooth-devmode-rust:${ISOLATION_ID}
-    container_name: sawtooth-devmode-rust
+    image: sawtooth-devmode-engine-rust:${ISOLATION_ID}
+    container_name: sawtooth-devmode-engine-rust
 
   sawtooth-meta:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -188,10 +188,10 @@ services:
         - http_proxy
         - https_proxy
         - no_proxy
-    image: sawtooth-devmode-rust-local:${ISOLATION_ID}
+    image: sawtooth-devmode-engine-rust-local:${ISOLATION_ID}
     volumes:
       - ./:/project/sawtooth-core
-    container_name: sawtooth-devmode-rust-local
+    container_name: sawtooth-devmode-engine-rust-local
     depends_on:
       - validator
     command: |
@@ -199,7 +199,7 @@ services:
         cd sdk/examples/devmode_rust
         cargo build --release
         mkdir -p bin
-        cp ./target/release/devmode-rust bin/devmode-rust
-        devmode-rust -v --connect tcp://validator:5050
+        cp ./target/release/devmode-engine-rust bin/devmode-engine-rust
+        devmode-engine-rust -v --connect tcp://validator:5050
       "
     stop_signal: SIGKILL

--- a/docker/compose/copy-debs.yaml
+++ b/docker/compose/copy-debs.yaml
@@ -206,7 +206,7 @@ services:
       "
 
   devmode-rust:
-    image: sawtooth-devmode-rust:${ISOLATION_ID}
+    image: sawtooth-devmode-engine-rust:${ISOLATION_ID}
     volumes:
       - ../../build/debs:/build/debs
     command: |

--- a/docker/compose/sawtooth-build.yaml
+++ b/docker/compose/sawtooth-build.yaml
@@ -100,6 +100,6 @@ services:
     build:
       context: ../../
       dockerfile: ./sdk/examples/devmode_rust/Dockerfile
-    image: sawtooth-devmode-rust-local:${ISOLATION_ID}
+    image: sawtooth-devmode-engine-rust-local:${ISOLATION_ID}
     volumes:
       - ../../:/project/sawtooth-core

--- a/docker/compose/sawtooth-default.yaml
+++ b/docker/compose/sawtooth-default.yaml
@@ -59,11 +59,11 @@ services:
         \""
 
   devmode-engine:
-    image: hyperledger/sawtooth-devmode-engine:1.1
-    container_name: sawtooth-devmode-engine-default
+    image: hyperledger/sawtooth-devmode-engine-rust:1.1
+    container_name: sawtooth-devmode-engine-rust-default
     depends_on:
       - validator
-    entrypoint: devmode-rust -C tcp://validator:5050
+    entrypoint: devmode-engine-rust -C tcp://validator:5050
 
   rest-api:
     image: hyperledger/sawtooth-rest-api:1.1

--- a/docker/kubernetes/sawtooth-kubernetes-default.yaml
+++ b/docker/kubernetes/sawtooth-kubernetes-default.yaml
@@ -22,7 +22,7 @@ items:
               - bash
             args:
               - -c
-              - "devmode-rust -C tcp://$HOSTNAME:5050"
+              - "devmode-engine-rust -C tcp://$HOSTNAME:5050"
 
           - name: sawtooth-settings-tp
             image: hyperledger/sawtooth-settings-tp:1.1

--- a/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_basic_auth_proxy.yaml
@@ -63,7 +63,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_block_info_injector.yaml
+++ b/integration/sawtooth_integration/docker/test_block_info_injector.yaml
@@ -115,7 +115,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_config_smoke.yaml
+++ b/integration/sawtooth_integration/docker/test_config_smoke.yaml
@@ -61,7 +61,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_devmode_engine_liveness.yaml
+++ b/integration/sawtooth_integration/docker/test_devmode_engine_liveness.yaml
@@ -66,7 +66,7 @@ services:
     image: sawtooth-devmode$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
-    command: devmode-rust --connect tcp://validator-0:5005 -vv
+    command: devmode-engine-rust --connect tcp://validator-0:5005 -vv
     stop_signal: SIGKILL
 
   devmode-engine-1:
@@ -76,7 +76,7 @@ services:
     image: sawtooth-devmode$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
-    command: devmode-rust --connect tcp://validator-1:5005 -vv
+    command: devmode-engine-rust --connect tcp://validator-1:5005 -vv
     stop_signal: SIGKILL
 
   devmode-engine-2:
@@ -86,7 +86,7 @@ services:
     image: sawtooth-devmode$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
-    command: devmode-rust --connect tcp://validator-2:5005 -vv
+    command: devmode-engine-rust --connect tcp://validator-2:5005 -vv
     stop_signal: SIGKILL
 
   devmode-engine-3:
@@ -96,7 +96,7 @@ services:
     image: sawtooth-devmode$INSTALL_TYPE:$ISOLATION_ID
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
-    command: devmode-rust --connect tcp://validator-3:5005 -vv
+    command: devmode-engine-rust --connect tcp://validator-3:5005 -vv
     stop_signal: SIGKILL
 
   devmode-engine-4:
@@ -107,7 +107,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     command: |
-      bash -c "sleep 15 && devmode-rust --connect tcp://validator-4:5005 -v"
+      bash -c "sleep 15 && devmode-engine-rust --connect tcp://validator-4:5005 -v"
     stop_signal: SIGKILL
 
   validator-0:

--- a/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
+++ b/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
@@ -74,7 +74,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_intkey_cli.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_cli.yaml
@@ -77,7 +77,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_python.yaml
@@ -77,7 +77,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
+++ b/integration/sawtooth_integration/docker/test_intkey_smoke_rust.yaml
@@ -89,7 +89,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_namespace_restriction.yaml
+++ b/integration/sawtooth_integration/docker/test_namespace_restriction.yaml
@@ -129,7 +129,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_peer_list.yaml
+++ b/integration/sawtooth_integration/docker/test_peer_list.yaml
@@ -144,7 +144,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator-0:5005 -v
+    command: devmode-engine-rust --connect tcp://validator-0:5005 -v
     stop_signal: SIGKILL
 
   devmode-1:
@@ -155,7 +155,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator-1:5005 -v
+    command: devmode-engine-rust --connect tcp://validator-1:5005 -v
     stop_signal: SIGKILL
 
   devmode-2:
@@ -166,7 +166,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator-2:5005 -v
+    command: devmode-engine-rust --connect tcp://validator-2:5005 -v
     stop_signal: SIGKILL
 
   devmode-3:
@@ -177,7 +177,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator-3:5005 -v
+    command: devmode-engine-rust --connect tcp://validator-3:5005 -v
     stop_signal: SIGKILL
 
   devmode-4:
@@ -188,7 +188,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator-4:5005 -v
+    command: devmode-engine-rust --connect tcp://validator-4:5005 -v
     stop_signal: SIGKILL
 
   rest-api-0:

--- a/integration/sawtooth_integration/docker/test_permission.yaml
+++ b/integration/sawtooth_integration/docker/test_permission.yaml
@@ -61,7 +61,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_track_and_trade.yaml
+++ b/integration/sawtooth_integration/docker/test_track_and_trade.yaml
@@ -90,7 +90,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_transactor_permissioning.yaml
+++ b/integration/sawtooth_integration/docker/test_transactor_permissioning.yaml
@@ -112,7 +112,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_two_families.yaml
+++ b/integration/sawtooth_integration/docker/test_two_families.yaml
@@ -90,7 +90,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
+++ b/integration/sawtooth_integration/docker/test_web_socket_subscription.yaml
@@ -83,7 +83,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_workload.yaml
+++ b/integration/sawtooth_integration/docker/test_workload.yaml
@@ -77,7 +77,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
+++ b/integration/sawtooth_integration/docker/test_xo_smoke_python.yaml
@@ -76,7 +76,7 @@ services:
     volumes:
       - $SAWTOOTH_CORE:/project/sawtooth-core
     working_dir: /project/sawtooth-core/sdk/examples/devmode_rust
-    command: devmode-rust --connect tcp://validator:5005 -v
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
     stop_signal: SIGKILL
 
   rest-api:

--- a/integration/sawtooth_integration/tests/node_controller.py
+++ b/integration/sawtooth_integration/tests/node_controller.py
@@ -257,7 +257,7 @@ def start_processors(num, processor_func):
 # consensus engine
 
 def engine_cmd(num):
-    return 'devmode-rust --connect {s} {v}'.format(
+    return 'devmode-engine-rust --connect {s} {v}'.format(
         s=engine_connection_address(num),
         v='-v'
     )

--- a/integration/sawtooth_integration/tests/test_systemd.sh
+++ b/integration/sawtooth_integration/tests/test_systemd.sh
@@ -27,7 +27,7 @@ intkey-tp-python
 xo-tp-python
 settings-tp
 identity-tp
-devmode-rust
+devmode-engine-rust
 "
 
 if [ -z $ISOLATION_ID ]

--- a/sdk/examples/devmode_rust/Cargo.toml
+++ b/sdk/examples/devmode_rust/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "sawtooth-devmode-rust"
+name = "sawtooth-devmode-engine-rust"
 version = "0.1.0"
 authors = ["Intel Corporation"]
 description = "Hyperledger Sawtooth DevMode Rust consensus engine"
 
 [[bin]]
-name = "devmode-rust"
+name = "devmode-engine-rust"
 path = "src/main.rs"
 
 [dependencies]
@@ -19,8 +19,8 @@ sawtooth_sdk = { path = "../../rust" }
 maintainer = "sawtooth"
 depends = "$auto"
 assets = [
-    ["packaging/systemd/sawtooth-devmode-rust.service", "/lib/systemd/system/sawtooth-devmode-rust.service", "640"],
-    ["packaging/systemd/sawtooth-devmode-rust", "/etc/default/sawtooth-devmode-rust", "640"],
-    ["target/release/devmode-rust", "/usr/bin/devmode-rust", "755"]
+    ["packaging/systemd/sawtooth-devmode-engine-rust.service", "/lib/systemd/system/sawtooth-devmode-engine-rust.service", "640"],
+    ["packaging/systemd/sawtooth-devmode-engine-rust", "/etc/default/sawtooth-devmode-engine-rust", "640"],
+    ["target/release/devmode-engine-rust", "/usr/bin/devmode-engine-rust", "755"]
 ]
 maintainer-scripts = "packaging/ubuntu"

--- a/sdk/examples/devmode_rust/Dockerfile
+++ b/sdk/examples/devmode_rust/Dockerfile
@@ -40,4 +40,4 @@ CMD cd sdk/examples/devmode_rust \
  && rm -rf ./bin/ \
  && mkdir -p ./bin/ \
  && cargo build --release \
- && cp ./target/release/devmode-rust ./bin/devmode-rust
+ && cp ./target/release/devmode-engine-rust ./bin/devmode-engine-rust

--- a/sdk/examples/devmode_rust/Dockerfile-installed
+++ b/sdk/examples/devmode_rust/Dockerfile-installed
@@ -50,8 +50,8 @@ RUN /root/.cargo/bin/cargo deb
 # -------------=== devmode rust docker build ===-------------
 FROM ubuntu:xenial
 
-COPY --from=devmode-rust-builder /project/sdk/examples/devmode_rust/target/debian/sawtooth-devmode-rust_*.deb /tmp
+COPY --from=devmode-rust-builder /project/sdk/examples/devmode_rust/target/debian/sawtooth-devmode-engine-rust_*.deb /tmp
 
 RUN apt-get update \
- && dpkg -i /tmp/sawtooth-devmode-rust_*.deb || true \
+ && dpkg -i /tmp/sawtooth-devmode-engine-rust_*.deb || true \
  && apt-get -f -y install

--- a/sdk/examples/devmode_rust/packaging/systemd/sawtooth-devmode-engine-rust
+++ b/sdk/examples/devmode_rust/packaging/systemd/sawtooth-devmode-engine-rust
@@ -13,4 +13,4 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-#SAWTOOTH_DEVMODE_RUST_ARGS=-v -C tcp://localhost:5050
+#SAWTOOTH_DEVMODE_ENGINE_RUST_ARGS=-v -C tcp://localhost:5050

--- a/sdk/examples/devmode_rust/packaging/systemd/sawtooth-devmode-engine-rust.service
+++ b/sdk/examples/devmode_rust/packaging/systemd/sawtooth-devmode-engine-rust.service
@@ -20,8 +20,8 @@ After=network.target
 [Service]
 User=sawtooth
 Group=sawtooth
-EnvironmentFile=-/etc/default/sawtooth-devmode-rust
-ExecStart=/usr/bin/devmode-rust $SAWTOOTH_DEVMODE_RUST_ARGS
+EnvironmentFile=-/etc/default/sawtooth-devmode-engine-rust
+ExecStart=/usr/bin/devmode-engine-rust $SAWTOOTH_DEVMODE_ENGINE_RUST_ARGS
 Restart=on-failure
 
 [Install]

--- a/sdk/examples/devmode_rust/packaging/ubuntu/changelog
+++ b/sdk/examples/devmode_rust/packaging/ubuntu/changelog
@@ -1,4 +1,4 @@
-sawtooth-devmode-rust (@VERSION@) unstable; urgency=low
+sawtooth-devmode-engine-rust (@VERSION@) unstable; urgency=low
 
   * change data here
 


### PR DESCRIPTION
This is part of an effort to standardize consensus engine naming. The packages
and published docker images will be named sawtooth-XXXX-engine, and the
binaries will be XXXX-engine.

Devmode-rust is an outlier with the language name included because it is
provided as an example and may be re-implemented in other languages.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>