### PR TITLE
Fix Txn Fam intro: Val Reg name + repo/language info

### DIFF
--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -3,44 +3,49 @@ Transaction Family Specifications
 *********************************
 
 Sawtooth includes several transaction families as examples for developing
-your own transaction family.
+your own transaction family. These transaction families are available in the
+``sawtooth-core`` repository unless noted below.
 
 * The :doc:`/transaction_family_specifications/blockinfo_transaction_family`
   provides a way to store information about a configurable number of historic
-  blocks. BlockInfo is written in Python.
-  The family name is ``block_info``;
-  the associated transaction processor is ``block-info-tp``.
+  blocks.
+  The family name is ``block_info``.
+  The transaction processor is ``block-info-tp``.
 
 * The :doc:`/transaction_family_specifications/identity_transaction_family`
   is an extensible role- and policy-based system for defining permissions in a
   way that can be used by other Sawtooth components.
-  Identity is written in Python.
-  The family name is ``sawtooth_identity``;
-  the associated transaction processor is ``identity-tp`` (see
-  :doc:`/cli/identity-tp`).
+  The family name is ``sawtooth_identity``.
+  The transaction processor is :doc:`/cli/identity-tp`.
 
 * The :doc:`/transaction_family_specifications/integerkey_transaction_family`
-  simply sets, increments, and decrements the value of entries stored in a state
-  dictionary. IntegerKey is available in Go, Java, and JavaScript (Node.js).
-  The family name is ``intkey``;
-  the associated transaction processor executables are ``intkey-tp-go``,
-  and ``intkey-tp-java``;
-  the processor in its own repo is
-  `JavaScript <https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/examples/intkey/>`__.
-  The :doc:`intkey command </cli/intkey>` provides an example CLI client.
+  (also called "intkey") simply sets, increments, and decrements the value of
+  entries stored in a state dictionary.
+  The :doc:`intkey command </cli/intkey>` command provides an example CLI client.
+
+  intkey is available in several languages, including Go, Java, and JavaScript
+  (Node.js); see the ``sawtooth-sdk-{language}`` repositories under
+  ``examples``.
+
+  The family name is ``intkey``.
+  The transaction processor is ``intkey-tp-{language}``.
 
 * The :doc:`/transaction_family_specifications/validator_registry_transaction_family`
   provides a way to add new validators to the network. It is used by the PoET
   consensus algorithm implementation to keep track of other validators.
+
+  This transaction family is in the
+  `sawtooth-poet <https://github.com/hyperledger/sawtooth-poet>`__ repository.
+
   The family name is ``sawtooth_validator_registry``.
   The transaction processor is ``poet-validator-registry-tp``.
 
 * The :doc:`/transaction_family_specifications/settings_transaction_family`
   provides a methodology for storing on-chain configuration settings.
-  The family name is ``sawtooth_settings``;
-  the associated transaction processor is ``settings-tp`` (see
-  :doc:`/cli/settings-tp`).
   The :doc:`sawset command </cli/sawset>` provides an example CLI client.
+
+  The family name is ``sawtooth_settings``.
+  The transaction processor is :doc:`/cli/settings-tp`.
 
   .. note::
 
@@ -49,20 +54,23 @@ your own transaction family.
 
 * The :doc:`/transaction_family_specifications/smallbank_transaction_family`
   provides a cross-platform workload for comparing the performance of
-  blockchain systems. Smallbank is written in Go.
-  The family name is ``smallbank``;
-  the associated transaction processor is ``smallbank-tp``.
+  blockchain systems.
+  The family name is ``smallbank``.
+  The transaction processor is ``smallbank-tp``.
 
 * The :doc:`/transaction_family_specifications/xo_transaction_family`
   allows two users to play a simple game of tic-tac-toe (see
   :doc:`/app_developers_guide/intro_xo_transaction_family`).
-  XO is written in Go, JavaScript/Node.js, and Python.
-  The family name is ``xo``;
-  the associated transaction processor executables  are ``xo-tp-go``,
-  and ``xo-tp-python``;
-  the processor in its own repo is
-  `JavaScript <https://github.com/hyperledger/sawtooth-sdk-javascript/blob/master/examples/xo/>`__.
   The :doc:`xo command </cli/xo>` provides an example CLI client.
+
+  XO is available in several languages. The Rust and Python implementations are
+  in `sawtooth-core/sdk/examples
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples>`__.
+  The others are in separate ``sawtooth-sdk-{language}`` repositories under
+  ``examples``.
+
+  The family name is ``xo``.
+  The transaction processor is ``xo-tp-{language}``.
 
 
 .. toctree::

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -32,8 +32,8 @@ your own transaction family.
 * The :doc:`/transaction_family_specifications/validator_registry_transaction_family`
   provides a way to add new validators to the network. It is used by the PoET
   consensus algorithm implementation to keep track of other validators.
-  The family name is ``poet_validator_registry``;
-  the associated transaction processor is ``poet-validator-registry-tp``.
+  The family name is ``sawtooth_validator_registry``.
+  The transaction processor is ``poet-validator-registry-tp``.
 
 * The :doc:`/transaction_family_specifications/settings_transaction_family`
   provides a methodology for storing on-chain configuration settings.


### PR DESCRIPTION
- Fix the family name for sawtooth_validator_registry

- Remove "This transaction family is written in {language}"

- Correct and clarify repo information for transaction families available in multiple languages

- Make the blurb structure consistent