### PR TITLE
 Store Transaction Receipts Generated at Genesis time

### DIFF
--- a/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
+++ b/integration/sawtooth_integration/docker/test_events_and_receipts.yaml
@@ -70,7 +70,9 @@ services:
     # start the validator with an empty genesis batch
     command: "bash -c \"\
         sawadm keygen && \
-        sawadm genesis && \
+        sawtooth keygen my_key && \
+        sawset genesis -k /root/.sawtooth/keys/my_key.priv && \
+        sawadm genesis config-genesis.batch && \
         sawtooth-validator --endpoint tcp://validator:8800 -v \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \

--- a/integration/sawtooth_integration/tests/test_events_and_receipts.py
+++ b/integration/sawtooth_integration/tests/test_events_and_receipts.py
@@ -21,7 +21,11 @@ import urllib.error
 
 import cbor
 
+from sawtooth_validator.journal.block_wrapper import NULL_BLOCK_IDENTIFIER
+
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+from sawtooth_intkey.processor.handler import INTKEY_ADDRESS_PREFIX
 from sawtooth_intkey.processor.handler import make_intkey_address
 from sawtooth_sdk.messaging.stream import Stream
 
@@ -46,6 +50,27 @@ class TestEventsAndReceipts(unittest.TestCase):
         response = self._unsubscribe()
         self.assert_unsubscribe_response(response)
 
+    def test_subscribe_and_unsubscribe_with_catch_up(self):
+        """Tests that a client can subscribe and unsubscribe from events."""
+        response = self._subscribe(
+            last_known_block_ids=[NULL_BLOCK_IDENTIFIER])
+        self.assert_subscribe_response(response)
+
+        # Ensure that it receives the genesis block
+        msg = self.stream.receive().result()
+        self.assertEqual(
+            msg.message_type,
+            validator_pb2.Message.CLIENT_EVENTS)
+        event_list = events_pb2.EventList()
+        event_list.ParseFromString(msg.content)
+        events = event_list.events
+        self.assertEqual(len(events), 2)
+        self.assert_block_commit_event(events[0], 0)
+        self.assert_state_event(events[1], '000000')
+
+        response = self._unsubscribe()
+        self.assert_unsubscribe_response(response)
+
     def test_block_commit_event_received(self):
         """Tests that block commit events are properly received on block
         boundaries."""
@@ -60,8 +85,9 @@ class TestEventsAndReceipts(unittest.TestCase):
             event_list = events_pb2.EventList()
             event_list.ParseFromString(msg.content)
             events = event_list.events
-            self.assertEqual(len(events), 1)
+            self.assertEqual(len(events), 2)
             self.assert_block_commit_event(events[0], i)
+            self.assert_state_event(events[1], INTKEY_ADDRESS_PREFIX)
 
         self._unsubscribe()
 
@@ -122,7 +148,7 @@ class TestEventsAndReceipts(unittest.TestCase):
             event_list = events_pb2.EventList()
             event_list.ParseFromString(msg.content)
             events = event_list.events
-            self.assertEqual(len(events), 1)
+            self.assertEqual(len(events), 2)
             block_commit_event = events[0]
             block_id = list(filter(
                 lambda attr: attr.key == "block_id",
@@ -155,6 +181,7 @@ class TestEventsAndReceipts(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        wait_for_rest_apis(['rest-api:8008'])
         cls.batch_submitter = BatchSubmitter(WAIT)
 
     def setUp(self):
@@ -189,6 +216,22 @@ class TestEventsAndReceipts(unittest.TestCase):
             subscriptions = [
                 events_pb2.EventSubscription(
                     event_type="sawtooth/block-commit"),
+                # Subscribe to the settings state events, to test genesis
+                # catch-up.
+                events_pb2.EventSubscription(
+                    event_type="sawtooth/state-delta",
+                    filters=[events_pb2.EventFilter(
+                        key='address',
+                        match_string='000000.*',
+                        filter_type=events_pb2.EventFilter.REGEX_ANY)]),
+                # Subscribe to the intkey state events, to test additional
+                # events.
+                events_pb2.EventSubscription(
+                    event_type="sawtooth/state-delta",
+                    filters=[events_pb2.EventFilter(
+                        key='address',
+                        match_string='{}.*'.format(INTKEY_ADDRESS_PREFIX),
+                        filter_type=events_pb2.EventFilter.REGEX_ANY)]),
             ]
         if last_known_block_ids is None:
             last_known_block_ids = []
@@ -237,6 +280,13 @@ class TestEventsAndReceipts(unittest.TestCase):
             client_receipt_pb2.ClientReceiptGetResponse.OK)
 
         return receipt_response.receipts
+
+    def assert_state_event(self, event, address_prefix):
+        self.assertEqual(event.event_type, "sawtooth/state-delta")
+        state_change_list = transaction_receipt_pb2.StateChangeList()
+        state_change_list.ParseFromString(event.data)
+        for change in state_change_list.state_changes:
+            self.assertTrue(change.address.startswith(address_prefix))
 
     def assert_events_get_response(self, msg):
         self.assertEqual(

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -353,7 +353,8 @@ class Validator:
             data_dir=data_dir,
             config_dir=config_dir,
             chain_id_manager=chain_id_manager,
-            batch_sender=batch_sender)
+            batch_sender=batch_sender,
+            receipt_store=receipt_store)
 
         responder = Responder(completer)
 

--- a/validator/tests/test_genesis/tests.py
+++ b/validator/tests/test_genesis/tests.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -84,7 +85,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         self.assertEqual(True, genesis_ctrl.requires_genesis())
 
@@ -105,7 +107,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -127,7 +130,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -154,7 +158,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         self.assertEqual(False, genesis_ctrl.requires_genesis())
 
@@ -184,7 +189,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         with self.assertRaises(InvalidGenesisStateError):
             genesis_ctrl.requires_genesis()
@@ -215,7 +221,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         with self.assertRaises(InvalidGenesisStateError):
             genesis_ctrl.requires_genesis()
@@ -262,7 +269,8 @@ class TestGenesisController(unittest.TestCase):
             data_dir=self._temp_dir,
             config_dir=self._temp_dir,
             chain_id_manager=ChainIdManager(self._temp_dir),
-            batch_sender=Mock('batch_sender'))
+            batch_sender=Mock('batch_sender'),
+            receipt_store=MagicMock())
 
         on_done_fn = Mock(return_value='')
         genesis_ctrl.start(on_done_fn)


### PR DESCRIPTION
When generated the genesis block, the transaction receipts generated must also be stored in the receipt store.  These transactions must be made available for event subscribers connect receive any catch-up events based on their filters.

Additionally,

- Updated the integration test for events and receipts to check for state events as well as block events, to validate this case.