### PR TITLE
1.1 doc backports: fix typos

### DIFF
--- a/docs/source/app_developers_guide/sdk_table.rst
+++ b/docs/source/app_developers_guide/sdk_table.rst
@@ -37,12 +37,12 @@ The Maturity column shows the general maturity level of each feature:
 The available SDKs are in the following repositories:
 
 * Python:
-  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python
-  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_python>`_
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/python
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/python>`_
 
 * Rust:
-  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust
-  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/examples/xo_rust>`_
+  `https://github.com/hyperledger/sawtooth-core/tree/master/sdk/rust
+  <https://github.com/hyperledger/sawtooth-core/tree/master/sdk/rust>`_
 
 * Go:
   `https://github.com/hyperledger/sawtooth-sdk-go

--- a/docs/source/cli/sawadm.rst
+++ b/docs/source/cli/sawadm.rst
@@ -39,7 +39,7 @@ genesis time.
 The optional argument `input_file` specifies one or more files containing
 serialized ``BatchList`` protobuf messages to add to the genesis data. (Use a
 space to separate multiple files.) If no input file is specified,
-``sawadm keygen`` produces an empty genesis block.
+this command produces an empty genesis block.
 
 The output is a file containing a serialized ``GenesisData`` protobuf message.
 This file, when placed at `sawtooth_data`/``genesis.batch``, will trigger

--- a/docs/source/community/issue_tracking.rst
+++ b/docs/source/community/issue_tracking.rst
@@ -16,7 +16,10 @@ Hyperledger Sawtooth uses JIRA as our issue tracking system:
 https://jira.hyperledger.org/projects/STL
 
 If you want to contribute to Hyperledger Sawtooth quickly, we have a list of
-issues that will help you get involved right away. See the open Sawtooth issues:
+issues that will help you get involved right away. Log into
+`jira.hyperledger.org <https://jira.hyperledger.org>`_ (requires a
+`Linux Foundation Account <https://identity.linuxfoundation.org/>`_)
+and see the Sawtooth "help-wanted" list:
 
 https://jira.hyperledger.org/issues/?filter=10612
 

--- a/docs/source/community/join_the_discussion.rst
+++ b/docs/source/community/join_the_discussion.rst
@@ -14,7 +14,7 @@ For general Hyperledger Sawtooth discussions:
 
 For Hyperledger Sawtooth Consensus discussions:
 
-  `#sawtooth-consensus <https://chat.hyperledger.org/channel/sawtooth-consensus>`_
+  `#sawtooth-consensus-dev <https://chat.hyperledger.org/channel/sawtooth-consensus-dev>`_
 
 
 Mailing Lists

--- a/docs/source/sdks.rst
+++ b/docs/source/sdks.rst
@@ -24,8 +24,11 @@ Go
 Javascript
 ----------
 
-- `Transaction Processor and Signing
-  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/>`__
+- `Transaction Processor
+  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/module-processor.html>`__
+
+- `Signing
+  <https://sawtooth.hyperledger.org/docs/js-sdk/releases/latest/module-signing.html>`__
 
 Rust
 ----

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -32,8 +32,8 @@ your own transaction family.
 * The :doc:`/transaction_family_specifications/validator_registry_transaction_family`
   provides a way to add new validators to the network. It is used by the PoET
   consensus algorithm implementation to keep track of other validators.
-  The family name is ``poet_validator_registry``;
-  the associated transaction processor is ``poet-validator-registry-tp``.
+  The family name is ``sawtooth_validator_registry``.
+  The transaction processor is ``poet-validator-registry-tp``.
 
 * The :doc:`/transaction_family_specifications/settings_transaction_family`
   provides a methodology for storing on-chain configuration settings.

--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -36,9 +36,9 @@ Address
 The top-level namespace of this transaction family is 00b10c. This namespace is
 further subdivided based on the next two characters as follows:
 
-00b10c00
-  Information about other namespaces; the "metadata namespace"
 00b10c01
+  Information about the block info config and metadata; the "metadata namespace"
+00b10c00
   Historic block information; the "block info namespace"
 
 Under the metadata namespace, the “zero-address” formed by concatenating the


### PR DESCRIPTION
Fix errors, broken links, and major typos in the Sawtooth core 1-1 documentation:
- Correct link to Rocket.Chat consensus channel
- Clarify Sawtooth help-wanted link (must log into JIRA)
- Fix namespaces description in block_info docs
- Fix SDK location in SDK table page
- Make JS links consistent in SDK doc cover page
- Delete wrong sawadm subcommand name in CLI ref
- Fix family name of Validator Registry in Txn Fam doc 
