### PR TITLE
Rename missed sawtooth-devmode-engine to sawtooth-devmode-engine-rust

### DIFF
--- a/docker/kubernetes/sawtooth-kubernetes-default.yaml
+++ b/docker/kubernetes/sawtooth-kubernetes-default.yaml
@@ -17,7 +17,7 @@ items:
       spec:
         containers:
           - name: sawtooth-devmode-engine
-            image: hyperledger/sawtooth-devmode-engine:1.1
+            image: hyperledger/sawtooth-devmode-engine-rust:1.1
             command:
               - bash
             args:


### PR DESCRIPTION
The published image for devmode engine in rust has the name
sawtooth-devmode-engine-rust, but it was mentioned in kubernetes
deployment yaml file as sawtooth-devmode-engine.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>