### PR TITLE
Add ca-certificates as a dependency for rest-api - 1-1 Backport

### DIFF
--- a/rest_api/stdeb.cfg
+++ b/rest_api/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+Depends3: ca-certificates


### PR DESCRIPTION
When the rest-api docker container is configured to send metrics to InfluxDB via
a https URL, the following error is printed due to ca-certificates not being
installed in the image.

Cannot write to SERVER_URL: [SSL: CERTIFICATE_VERIFY_FAILED] certificate
verify failed (_ssl.c:645)

This change is in master #1951 

Signed-off-by: Richard Berg <rberg@bitwise.io>