### PR TITLE
Create sawtooth-intkey-workload docker image - 1-1 backport

### DIFF
--- a/ci/sawtooth-intkey-workload
+++ b/ci/sawtooth-intkey-workload
@@ -1,0 +1,41 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image with intkey-workload from
+#   the Sawtooth Package Repository.
+#
+# Build:
+#   $ cd sawtooth-core/ci
+#   $ docker build . -f sawtooth-intkey-workload -t sawtooth-intkey-workload
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -it sawtooth-intkey-workload bash
+
+FROM ubuntu:xenial
+
+LABEL "install-type"="repo"
+
+RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/bumper/stable xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    sawtooth-intkey-workload \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["intkey-workload", "--rate 10"]


### PR DESCRIPTION
This image will be used during docker / kubernetes based testing, and is
suitable for publishing to Dockerhub.

This is in master #1955 

Signed-off-by: Richard Berg <rberg@bitwise.io>