### PR TITLE
1-1: Remove init of pylogger.rs from python code

### DIFF
--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -62,7 +62,6 @@ class Library:
 
 
 LIBRARY = Library(ctypes.CDLL)
-LIBRARY.call("pylogger_init", LOGGER.getEffectiveLevel())
 PY_LIBRARY = Library(ctypes.PyDLL)
 
 

--- a/validator/src/pylogger.rs
+++ b/validator/src/pylogger.rs
@@ -40,14 +40,6 @@ pub fn set_up_logger(verbosity: u64, py: Python) {
     warn!("Started logger at level {}", verbosity_level);
 }
 
-#[no_mangle]
-pub extern "C" fn pylogger_init(verbosity: usize) {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    PyLogger::init(determine_log_level(verbosity as u64), py)
-        .expect("Failed to initialize PyLogger");
-}
-
 pub fn exception(py: Python, msg: &str, err: PyErr) {
     let logger = PyLogger::new(py).expect("Failed to create new PyLogger");
     logger.exception(py, msg, err);


### PR DESCRIPTION
The Rust main.rs already inits the PyLogger.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>