### PR TITLE
Fix bionic build behind proxy network

### DIFF
--- a/docker/sawtooth-shell
+++ b/docker/sawtooth-shell
@@ -21,9 +21,16 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+   http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+   key_server_options="--keyserver-options http-proxy=${http_proxy}"; \
+ fi; \
+ echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q \

--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -21,9 +21,16 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+   http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+   key_server_options="--keyserver-options http-proxy=${http_proxy}"; \
+ fi; \
+ echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q \

--- a/sdk/examples/intkey_python/Dockerfile
+++ b/sdk/examples/intkey_python/Dockerfile
@@ -21,9 +21,16 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+   http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+   key_server_options="--keyserver-options http-proxy=${http_proxy}"; \
+ fi; \
+ echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q \

--- a/sdk/examples/xo_python/Dockerfile
+++ b/sdk/examples/xo_python/Dockerfile
@@ -21,9 +21,16 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+   http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+   key_server_options="--keyserver-options http-proxy=${http_proxy}"; \
+ fi; \
+ echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q \

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -21,9 +21,16 @@ FROM ubuntu:bionic
 RUN apt-get update \
  && apt-get install gnupg -y
 
-RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
- && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
- || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+RUN \
+ if [ ! -z $HTTP_PROXY ] && [ -z $http_proxy ]; then \
+   http_proxy=$HTTP_PROXY; \
+ fi; \
+ if [ ! -z $http_proxy ]; then \
+   key_server_options="--keyserver-options http-proxy=${http_proxy}"; \
+ fi; \
+ echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 ${key_server_options} --recv-keys 8AA7AF1F1091A5FD) \
  && apt-get update
 
 RUN apt-get install -y -q \


### PR DESCRIPTION
Supply proxy address as keysrver option, allowing apt-key to
fetch required keys added for the repository.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>