### PR TITLE
1-1 BACKPORT: Allow subscribers to connect when no Genesis Block

### DIFF
--- a/validator/sawtooth_validator/server/events/broadcaster.py
+++ b/validator/sawtooth_validator/server/events/broadcaster.py
@@ -113,7 +113,8 @@ class EventBroadcaster(ChainObserver):
         '''
         # If latest known block is not the current chain head, catch up
         catchup_up_blocks = []
-        if last_known_block_id != self._block_store.chain_head.identifier:
+        chain_head = self._block_store.chain_head
+        if chain_head and last_known_block_id != chain_head.identifier:
             # Start from the chain head and get blocks until we reach the
             # known block
             for block in self._block_store.get_predecessor_iter():


### PR DESCRIPTION
This change handles the case when an event subscriber connects to the
validator before it has either generated or received the genesis block.
In that instance, chain head is `None`, and an exception is raised, then
the subscriber is left in an invalid state. This fix mitigates that
issue.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>