### PR TITLE
1-1 BACKPORT: Use checked subtraction in queue limit

### DIFF
--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -890,7 +890,7 @@ impl QueueLimit {
             // b. Drained the queue, but the queue was not bigger than the
             //    current running average
 
-            let remainder = queue_length - consumed;
+            let remainder = queue_length.checked_sub(consumed).unwrap_or(0);
 
             if remainder > self.avg.value() || consumed > self.avg.value() {
                 self.avg.update(consumed);


### PR DESCRIPTION
Backport of PR #1981 

Ensure that checked subtraction is used when updating the queue limit.
There are scenarios (particularly a race condition that can occur during
genesis block creation) where the current queue limit is less than the
consumed number of batches. This race condition would result in a
"panicked at 'attempt to subtract with overflow'" error.  This change
fixes this issue.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>