### PR TITLE
Allow transaction processor to receive raw transaction header from client

### DIFF
--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -22,9 +22,11 @@ import "transaction.proto";
 
 
 // The registration request from the transaction processor to the
-// validator/executor
+// validator/executor.
+//
+// The protocol_version field is used to check if the validator supports
+// requested features by a transaction processor.
 message TpRegisterRequest {
-
     // A settled upon name for the capabilities of the transaction processor.
     // For example: intkey, xo
     string family = 1;
@@ -42,6 +44,11 @@ message TpRegisterRequest {
     // The maximum number of transactions that this transaction processor can
     // handle at once.
     uint32 max_occupancy = 5;
+
+    // Validator can make use of this field to check if the requested features
+    // are supported. Registration requests can be either accepted or rejected
+    // based on this field.
+    uint32 protocol_version = 6;
 }
 
 // A response sent from the validator to the transaction processor
@@ -54,6 +61,10 @@ message TpRegisterResponse {
     }
 
     Status status = 1;
+
+    // Respond back with protocol_version, the value that can be used by SDK to
+    // know if validator supports expected feature.
+    uint32 protocol_version = 2;
 }
 
 // The unregistration request from the transaction processor to the

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -26,7 +26,21 @@ import "transaction.proto";
 //
 // The protocol_version field is used to check if the validator supports
 // requested features by a transaction processor.
+// Following are the versions supported:
+//     1    Transaction processor can request for either raw header bytes or
+//          deserialized TransactionHeader field in the TpProcessRequest
+//          message. The default option is set to send deserialized
+//          TransactionHeader.
 message TpRegisterRequest {
+    // enum used to fill in transaction header field in TpProcessRequest.
+    // This field can be set before transaction processor registers with
+    // validator.
+    enum TpProcessRequestHeaderStyle {
+        HEADER_STYLE_UNSET = 0;
+        EXPANDED = 1;
+        RAW = 2;
+    }
+
     // A settled upon name for the capabilities of the transaction processor.
     // For example: intkey, xo
     string family = 1;
@@ -49,6 +63,10 @@ message TpRegisterRequest {
     // are supported. Registration requests can be either accepted or rejected
     // based on this field.
     uint32 protocol_version = 6;
+
+    // Setting it to RAW, validator would fill in serialized transaction header
+    // when sending TpProcessRequest to the transaction processor.
+    TpProcessRequestHeaderStyle request_header_style = 7;
 }
 
 // A response sent from the validator to the transaction processor
@@ -90,10 +108,21 @@ message TpUnregisterResponse {
 // The request from the validator/executor of the transaction processor
 // to verify a transaction.
 message TpProcessRequest {
-    TransactionHeader header = 1;  // The transaction header
-    bytes payload = 2;  // The transaction payload
-    string signature = 3;  // The transaction header_signature
-    string context_id = 4; // The context_id for state requests.
+    // The de-serialized transaction header from client request
+    TransactionHeader header = 1;
+
+    // The transaction payload
+    bytes payload = 2;
+
+    // The transaction header_signature
+    string signature = 3;
+
+    // The context_id for state requests.
+    string context_id = 4;
+
+    // The serialized header as received by client.
+    // Controlled by a flag during transaction processor registration.
+    bytes header_bytes = 5;
 }
 
 

--- a/validator/sawtooth_validator/execution/processor_handlers.py
+++ b/validator/sawtooth_validator/execution/processor_handlers.py
@@ -49,6 +49,14 @@ class ProcessorRegisterHandler(Handler):
         else:
             max_occupancy = request.max_occupancy
 
+        # If the request_header_style parameter is not set in the request,
+        # consider default behavior of sending EXPANDED (de-serialized) header.
+        # This is for backward compatibility.
+        if request.request_header_style == \
+                processor_pb2.TpRegisterRequest.HEADER_STYLE_UNSET:
+            header_style = processor_pb2.TpRegisterRequest.EXPANDED
+        else:
+            header_style = request.request_header_style
 
         # Reject the request if requested version cannot be handled,
         # validator does backward compatible support.
@@ -76,7 +84,8 @@ class ProcessorRegisterHandler(Handler):
         processor = processor_manager.Processor(
             connection_id,
             request.namespaces,
-            max_occupancy)
+            max_occupancy,
+            header_style)
 
         self._collection[processor_type] = processor
 

--- a/validator/sawtooth_validator/execution/processor_manager.py
+++ b/validator/sawtooth_validator/execution/processor_manager.py
@@ -194,12 +194,13 @@ class ProcessorManager:
 
 
 class Processor:
-    def __init__(self, connection_id, namespaces, max_occupancy):
+    def __init__(self, connection_id, namespaces, max_occupancy, header_style):
         self._lock = RLock()
         self.connection_id = connection_id
         self.namespaces = namespaces
         self._max_occupancy = max_occupancy
         self._current_occupancy = 0
+        self._header_style = header_style
 
     def __repr__(self):
         return "{}: {}".format(self.connection_id,
@@ -219,6 +220,9 @@ class Processor:
     def has_vacancy(self):
         with self._lock:
             return self._current_occupancy < self._max_occupancy
+
+    def request_header_style(self):
+        return self._header_style
 
 
 class ProcessorType:


### PR DESCRIPTION
The PR has two commits
1. Introduce a protocol_version field for TpRegisterRequest.
2. Allow transaction processor to receive raw transaction header bytes.

RFC describes details on need to have raw (serialized version from client request) transaction header, sent to transaction processor. Transaction processor can register to get raw transaction header.

CXX SDK changes: https://github.com/hyperledger/sawtooth-sdk-cxx/pull/6
Rust SDK changes: https://github.com/hyperledger/sawtooth-sdk-rust/pull/4
Python SDK changes: https://github.com/hyperledger/sawtooth-sdk-python/pull/4