### PR TITLE
Consensus fixes

### DIFF
--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -835,6 +835,11 @@ class BlockListRequest(_ClientRequestHandler):
                     return self._status.INVALID_PAGING
 
                 return self._status.NO_ROOT
+            except KeyError:
+                if paging.start:
+                    return self._status.INVALID_PAGING
+
+                return self._status.NO_ROOT
 
             paging_response = client_list_control_pb2.ClientPagingResponse(
                 next=next_block_num,

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -534,9 +534,9 @@ impl BlockManager {
         }
     }
 
-    pub fn contains_any_transactions<'a>(
+    pub fn contains_any_transactions(
         &self,
-        block_id: &'a str,
+        block_id: &str,
         ids: &[&String],
     ) -> Result<Option<String>, BlockManagerError> {
         let _lock = self
@@ -715,7 +715,7 @@ impl BlockManager {
         self.state.put(branch)
     }
 
-    pub fn get<'a>(&self, block_ids: &'a [&'a str]) -> Box<Iterator<Item = Option<Block>>> {
+    pub fn get(&self, block_ids: &[&str]) -> Box<Iterator<Item = Option<Block>>> {
         Box::new(GetBlockIterator::new(Arc::clone(&self.state), block_ids))
     }
 

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -80,7 +80,10 @@ impl RefCount {
     fn decrease_internal_ref_count(&mut self) {
         match self.internal_ref_count.checked_sub(1) {
             Some(ref_count) => self.internal_ref_count = ref_count,
-            None => panic!("The internal ref-count fell below zero, its lowest possible value"),
+            None => panic!(
+                "The internal ref-count for {} fell below zero, its lowest possible value",
+                self.block_id
+            ),
         }
     }
 
@@ -91,7 +94,10 @@ impl RefCount {
     fn decrease_external_ref_count(&mut self) {
         match self.external_ref_count.checked_sub(1) {
             Some(ref_count) => self.external_ref_count = ref_count,
-            None => panic!("The external ref-count fell below zero, its lowest possible value"),
+            None => panic!(
+                "The external ref-count for {} fell below zero, its lowest possible value",
+                self.block_id
+            ),
         }
     }
 }

--- a/validator/src/state/settings_view.rs
+++ b/validator/src/state/settings_view.rs
@@ -108,7 +108,6 @@ impl SettingsView {
         {
             let cache = self.cache.borrow();
             if cache.contains_key(key) {
-                eprintln!("{} in cache", key);
                 return if let Some(str_value) = cache.get(key).unwrap() {
                     Ok(Some(value_parser(&str_value)?))
                 } else {


### PR DESCRIPTION
This PR has several minor fixes for various consensus proxy methods, as well as the client handlers (which has an effect on the PoET engine). 

~Probably more controversially, this removes the `panic` when a block is unref'ed in the `BlockManager` and it is already at `0`.  This panic makes the system quite unstable as a validator will crash in this situation.~

Updated to improve the panic message (and remove the controversy for a future PR). 