### PR TITLE
Revert "Remove init of pylogger.rs from python code"

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -38,6 +38,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && apt-get install -y -q \
     build-essential \
     git \
+    latexmk \
     libffi-dev \
     libssl-dev \
     libzmq3-dev \
@@ -96,7 +97,7 @@ RUN apt-get update && apt-get install -y -q \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install \
-    sphinx==1.5.6 \
+    sphinx \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \
     sphinx_rtd_theme

--- a/families/settings/sawtooth_settings/src/handler.rs
+++ b/families/settings/sawtooth_settings/src/handler.rs
@@ -224,7 +224,7 @@ fn apply_vote(
                 _ => {
                     return Err(ApplyError::InvalidTransaction(String::from(
                         "Transaction type unset",
-                    )))
+                    )));
                 }
             }
         }

--- a/sdk/examples/intkey_rust/src/handler.rs
+++ b/sdk/examples/intkey_rust/src/handler.rs
@@ -86,7 +86,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Verb must be 'set', 'inc', or 'dec'",
-                )))
+                )));
             }
             Some(verb_raw) => verb_raw.clone(),
         };
@@ -98,7 +98,7 @@ impl IntkeyPayload {
             _ => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Verb must be 'set', 'inc', or 'dec'",
-                )))
+                )));
             }
         };
 
@@ -108,7 +108,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Must have a value",
-                )))
+                )));
             }
         };
 
@@ -119,7 +119,7 @@ impl IntkeyPayload {
             _ => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Value must be an integer",
-                )))
+                )));
             }
         };
 
@@ -127,7 +127,7 @@ impl IntkeyPayload {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Name must be a string",
-                )))
+                )));
             }
             Some(name_raw) => name_raw.clone(),
         };
@@ -193,7 +193,7 @@ impl<'a> IntkeyState<'a> {
                     _ => {
                         return Err(ApplyError::InternalError(String::from(
                             "No map returned from state",
-                        )))
+                        )));
                     }
                 };
 
@@ -284,7 +284,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Request must contain a payload",
-                )))
+                )));
             }
         };
 
@@ -306,7 +306,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                         return Err(ApplyError::InvalidTransaction(format!(
                             "{} already set",
                             payload.get_name()
-                        )))
+                        )));
                     }
                     Ok(None) => (),
                     Err(err) => return Err(err),
@@ -319,7 +319,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                     Ok(None) => {
                         return Err(ApplyError::InvalidTransaction(String::from(
                             "inc requires a set value",
-                        )))
+                        )));
                     }
                     Err(err) => return Err(err),
                 };
@@ -338,7 +338,7 @@ impl TransactionHandler for IntkeyTransactionHandler {
                     Ok(None) => {
                         return Err(ApplyError::InvalidTransaction(String::from(
                             "dec requires a set value",
-                        )))
+                        )));
                     }
                     Err(err) => return Err(err),
                 };

--- a/sdk/examples/xo_rust/src/handler/game.rs
+++ b/sdk/examples/xo_rust/src/handler/game.rs
@@ -113,7 +113,7 @@ impl Game {
                 return Err(ApplyError::InvalidTransaction(format!(
                     "Invalid state {}",
                     other_state
-                )))
+                )));
             }
         };
 
@@ -129,7 +129,8 @@ impl Game {
                 } else {
                     ch.to_string()
                 }
-            }).collect();
+            })
+            .collect();
         self.board = board_vec.join("");
         Ok(())
     }
@@ -142,7 +143,7 @@ impl Game {
             (true, true) => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Two winners (there can only be one)",
-                )))
+                )));
             }
             (true, false) => Some(String::from("P1-WIN")),
             (false, true) => Some(String::from("P2-WIN")),

--- a/sdk/examples/xo_rust/src/handler/mod.rs
+++ b/sdk/examples/xo_rust/src/handler/mod.rs
@@ -65,7 +65,7 @@ impl TransactionHandler for XoTransactionHandler {
             None => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Invalid header",
-                )))
+                )));
             }
         };
 
@@ -108,7 +108,7 @@ impl TransactionHandler for XoTransactionHandler {
                         "P1-WIN" | "P2-WIN" | "TIE" => {
                             return Err(ApplyError::InvalidTransaction(String::from(
                                 "Invalid action: Game has ended",
-                            )))
+                            )));
                         }
                         "P1-NEXT" => {
                             let p1 = g.get_player1();
@@ -129,7 +129,7 @@ impl TransactionHandler for XoTransactionHandler {
                         _ => {
                             return Err(ApplyError::InvalidTransaction(String::from(
                                 "Invalid state",
-                            )))
+                            )));
                         }
                     }
 

--- a/sdk/examples/xo_rust/src/handler/payload.rs
+++ b/sdk/examples/xo_rust/src/handler/payload.rs
@@ -31,7 +31,7 @@ impl XoPayload {
             Err(_) => {
                 return Err(ApplyError::InvalidTransaction(String::from(
                     "Invalid payload serialization",
-                )))
+                )));
             }
         };
 
@@ -83,7 +83,7 @@ impl XoPayload {
                 Err(_) => {
                     return Err(ApplyError::InvalidTransaction(String::from(
                         "Space must be an integer",
-                    )))
+                    )));
                 }
             };
             if space_parsed < 1 || space_parsed > 9 {

--- a/sdk/examples/xo_rust/src/main.rs
+++ b/sdk/examples/xo_rust/src/main.rs
@@ -40,7 +40,8 @@ fn main() {
         (@arg connect: -C --connect +takes_value
          "connection endpoint for validator")
         (@arg verbose: -v --verbose +multiple
-         "increase output verbosity")).get_matches();
+         "increase output verbosity"))
+    .get_matches();
 
     let endpoint = matches
         .value_of("connect")
@@ -57,7 +58,8 @@ fn main() {
     let stdout = ConsoleAppender::builder()
         .encoder(Box::new(PatternEncoder::new(
             "{h({l:5.5})} | {({M}:{L}):20.20} | {m}{n}",
-        ))).build();
+        )))
+        .build();
 
     let config = match Config::builder()
         .appender(Appender::builder().build("stdout", Box::new(stdout)))

--- a/sdk/rust/src/consensus/zmq_driver.rs
+++ b/sdk/rust/src/consensus/zmq_driver.rs
@@ -355,7 +355,7 @@ fn handle_update(
             return Err(Error::ReceiveError(format!(
                 "Received unexpected message type: {:?}",
                 unexpected
-            )))
+            )));
         }
     };
 

--- a/sdk/rust/src/processor/handler.rs
+++ b/sdk/rust/src/processor/handler.rs
@@ -214,7 +214,7 @@ impl TransactionContext {
                     None => {
                         return Err(ContextError::ResponseAttributeError(String::from(
                             "TpStateGetResponse is missing entries.",
-                        )))
+                        )));
                     }
                 };
                 match entry.get_data().len() {

--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -64,6 +64,7 @@ class Library:
 
 
 LIBRARY = Library(ctypes.CDLL)
+LIBRARY.call("pylogger_init", LOGGER.getEffectiveLevel())
 PY_LIBRARY = Library(ctypes.PyDLL)
 
 

--- a/validator/src/pylogger.rs
+++ b/validator/src/pylogger.rs
@@ -40,6 +40,16 @@ pub fn set_up_logger(verbosity: u64, py: Python) {
     warn!("Started logger at level {}", verbosity_level);
 }
 
+#[no_mangle]
+#[allow(unused)]
+#[allow(private_no_mangle_fns)]
+pub extern "C" fn pylogger_init(verbosity: usize) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    PyLogger::init(determine_log_level(verbosity as u64), py)
+        .expect("Failed to initialize PyLogger");
+}
+
 pub fn exception(py: Python, msg: &str, err: PyErr) {
     let logger = PyLogger::new(py).expect("Failed to create new PyLogger");
     logger.exception(py, msg, err);

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -393,7 +393,7 @@ impl MerkleDatabase {
                     return Err(StateDatabaseError::NotFound(format!(
                         "invalid address {} from root {}",
                         address, self.root_hash
-                    )))
+                    )));
                 }
                 Some(child_hash) => get_node_by_hash(&self.db, child_hash)?,
             }
@@ -425,7 +425,7 @@ impl MerkleDatabase {
                             "invalid address {} from root {}",
                             tokens.join(""),
                             self.root_hash
-                        )))
+                        )));
                     }
                     (false, false) => {
                         new_branch = true;


### PR DESCRIPTION
This reverts commit ba9517ec0937e0674ee561fdd6ee79d31d004f8c.

This restores proper logging in the rust code.  With the removal of this
init of pylogger, log messages from the lower layer (i.e. libsawtooth)
are not included in the logs.  This makes debugging difficult.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>