### PR TITLE
1-1 BACKPORT: Add consensus engine steps/info in Sys Admin Guide

### DIFF
--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -5,7 +5,7 @@ System Administrator's Guide
 This guide explains how to install, configure, and run Hyperledger Sawtooth
 on a Ubuntu system for proof-of-concept or production use in a Sawtooth network.
 
-It includes steps to configure a consensus mechanism, using PoET simulator
+It includes steps to configure a consensus algorithm, using PoET simulator
 consensus as an example, and to start the Sawtooth components as services.
 
 It also includes optional procedures to change the user, client, and validator

--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -10,7 +10,7 @@ Creating the Genesis Block
 
 The first node in a new Sawtooth network must create the genesis block to
 initialize the Settings transaction processor and specify the consensus
-mechanism. The settings in the genesis block enable other nodes to join the
+algorithm. The settings in the genesis block enable other nodes to join the
 network and use these on-chain settings.
 
 Before you start the first Sawtooth node, use this procedure to create and
@@ -65,7 +65,8 @@ submit the genesis block.
 
       [sawtooth@system]$ sawset proposal create --key /etc/sawtooth/keys/validator.priv \
       -o config.batch \
-      sawtooth.consensus.algorithm=poet \
+      sawtooth.consensus.algorithm.name=PoET \
+      sawtooth.consensus.algorithm.version=0.1 \
       sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
@@ -80,8 +81,11 @@ submit the genesis block.
    ``-o config.batch``
     Wraps the proposal transaction in a batch named ``config.batch``.
 
-   ``sawtooth.consensus.algorithm=poet``
+   ``sawtooth.consensus.algorithm.name=PoET``
     Changes the consensus algorithm to PoET.
+
+   ``sawtooth.consensus.algorithm.version=0.1``
+    Specifies the version of the consensus algorithm.
 
    ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)"``
     Adds the public key for the PoET Validator Registry transaction

--- a/docs/source/sysadmin_guide/installation.rst
+++ b/docs/source/sysadmin_guide/installation.rst
@@ -33,7 +33,8 @@ for proof-of-concept or production use in a Sawtooth network.
         $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
         $ sudo apt-add-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe'
 
-#. Update your package lists, then install Sawtooth.
+#. Update your package lists, then install Sawtooth and the PoET consensus
+   engine.
 
    .. code-block:: console
 

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -51,7 +51,8 @@ PoET Validator Registry transaction processors.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...

--- a/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
+++ b/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
@@ -18,8 +18,8 @@ on the first node.
 
 .. |Intel (R)| unicode:: Intel U+00AE .. registered copyright symbol
 
-Each node in this Sawtooth network runs a validator, a REST API, and the
-following transaction processors:
+Each node in this Sawtooth network runs a validator, a REST API, the PoET
+consensus engine, and the following transaction processors:
 
 * :doc:`Settings <../transaction_family_specifications/settings_transaction_family>`
   (``settings-tp``)

--- a/docs/source/sysadmin_guide/systemd.rst
+++ b/docs/source/sysadmin_guide/systemd.rst
@@ -4,7 +4,7 @@ Running Sawtooth as a Service
 
 When you installed Sawtooth with ``apt-get``, ``systemd`` units were added for
 the Sawtooth components (validator, REST API, transaction processors, and
-consensus engines). This procedure describes how to use the ``systemctl``
+consensus engine). This procedure describes how to use the ``systemctl``
 command to start, stop, and restart Sawtooth components as ``systemd`` services.
 
 To learn more about ``systemd`` and the ``systemctl`` command, see the `Digital
@@ -38,12 +38,13 @@ Use these commands to start each Sawtooth component as a service:
     $ sudo systemctl start sawtooth-identity-tp.service
     $ sudo systemctl start sawtooth-poet-engine.service
 
-This command starts the required transaction processors:
+These commands start the required transaction processors:
 PoET Validator Registry (``sawtooth-poet-validator-registry-tp``),
 Settings (``sawtooth-settings-tp``), and
-Identity (``sawtooth-identity-tp``).  It also starts the IntegerKey
+Identity (``sawtooth-identity-tp``). They also start the IntegerKey
 transaction processor (``sawtooth-intkey-tp-python``), which is used in a
 later procedure to test basic Sawtooth functionality.
+The last command starts the PoET consensus engine (``sawtooth-poet-engine``).
 
 
 Check Service Status


### PR DESCRIPTION
- Update the consensus settings and PoET consensus engine name
  in the genesis block procedure

- Update the example output in the testing procedure

- Correct the terminology (consensus engine, consensus algorithm)

- Update text to include the consensus engine component in
  descriptions and steps

Note: This is a subset of the doc changes from PR #1992 (in master). This
commit contains only the essential corrections needed for the 1-1 documentation.

Signed-off-by: Anne Chenette <chenette@bitwise.io>