### PR TITLE
Fix rust lint output formatting

### DIFF
--- a/bin/run_lint_rust
+++ b/bin/run_lint_rust
@@ -54,7 +54,7 @@ for dir in $dirs; do
         exitcode=1
         if [[ $rustfmt_exit == 1 ]]; then
           echo "Incorrect formatting: $dir (error code: $rustfmt_exit)"
-          echo -e $diff
+          echo "$diff"
         else
             echo "rustfmt encountered an operational error"
         fi

--- a/bin/run_lint_validator
+++ b/bin/run_lint_validator
@@ -43,7 +43,7 @@ for dir in $dirs; do
         exitcode=1
         if [[ $rustfmt_exit == 1 ]]; then
           echo "Incorrect formatting: $dir (error code: $rustfmt_exit)"
-          echo -e $diff
+          echo "$diff"
         else
             echo "rustfmt encountered an operational error"
         fi


### PR DESCRIPTION
Fix diff output formatting. Add quotes to avoid field splitting.
The diff shown by lint becomes unreadable otherwise.

Signed-off-by: Rajeev Ranjan <rajeev2.ranjan@intel.com>