### PR TITLE
Downgrade pylint dependency, typed_ast

### DIFF
--- a/docker/lint
+++ b/docker/lint
@@ -42,6 +42,7 @@ RUN apt-get install -y -q \
     python3-zmq \
     && pip3 install \
     pylint \
+    'typed_ast<1.3' \
     pycodestyle \
     bandit \
     coverage --upgrade


### PR DESCRIPTION
Due to changes to a pylint dependency, Python code that uses await and
async as method names, such as asyncio.await, as in Python3.4 fails to
parse with a syntax error. This was causing pyzmq imports to fail during
linting but not during runtime.

Signed-off-by: Boyd Johnson <bjohnson@bitwise.io>