### PR TITLE
Use new handler for consensus gossip messages

### DIFF
--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -37,6 +37,7 @@ from sawtooth_validator.gossip.permission_verifier import \
 from sawtooth_validator.gossip.permission_verifier import \
     NetworkConsensusPermissionHandler
 
+from sawtooth_validator.gossip.gossip_handlers import GossipConsensusHandler
 from sawtooth_validator.gossip.gossip_handlers import GossipBroadcastHandler
 from sawtooth_validator.gossip.gossip_handlers import \
     GossipMessageDuplicateHandler
@@ -242,6 +243,13 @@ def add(
         ),
         thread_pool)
 
+    # GOSSIP_MESSAGE ) Determines if this is a consensus message and notifies
+    # the consensus engine if it is
+    dispatcher.add_handler(
+        validator_pb2.Message.GOSSIP_MESSAGE,
+        GossipConsensusHandler(gossip=gossip, notifier=consensus_notifier),
+        thread_pool)
+
     # GOSSIP_MESSAGE ) Determines if we should broadcast the
     # message to our peers. It is important that this occur prior
     # to the sending of the message to the completer, as this step
@@ -250,10 +258,7 @@ def add(
     # should occur
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_MESSAGE,
-        GossipBroadcastHandler(
-            gossip=gossip,
-            completer=completer,
-            notifier=consensus_notifier),
+        GossipBroadcastHandler(gossip=gossip, completer=completer),
         thread_pool)
 
     # GOSSIP_MESSAGE ) Send message to completer


### PR DESCRIPTION
Instead of using the `GossipBroadcastHandler` to send peer messages to the consensus engine, use a new handler `GossipConsensusHandler`. Notifying the consensus engine isn't a "broadcast" function, so it should have a different handler. Now, the `GossipBroadcastHandler` will simply pass when it encounters a peer message.

In addition to being more correct and accurate from an understandability perspective, this change allows for correct behavior of the time-to-live (TTL) functionality for gossip. Without this change, if TTL is set to <= 1, consensus messages will never be delivered to the consensus engine. With this change, TTL can be set to any value and consensus messages will be unaffected.