### PR TITLE
Enable sawtooth process statistics in telegraf

### DIFF
--- a/docker/telegraf.conf
+++ b/docker/telegraf.conf
@@ -1735,14 +1735,14 @@
 
 
 # # Monitor process cpu and memory usage
-# [[inputs.procstat]]
+[[inputs.procstat]]
 #   ## Must specify one of: pid_file, exe, or pattern
 #   ## PID file to monitor process
 #   pid_file = "/var/run/nginx.pid"
 #   ## executable name (ie, pgrep <exe>)
 #   # exe = "nginx"
 #   ## pattern as argument for pgrep (ie, pgrep -f <pattern>)
-#   # pattern = "nginx"
+pattern = "(sawtooth-.*)$"
 #   ## user as argument for pgrep (ie, pgrep -u <user>)
 #   # user = "nginx"
 #
@@ -1754,7 +1754,7 @@
 #   ## comment this out if you want raw cpu_time stats
 #   fielddrop = ["cpu_time_*"]
 #   ## This is optional; moves pid into a tag instead of a field
-#   pid_tag = false
+pid_tag = true
 
 
 # # Read metrics from one or many prometheus clients


### PR DESCRIPTION
Enable sawtooth process statistics in telegraf, these can be then
tracked in grafana.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>