### PR TITLE
Ensure REST API works properly behind a Digest Auth proxy

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -244,6 +244,8 @@ test_integration() {
     copy_coverage .coverage.test_basic_auth_proxy
     run_docker_test test_transactor_permissioning
     copy_coverage .coverage.test_transactor_permissioning
+    run_docker_test test_digest_auth_proxy
+    copy_coverage .coverage.test_digest_auth_proxy
 }
 
 test_deployment() {

--- a/docker/apache-digest-auth-proxy
+++ b/docker/apache-digest-auth-proxy
@@ -1,0 +1,89 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds an image to be used in testing REST API behavior behind a proxy with
+#   Digest Authentication. Redirects from 'digest_auth_proxy/sawtooth' to
+#   'rest-api:8008' with both HTTP and HTTPS.
+#
+# Build:
+#   $ cd sawtooth-core/docker
+#   $ docker build . \
+#     -f apache-digest-auth-proxy \
+#     -t apache-digest-auth-proxy
+#
+# Run:
+#   $ cd sawtooth-core
+#   $ docker run -v $(pwd):/project/sawtooth-core \
+#     -v /var/run/docker.sock:/var/run/docker.sock \
+#     apache-digest-auth-proxy
+
+FROM ubuntu:bionic
+
+RUN apt-get update \
+    && apt-get install -y apache2 \
+    && a2enmod proxy_http \
+    && a2enmod headers \
+    && a2enmod ssl \
+    && a2enmod auth_digest
+
+RUN a2enmod auth_digest
+
+RUN openssl req -x509 -nodes -days 7300 -newkey rsa:2048 \
+    -keyout /tmp/.ssl.key -out /tmp/.ssl.crt \
+    -subj /C=US/ST=MN/L=Mpls/O=Sawtooth/CN=digest-auth-proxy
+
+RUN echo "sawtooth:realm:bd24b22203b23a5c90eb59aa1f388a69\n93\ne1a57" >/tmp/.password
+
+RUN echo "\
+\n\
+ServerName digest-auth-proxy\n\
+ServerAdmin sawtooth@sawtooth\n\
+DocumentRoot /var/www/html\n\
+\n\
+" >>/etc/apache2/apache2.conf
+
+RUN echo "\
+<VirtualHost *:80>\n\
+</VirtualHost>\n\
+\n\
+<VirtualHost *:443>\n\
+        SSLEngine on\n\
+        SSLCertificateFile /tmp/.ssl.crt\n\
+        SSLCertificateKeyFile /tmp/.ssl.key\n\
+        RequestHeader set X-Forwarded-Proto \"https\"\n\
+</VirtualHost>\n\
+\n\
+<Location />\n\
+        Options Indexes FollowSymLinks\n\
+        AuthType Digest\n\
+        AuthName \"realm\"\n\
+        AuthDigestDomain \"/\"\n\
+        AuthUserFile \"/tmp/.password\"\n\
+        Require user sawtooth\n\
+        Require all denied\n\
+</Location>\n\
+\n\
+ProxyPass /sawtooth http://rest-api:8008\n\
+ProxyPassReverse /sawtooth http://rest-api:8008\n\
+RequestHeader set X-Forwarded-Path \"/sawtooth\"\n\
+\n\
+" >/etc/apache2/sites-enabled/000-default.conf
+
+EXPOSE 80
+EXPOSE 443
+EXPOSE 8008
+
+CMD ["apachectl start"]

--- a/docker/compose/external.yaml
+++ b/docker/compose/external.yaml
@@ -27,6 +27,17 @@ services:
     image: apache-basic-auth-proxy:${ISOLATION_ID}
     container_name: apache-basic-auth-proxy-default
 
+  apache-digest-auth-proxy:
+    build:
+      context: ../
+      dockerfile: ./apache-digest-auth-proxy
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: apache-digest-auth-proxy:${ISOLATION_ID}
+    container_name: apache-digest-auth-proxy-default
+
   sawtooth-stats-grafana:
     build:
       context: ../

--- a/integration/sawtooth_integration/docker/test_digest_auth_proxy.yaml
+++ b/integration/sawtooth_integration/docker/test_digest_auth_proxy.yaml
@@ -1,0 +1,146 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+services:
+
+  settings-tp:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    depends_on:
+      - validator
+    command: settings-tp -vv -C tcp://validator:4004
+    stop_signal: SIGKILL
+
+  validator:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        sawadm keygen && \
+        sawset genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
+        sawtooth-validator -v \
+            --endpoint tcp://validator:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth0:8800 \
+            --bind consensus:tcp://eth0:5005 \
+    \""
+    stop_signal: SIGKILL
+
+  devmode:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator:5005 -v
+    stop_signal: SIGKILL
+
+  rest-api:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    depends_on:
+      - validator
+    command: sawtooth-rest-api -v --connect tcp://validator:4004 --bind rest-api:8008
+    stop_signal: SIGKILL
+
+  digest-auth-proxy:
+    build:
+      context: ../../..
+      dockerfile: ./docker/apache-digest-auth-proxy
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: apache-digest-auth-proxy:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 80
+      - 443
+      - 8008
+    depends_on:
+      - validator
+      - rest-api
+    command: "bash -c \"\
+        apachectl start && \
+        tail -f /dev/null \
+        \""
+    stop_signal: SIGKILL
+
+  test-digest-auth-proxy:
+    build:
+      context: ../../..
+      dockerfile: ./integration/sawtooth_integration/docker/integration-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: integration-tests:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 80
+      - 443
+    depends_on:
+      - validator
+      - rest-api
+      - digest-auth-proxy
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration/sawtooth_integration/tests
+        test_digest_auth_proxy.TestDigestAuth
+    stop_signal: SIGKILL
+    environment:
+      PYTHONPATH: "/project/sawtooth-core/sdk/python:\
+        /project/sawtooth-core/integration:"

--- a/integration/sawtooth_integration/tests/test_digest_auth_proxy.py
+++ b/integration/sawtooth_integration/tests/test_digest_auth_proxy.py
@@ -1,0 +1,87 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# pylint: disable=protected-access
+
+import unittest
+import logging
+import json
+from urllib.error import HTTPError
+from requests.auth import HTTPDigestAuth
+import requests
+
+from sawtooth_integration.tests.integration_tools import wait_until_status
+
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+
+
+class TestDigestAuth(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        wait_until_status('http://rest-api:8008/blocks', status_code=200)
+        wait_until_status('http://digest-auth-proxy/sawtooth', status_code=401)
+
+    def test_http_digest_auth(self):
+        """Checks that a Digest Auth request can be made with unencrypted HTTP.
+        """
+        url = 'http://digest-auth-proxy/sawtooth/blocks'
+        self._assert_valid_authed_request(url)
+
+    def test_ssl_digest_auth(self):
+        """Checks that a Digest Auth request can be made with encrypted HTTPS.
+        """
+        url = 'https://digest-auth-proxy/sawtooth/blocks'
+        self._assert_valid_authed_request(url)
+
+    def _assert_valid_authed_request(self, url):
+        """Asserts that a Digest Auth request was made successfully through a
+        proxy to the REST API, and that the returned "link" parameter properly
+        reflects the url of the proxy.
+
+        The proxy should redirect from the passed url's domain to
+        `http://rest-api:8008`, and be configured with a Digest Auth
+        username:password combination of 'sawtooth:sawtooth'.
+
+        In order to get back the correct link, the proxy must both forward the
+        host and add a custom RequestHeader of 'X-Forwarded-Path: /sawtooth'.
+        """
+        user = 'sawtooth'
+        pw = 'sawtooth'
+
+        try:
+            response = requests.get(url, auth=HTTPDigestAuth(user, pw),
+                                    verify=False)
+        except HTTPError as e:
+            LOGGER.error('An error occured while requesting "%s"', url)
+
+            try:
+                error = json.loads(e.file.read().decode())['error']
+                fail_msg = 'REST API Error: {} - {}:'.format(
+                    error['code'], error['title'])
+            except json.decoder.JSONDecodeError:
+                fail_msg = 'HTTP Error: {} - {}'.format(e.code, e.msg)
+
+            self.fail(fail_msg)
+
+        self.assertEqual(200, response.status_code)
+        LOGGER.info('Authorization succeeded, 200 response received.')
+
+        link = json.loads(response.text)['link']
+
+        LOGGER.info('Verifying link: "%s"', link)
+        self.assertTrue(link.startswith(url))
+        LOGGER.info('Link verified.')


### PR DESCRIPTION
Created a new integration test to test the REST API behind a Digest Auth
Proxy. Added proxy container docker-compose file for Digest Auth Proxy
to mimic basic-auth-proxy in docker/compose/external.yaml

Resolves: #STL-512
Signed-off-by: nickylimjj <nickylimjj.nl@gmail.com>