### PR TITLE
Add sawtooth-signing and cli to smallbank-workload

### DIFF
--- a/perf/smallbank_workload/Dockerfile-installed-bionic
+++ b/perf/smallbank_workload/Dockerfile-installed-bionic
@@ -14,6 +14,45 @@
 
 # docker build -f perf/smallbank_workload/Dockerfile-installed-bionic -t sawtooth-smallbank-workload .
 
+# -------------=== cli build ===-------------
+FROM ubuntu:bionic as cli-builder
+
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+ENV VERSION=AUTO_STRICT
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    git \
+    python3 \
+    python3-protobuf \
+    python3-stdeb \
+    python3-toml \
+    python3-grpcio-tools \
+    python3-grpcio
+
+COPY . /project
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && dpkg -i /tmp/python3-sawtooth-*.deb || true \
+ && apt-get -f -y install
+
+RUN /project/bin/protogen \
+ && cd /project/cli \
+ && if [ -d "debian" ]; then rm -rf debian; fi \
+ && python3 setup.py clean --all \
+ && python3 setup.py --command-packages=stdeb.command debianize \
+ && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
+ && dpkg-buildpackage -b -rfakeroot -us -uc
+
+
 # -------------=== smallbank workload build ===-------------
 FROM ubuntu:bionic as smallbank-workload-builder
 
@@ -49,8 +88,18 @@ RUN /root/.cargo/bin/cargo deb
 # -------------=== smallbank workload docker build ===-------------
 FROM ubuntu:bionic
 
+RUN apt-get update \
+ && apt-get install gnupg -y
+
+COPY --from=cli-builder /project/python3-sawtooth-cli* /tmp
 COPY --from=smallbank-workload-builder /project/perf/smallbank_workload/target/debian/sawtooth-smallbank-workload*.deb /tmp
 
-RUN apt-get update \
- && dpkg -i /tmp/sawtooth-smallbank-workload*.deb || true \
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-signing \
+ && dpkg -i /tmp/*sawtooth*.deb || true \
  && apt-get -f -y install

--- a/perf/smallbank_workload/Dockerfile-installed-xenial
+++ b/perf/smallbank_workload/Dockerfile-installed-xenial
@@ -14,6 +14,42 @@
 
 # docker build -f perf/smallbank_workload/Dockerfile-installed-xenial -t sawtooth-smallbank-workload .
 
+# -------------=== cli build ===-------------
+FROM ubuntu:xenial as cli-builder
+
+ENV VERSION=AUTO_STRICT
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && apt-get install -y -q \
+    git \
+    python3 \
+    python3-protobuf \
+    python3-stdeb \
+    python3-toml \
+    python3-grpcio-tools \
+    python3-grpcio
+
+COPY . /project
+
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD) \
+ && apt-get update \
+ && dpkg -i /tmp/python3-sawtooth-*.deb || true \
+ && apt-get -f -y install
+
+RUN /project/bin/protogen \
+ && cd /project/cli \
+ && if [ -d "debian" ]; then rm -rf debian; fi \
+ && python3 setup.py clean --all \
+ && python3 setup.py --command-packages=stdeb.command debianize \
+ && if [ -d "packaging/ubuntu" ]; then cp -R packaging/ubuntu/* debian/; fi \
+ && dpkg-buildpackage -b -rfakeroot -us -uc
+
+
 # -------------=== smallbank workload build ===-------------
 FROM ubuntu:xenial as smallbank-workload-builder
 
@@ -49,8 +85,15 @@ RUN /root/.cargo/bin/cargo deb
 # -------------=== smallbank workload docker build ===-------------
 FROM ubuntu:xenial
 
+COPY --from=cli-builder /project/python3-sawtooth-cli* /tmp
 COPY --from=smallbank-workload-builder /project/perf/smallbank_workload/target/debian/sawtooth-smallbank-workload*.deb /tmp
 
-RUN apt-get update \
- && dpkg -i /tmp/sawtooth-smallbank-workload*.deb || true \
+RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sources.list \
+ && echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial universe" >> /etc/apt/sources.list \
+ && (apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA \
+ || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD44FC67F19B2466EA) \
+ && apt-get update \
+ && apt-get install -y -q \
+    python3-sawtooth-signing \
+ && dpkg -i /tmp/*sawtooth*.deb || true \
  && apt-get -f -y install


### PR DESCRIPTION
This change adds sawtooth-cli to the smallbank-workload docker images. This
is necessary because smallbank-workload requires a private key at
runtime.

Signed-off-by: Richard Berg <rberg@bitwise.io>