### PR TITLE
Fix prune error

### DIFF
--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -132,11 +132,11 @@ impl MerkleDatabase {
             // deleting a parent
             let mut successor = change_log.take_successors().pop().unwrap();
 
+            let mut deletions = successor.take_deletions();
+            deletions.push(root_bytes.clone());
+
             let (deletion_candidates, duplicates): (Vec<Vec<u8>>, Vec<Vec<u8>>) =
-                MerkleDatabase::remove_duplicate_hashes(
-                    &mut db_writer,
-                    successor.take_deletions(),
-                )?;
+                MerkleDatabase::remove_duplicate_hashes(&mut db_writer, deletions)?;
 
             for hash in &deletion_candidates {
                 let hash_hex = ::hex::encode(hash);


### PR DESCRIPTION
This PR fixes a couple bugs in the merkle prune and tests.
In one of the cases for prunning, the root is supposed to be removed but that was not happening and the tests did not catch this error.