### PR TITLE
Upgrade packages to address High risk CVEs

### DIFF
--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -23,7 +23,7 @@ RUN apt-get update && \
 	libidn2-0 \
 	systemd \
 	udev \
-	perl-base \
+	perl-base && \
     rm -rf /var/lib/apt/lists/*
 
 COPY grafana/dashboards /etc/grafana/dashboards

--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -17,7 +17,13 @@ FROM grafana/grafana:4.6.3
 
 RUN apt-get update && \
     apt-get install -y \
-        curl && \
+	curl=7.38.0-4+deb8u14 \
+	apt=1.0.9.8.5 \
+	libidn11=1.29-1+deb8u3 \
+	libidn2-0=0.10-2+deb8u1 \
+	systemd=215-17+deb8u10 \
+	udev=215-17+deb8u10 \
+	perl-base=5.20.2-3+deb8u12 && \
     rm -rf /var/lib/apt/lists/*
 
 COPY grafana/dashboards /etc/grafana/dashboards

--- a/docker/grafana/sawtooth-stats-grafana
+++ b/docker/grafana/sawtooth-stats-grafana
@@ -17,13 +17,13 @@ FROM grafana/grafana:4.6.3
 
 RUN apt-get update && \
     apt-get install -y \
-	curl=7.38.0-4+deb8u14 \
-	apt=1.0.9.8.5 \
-	libidn11=1.29-1+deb8u3 \
-	libidn2-0=0.10-2+deb8u1 \
-	systemd=215-17+deb8u10 \
-	udev=215-17+deb8u10 \
-	perl-base=5.20.2-3+deb8u12 && \
+	curl \
+	apt \
+	libidn11 \
+	libidn2-0 \
+	systemd \
+	udev \
+	perl-base \
     rm -rf /var/lib/apt/lists/*
 
 COPY grafana/dashboards /etc/grafana/dashboards


### PR DESCRIPTION
Several high risk CVEs found in the sawtooth-stats-grafana image via Anchore scanning.  These vulnerabilities will prevent this image from being deployed in a highly locked down environment.

Signed-off-by: Kevin O'Donnell <kodonnel@gmail.com>