### PR TITLE
Return an error on an empty new chain

### DIFF
--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -264,6 +264,12 @@ impl<BC: BlockCache, BV: BlockValidator> ChainControllerState<BC, BV> {
         result.committed_batches = commit;
         result.uncommitted_batches = uncommit;
 
+        if result.new_chain.is_empty() {
+            return Err(ChainControllerError::ForkResolutionError(
+                "On fork comparison, new chain is empty".into(),
+            ));
+        }
+
         if result.new_chain[0].previous_block_id() != chain_head.header_signature() {
             let mut moved_to_fork_count =
                 COLLECTOR.counter("ChainController.chain_head_moved_to_fork_count", None, None);


### PR DESCRIPTION
Under certain circumstances, the validator will be told to compare chains by the consensus engine that will result in an empty new chain. If this is the case, checking index `0` will result in an index-out-of-bounds panic error.  Returning an error will be logged.

~Additionally, apply new rust format changes for the latest rust version.~