### PR TITLE
Filter out None when getting public keys in gossip

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -204,9 +204,13 @@ class Gossip:
     def get_peers_public_keys(self):
         """Returns the list of public keys for all peers."""
         with self._lock:
-            return [
-                self._network.connection_id_to_public_key(peer)
-                for peer in copy.copy(self._peers)]
+            # Use a generator inside the list comprehension to filter out None
+            # values in a single pass
+            return [key for key
+                    in (self._network.connection_id_to_public_key(peer)
+                        for peer
+                        in copy.copy(self._peers))
+                    if key is not None]
 
     @property
     def endpoint(self):


### PR DESCRIPTION
When returning a list of public keys in the `get_peers_public_keys`
method, `Gossip` should filter out None values.

This fixes a bug where consensus activation could not occur because None
values in the list would cause it to fail.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Corresponding 1.1 backport: #2038 