### PR TITLE
1.1 BACKPORT: Filter out None in consensus startup info's peers

### DIFF
--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -62,6 +62,7 @@ class ConsensusProxy:
             peers=[
                 self._gossip.peer_to_public_key(peer)
                 for peer in self._gossip.get_peers()
+                if peer is not None
             ],
             local_peer_info=self._public_key)
 


### PR DESCRIPTION
When the validator accepts a registration from a consensus engine, it
will return a list of its connected peers in a StartupState object.

This fixes a bug where, if the list of peers contained a None value,
registration would fail when it attempted to encode the public key as
hex.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Corresponding master PR: #2037 