### PR TITLE
Backport 1-1: Update docs for new consensus settings

### DIFF
--- a/docs/source/app_developers_guide/creating_sawtooth_network.rst
+++ b/docs/source/app_developers_guide/creating_sawtooth_network.rst
@@ -60,8 +60,8 @@ A Sawtooth network has the following requirements:
   ``trust`` authorization.
 
 * The genesis block is created for the first validator node only. It includes
-  on-chain configuration settings, such as the consensus type, that will be
-  available to the new validator nodes once they join the network.
+  on-chain configuration settings that will be available to the new validator
+  nodes once they join the network.
 
 .. note::
 
@@ -519,7 +519,8 @@ in :doc:`ubuntu`.
 
       $ sawset proposal create -k /etc/sawtooth/keys/validator.priv \
       -o config.batch \
-      sawtooth.consensus.algorithm=poet \
+      sawtooth.consensus.algorithm.name=PoET \
+      sawtooth.consensus.algorithm.version=0.1 \
       sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/simulator_rk_pub.pem)" \
       sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement) \
       sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
@@ -885,7 +886,8 @@ setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
@@ -1371,7 +1373,8 @@ Use the following steps to create and submit a batch containing the new setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm: poet
+      sawtooth.consensus.algorithm.name: PoET
+      sawtooth.consensus.algorithm.version: 0.1
       sawtooth.poet.initial_wait_time: 15
       sawtooth.poet.key_block_claim_limit: 100000
       sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...

--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -246,7 +246,8 @@ a ``GenesisData`` list of batches for the genesis block.
         $ sawset proposal create \
           -k <signing-key-file> \
           -o sawset.batch \
-          sawtooth.consensus.algorithm=poet \
+          sawtooth.consensus.algorithm.name=PoET \
+          sawtooth.consensus.algorithm.version=0.1 \
           sawtooth.poet.initial_wait_timer={value} \
           sawtooth.poet.target_wait_time={value} \
           sawtooth.poet.population_estimate_sample_size={value}
@@ -310,8 +311,7 @@ If any transactions in the genesis block set or change settings, Sawtooth
 requires the `Sawtooth Settings transaction processor <../cli/settings-tp>`_
 or an equivalent implementation.
 For example, if the genesis block configures PoET consensus, this transaction
-processor is handles the transactions with PoET settings. (If no
-consensus is specified, Sawtooth uses dev mode consensus.)
+processor handles the transactions with PoET settings.
 
 When the genesis block is committed, the consensus settings are stored in
 state. All subsequent blocks are processed with the configured consensus

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -239,7 +239,8 @@ Create and submit a proposal:
 .. code-block:: console
 
     [sawtooth@system]$ sawset proposal create -k /etc/sawtooth/keys/validator.priv \
-    sawtooth.consensus.algorithm=poet \
+    sawtooth.consensus.algorithm.name=PoET \
+    sawtooth.consensus.algorithm.version=0.1 \
     sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)" \
     sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement) \
     sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename) \
@@ -259,8 +260,11 @@ lines of output showing that the SGX enclave has been initialized:
     There’s quite a bit going on in the previous ``sawset proposal`` command, so
     let’s take a closer look at what it accomplishes:
 
-    ``sawtooth.consensus.algorithm=poet``
+    ``sawtooth.consensus.algorithm.name=PoET``
       Changes the consensus algorithm to PoET.
+
+    ``sawtooth.consensus.algorithm.version=0.1``
+      Changes the version of the consensus algorithm to 0.1.
 
     ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)"``
       Adds the public key that the validator registry transaction processor uses


### PR DESCRIPTION
Updates documentation to include information about the new consensus
engine settings, `sawtooth.consensus.algorithm.name` and
`sawtooth.consensus.algorithm.version`, and remove erroneous
information.

Signed-off-by: danintel <daniel.anderson@intel.com>