### PR TITLE
Update algorithm name, version settings for PBFT

### DIFF
--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -68,8 +68,8 @@ multiple keys to create the genesis block is outside the scope of this guide.
     .. code-block:: none
 
        [package]
-       name = "sawtooth-pbft-engine"
-       version = "0.1.0"
+       name = "pbft"
+       version = "0.1"
        ...
 
 #. Create batches for the required and optional consensus settings.
@@ -83,7 +83,7 @@ multiple keys to create the genesis block is outside the scope of this guide.
            [sawtooth@system]$ sawset proposal create \
            --key /etc/sawtooth/keys/validator.priv \
            -o config-consensus.batch \
-           sawtooth.consensus.algorithm.name=sawtooth-pbft-engine \
+           sawtooth.consensus.algorithm.name=pbft \
            sawtooth.consensus.algorithm.version=VERSION \
            sawtooth.consensus.pbft.peers=[VAL1KEY, VAL2KEY, VAL3KEY]
 

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -72,8 +72,8 @@ accepted transaction types to those from this network's transaction processors
 
      .. code-block:: console
 
-        sawtooth.consensus.algorithm.name=sawtooth-pbft-engine
-        sawtooth.consensus.algorithm.version=0.1.2
+        sawtooth.consensus.algorithm.name=pbft
+        sawtooth.consensus.algorithm.version=0.1
         sawtooth.consensus.pbft.peers=03e27504580fa15...
         sawtooth.consensus.pbft.block_duration=200
         sawtooth.consensus.pbft.checkpoint_period=100


### PR DESCRIPTION
Updates the values of `sawtooth.consensus.algorithm.name` and `.version`
for PBFT in the docs to be `pbft` and `0.1` respectively to match the
changes to the PBFT consensus engine. See:
https://github.com/hyperledger/sawtooth-pbft/pull/118

Signed-off-by: Logan Seeley <seeley@bitwise.io>