### PR TITLE
Use new handler for consensus gossip messages

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -222,11 +222,26 @@ class GossipBatchResponseHandler(Handler):
         return self._responder.get_request(batch_id)
 
 
+class GossipConsensusHandler(Handler):
+    def __init__(self, gossip, notifier):
+        self._gossip = gossip
+        self._notifier = notifier
+
+    def handle(self, connection_id, message_content):
+        obj, tag, _ = message_content
+
+        if tag == GossipMessage.CONSENSUS:
+            self._notifier.notify_peer_message(
+                message=obj,
+                sender_id=bytes.fromhex(
+                    self._gossip.peer_to_public_key(connection_id)))
+        return HandlerResult(status=HandlerStatus.PASS)
+
+
 class GossipBroadcastHandler(Handler):
-    def __init__(self, gossip, completer, notifier):
+    def __init__(self, gossip, completer):
         self._gossip = gossip
         self._completer = completer
-        self._notifier = notifier
 
     def handle(self, connection_id, message_content):
         obj, tag, ttl = message_content
@@ -248,10 +263,8 @@ class GossipBroadcastHandler(Handler):
             if not self._completer.get_block(obj.header_signature):
                 self._gossip.broadcast_block(obj, exclude, time_to_live=ttl)
         elif tag == GossipMessage.CONSENSUS:
-            self._notifier.notify_peer_message(
-                message=obj,
-                sender_id=bytes.fromhex(
-                    self._gossip.peer_to_public_key(connection_id)))
+            # We do not want to forward consensus messages
+            pass
         else:
             LOGGER.info("received %s, not BATCH or BLOCK or CONSENSUS", tag)
         return HandlerResult(status=HandlerStatus.PASS)

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -37,6 +37,7 @@ from sawtooth_validator.gossip.permission_verifier import \
 from sawtooth_validator.gossip.permission_verifier import \
     NetworkConsensusPermissionHandler
 
+from sawtooth_validator.gossip.gossip_handlers import GossipConsensusHandler
 from sawtooth_validator.gossip.gossip_handlers import GossipBroadcastHandler
 from sawtooth_validator.gossip.gossip_handlers import \
     GossipMessageDuplicateHandler
@@ -242,6 +243,13 @@ def add(
         ),
         thread_pool)
 
+    # GOSSIP_MESSAGE ) Determines if this is a consensus message and notifies
+    # the consensus engine if it is
+    dispatcher.add_handler(
+        validator_pb2.Message.GOSSIP_MESSAGE,
+        GossipConsensusHandler(gossip=gossip, notifier=consensus_notifier),
+        thread_pool)
+
     # GOSSIP_MESSAGE ) Determines if we should broadcast the
     # message to our peers. It is important that this occur prior
     # to the sending of the message to the completer, as this step
@@ -250,10 +258,7 @@ def add(
     # should occur
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_MESSAGE,
-        GossipBroadcastHandler(
-            gossip=gossip,
-            completer=completer,
-            notifier=consensus_notifier),
+        GossipBroadcastHandler(gossip=gossip, completer=completer),
         thread_pool)
 
     # GOSSIP_MESSAGE ) Send message to completer


### PR DESCRIPTION
Instead of using the `GossipBroadcastHandler` to send peer messages to
the consensus engine, use a new handler `GossipConsensusHandler`.
Notifying the consensus engine isn't a "broadcast" function, so it
should have a different handler. Now, the `GossipBroadcastHandler` will
simply pass when it encounters a peer message.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Backport of PR https://github.com/hyperledger/sawtooth-core/pull/2019