### PR TITLE
Fix terminology for PBFT member nodes (was peers)

### DIFF
--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -128,8 +128,8 @@ multiple keys to create the genesis block is outside the scope of this guide.
           Specifies the version of the consensus algorithm.
 
          (PBFT only) ``sawtooth.consensus.pbft.peers``
-          Lists the peer nodes on the initial network as a JSON-formatted string
-          of the validators' public keys, using the following format:
+          Lists the member nodes on the initial network as a JSON-formatted
+          string of the validators' public keys, using the following format:
 
           ``[<public-key-1>, <public-key-2>, ..., <public-key-n>]``
 

--- a/docs/source/sysadmin_guide/testing_sawtooth.rst
+++ b/docs/source/sysadmin_guide/testing_sawtooth.rst
@@ -46,7 +46,7 @@ to test basic Sawtooth functionality.
 
 #. (PBFT only) Ensure that the on-chain setting
    ``sawtooth.consensus.pbft.peers`` lists the validator public keys of all
-   peer nodes on the network.
+   PBFT member nodes on the network.
 
    a. Connect to the first validator node (the one that created the genesis
       block).


### PR DESCRIPTION
Sawtooth already uses the term "peer" for static/dynamic peering, so the
PBFT doc was overloading this term. This PR changes "peer" to "(PBFT) member node"
and adds a glossary definition for "member node".

Note: The PBFT documentation is fixed in a related-but-separate PR for
the hyperledger/sawtooth-pbft repo.

Signed-off-by: Anne Chenette <chenette@bitwise.io>