### PR TITLE
Xetex pdf

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -95,6 +95,7 @@ RUN apt-get update && apt-get install -y -q \
     texlive-latex-base \
     texlive-latex-extra \
     texlive-latex-recommended \
+    texlive-xetex \
     zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -140,7 +140,7 @@ latexpdf: templates cli
 	@mkdir -p source/_static
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
+	$(MAKE) PDFLATEX=xelatex -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 latexpdfja: templates cli


### PR DESCRIPTION
This solves a recent build error relating to unicode in the documentation.
03:57:57 Underfull \hbox (badness 10000) in paragraph at lines 545--548 03:57:57 []\T1/ptm/m/n/10 Generate sign-up data: $\OT1/cmr/m/n/10 (\OML/cmm/m/it/10 PPK; 03:57:57 report; PSEmanifest; sealedSignUpData\OT1/cmr/m/n/10 ) = 03:57:57 [6] [7] [8] [9] 03:57:57 03:57:57 ! Package inputenc Error: Unicode char σ (U+3C3) 03:57:57 (inputenc) not set up for use with LaTeX.

The error started after a upgrade to Sphinx 2.0.0 from 1.8.5