### PR TITLE
Consensus backwards compatibility fix

### DIFF
--- a/adm/build.rs
+++ b/adm/build.rs
@@ -29,6 +29,7 @@ use std::time::{Duration, UNIX_EPOCH};
 use protoc_rust::Customize;
 
 const PROTO_FILES_DIR: &str = "../protos";
+const SETTINGS_PROTO_FILES_DIR: &str = "../families/settings/protos";
 const PROTO_DIR_NAME: &str = "proto";
 const GENERATED_SOURCE_HEADER: &str = r#"
 /*
@@ -48,7 +49,11 @@ struct ProtoFile {
 
 fn main() {
     // Generate protobuf files
-    let proto_src_files = glob_simple(&format!("{}/*.proto", PROTO_FILES_DIR));
+    let mut proto_src_files = glob_simple(&format!("{}/*.proto", PROTO_FILES_DIR));
+    proto_src_files.append(&mut glob_simple(&format!(
+        "{}/*.proto",
+        SETTINGS_PROTO_FILES_DIR
+    )));
     let last_build_time = read_last_build_time();
 
     let latest_change =
@@ -74,7 +79,7 @@ fn main() {
                 .iter()
                 .map(|proto_file| proto_file.file_path.as_ref())
                 .collect::<Vec<&str>>(),
-            includes: &["src", PROTO_FILES_DIR],
+            includes: &["src", PROTO_FILES_DIR, SETTINGS_PROTO_FILES_DIR],
             customize: Customize::default(),
         })
         .expect("unable to run protoc");

--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -116,10 +116,12 @@ genesis block also includes the keys for the other nodes in the initial network.
        ``config-consensus.batch``.
 
       ``sawtooth.consensus.algorithm.name``
-       Specifies the consensus algorithm for this network.
+       Specifies the consensus algorithm for this network; this setting is
+       required.
 
       ``sawtooth.consensus.algorithm.version``
-       Specifies the version of the consensus algorithm.
+       Specifies the version of the consensus algorithm; this setting is
+       required.
 
       (PBFT only) ``sawtooth.consensus.pbft.members``
        Lists the member nodes on the initial network as a JSON-formatted
@@ -208,6 +210,12 @@ genesis block also includes the keys for the other nodes in the initial network.
        Processing config-consensus.batch...
        ...
        Generating /var/lib/sawtooth/genesis.batch
+
+   .. note::
+
+      The ``sawtooth.consensus.algorithm.name`` and
+      ``sawtooth.consensus.algorithm.version`` settings are required; ``sawadm
+      genesis`` will fail if they are not present in one of the batches.
 
 #. When this command finishes, the genesis block is complete. Log out of the
    ``sawtooth`` account.

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -199,6 +199,12 @@ Use the same terminal window as the previous step.
          sawtooth.consensus.algorithm.name=Devmode \
          sawtooth.consensus.algorithm.version=0.1 -o config.batch
 
+   .. note::
+
+      The ``sawtooth.consensus.algorithm.name`` and
+      ``sawtooth.consensus.algorithm.version`` settings are required; ``sawadm
+      genesis`` will fail if they are not present in one of the batches.
+
 #. Combine the previously created batches into a single genesis batch that will be committed in the genesis block:
 
    .. code-block:: console

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -374,4 +374,18 @@ def get_configured_engine(block, settings_view_factory):
     conf_version = settings_view.get_setting(
         'sawtooth.consensus.algorithm.version')
 
-    return conf_name, conf_version
+    # Fallback to devmode if nothing else is set
+    name = "Devmode"
+    version = "0.1"
+
+    # If name and version settings aren't set, check for PoET
+    if conf_name is None or conf_version is None:
+        algorithm = settings_view.get_setting('sawtooth.consensus.algorithm')
+        if algorithm and (algorithm.lower() == 'poet'):
+            name = "PoET"
+    # Otherwise use name and version settings
+    else:
+        name = conf_name
+        version = conf_version
+
+    return name, version

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -62,15 +62,8 @@ class ConsensusActivationObserver(ChainObserver):
                 break
 
     def _update_active_engine(self, block):
-        header = BlockHeader()
-        header.ParseFromString(block.header)
-        settings_view = self._settings_view_factory.create_settings_view(
-            header.state_root_hash)
-
-        conf_name = settings_view.get_setting(
-            'sawtooth.consensus.algorithm.name')
-        conf_version = settings_view.get_setting(
-            'sawtooth.consensus.algorithm.version')
+        conf_name, conf_version = get_configured_engine(
+            block, self._settings_view_factory)
 
         # Deactivate the old engine, if necessary
         old_engine_info = None
@@ -141,15 +134,8 @@ class ConsensusProxy:
                 engine_version)
             return
 
-        header = BlockHeader()
-        header.ParseFromString(chain_head.header)
-        settings_view = self._settings_view_factory.create_settings_view(
-            header.state_root_hash)
-
-        conf_name = settings_view.get_setting(
-            'sawtooth.consensus.algorithm.name')
-        conf_version = settings_view.get_setting(
-            'sawtooth.consensus.algorithm.version')
+        conf_name, conf_version = get_configured_engine(
+            chain_head, self._settings_view_factory)
 
         if engine_name == conf_name and engine_version == conf_version:
             try:
@@ -376,3 +362,16 @@ class ConsensusProxy:
             header_signature=signature)
 
         return message
+
+
+def get_configured_engine(block, settings_view_factory):
+    header = BlockHeader()
+    header.ParseFromString(block.header)
+    settings_view = settings_view_factory.create_settings_view(
+        header.state_root_hash)
+
+    conf_name = settings_view.get_setting('sawtooth.consensus.algorithm.name')
+    conf_version = settings_view.get_setting(
+        'sawtooth.consensus.algorithm.version')
+
+    return conf_name, conf_version


### PR DESCRIPTION
When consensus is not set on-chain, fall back to PoET if PoET settings are set, otherwise devmode