### PR TITLE
Remove futures from _SendReceive after a certain timeout.

### DIFF
--- a/validator/sawtooth_validator/networking/future.py
+++ b/validator/sawtooth_validator/networking/future.py
@@ -35,7 +35,7 @@ class FutureTimeoutError(Exception):
 
 class Future:
     def __init__(self, correlation_id, request=None, callback=None,
-                 timer_ctx=None):
+                 timeout=None, timer_ctx=None):
         self.correlation_id = correlation_id
         self._request = request
         self._result = None
@@ -43,6 +43,7 @@ class Future:
         self._create_time = time.time()
         self._callback_func = callback
         self._reconcile_time = None
+        self._timeout = timeout
         self._timer_ctx = timer_ctx
 
     def done(self):
@@ -83,6 +84,11 @@ class Future:
 
     def get_duration(self):
         return self._reconcile_time - self._create_time
+
+    def is_expired(self):
+        if self._result is None and self._timeout is not None:
+            return (time.time() - self._create_time) > self._timeout
+        return False
 
     def timer_stop(self):
         if self._timer_ctx:
@@ -125,3 +131,20 @@ class FutureCollection:
         except KeyError:
             raise FutureCollectionKeyError(
                 "no such correlation id: {}".format(correlation_id))
+
+    def remove_expired(self):
+        correlation_ids = [
+            correlation_id
+            for correlation_id, future
+            in self._futures.items()
+            if future.is_expired()
+        ]
+        for correlation_id in correlation_ids:
+            self._futures[correlation_id].timer_stop()
+            del self._futures[correlation_id]
+
+    def clean(self):
+        correlation_ids = list(self._futures.keys())
+        for correlation_id in correlation_ids:
+            self._futures[correlation_id].timer_stop()
+            del self._futures[correlation_id]


### PR DESCRIPTION
Some futures produced during peering attempts were never resolved and
_SendReceive did not clean them up in any way. On a longer time scale,
this was leading to excessive memory usage by the validator service.

This commit adds the possibility to set a timeout for a Future object.
If a timeout was set for a Future, FutureCollection is able to clean
that future after a timeout when the remove_expired method is called.
This method is called periodically by _SendReceive (the timeout is equal
to connection_timeout).

Also, futures are explicitly removed when stopping an
OutboundConnection.

Signed-off-by: Yevhenii Babichenko <babichenko@482.solutions>