### PR TITLE
Update name of on-chain PBFT members list

### DIFF
--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -85,7 +85,7 @@ multiple keys to create the genesis block is outside the scope of this guide.
            -o config-consensus.batch \
            sawtooth.consensus.algorithm.name=pbft \
            sawtooth.consensus.algorithm.version=VERSION \
-           sawtooth.consensus.pbft.peers=[VAL1KEY, VAL2KEY, VAL3KEY]
+           sawtooth.consensus.pbft.members=[VAL1KEY, VAL2KEY, VAL3KEY]
 
         Replace ``VERSION`` with the version number from
         ``sawtooth-pbft/Cargo.toml``.
@@ -127,7 +127,7 @@ multiple keys to create the genesis block is outside the scope of this guide.
          ``sawtooth.consensus.algorithm.version``
           Specifies the version of the consensus algorithm.
 
-         (PBFT only) ``sawtooth.consensus.pbft.peers``
+         (PBFT only) ``sawtooth.consensus.pbft.members``
           Lists the member nodes on the initial network as a JSON-formatted
           string of the validators' public keys, using the following format:
 

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -74,7 +74,7 @@ accepted transaction types to those from this network's transaction processors
 
         sawtooth.consensus.algorithm.name=pbft
         sawtooth.consensus.algorithm.version=0.1
-        sawtooth.consensus.pbft.peers=03e27504580fa15...
+        sawtooth.consensus.pbft.members=03e27504580fa15...
         sawtooth.consensus.pbft.block_duration=200
         sawtooth.consensus.pbft.checkpoint_period=100
         sawtooth.consensus.pbft.view_change_timeout=4000

--- a/docs/source/sysadmin_guide/testing_sawtooth.rst
+++ b/docs/source/sysadmin_guide/testing_sawtooth.rst
@@ -45,7 +45,7 @@ to test basic Sawtooth functionality.
       * PoET requires at least three nodes.
 
 #. (PBFT only) Ensure that the on-chain setting
-   ``sawtooth.consensus.pbft.peers`` lists the validator public keys of all
+   ``sawtooth.consensus.pbft.members`` lists the validator public keys of all
    PBFT member nodes on the network.
 
    a. Connect to the first validator node (the one that created the genesis
@@ -62,7 +62,7 @@ to test basic Sawtooth functionality.
 
       .. code-block:: console
 
-         sawtooth.consensus.pbft.peers=03e27504580fa15...
+         sawtooth.consensus.pbft.members=03e27504580fa15...
 
    #. To change the setting, run this command on the same node that created the
       genesis block:
@@ -71,7 +71,7 @@ to test basic Sawtooth functionality.
 
          [sawtooth@system]$ sawset proposal create \
          --key /etc/sawtooth/keys/validator.priv \
-         sawtooth.consensus.pbft.peers=[VAL1KEY, VAL2KEY, VAL3KEY]
+         sawtooth.consensus.pbft.members=[VAL1KEY, VAL2KEY, VAL3KEY]
 
       Replace ``VAL1KEY``, ``VAL2KEY``, and ``VAL3KEY``, with the
       validator public keys of the other nodes on the network. This


### PR DESCRIPTION
Updates docs to reflect change to the name of the on-chain list of
members in a PBFT network. Corresponds to this PBFT PR:
https://github.com/hyperledger/sawtooth-pbft/pull/126

Signed-off-by: Logan Seeley <seeley@bitwise.io>