### PR TITLE
Run docker-compose down on run-lint.yaml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -151,6 +151,7 @@ pipeline {
     post {
         always {
             sh 'docker-compose -f docker/compose/sawtooth-build.yaml down'
+            sh 'docker-compose -f docker/compose/run-lint.yaml down'
             sh 'docker-compose -f docker/compose/copy-debs.yaml down'
         }
         success {


### PR DESCRIPTION
The containers lint-validator_1, lint-rust_1, and lint-python_1 were
being left over after the build completes, this change removes these
containers.

Signed-off-by: Richard Berg <rberg@bitwise.io>