### PR TITLE
Allow re-registering consensus engines

### DIFF
--- a/validator/sawtooth_validator/consensus/registry.py
+++ b/validator/sawtooth_validator/consensus/registry.py
@@ -40,6 +40,10 @@ class ConsensusRegistry:
 
     def register_engine(self, connection_id, name, version):
         with self._lock:
+            # If this engine is already registered, remove the old connection
+            self._registry = list(filter(
+                lambda e: e.name != name and e.version != version,
+                self._registry))
             self._registry.append(EngineInfo(connection_id, name, version))
 
     def activate_engine(self, name, version):


### PR DESCRIPTION
To support a consensus engine restarting independently of the validator,
the consensus registry must be able to register a conensus engine again.
When this happens, the engine will register with the same name and
version, but a different connection ID. The registry will simply remove
any old entries associated with the engine name and version before
adding the engine to the registry.

Signed-off-by: Logan Seeley <seeley@bitwise.io>