### PR TITLE
Improve consensus engine behaviour between registration and activation

### DIFF
--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -151,28 +151,6 @@ class ConsensusRegisterActivateHandler(Handler):
         return HandlerResult(status=HandlerStatus.PASS)
 
 
-class ConsensusRegisterBlockNewSyncHandler(Handler):
-    def __init__(self, proxy, consensus_notifier):
-        self._proxy = proxy
-        self._consensus_notifier = consensus_notifier
-        self._request_type = validator_pb2.Message.CONSENSUS_REGISTER_REQUEST
-
-    @property
-    def request_type(self):
-        return self._request_type
-
-    def handle(self, connection_id, message_content):
-        forks = self._proxy.forks()
-
-        if not forks:
-            return HandlerResult(status=HandlerStatus.PASS)
-
-        for block in forks:
-            self._consensus_notifier.notify_block_new(block)
-
-        return HandlerResult(status=HandlerStatus.PASS)
-
-
 class ConsensusSendToHandler(ConsensusServiceHandler):
     def __init__(self, proxy):
         super().__init__(

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -16,6 +16,10 @@
 import hashlib
 import logging
 
+from sawtooth_validator.journal.chain import ChainObserver
+from sawtooth_validator.journal.event_extractors import \
+    ReceiptEventExtractor
+from sawtooth_validator.server.events.subscription import EventSubscription
 from sawtooth_validator.protobuf.block_pb2 import BlockHeader
 from sawtooth_validator.protobuf.consensus_pb2 import ConsensusPeerMessage
 from sawtooth_validator.protobuf.consensus_pb2 import \
@@ -27,6 +31,73 @@ LOGGER = logging.getLogger(__name__)
 
 class UnknownBlock(Exception):
     """The given block could not be found."""
+
+
+class ConsensusActivationObserver(ChainObserver):
+    """Observes chain updates and activates new engines, when the settings
+    have been updated in state, as of the commit."""
+
+    def __init__(self, consensus_registry, consensus_notifier,
+                 settings_view_factory):
+        self._registry = consensus_registry
+        self._notifier = consensus_notifier
+        self._settings_view_factory = settings_view_factory
+
+    def chain_update(self, block, receipts):
+        # Check to see if there is an active engine at all:
+        if not self._registry.has_active_engine():
+            self._update_active_engine(block)
+            return
+
+        # Otherwise, check to see if the settings changed, before updating
+        # the active engine.
+        receipt_events = ReceiptEventExtractor(receipts).extract([
+            EventSubscription(event_type="setting/update")])
+
+        for event in receipt_events:
+            if self._is_consensus_algorithm_setting(event):
+                self._update_active_engine(block)
+                break
+
+    def _update_active_engine(self, block):
+        header = BlockHeader()
+        header.ParseFromString(block.header)
+        settings_view = self._settings_view_factory.create_settings_view(
+            header.state_root_hash)
+
+        conf_name = settings_view.get_setting(
+            'sawtooth.consensus.algorithm.name')
+        conf_version = settings_view.get_setting(
+            'sawtooth.consensus.algorithm.version')
+
+        if not self._registry.is_active_engine_name_version(
+                conf_name, conf_version):
+
+            # Deactivate the old engine, if necessary
+            old_engine_info = None
+            if self._registry.has_active_engine():
+                old_engine_info = self._registry.get_active_engine_info()
+
+            self._registry.activate_engine(conf_name, conf_version)
+
+            if old_engine_info is not None:
+                self._notifier.notify_engine_deactivated(
+                    old_engine_info.connection_id)
+            self._notifier.notify_engine_activated(block)
+
+            LOGGER.info(
+                "Consensus engine %s %s activated as of block %s",
+                conf_name,
+                conf_version,
+                block.header_signature)
+
+    def _is_consensus_algorithm_setting(self, event):
+        if event.event_type != 'setting/update':
+            return False
+
+        key = event.attributes[0].value
+        return key in ('sawtooth.consensus.algorithm.name',
+                       'sawtooth.consensus.algorithm.version')
 
 
 class ConsensusProxy:
@@ -54,12 +125,15 @@ class ConsensusProxy:
 
     def activate_if_configured(self, engine_name, engine_version):
         # Wait until chain head is committed
-        chain_head = None
-        while chain_head is None:
-            try:
-                chain_head = self.chain_head_get()
-            except UnknownBlock:
-                pass
+        try:
+            chain_head = self.chain_head_get()
+        except UnknownBlock:
+            LOGGER.debug(
+                "Unable to determine if engine %s %s is configured until "
+                "chain head received",
+                engine_name,
+                engine_version)
+            return
 
         header = BlockHeader()
         header.ParseFromString(chain_head.header)

--- a/validator/sawtooth_validator/consensus/registry.py
+++ b/validator/sawtooth_validator/consensus/registry.py
@@ -21,6 +21,10 @@ class EngineNotRegistered(Exception):
     """The engine is not registered."""
 
 
+class EngineAlreadyActive(Exception):
+    """The engine is already active."""
+
+
 EngineInfo = namedtuple('EngineInfo', ['connection_id', 'name', 'version'])
 
 
@@ -51,9 +55,13 @@ class ConsensusRegistry:
 
     def activate_engine(self, name, version):
         with self._lock:
-            # If there is already an active engine, remove it
             if self._active is not None:
-                self._active = None
+                if (self._active.name == name
+                        and self._active.version == version):
+                    raise EngineAlreadyActive()
+                else:
+                    # A different engine is active; remove it
+                    self._active = None
             try:
                 self._active = next(
                     e for e in self._registry

--- a/validator/sawtooth_validator/consensus/registry.py
+++ b/validator/sawtooth_validator/consensus/registry.py
@@ -35,6 +35,9 @@ class ConsensusRegistry:
         self._lock = RLock()
 
     def __bool__(self):
+        return self.has_active_engine()
+
+    def has_active_engine(self):
         with self._lock:
             return self._active is not None
 

--- a/validator/sawtooth_validator/server/consensus_handlers.py
+++ b/validator/sawtooth_validator/server/consensus_handlers.py
@@ -29,10 +29,6 @@ def add(
     handler = handlers.ConsensusRegisterActivateHandler(consensus_proxy)
     dispatcher.add_handler(handler.request_type, handler, thread_pool)
 
-    handler = handlers.ConsensusRegisterBlockNewSyncHandler(
-        consensus_proxy, consensus_notifier)
-    dispatcher.add_handler(handler.request_type, handler, thread_pool)
-
     handler = handlers.ConsensusSendToHandler(consensus_proxy)
     dispatcher.add_handler(handler.request_type, handler, thread_pool)
 

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -25,6 +25,7 @@ from sawtooth_validator.concurrent.threadpool import \
 from sawtooth_validator.execution.context_manager import ContextManager
 from sawtooth_validator.consensus.notifier import ConsensusNotifier
 from sawtooth_validator.consensus.proxy import ConsensusProxy
+from sawtooth_validator.consensus.proxy import ConsensusActivationObserver
 from sawtooth_validator.consensus.registry import ConsensusRegistry
 from sawtooth_validator.database.lmdb_nolock_database import LMDBNoLockDatabase
 from sawtooth_validator.database.native_lmdb import NativeLmdbDatabase
@@ -253,6 +254,11 @@ class Validator:
             consensus_registry,
             identity_signer.get_public_key().as_hex())
 
+        consensus_activation_observer = ConsensusActivationObserver(
+            consensus_registry,
+            consensus_notifier,
+            settings_view_factory=SettingsViewFactory(state_view_factory))
+
         # -- Setup P2P Networking -- #
         gossip = Gossip(
             network_service,
@@ -353,7 +359,8 @@ class Validator:
                 receipt_store,
                 batch_tracker,
                 identity_observer,
-                settings_observer
+                settings_observer,
+                consensus_activation_observer
             ])
 
         genesis_controller = GenesisController(

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -766,6 +766,9 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
 
                 info!("Chain head updated to {}", &block);
 
+                self.consensus_notifier
+                    .notify_block_commit(&block.header_signature);
+
                 let mut chain_head_gauge =
                     COLLECTOR.gauge("ChainController.chain_head", None, None);
                 chain_head_gauge.set_value(&block.header_signature[0..8]);
@@ -850,9 +853,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                 break;
             }
         }
-
-        self.consensus_notifier
-            .notify_block_commit(&block.header_signature);
 
         Ok(())
     }

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -317,10 +317,11 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
             .read()
             .expect("No lock holder should have poisoned the lock");
 
-        state
-            .chain_reader
-            .chain_head()
-            .expect("Invalid block store. Head of the block chain cannot be determined")
+        if let Some(head) = &state.chain_head {
+            self.get_block(head.block_id())
+        } else {
+            None
+        }
     }
 
     pub fn block_validation_result(&self, block_id: &str) -> Option<BlockValidationResult> {


### PR DESCRIPTION
This PR removes the NewBlockSync handler when an engine registered, which would send all forks to the engine, whether they had been validated or not.  This broke the contract with consensus engines (as it currently stands) and would cause problems with PoET networks during catch up.

While there is no active consensus engine, the notifications are queued, with activation messages having priority.

Instead of busy-waiting for the genesis block, this PR includes a new ChainObserver that will activate the configured engine, if those settings have changed.

Additionally, a timeout has been added on the notification send's expected result, so as not to hang threads while waiting on a response that might never come.