### PR TITLE
1-1 BACKPORT: Fix TxnExecutionResult.data field

### DIFF
--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -425,7 +425,6 @@ class ContextManager:
 
         Args:
             context_id (str): the context id returned by create_context
-            data_type (str): type of data to append
             data (bytes): data to append
 
         Returns:

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -932,7 +932,7 @@ impl<'a> From<&'a TxnExecutionResult> for TransactionReceipt {
         let mut receipt = TransactionReceipt::new();
 
         receipt.set_data(protobuf::RepeatedField::from_vec(
-            result.data.iter().map(|(_, data)| data.clone()).collect(),
+            result.data.iter().map(|data| data.clone()).collect(),
         ));
         receipt.set_state_changes(protobuf::RepeatedField::from_vec(
             result.state_changes.clone(),

--- a/validator/src/scheduler/execution_result_ffi.rs
+++ b/validator/src/scheduler/execution_result_ffi.rs
@@ -38,7 +38,7 @@ pub struct PyTxnExecutionResult {
     pub state_hash: Option<String>,
     pub state_changes: Vec<StateChange>,
     pub events: Vec<Event>,
-    pub data: Vec<(String, Vec<u8>)>,
+    pub data: Vec<Vec<u8>>,
     pub error_message: String,
     pub error_data: Vec<u8>,
 }

--- a/validator/src/scheduler/mod.rs
+++ b/validator/src/scheduler/mod.rs
@@ -60,7 +60,7 @@ pub struct TxnExecutionResult {
     pub is_valid: bool,
     pub state_changes: Vec<StateChange>,
     pub events: Vec<Event>,
-    pub data: Vec<(String, Vec<u8>)>,
+    pub data: Vec<Vec<u8>>,
     pub error_message: String,
     pub error_data: Vec<u8>,
 }


### PR DESCRIPTION
Fixes the `TxnExecutionResult.data` to be consistent. Before this
change, some components assumed this field was a list of
(data type,bytes) pairs, others assumed it was just a list of bytes.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

Corresponding master PR: #2064