### PR TITLE
Telemetry docs

### DIFF
--- a/docs/source/sysadmin_guide/grafana_configuration.rst
+++ b/docs/source/sysadmin_guide/grafana_configuration.rst
@@ -43,7 +43,7 @@ InfluxDB is used to store Sawtooth metrics data.
 
    .. code-block:: console
 
-      $ docker pull influxdb
+      $ docker pull influxdb:1.5-alpine
 
 #. Create an InfluxDB data directory to provide persistent storage on the local
    file system.

--- a/docs/source/sysadmin_guide/grafana_configuration.rst
+++ b/docs/source/sysadmin_guide/grafana_configuration.rst
@@ -41,6 +41,12 @@ InfluxDB is used to store Sawtooth metrics data.
 
 #. Pull the InfluxDB Docker image from Docker Hub.
 
+   .. note::
+
+      The version of InfluxDB noted below has been validated in multi-node
+      environments. Newer versions of InfluxDB may result in `HTTP 500` errors
+      in the Docker container.
+
    .. code-block:: console
 
       $ docker pull influxdb:1.5-alpine


### PR DESCRIPTION
# CHANGES

`grafana`
- Add specific version; last version of these docs are 2 minor patches behind - however, lots of HTTP 500s in the Influx DB host during ingestion on N+1 nodes. Defining this version and adding nodes works **wonderfully**
- Define a safe/sane version