### PR TITLE
Update smallbank-workload to install the sdk

### DIFF
--- a/perf/smallbank_workload/Dockerfile-installed-bionic
+++ b/perf/smallbank_workload/Dockerfile-installed-bionic
@@ -100,6 +100,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci bionic universe" >> /etc/apt/sou
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD 44FC67F19B2466EA) \
  && apt-get update \
  && apt-get install -y -q \
-    python3-sawtooth-signing \
+    python3-sawtooth-sdk \
  && dpkg -i /tmp/*sawtooth*.deb || true \
  && apt-get -f -y install

--- a/perf/smallbank_workload/Dockerfile-installed-xenial
+++ b/perf/smallbank_workload/Dockerfile-installed-xenial
@@ -94,6 +94,6 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/ci xenial universe" >> /etc/apt/sou
  || apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 8AA7AF1F1091A5FD44FC67F19B2466EA) \
  && apt-get update \
  && apt-get install -y -q \
-    python3-sawtooth-signing \
+    python3-sawtooth-sdk \
  && dpkg -i /tmp/*sawtooth*.deb || true \
  && apt-get -f -y install


### PR DESCRIPTION
This fixes an error in the sawtooth cli that the sdk is missing.

Signed-off-by: Richard Berg <rberg@bitwise.io>