### PR TITLE
Raise and handle EngineNotRegistered

### DIFF
--- a/validator/sawtooth_validator/consensus/registry.py
+++ b/validator/sawtooth_validator/consensus/registry.py
@@ -67,8 +67,7 @@ class ConsensusRegistry:
                     e for e in self._registry
                     if e.name == name and e.version == version)
             except StopIteration:
-                # If engine isn't registered, just leave _active as None
-                pass
+                raise EngineNotRegistered()
 
     def deactivate_current_engine(self):
         with self._lock:


### PR DESCRIPTION
Raise an `EngineNotRegistered` exception when attempting to activate a consensus engine that has not been registered.  This will inform the callers not to do any following activities for the engine (like sending it a notification) if it hasn't yet connected.

Fixes an issue where duplicate activations were being sent to the engine due to the notifier queuing messages when there was no active engine.