### PR TITLE
Correct step number in BlockInfo txn family spec

### DIFF
--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -53,7 +53,7 @@ as follows:
 
   1. Convert block_num to a hex string and remove the leading “0x”
   2. Left pad the string with 0s until it is 62 characters long
-  3. Concatenate the block info namespace and the string from step 3
+  3. Concatenate the block info namespace and the string from step 2
 
 For example, in Python the address could be constructed with:
 


### PR DESCRIPTION
Signed-off-by: Anne Chenette <chenette@bitwise.io>