### PR TITLE
Replace unix with not wasm32 in platform-specific dependencies

### DIFF
--- a/families/block_info/sawtooth_block_info/Cargo.toml
+++ b/families/block_info/sawtooth_block_info/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.3"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.1.3"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = "0.2"
 rust-crypto = "0.2"
 rustc-serialize = "0.3"

--- a/families/identity/sawtooth_identity/Cargo.toml
+++ b/families/identity/sawtooth_identity/Cargo.toml
@@ -33,7 +33,7 @@ protobuf = "2.0"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.1.3"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 log = "0.3"
 log4rs = "0.7"
 rust-crypto = "0.2"

--- a/families/settings/sawtooth_settings/Cargo.toml
+++ b/families/settings/sawtooth_settings/Cargo.toml
@@ -49,7 +49,7 @@ log = "0.3"
 rust_crypto = {git = "https://github.com/agunde406/rust-crypto", branch="wasm_sha2"}
 sabre-sdk = "0.1.3"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 sawtooth-sdk = "0.2"
 rust-crypto = "0.2"
 rustc-serialize = "0.3"


### PR DESCRIPTION
This will allow sabre smart contracts to be compiled on more
platforms when not compiling into wasm.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>

To test: Add the wasm32 target rustup target add wasm32-unknown-unknown --toolchain nightly and run both cargo build and cargo +nightly build --target wasm32-unknown-unknown (in the respective directories). Both should pass.