### PR TITLE
 Make sawadm genesis required settings optional

### DIFF
--- a/adm/src/commands/genesis.rs
+++ b/adm/src/commands/genesis.rs
@@ -76,7 +76,9 @@ pub fn run<'a>(args: &ArgMatches<'a>) -> Result<(), CliError> {
         });
 
     validate_depedencies(&batches)?;
-    check_required_settings(&batches)?;
+    if !args.is_present("ignore_required_settings") {
+        check_required_settings(&batches)?;
+    }
 
     let mut genesis_data = GenesisData::new();
     genesis_data.set_batches(protobuf::RepeatedField::from_vec(batches));

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -110,7 +110,7 @@ fn parse_args<'a>() -> ArgMatches<'a> {
             (@arg input_file:
              +takes_value ... "file or files containing batches to add to the resulting")
             (@arg output: -o --output "choose the output file for GenesisData")
-            (@arg ignore_required_settings: --ignore-required-settings
+            (@arg ignore_required_settings: --("ignore-required-settings")
              "skip the check for settings that are required at genesis (necessary if using a
               settings transaction family other than sawtooth_settings)"))
         (@arg verbose: -v... "increase the logging level.")

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -109,7 +109,10 @@ fn parse_args<'a>() -> ArgMatches<'a> {
             (about: "creates the genesis.batch file for initializing the validator")
             (@arg input_file:
              +takes_value ... "file or files containing batches to add to the resulting")
-            (@arg output: -o --output "choose the output file for GenesisData"))
+            (@arg output: -o --output "choose the output file for GenesisData")
+            (@arg ignore_required_settings: --ignore-required-settings
+             "skip the check for settings that are required at genesis (necessary if using a
+              settings transaction family other than sawtooth_settings)"))
         (@arg verbose: -v... "increase the logging level.")
     );
     app.get_matches()

--- a/adm/src/main.rs
+++ b/adm/src/main.rs
@@ -107,8 +107,8 @@ fn parse_args<'a>() -> ArgMatches<'a> {
             (@arg quiet: -q --quiet "do not display output"))
         (@subcommand genesis =>
             (about: "creates the genesis.batch file for initializing the validator")
-         (@arg input_file:
-          +takes_value ... "file or files containing batches to add to the resulting")
+            (@arg input_file:
+             +takes_value ... "file or files containing batches to add to the resulting")
             (@arg output: -o --output "choose the output file for GenesisData"))
         (@arg verbose: -v... "increase the logging level.")
     );

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -39,12 +39,13 @@ def add_genesis_parser(subparsers, parent_parser):
         'initializing the validator.',
         epilog='This command generates a serialized GenesisData protobuf '
         'message and stores it in the genesis.batch file. One or more input '
-        'files (optional) can contain serialized BatchList protobuf messages '
-        'to add to the GenesisData. The output shows the location of this '
-        'file. By default, the genesis.batch file is stored in '
-        '/var/lib/sawtooth. If $SAWTOOTH_HOME is set, the location is '
+        'files contain serialized BatchList protobuf messages to add to the '
+        'GenesisData. The output shows the location of this file. By default, '
+        'the genesis.batch file is stored in /var/lib/sawtooth. If '
+        '$SAWTOOTH_HOME is set, the location is '
         '$SAWTOOTH_HOME/data/genesis.batch. Use the --output option to change '
-        'the name of the file.',
+        'the name of the file. The following settings must be present in the '
+        'input batches:\n{}\n'.format(REQUIRED_SETTINGS),
         parents=[parent_parser])
 
     parser.add_argument(

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -24,6 +24,11 @@ from sawtooth_cli.protobuf.settings_pb2 import SettingsPayload
 from sawtooth_cli.protobuf.transaction_pb2 import TransactionHeader
 
 
+REQUIRED_SETTINGS = [
+    'sawtooth.consensus.algorithm.name',
+    'sawtooth.consensus.algorithm.version']
+
+
 def add_genesis_parser(subparsers, parent_parser):
     """Creates the arg parsers needed for the genesis command.
     """
@@ -129,10 +134,7 @@ def _validate_depedencies(batches):
 
 def _check_required_settings(batches):
     """Ensure that all settings required at genesis are set."""
-    required_settings = [
-        'sawtooth.consensus.algorithm.name',
-        'sawtooth.consensus.algorithm.version']
-
+    required_settings = REQUIRED_SETTINGS.copy()
     for batch in batches:
         for txn in batch.transactions:
             txn_header = TransactionHeader()

--- a/cli/sawtooth_cli/admin_command/genesis.py
+++ b/cli/sawtooth_cli/admin_command/genesis.py
@@ -54,6 +54,13 @@ def add_genesis_parser(subparsers, parent_parser):
         help='file or files containing batches to add to the resulting '
         'GenesisData')
 
+    parser.add_argument(
+        '--ignore-required-settings',
+        action='store_true',
+        help='skip the check for settings that are required at genesis '
+        '(necessary if using a settings transaction family other than '
+        'sawtooth_settings)')
+
 
 def do_genesis(args, data_dir=None):
     """Given the command args, take an series of input files containing
@@ -81,7 +88,8 @@ def do_genesis(args, data_dir=None):
         genesis_batches += input_data.batches
 
     _validate_depedencies(genesis_batches)
-    _check_required_settings(genesis_batches)
+    if not args.ignore_required_settings:
+        _check_required_settings(genesis_batches)
 
     if args.output:
         genesis_file = args.output

--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -215,7 +215,8 @@ genesis block also includes the keys for the other nodes in the initial network.
 
       The ``sawtooth.consensus.algorithm.name`` and
       ``sawtooth.consensus.algorithm.version`` settings are required; ``sawadm
-      genesis`` will fail if they are not present in one of the batches.
+      genesis`` will fail if they are not present in one of the batches unless
+      the ``--ignore-required-settings`` flag is used.
 
 #. When this command finishes, the genesis block is complete. Log out of the
    ``sawtooth`` account.

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -204,7 +204,8 @@ Use the same terminal window as the previous step.
 
       The ``sawtooth.consensus.algorithm.name`` and
       ``sawtooth.consensus.algorithm.version`` settings are required; ``sawadm
-      genesis`` will fail if they are not present in one of the batches.
+      genesis`` will fail if they are not present in one of the batches unless
+      the ``--ignore-required-settings`` flag is used.
 
 #. Combine the previously created batches into a single genesis batch that will be committed in the genesis block:
 

--- a/docs/source/cli/sawadm.rst
+++ b/docs/source/cli/sawadm.rst
@@ -36,10 +36,12 @@ initialization of a validator. A network requires an initial block (known as the
 block is produced from a list of batches, which will be applied at
 genesis time.
 
-The optional argument `input_file` specifies one or more files containing
-serialized ``BatchList`` protobuf messages to add to the genesis data. (Use a
-space to separate multiple files.) If no input file is specified,
-this command produces an empty genesis block.
+The `input_file` argument specifies one or more files containing serialized
+``BatchList`` protobuf messages to add to the genesis data. (Use a
+space to separate multiple files.) At least one input file must be specified
+and it must contain the required settings, unless the
+``--ignore-required-settings`` argument is used (run ``sawadm genesis --help``
+for more info).
 
 The output is a file containing a serialized ``GenesisData`` protobuf message.
 This file, when placed at `sawtooth_data`/``genesis.batch``, will trigger


### PR DESCRIPTION
Adds the `--ignore-required-settings` flag to the `sawadm genesis`
command that allows bypassing the required settings check. Because the
sawtooth settings transaction family is a reference implementation, it's
possible that a different settings transaction family could be used to
set the required settings at genesis. This bypass allows `sawadm
genesis` to pass in this situation. However, the genesis chain
controller will still fail if the required settings aren't in state
as a result of the genesis block, so the same requirements are enforced.

Signed-off-by: Logan Seeley <seeley@bitwise.io>