### PR TITLE
Remove optional PBFT settings

### DIFF
--- a/docker/compose/sawtooth-default-pbft.yaml
+++ b/docker/compose/sawtooth-default-pbft.yaml
@@ -222,10 +222,6 @@ services:
             sawtooth.consensus.algorithm.name=pbft \
             sawtooth.consensus.algorithm.version=0.1 \
             sawtooth.consensus.pbft.peers=\\['\"'$$(cat /pbft-shared/validators/validator-0.pub)'\"','\"'$$(cat /pbft-shared/validators/validator-1.pub)'\"','\"'$$(cat /pbft-shared/validators/validator-2.pub)'\"','\"'$$(cat /pbft-shared/validators/validator-3.pub)'\"'\\] \
-            sawtooth.consensus.pbft.block_duration=2000 \
-            sawtooth.consensus.pbft.view_change_timeout=4000 \
-            sawtooth.consensus.pbft.message_timeout=10 \
-            sawtooth.consensus.pbft.max_log_size=1000 \
             sawtooth.publisher.max_batches_per_block=1200 \
             -o config.batch
         fi &&

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -75,9 +75,6 @@ accepted transaction types to those from this network's transaction processors
         sawtooth.consensus.algorithm.name=pbft
         sawtooth.consensus.algorithm.version=0.1
         sawtooth.consensus.pbft.members=03e27504580fa15...
-        sawtooth.consensus.pbft.block_duration=200
-        sawtooth.consensus.pbft.message_timeout=10
-        sawtooth.consensus.pbft.max_log_size=1000
         sawtooth.publisher.max_batches_per_block: 200
         sawtooth.settings.vote.authorized_keys: 03e27504580fa15...
         sawtooth.validator.transaction_families: [{"family": "in...


### PR DESCRIPTION
Removes the optional PBFT settings from the docs and docker compose
file; some of the setting names are outdated, and the default values
should be used unless otherwise needed.

Signed-off-by: Logan Seeley <seeley@bitwise.io>