### PR TITLE
Add PBFT steps to Docker NW proc; correct existing info

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -68,6 +68,7 @@ html: templates cli
 	@echo
 	@echo "Build finished. The HTML pages are in $(HTMLDIR)."
 	@cp $(SAWTOOTH)/docker/compose/sawtooth-default.yaml $(HTMLDIR)/app_developers_guide/sawtooth-default.yaml
+	@cp $(SAWTOOTH)/docker/compose/sawtooth-default-pbft.yaml $(HTMLDIR)/app_developers_guide/sawtooth-default-pbft.yaml
 	@cp $(SAWTOOTH)/docker/compose/sawtooth-default-poet.yaml $(HTMLDIR)/app_developers_guide/sawtooth-default-poet.yaml
 	@cp $(SAWTOOTH)/docker/kubernetes/sawtooth-kubernetes-default.yaml $(HTMLDIR)/app_developers_guide/sawtooth-kubernetes-default.yaml
 	@cp $(SAWTOOTH)/docker/kubernetes/sawtooth-kubernetes-default-poet.yaml $(HTMLDIR)/app_developers_guide/sawtooth-kubernetes-default-poet.yaml

--- a/docs/source/_includes/pbft-vs-poet-cfg.inc
+++ b/docs/source/_includes/pbft-vs-poet-cfg.inc
@@ -1,0 +1,13 @@
+* :term:`PBFT consensus` provides a voting-based consensus algorithm with
+  Byzantine fault tolerance (BFT) that has finality (does not fork).
+
+* :term:`PoET consensus` provides a leader-election lottery system that can
+  fork.  This network uses PoET simulator consensus, which is also called `PoET
+  CFT` because it is crash fault tolerant.
+
+  .. note::
+
+     The other type of PoET consensus, PoET-SGX, relies on Intel Software Guard
+     Extensions (SGX) that is Byzantine fault tolerant (BFT). PoET CFT provides
+     the same consensus algorithm on an SGX simulator.
+

--- a/docs/source/app_developers_guide/docker_test_network.rst
+++ b/docs/source/app_developers_guide/docker_test_network.rst
@@ -3,9 +3,14 @@
 Using Docker for a Sawtooth Test Network
 ========================================
 
-In this procedure, you will use a Docker Compose file that creates a new
-application development environment with five validator nodes and four
-transaction processors (Settings, IntegerKey, XO, and PoET Validator Registry).
+This procedure describes how to use Docker to create a network of five Sawtooth
+nodes for an application development environment, using either PBFT or PoET
+consensus. (Devmode consensus is not recommended for a network.)
+
+.. include:: ../_includes/pbft-vs-poet-cfg.inc
+
+
+.. _about-sawtooth-nw-env-docker-label:
 
 About the Sawtooth Network Environment
 --------------------------------------
@@ -17,17 +22,13 @@ The following figure shows an example network with two validator nodes:
    :align: center
    :alt: Docker: Sawtooth network with five nodes
 
-Like the single-node environment, this environment uses parallel transaction
-processing and static peering. However, it has the following differences:
+.. include:: ../_includes/about-nw-each-node-runs.inc
 
-* PoET simulator consensus instead of dev mode, because dev mode's random-leader
-  consensus is not recommended for multi-node or production networks. Sawtooth
-  offers two versions of :term:`PoET consensus`. PoET-SGX relies on Intel
-  Software Guard Extensions (SGX) to implement a leader-election lottery system.
-  PoET simulator provides the same consensus algorithm on an SGX simulator.
+Like the :doc:`single-node test environment <docker>`, this environment uses
+parallel transaction processing and static peering.
 
-* An additional transaction processor, PoET Validator Registry, handles PoET
-  settings for a multiple-node network.
+
+.. _prereqs-multi-docker-label:
 
 Prerequisites
 -------------
@@ -50,41 +51,64 @@ For more information, see :ref:`stop-sawtooth-docker-label`.
 Step 1: Download the Docker Compose File
 ----------------------------------------
 
-Download the Docker Compose file for a multiple-node network,
-`sawtooth-default-poet.yaml <./sawtooth-default-poet.yaml>`_.
-Save this file in the same directory as the single-node compose file
-(``sawtooth-default.yaml``).
+Download the Docker Compose file for a multiple-node network.
 
+* For PBFT: Download
+  `sawtooth-default-pbft.yaml <./sawtooth-default-pbft.yaml>`_
+
+* For PoET: Download
+  `sawtooth-default-poet.yaml <./sawtooth-default-poet.yaml>`_
 
 Step 2: Start the Sawtooth Network
 ----------------------------------
 
-#. Use the following command to start the multiple-node Sawtooth network:
+.. note::
 
-   .. code-block:: console
+   The Docker Compose file for Sawtooth handles environment setup steps such as
+   generating keys and creating a genesis block. To learn how the typical
+   network startup process works, see :doc:`ubuntu_test_network`.
 
-      user@host$ docker-compose -f sawtooth-default-poet.yaml up
+1. Open a terminal window.
 
-#. This Compose file creates five validator nodes, numbered from 0 to 4.
-   Note the container names for the Sawtooth components on each node:
+#. Change to the directory where you saved the Docker Compose file.
+
+#. Start the Sawtooth network.
+
+   * For PBFT:
+
+     .. code-block:: console
+
+        user@host$ docker-compose -f sawtooth-default-pbft.yaml up
+
+   * For PoET:
+
+     .. code-block:: console
+
+        user@host$ docker-compose -f sawtooth-default-poet.yaml up
+
+#. This Compose file creates five Sawtooth nodes named ``validator-#``
+   (numbered from 0 to 4). Note the container names for the Sawtooth components
+   on each node:
 
    ``validator-0``:
 
     * ``sawtooth-validator-default-0``
     * ``sawtooth-rest-api-default-0``
+    * ``sawtooth-pbft-engine-default-0`` or ``sawtooth-poet-engine-0``
     * ``sawtooth-settings-tp-default-0``
     * ``sawtooth-intkey-tp-python-default-0``
     * ``sawtooth-xo-tp-python-default-0``
-    * ``sawtooth-poet-validator-registry-tp-0``
+    * (PoET only) ``sawtooth-poet-validator-registry-tp-0``
 
    ``validator-1``:
 
     * ``sawtooth-validator-default-1``
     * ``sawtooth-rest-api-default-1``
+    * ``sawtooth-pbft-engine-default-1`` or ``sawtooth-poet-engine-1``
     * ``sawtooth-settings-tp-default-1``
     * ``sawtooth-intkey-tp-python-default-1``
     * ``sawtooth-xo-tp-python-default-1``
-    * ``sawtooth-poet-validator-registry-tp-1``
+    * (PoET only) ``sawtooth-poet-validator-registry-tp-1``
 
    ... and so on.
 
@@ -92,19 +116,28 @@ Step 2: Start the Sawtooth Network
 
     * ``sawtooth-shell-default``
 
-Step 3: Verify Connectivity
----------------------------
+Step 3: Check the REST API Process
+----------------------------------
 
-You can connect to a Docker container, such as
-``sawtooth-poet-validator-registry-tp-0``, then use the following ``ps``
-command to verify that the component is running.
+Use these commands on one or more nodes to confirm that the REST API is
+running.
 
-.. code-block:: console
+1. Connect to the REST API container on a node, such as
+   ``sawtooth-poet-rest-api-default-0``.
 
-   # ps --pid 1 fw
-   PID TTY      STAT   TIME COMMAND
-   1 ?        Ssl    0:04 python3 /project/sawtooth-core/bin/poet-validator-registry-tp -C tcp://validator-0:4004
+   .. code-block:: console
 
+      user@host$ docker exec -it sawtooth-rest-api-default-0 bash
+      root@b1adcfe0#
+
+#. Use the following command to verify that this component is running.
+
+   .. code-block:: console
+
+      root@b1adcfe0# ps --pid 1 fw
+      PID TTY      STAT   TIME COMMAND
+        1 ?        Ssl    0:00 /usr/bin/python3 /usr/bin/sawtooth-rest-api
+        --connect tcp://validator-0:4004 --bind rest-api-0:8008
 
 .. _confirm-nw-funct-docker-label:
 
@@ -175,10 +208,9 @@ However, Sawtooth allows you to limit the types of transactions that can be
 submitted.
 
 In this step, you will configure the validator network to accept transactions
-only from the four transaction processors in the example environment:
-IntegerKey, Settings, XO, and Validator Registry. Transaction-type restrictions
-are an on-chain setting, so this configuration change is applied to all
-validators.
+only from the transaction processors running in the example environment.
+Transaction-type restrictions are an on-chain setting, so this configuration
+change is made on one node, then applied to all other nodes.
 
 The :doc:`Settings transaction processor
 <../transaction_family_specifications/settings_transaction_family>`
@@ -199,10 +231,19 @@ setting.
 #. Run the following command from the validator container to check the setting
    change.
 
-   .. code-block:: console
+   * For PBFT:
 
-      # sawset proposal create --url http://sawtooth-rest-api-default-0:8008 --key /etc/sawtooth/keys/validator.priv \
-      sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]'
+     .. code-block:: console
+
+        root@c0c0ab33# sawset proposal create --url http://sawtooth-rest-api-default-0:8008 --key /etc/sawtooth/keys/validator.priv \
+        sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}]'
+
+   * For PoET:
+
+     .. code-block:: console
+
+        root@c0c0ab33# sawset proposal create --url http://sawtooth-rest-api-default-0:8008 --key /etc/sawtooth/keys/validator.priv \
+        sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]'
 
    This command sets ``sawtooth.validator.transaction_families`` to a JSON array
    that specifies the family name and version of each allowed transaction
@@ -227,7 +268,7 @@ setting.
       .
       .
       [22:18:33.137 [MainThread] core DEBUG] received message of type: TP_PROCESS_REQUEST
-      [22:18:33.219 [MainThread] handler INFO] Setting setting sawtooth.validator.transaction_families changed from None to [{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]
+      [22:18:33.219 [MainThread] handler INFO] Setting setting sawtooth.validator.transaction_families changed from None to [{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, ...
 
 #. Run the following command to check the setting change. You can use any
    container for this step. Also, you can specify any REST API on the network;
@@ -239,21 +280,34 @@ setting.
 
    The output should be similar to this example:
 
-   .. code-block:: console
+   * For PBFT:
 
-      sawtooth.consensus.algorithm.name: PoET
-      sawtooth.consensus.algorithm.version: 0.1
-      sawtooth.poet.initial_wait_time: 15
-      sawtooth.poet.key_block_claim_limit: 100000
-      sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
-      sawtooth.poet.target_wait_time: 15
-      sawtooth.poet.valid_enclave_basenames: b785c58b77152cb...
-      sawtooth.poet.valid_enclave_measurements: c99f21955e38dbb...
-      sawtooth.poet.ztest_minimum_win_count: 100000
-      sawtooth.publisher.max_batches_per_block: 200
-      sawtooth.settings.vote.authorized_keys: 03e27504580fa15...
-      sawtooth.validator.transaction_families: [{"family": "in...
+     .. code-block:: console
 
+        sawtooth.consensus.algorithm.name: pbft
+        sawtooth.consensus.algorithm.version: 0.1
+        sawtooth.consensus.pbft.members=["0242fcde86373d0aa376055fc6...
+        sawtooth.publisher.max_batches_per_block=1200
+        sawtooth.settings.vote.authorized_keys: 0242fcde86373d0aa376...
+        sawtooth.validator.transaction_families: [{"family": "intkey...
+
+   * For PoET:
+
+     .. code-block:: console
+
+        sawtooth.consensus.algorithm.name: PoET
+        sawtooth.consensus.algorithm.version: 0.1
+        sawtooth.poet.initial_wait_time: 15
+        sawtooth.poet.report_public_key_pem: -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhki...
+        sawtooth.poet.target_wait_time: 5
+        sawtooth.poet.valid_enclave_basenames: b785c58b77152cbe7fd55ee3...
+        sawtooth.poet.valid_enclave_measurements: c99f21955e38dbb03d2ca...
+        sawtooth.publisher.max_batches_per_block: 100
+        sawtooth.settings.vote.authorized_keys: 036631291bbe87c3c9dde22...
+        sawtooth.validator.transaction_families: [{"family": "intkey", ...
+
+     ??? REVIEWERS: WHAT ABOUT ZTEST? `sawtooth.poet.ztest_minimum_win_count: 100000`
 
 Step 6: Stop the Sawtooth Network (Optional)
 --------------------------------------------
@@ -262,9 +316,22 @@ If you need to stop or reset the multiple-node Sawtooth environment, enter
 CTRL-c in the window where you ran ``docker-compose up``, then run the following
 command from your host system:
 
-.. code-block:: console
+#. Enter CTRL-c in the window where you ran ``docker-compose up``.
 
-   user@host$ docker-compose -f sawtooth-default-poet.yaml down
+#. After all containers have shut down, you can reset the environment (remove
+   all containers and data) with the following command:
+
+   * For PBFT:
+
+     .. code-block:: console
+
+        user@host$ docker-compose -f sawtooth-default-pbft.yaml down
+
+   * For PoET:
+
+     .. code-block:: console
+
+        user@host$ docker-compose -f sawtooth-default-poet.yaml down
 
 
 .. Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
Update the App Dev Guide's multi-node procedure, "Using Docker for a Sawtooth Test Network", to add PBFT info, steps, and example information. This new info requires some corrections or rewrites to existing content. 

Also updated the docs/Makefile to copy the example PBFT yaml file to the same docs directory as the PoET yaml file.
For example, the step showing how to run `ps` in the PoET Validator Registry container now shows how to check that the REST API process is running.

This PR also corrects and clarifies existing information (text and steps) in this procedure:
    
- Add prerequisites for Docker and Docker Engine; clarify info on shutting down a single node, if running
- Clarify which container is being used in each step
- Fix error in "sawtooth proposal create" (intro text was wrong)
- Add example output to steps that needed it (for clarification)
- Correct prompts throughout
- Update obsolete terminology: validator node -> Sawtooth node (or just "node")