### PR TITLE
Proposed patches to allow Validator and REST API to work with IPv6

### DIFF
--- a/integration/sawtooth_integration/docker/integration-tests.dockerfile
+++ b/integration/sawtooth_integration/docker/integration-tests.dockerfile
@@ -37,6 +37,7 @@ RUN apt-get install -y -q \
     python3-pip \
     python3-protobuf \
     python3-pyformance \
+    python3-netifaces \
     python3-requests \
     python3-sawtooth-intkey \
     python3-sawtooth-xo \

--- a/integration/sawtooth_integration/docker/test_ipv6.yaml
+++ b/integration/sawtooth_integration/docker/test_ipv6.yaml
@@ -1,0 +1,560 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "2.1"
+
+networks:
+  test_net:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: "fc00::/64"
+        - subnet: "192.168.85.0/24"
+
+x-extra-hosts:
+  &shared-extra-hosts
+  - "validator-0-ipv4:192.168.85.10"
+  - "validator-0-ipv6:fc00::10"
+  - "validator-1-ipv4:192.168.85.11"
+  - "validator-1-ipv6:fc00::11"
+  - "validator-2-ipv4:192.168.85.12"
+  - "validator-2-ipv6:fc00::12"
+  - "validator-3-ipv4:192.168.85.13"
+  - "validator-3-ipv6:fc00::13"
+  - "validator-4-ipv4:192.168.85.14"
+  - "validator-4-ipv6:fc00::14"
+  - "rest-api-0-ipv4:192.168.85.30"
+  - "rest-api-0-ipv6:fc00::30"
+  - "rest-api-1-ipv4:192.168.85.31"
+  - "rest-api-1-ipv6:fc00::31"
+  - "rest-api-2-ipv4:192.168.85.32"
+  - "rest-api-2-ipv6:fc00::32"
+  - "rest-api-3-ipv4:192.168.85.33"
+  - "rest-api-3-ipv6:fc00::33"
+  - "rest-api-4-ipv4:192.168.85.34"
+  - "rest-api-4-ipv6:fc00::34"
+
+services:
+  validator-0:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawset genesis \
+          -k /etc/sawtooth/keys/validator.priv \
+          -o config-genesis.batch && \
+        sawset proposal create \
+          -k /etc/sawtooth/keys/validator.priv \
+          sawtooth.consensus.algorithm.name=Devmode \
+          sawtooth.consensus.algorithm.version=0.1 \
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
+        sawtooth-validator -vv \
+            --endpoint tcp://validator-0-ipv6:8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://[::]:8800 \
+            --bind consensus:tcp://eth0:5005 \
+    \""
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.10
+        ipv6_address: fc00::10
+
+    extra_hosts:
+      *shared-extra-hosts
+
+  validator-1:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    depends_on:
+      - validator-0
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator-1-ipv6:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://[::]:8800 \
+          --bind consensus:tcp://eth0:5005 \
+          --peers tcp://validator-0-ipv6:8800
+    \""
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.11
+        ipv6_address: fc00::11
+
+    extra_hosts:
+      *shared-extra-hosts
+
+  validator-2:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    depends_on:
+      - validator-0
+      - validator-1
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator-2-ipv6:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://[::]:8800 \
+          --bind consensus:tcp://eth0:5005 \
+          --peers tcp://validator-1-ipv6:8800
+    \""
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.12
+        ipv6_address: fc00::12
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  validator-3:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    depends_on:
+      - validator-0
+      - validator-1
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator-3-ipv6:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://[::]:8800 \
+          --bind consensus:tcp://eth0:5005 \
+          --peers tcp://validator-1-ipv6:8800
+    \""
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.13
+        ipv6_address: fc00::13
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  validator-4:
+    build:
+      context: ../../..
+      dockerfile: ./validator/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-validator$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8800
+    depends_on:
+      - validator-2
+      - validator-3
+    command: "bash -c \"\
+        sawadm keygen --force && \
+        sawtooth-validator -vv \
+          --endpoint tcp://validator-4-ipv6:8800 \
+          --bind component:tcp://eth0:4004 \
+          --bind network:tcp://[::]:8800 \
+          --bind consensus:tcp://eth0:5005 \
+          --peers tcp://validator-2-ipv6:8800,tcp://validator-3-ipv6:8800
+    \""
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.14
+        ipv6_address: fc00::14
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  devmode-0:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator-0-ipv4:5005 -v
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.20
+        ipv6_address: fc00::20
+
+  devmode-1:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator-1-ipv4:5005 -v
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.21
+        ipv6_address: fc00::21
+
+  devmode-2:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator-2-ipv4:5005 -v
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.22
+        ipv6_address: fc00::22
+
+  devmode-3:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator-3-ipv4:5005 -v
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.23
+        ipv6_address: fc00::23
+
+  devmode-4:
+    image: hyperledger/sawtooth-devmode-engine-rust:nightly
+    command: devmode-engine-rust --connect tcp://validator-4-ipv4:5005 -v
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.24
+        ipv6_address: fc00::24
+
+  rest-api-0:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-0-ipv4:4004 --bind [::]:8008
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.30
+        ipv6_address: fc00::30
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  rest-api-1:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-1-ipv4:4004 --bind [::]:8008
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.31
+        ipv6_address: fc00::31
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  rest-api-2:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-2-ipv4:4004 --bind [::]:8008
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.32
+        ipv6_address: fc00::32
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  rest-api-3:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-3-ipv4:4004 --bind [::]:8008
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.33
+        ipv6_address: fc00::33
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  rest-api-4:
+    build:
+      context: ../../..
+      dockerfile: ./rest_api/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-rest-api$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+      - 8008
+    command: sawtooth-rest-api -v --connect tcp://validator-4-ipv4:4004 --bind [::]:8008
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.34
+        ipv6_address: fc00::34
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  settings-tp-0:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -v -C tcp://validator-0-ipv4:4004
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.40
+        ipv6_address: fc00::40
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  settings-tp-1:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -v -C tcp://validator-1-ipv4:4004
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.41
+        ipv6_address: fc00::41
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  settings-tp-2:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -v -C tcp://validator-2-ipv4:4004
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.42
+        ipv6_address: fc00::42
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  settings-tp-3:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -v -C tcp://validator-3-ipv4:4004
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.43
+        ipv6_address: fc00::43
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  settings-tp-4:
+    build:
+      context: ../../..
+      dockerfile: ./families/settings/Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-settings-tp$INSTALL_TYPE:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 4004
+    command: settings-tp -v -C tcp://validator-4-ipv4:4004
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.44
+        ipv6_address: fc00::44
+
+    extra_hosts:
+        *shared-extra-hosts
+
+  test-ipv6:
+    build:
+      context: ../../..
+      dockerfile: integration/sawtooth_integration/docker/integration-tests.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: integration-tests:$ISOLATION_ID
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    expose:
+      - 8008
+
+    command: nose2-3
+        -c /project/sawtooth-core/integration/sawtooth_integration/nose2.cfg
+        -v
+        -s /project/sawtooth-core/integration
+        sawtooth_integration.tests.test_ipv6.TestIPv6
+
+    stop_signal: SIGKILL
+
+    networks:
+      test_net:
+        ipv4_address: 192.168.85.50
+        ipv6_address: fc00::50
+
+    extra_hosts:
+        *shared-extra-hosts

--- a/integration/sawtooth_integration/tests/test_ipv6.py
+++ b/integration/sawtooth_integration/tests/test_ipv6.py
@@ -1,0 +1,161 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+import json
+import shlex
+import logging
+import unittest
+import subprocess
+
+from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+
+
+EXPECTED = {
+    0: {1},
+    1: {0, 2, 3},
+    2: {1, 4},
+    3: {1, 4},
+    4: {2, 3},
+}
+
+
+class TestIPv6(unittest.TestCase):
+    def setUp(self):
+        endpoints = ['rest-api-{}-ipv6:8008'.format(i)
+                     for i in range(len(EXPECTED))]
+
+        wait_for_rest_apis(endpoints)
+
+    def test_ipv6(self):
+        '''Use various CLI commands for reporting peers to test IPv6
+        functionality in the validator.
+
+        Five validators are started, peered as described in EXPECTED
+        (see the test's associated yaml file for details).
+        '''
+
+        LOGGER.info('Testing `sawtooth peer list`')
+        for node_number, peer_numbers in EXPECTED.items():
+            actual_peers = _get_peers(node_number)
+
+            expected_peers = {
+                _make_tcp_address(peer_number)
+                for peer_number in peer_numbers
+            }
+
+            LOGGER.debug(
+                'Actual: %s -- Expected: %s',
+                actual_peers,
+                expected_peers)
+
+            self.assertEqual(
+                actual_peers,
+                expected_peers)
+
+        ###
+
+        LOGGER.info('Testing `sawtooth status show`')
+
+        sawtooth_status_expected = {
+            node_number: {
+                _make_tcp_address(node_number): [
+                    {'endpoint': _make_tcp_address(peer_number)}
+                    for peer_number in peers
+                ]
+            }
+            for node_number, peers in EXPECTED.items()
+        }
+
+        for node_number in EXPECTED:
+            status = json.loads(_run_peer_command(
+                'sawtooth status show --url {}'.format(
+                    _make_http_address(node_number))))
+
+            LOGGER.debug(
+                'Node %s status: %s',
+                node_number,
+                json.dumps(status, indent=4))
+
+            self.assertEqual(
+                sawtooth_status_expected[node_number],
+                {status['endpoint']: status['peers']},
+            )
+
+        ###
+
+        LOGGER.info('Testing `sawnet peers list`')
+
+        peers_list_expected = {
+            _make_tcp_address(node_number): [
+                _make_tcp_address(peer_number)
+                for peer_number in peers
+            ]
+            for node_number, peers in EXPECTED.items()
+        }
+
+        http_addresses = ','.join([
+            _make_http_address(node_number)
+            for node_number in EXPECTED
+        ])
+
+        # make sure pretty-print option works
+        subprocess.run(shlex.split(
+            'sawnet peers list {} --pretty'.format(http_addresses)))
+
+        sawnet_peers_output = json.loads(
+            _run_peer_command(
+                'sawnet peers list {}'.format(http_addresses)
+            )
+        )
+
+        self.assertEqual(
+            sawnet_peers_output,
+            peers_list_expected)
+
+        # run `sawnet peers graph`, but don't verify output
+        subprocess.run(shlex.split(
+            'sawnet peers graph {}'.format(http_addresses)))
+
+
+def _get_peers(node_number, fmt='json'):
+    cmd_output = _run_peer_command(
+        'sawtooth peer list --url {} --format {}'.format(
+            _make_http_address(node_number),
+            fmt))
+
+    if fmt == 'json':
+        parsed = json.loads(cmd_output)
+
+    elif fmt == 'csv':
+        parsed = cmd_output.split(',')
+
+    return set(parsed)
+
+
+def _run_peer_command(command):
+    return subprocess.check_output(
+        shlex.split(command)
+    ).decode().strip().replace("'", '"')
+
+
+def _make_http_address(node_number):
+    return 'http://rest-api-{}-ipv6:8008'.format(node_number)
+
+
+def _make_tcp_address(node_number):
+    return 'tcp://validator-{}-ipv6:8800'.format(node_number)

--- a/rest_api/sawtooth_rest_api/rest_api.py
+++ b/rest_api/sawtooth_rest_api/rest_api.py
@@ -207,7 +207,9 @@ def main():
         init_console_logging(verbose_level=opts.verbose)
 
         try:
-            host, port = rest_api_config.bind[0].split(":")
+            host, port = rest_api_config.bind[0].rsplit(":", 1)
+            # If we have an ipv6 address
+            host = host.replace("[", "").replace("]", "")
             port = int(port)
         except ValueError as e:
             print("Unable to parse binding {}: Must be in the format"


### PR DESCRIPTION
These are two simple patches to enable using IPv6 with Sawtooth.

1) Enable the validator to bind to an IPv6 address by passing the correct ZMQ flag.
2) Do some filtering to ensure that an IPv6 address passed in bracket format is accepted by the REST API.

Please let me know if you would like to see "more" in the REST API code, or if anything else is required.