### PR TITLE
Add Connect to REST API steps and links

### DIFF
--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -63,15 +63,16 @@ family.
    genesis block. To learn how the typical startup process works, see
    :doc:`ubuntu`.
 
+.. _launch-sawtooth-instance-aws:
 
-Step 1: Launch a Sawtooth Instance
-==================================
+Step 1: Launch a Sawtooth Instance with AWS
+===========================================
 
-#. Launch a Sawtooth instance from the `Hyperledger Sawtooth product page
-   on the AWS Marketplace <https://aws.amazon.com/marketplace/pp/B075TKQCC2>`_.
-   For more information, see the Amazon guide
-   `Launching an AWS Marketplace Instance
-   <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/launch-marketplace-console.html>`_.
+Launch a Sawtooth instance from the `Hyperledger Sawtooth product page
+on the AWS Marketplace <https://aws.amazon.com/marketplace/pp/B075TKQCC2>`_.
+For more information, see the Amazon guide
+`Launching an AWS Marketplace Instance
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/launch-marketplace-console.html>`_.
 
    .. note::
 
@@ -91,20 +92,22 @@ Step 1: Launch a Sawtooth Instance
       Security Groups documentation,
       `Adding, Removing, and Updating Rules <http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html#AddRemoveRules>`_.
 
-#. Log into this Sawtooth instance. Use the user name ``ubuntu`` when
-   connecting.
-
-   For more information, see the Amazon guide
-   `Connect to Your Linux Instance <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html>`_.
-
 Once launched, the Sawtooth instance continues to run until you stop it.
 If you're uncertain about the state or would like to start over, see
 :ref:`reset-aws-ubuntu-label`.
 
+.. _connect-to-instance-aws:
 
-.. _confirming-connectivity-aws-label:
+Step 2: Connect to the AWS Sawtooth Instance
+============================================
 
-Step 2: Check the Status of Sawtooth Components
+Connect to your Sawtooth instance. Use the user name ``ubuntu`` when
+connecting.
+
+For more information, see the Amazon guide
+`Connect to Your Linux Instance <http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstances.html>`_.
+
+Step 3: Check the Status of Sawtooth Components
 ===============================================
 
 #. You can use ``ps`` to check that each Sawtooth component is running:
@@ -131,8 +134,10 @@ Step 2: Check the Status of Sawtooth Components
       sawtooth-validator.service
            loaded active running   Sawtooth Validator Server
 
-Step 3: Confirm Connectivity to the REST API
-============================================
+.. _confirming-connectivity-aws-label:
+
+Step 4: Confirm Connectivity to the REST API (for AWS)
+======================================================
 
 Confirm that you can connect to the REST API from your host system. Enter
 the following ``curl`` command from a terminal window:
@@ -141,10 +146,41 @@ the following ``curl`` command from a terminal window:
 
    $ curl http://localhost:8008/blocks
 
+If the REST API is running and reachable, the output should be similar to this
+example:
+
+  .. code-block:: console
+
+     {
+       "data": [
+         {
+           "batches": [],
+           "header": {
+             "batch_ids": [],
+             "block_num": 0,
+             "mconsensus": "R2VuZXNpcw==",
+             "previous_block_id": "0000000000000000",
+             "signer_public_key": "03061436bef428626d11c17782f9e9bd8bea55ce767eb7349f633d4bfea4dd4ae9",
+             "state_root_hash": "708ca7fbb701799bb387f2e50deaca402e8502abe229f705693d2d4f350e1ad6"
+           },
+           "header_signature": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b"
+         }
+       ],
+       "head": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+       "link": "http://localhost:8008/blocks?head=119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+       "paging": {
+         "start_index": 0,
+         "total_count": 1
+       }
+     }
+
+If the REST API process or container is not running, the
+``curl`` command will time out or return nothing.
+
 
 .. _configure-tf-settings-aws-label:
 
-Step 4: Use Sawtooth Commands as a Client
+Step 5: Use Sawtooth Commands as a Client
 =========================================
 
 Sawtooth includes commands that act as a client application. This step describes
@@ -356,7 +392,7 @@ state data in a :term:`Merkle-Radix tree`; for more information, see
 
 .. _examine-logs-aws-label:
 
-Step 5: Examine Sawtooth Logs
+Step 6: Examine Sawtooth Logs
 =============================
 
 By default, Sawtooth logs are stored in the directory ``/var/log/sawtooth``.
@@ -393,7 +429,7 @@ For more information on log files, see
 
 .. _reset-aws-ubuntu-label:
 
-Step 6: Reset the AWS Environment (Optional)
+Step 7: Reset the AWS Environment (Optional)
 ============================================
 
 When you are done with the AWS environment (or if you want to reset it), you can

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -186,8 +186,10 @@ in other containers.
    :ref:`stop-sawtooth-docker-label`.
 
 
-Step 4: Log Into the Client Container
-=====================================
+.. _log-into-client-container-docker:
+
+Step 4: Log Into the Docker Client Container
+============================================
 
 Sawtooth includes commands that act as a client application. The client
 container is used to run these Sawtooth commands, which interact with the
@@ -215,10 +217,10 @@ be run in the terminal window for the client container.
 
 .. _confirming-connectivity-docker-label:
 
-Step 5: Confirm Connectivity to the REST API
-============================================
+Step 5: Confirm Connectivity to the REST API (for Docker)
+=========================================================
 
-#. To confirm that the REST API and validator are running and reachable from
+1. To confirm that the REST API and validator are running and reachable from
    the client container, run this ``curl`` command:
 
    .. code-block:: console

--- a/docs/source/app_developers_guide/intro_xo_transaction_family.rst
+++ b/docs/source/app_developers_guide/intro_xo_transaction_family.rst
@@ -80,37 +80,51 @@ Prerequisites
   start the XO transaction processor if necessary.
 
 
-Step 1: Confirm Connectivity to the REST API
+Step 1: Connect to the Sawtooth Node
+------------------------------------
+
+To connect to the Sawtooth node, use the steps for your platform:
+
+* Docker: See :ref:`log-into-client-container-docker`
+
+* Kubernetes: See :ref:`connect-to-shell-container-k8s`
+
+* AWS: See :ref:`connect-to-instance-aws`
+
+* Ubuntu: Open a client terminal window on the host system running Sawtooth
+
+
+Step 2: Confirm Connectivity to the REST API
 --------------------------------------------
 
-#. Connect to your Sawtooth node, as described in the procedure for
-   your platform in :doc:`installing_sawtooth`.
+Verify that you can connect to the REST API. The step will help determine if
+The REST API is at the default location (``http://localhost:8008``).
 
-#. Verify that you can connect to the REST API.
+The ``xo`` client sends requests to update and query the blockchain to the
+URL of the REST API (by default, ``http://127.0.0.1:8008``).
+If the REST API's URL is not ``http://127.0.0.1:8008``, you must add the
+``--url`` argument to each ``xo`` command in this procedure.
 
-   * Docker: See :ref:`confirming-connectivity-docker-label`
+* Docker: See :ref:`confirming-connectivity-docker-label`
 
-   * AWS: See :ref:`confirming-connectivity-aws-label`
+  .. important::
 
-   * Ubuntu: See :ref:`confirm-rest-api-ubuntu-label`
+     In the Docker environment, the REST API is at ``http://rest-api:8008``.
+     You must add ``--url http://rest-api:8008`` to all ``xo`` commands in this
+     procedure. For example:
 
-   .. Important::
+        .. code-block:: console
 
-      The ``xo`` client sends requests to update and query the blockchain to the
-      URL of the REST API (by default, ``http://127.0.0.1:8008``).
+           $ xo create my-game --username jack --url http://rest-api:8008
 
-      If the REST API's URL is not ``http://127.0.0.1:8008``, you must add the
-      ``--url`` argument to each ``xo`` command in this procedure.
+* Kubernetes: See :ref:`confirming-connectivity-k8s-label`
 
-      This example shows the format of this argument, using the default URL
-      for a Docker environment:
+* AWS: See :ref:`confirming-connectivity-aws-label`
 
-      .. code-block:: console
-
-         $ xo create my-game --username jack --url http://rest-api:8008
+* Ubuntu: See :ref:`confirming-rest-api-ubuntu-label`
 
 
-Step 2. Ubuntu only: Start the XO Transaction Processor
+Step 3. Ubuntu only: Start the XO Transaction Processor
 -------------------------------------------------------
 
 For Ubuntu: If the XO transaction processor is not running on your Sawtooth
@@ -136,7 +150,7 @@ node, start it now.
 For more information, see :ref:`start-tps-label`.
 
 
-Step 3. Create Players
+Step 4. Create Players
 ----------------------
 
 Create keys for two players to play the game:
@@ -157,7 +171,7 @@ Create keys for two players to play the game:
    The output may differ slightly from this example.
 
 
-Step 4. Create a Game
+Step 5. Create a Game
 ---------------------
 
 Create a game named ``my-game`` with the following command:
@@ -187,7 +201,7 @@ existing games:
    state rather than using ``curl`` with the REST API's URL to request state.
 
 
-Step 5. Take a Space as Player 1
+Step 6. Take a Space as Player 1
 --------------------------------
 
 .. note::
@@ -239,7 +253,7 @@ win or tie. If either condition occurs, no more ``take`` actions are allowed
 on the finished game.
 
 
-Step 6. Take a Space as Player 2
+Step 7. Take a Space as Player 2
 --------------------------------
 
 Next, take a space on the board as player 2, Jill.  In this example,
@@ -250,7 +264,7 @@ Jill takes space 1:
     $ xo take my-game 1 --username jill
 
 
-Step 7. Show the Current Game Board
+Step 8. Show the Current Game Board
 -----------------------------------
 
 Whenever you want to see the current state of the game board, enter the
@@ -286,7 +300,7 @@ than the state returned to the transaction processor:
    my-game,O---X----,P1-NEXT,02403a...,03729b...
 
 
-Step 8. Continue the Game
+Step 9. Continue the Game
 -------------------------
 
 Players take turns using ``xo take my-game <space>`` to mark spaces on the grid.
@@ -309,8 +323,8 @@ tie, as in this example:
       X | O | X
 
 
-Step 9. Delete the Game
------------------------
+Step 10. Delete the Game
+------------------------
 
 Either player can use the ``xo delete`` command to remove the game data from
 global state.

--- a/docs/source/app_developers_guide/kubernetes.rst
+++ b/docs/source/app_developers_guide/kubernetes.rst
@@ -242,23 +242,73 @@ Use these steps to start Sawtooth:
    The overview page shows the Sawtooth deployment (``sawtooth-0``)
    and pod (:samp:`sawtooth-0-{POD-ID}`).
 
+.. _connect-to-shell-container-k8s:
 
-Step 5: Test Basic Sawtooth Functionality
+Step 5: Connect to the Kubernetes Shell Container
+=================================================
+
+Connect to the shell container.
+
+.. code-block:: none
+
+   $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-0/{print $1}') --container sawtooth-shell -- bash
+
+.. note::
+
+   In the rest of this procedure, the prompt ``root@sawtooth-0#`` marks the
+   commands that should be run in a Sawtooth container.
+   (The actual prompt is similar to ``root@sawtooth-0-5ff6d9d578-5w45k:/#``.)
+
+.. _confirming-connectivity-k8s-label:
+
+Step 6: Confirm Connectivity to the REST API (for Kubernetes)
+=============================================================
+
+To verify that you can reach the REST API, run this ``curl`` command from the
+shell container:
+
+.. code-block:: console
+
+   root@sawtooth-0# curl http://localhost:8008/blocks
+
+If the validator and REST API are running and reachable, the output for each
+command should be similar to this example:
+
+.. code-block:: console
+
+   {
+     "data": [
+       {
+         "batches": [],
+         "header": {
+           "batch_ids": [],
+           "block_num": 0,
+           "mconsensus": "R2VuZXNpcw==",
+           "previous_block_id": "0000000000000000",
+           "signer_public_key": "03061436bef428626d11c17782f9e9bd8bea55ce767eb7349f633d4bfea4dd4ae9",
+           "state_root_hash": "708ca7fbb701799bb387f2e50deaca402e8502abe229f705693d2d4f350e1ad6"
+         },
+         "header_signature": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b"
+       }
+     ],
+     "head": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+     "link": "http://localhost:8008/blocks?head=119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+     "paging": {
+       "start_index": 0,
+       "total_count": 1
+     }
+   }
+
+If the validator process or the validator container is not running, the
+``curl`` command will time out or return nothing.
+
+
+Step 7: Test Basic Sawtooth Functionality
 =========================================
 
-1.  Connect to the shell container.
+Run these commands from the shell container.
 
-   .. code-block:: none
-
-      $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-0/{print $1}') --container sawtooth-shell -- bash
-
-   .. note::
-
-      In the rest of this procedure, the prompt ``root@sawtooth-0#`` marks the
-      commands that should be run in a Sawtooth container.
-      (The actual prompt is similar to ``root@sawtooth-0-5ff6d9d578-5w45k:/#``.)
-
-2. Display the list of blocks on the Sawtooth blockchain.
+1. Display the list of blocks on the Sawtooth blockchain.
 
    .. code-block:: console
 
@@ -316,7 +366,7 @@ The rest of this section introduces you to Sawtooth functionality.
 
 .. _sawtooth-client-kube-label:
 
-Step 6: Use Sawtooth Commands as a Client
+Step 8: Use Sawtooth Commands as a Client
 =========================================
 
 Sawtooth includes commands that act as a client interface for an application.
@@ -330,7 +380,7 @@ global state data.
    options and subcommands.
 
 To run the commands in this step, connect to the shell container as described in
-the previous step.
+an earlier step.
 
 Creating and Submitting Transactions with intkey
 ------------------------------------------------
@@ -515,7 +565,7 @@ state data in a :term:`Merkle-Radix tree` (for more information, see
 
 .. _check-status-kube-label:
 
-Step 7: Verify the Sawtooth Components
+Step 9: Verify the Sawtooth Components
 ======================================
 
 To check whether a Sawtooth component is running, connect to the component's
@@ -552,8 +602,8 @@ container and run the ``ps`` command.
 
 .. _examine-logs-kube-label:
 
-Step 8: Examine Sawtooth Logs
-=============================
+Step 10: Examine Sawtooth Logs
+==============================
 
 The Sawtooth log files are available on the Kubernetes dashboard.
 
@@ -629,8 +679,8 @@ For more information on log files, see
 
 .. _stop-sawtooth-kube-label:
 
-Step 9: Stop the Sawtooth Kubernetes Cluster
-============================================
+Step 11: Stop the Sawtooth Kubernetes Cluster
+=============================================
 
 Use the following commands to stop and reset the Sawtooth environment.
 

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -370,13 +370,15 @@ processor.
 
          [2018-03-14 16:00:17.223 INFO     processor_handlers] registered transaction processor: connection_id=eca3a9ad0ff1cdbc29e449cc61af4936bfcaf0e064952dd56615bc00bb9df64c4b01209d39ae062c555d3ddc5e3a9903f1a9e2d0fd2cdd47a9559ae3a78936ed, family=sawtooth_settings, version=1.0, namespaces=['000000']
 
-   #. Open a new terminal window (the client terminal window). In this
-      procedure, the prompt ``user@client$`` shows the commands that should be
-      run in this window.
+   The ``settings-tp`` transaction processor continues to run and to display log
+   messages in its terminal window.
 
-   #. At this point, you can see the authorized keys setting that was proposed
-      in :ref:`create-genesis-block-ubuntu-label`.
-      Run the following command in the client terminal window:
+   .. tip::
+
+      At this point, you can see the authorized keys setting that was proposed
+      in :ref:`create-genesis-block-ubuntu-label`. To see this setting, open a
+      new terminal window (the client terminal window) and run the following
+      command:
 
       .. code-block:: console
 
@@ -384,9 +386,6 @@ processor.
          sawtooth.consensus.algorithm.name: Devmode
          sawtooth.consensus.algorithm.version: 0.1
          sawtooth.settings.vote.authorized_keys: 0276023d4f7323103db8d8683a4b7bc1eae1f66...
-
-   The ``settings-tp`` transaction processor continues to run and to display log
-   messages in its terminal window.
 
 #. Start the IntegerKey transaction processor, ``intkey-tp-python``.
 
@@ -443,13 +442,21 @@ processor.
    The ``xo-tp-python`` transaction processor continues to run and to display
    log messages in its terminal window.
 
+.. _open-client-window-ubuntu-label:
 
-.. _confirm-rest-api-ubuntu-label:
+Step 9: Open a Client Terminal Window
+=====================================
 
-Step 9: Confirm Connectivity to the REST API
-============================================
+Open a new terminal window to use as the client terminal window.
 
-#. Run the following command in the client terminal window:
+In the following steps, the prompt ``user@client$`` shows the commands that
+should be run in this window.
+
+
+Step 10: Check the REST API Process
+===================================
+
+1. Run the following command in the client terminal window:
 
    .. code-block:: console
 
@@ -460,7 +467,53 @@ Step 9: Confirm Connectivity to the REST API
 #. If necessary, restart the REST API (see :ref:`start-rest-api-label`).
 
 
-Step 10: Use Sawtooth Commands as a Client
+.. _confirming-rest-api-ubuntu-label:
+
+Step 11: Confirm Connectivity to the REST API (for Ubuntu)
+==========================================================
+
+If the ``curl`` command is installed on your host system, you can use this
+step to verify that you can connect to the REST API.
+
+#. Open a new terminal window on your host system and run this ``curl`` command:
+
+   .. code-block:: console
+
+      user@host$ curl http://localhost:8008/blocks
+
+   If the validator and REST API are running and reachable, the output for each
+   command should be similar to this example:
+
+   .. code-block:: console
+
+     {
+       "data": [
+         {
+           "batches": [],
+           "header": {
+             "batch_ids": [],
+             "block_num": 0,
+             "mconsensus": "R2VuZXNpcw==",
+             "previous_block_id": "0000000000000000",
+             "signer_public_key": "03061436bef428626d11c17782f9e9bd8bea55ce767eb7349f633d4bfea4dd4ae9",
+             "state_root_hash": "708ca7fbb701799bb387f2e50deaca402e8502abe229f705693d2d4f350e1ad6"
+           },
+           "header_signature": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b"
+         }
+       ],
+       "head": "119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+       "link": "http://localhost:8008/blocks?head=119f076815af8b2c024b59998e2fab29b6ae6edf3e28b19de91302bd13662e6e43784263626b72b1c1ac120a491142ca25393d55ac7b9f3c3bf15d1fdeefeb3b",
+       "paging": {
+         "start_index": 0,
+         "total_count": 1
+       }
+     }
+
+   If the validator process or the validator container is not running, the
+   ``curl`` command will time out or return nothing.
+
+
+Step 12: Use Sawtooth Commands as a Client
 ==========================================
 
 Sawtooth includes commands that act as a client application. This step describes
@@ -676,7 +729,7 @@ state data in a :term:`Merkle-Radix tree`; for more information, see
 
 .. _examine-logs-ubuntu-label:
 
-Step 11: Examine Sawtooth Logs
+Step 13: Examine Sawtooth Logs
 ==============================
 
 By default, Sawtooth logs are stored in the directory ``/var/log/sawtooth``.
@@ -713,7 +766,7 @@ For more information on log files, see
 
 .. _stop-sawtooth-ubuntu-label:
 
-Step 12: Stop Sawtooth Components
+Step 14: Stop Sawtooth Components
 =================================
 
 Use this procedure if you need to stop or reset the Sawtooth environment for any


### PR DESCRIPTION
In the Docker, Kubernetes, AWS, and Ubuntu procedures:
- Add missing step to confirm REST API connectivity, if necessary.
- Rework existing "connect to Sawtooth" step to be consistent across the four
  procedures.
- Change titles so they're unique across the doc set (for clarity and because
  Sphinx complains).
- Add anchor tags for links from XO procedure.

In the "Playing with XO" procedure:
- Separate the first step (connect to Sawtooth) and expand with links to
  Docker, Kubernetes, and AWS. Text info suffices for Ubuntu.
- For "confirm REST API connectivity" step, correct or add links for the
  four procedures.

Signed-off-by: Anne Chenette <chenette@bitwise.io>