### PR TITLE
Add links to external PBFT, Sabre, and Seth docs in ST core docs

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -44,6 +44,9 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Community{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}join the conversation{% endtrans %}</span></p>
 
+  <p class="biglink"><a class="biglink" href="{{ pathto("glossary") }}">{% trans %}Glossary{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}understand Sawtooth terminology{% endtrans %}</span></p>
+
   <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Table of Contents{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}view the detailed list of documentation sections{% endtrans %}</span></p>
 

--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -32,6 +32,15 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("cli") }}">{% trans %}CLI Command Reference{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Sawtooth commands{% endtrans %}</span></p>
 
+  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth PBFT{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}learn about Sawtooth PBFT consensus{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth Sabre{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}write on-chain smart contracts with the Sawtooth Sabre transaction family{% endtrans %}</span></p>
+
+  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth Seth{% endtrans %}</a><br/>
+    <span class="linkdescr">{% trans %}support EVM smart contracts with the Sawtooth Seth transaction family{% endtrans %}</span></p>
+
   <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Community{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}join the conversation{% endtrans %}</span></p>
 

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -31,7 +31,8 @@ management, consensus, transaction scheduling, permissioning, and more.
    architecture/permissioning_requirement
    architecture/injecting_batches_block_validation_rules
    architecture/events_and_transactions_receipts
-   architecture/poet
+   PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/architecture.html>
+   PoET 1.0 Consensus <architecture/poet>
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -11,6 +11,9 @@ Table of Contents
    sysadmin_guide.rst
    api_references.rst
    cli.rst
+   Sawtooth PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>
+   Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>
+   Sawtooth Seth Transaction Family <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>
    community.rst
    glossary.rst
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -160,7 +160,7 @@ network. Sawtooth currently includes consensus engines for these algorithms:
       and a block catch-up procedure. A Sawtooth network with PBFT consensus
       requires four or more nodes.
 
-    * `PoET <https://github.com/hyperledger/sawtooth-poet>`__
+    * :doc:`PoET <architecture/poet>`
       (Proof of Elapsed Time) is a Nakamoto-style consensus algorithm that is
       designed to be a production-grade protocol capable of supporting large
       network populations. PoET relies on secure instruction execution to
@@ -184,7 +184,7 @@ network. Sawtooth currently includes consensus engines for these algorithms:
       is a leader-based consensus algorithm that provides crash fault tolerance
       for a small network with restricted membership.
 
-    * `Dev mode <https://github.com/hyperledger/sawtooth-core/blob/master/validator/sawtooth_validator/journal/consensus/dev_mode/dev_mode_consensus.py>`__
+    * Dev mode (short for "developer mode")
       is a simplified random-leader algorithm that is useful for developing and
       testing a transaction processor. Dev mode is not recommended for
       multi-node networks and should not be used for production.
@@ -333,7 +333,7 @@ can get the code to start building your own distributed ledger.
     Deploy Ethereum Virtual Machine (EVM) smart contracts to Sawtooth
 
   * `Sawtooth Marketplace <https://github.com/hyperledger/sawtooth-marketplace>`_:
-    Exchange customized "Assets" with other users on the blockchain
+    Exchange customized "assets" with other users on the blockchain
 
   * `Sawtooth Supply Chain <https://github.com/hyperledger/sawtooth-supply-chain>`_:
     Trace the provenance and other contextual information of any asset

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -151,7 +151,7 @@ transaction or two.
 The Sawtooth consensus API supports a wide variety of consensus algorithms on a
 network. Sawtooth currently includes consensus engines for these algorithms:
 
-    * `Sawtooth PBFT <https://github.com/hyperledger/sawtooth-pbft>`__
+    * `Sawtooth PBFT <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>`__
       (Practical Byzantine Fault Tolerance) is a voting-based consensus
       algorithm that provides Byzantine fault tolerance with finality.
       Sawtooth PBFT extends the
@@ -217,6 +217,16 @@ Additional transaction families provide models for specific areas\:
 
     * BlockInfo - Provides a methodology for storing information
       about a configurable number of historic blocks.
+
+The following projects provide smart-contract functionality for the Sawtooth
+platform\:
+
+    * `Sawtooth Sabre <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>`__ -
+      Implements on-chain smart contracts that are executed in a WebAssembly
+      (WASM) virtual machine
+
+    * `Sawtooth Seth <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>`__ -
+      Supports running Ethereum Virtual Machine (EVM) smart contracts on Sawtooth
 
 For more information, see :doc:`transaction_family_specifications`.
 
@@ -313,7 +323,13 @@ can get the code to start building your own distributed ledger.
     * Dockerfiles to support development or launching a network of validators
     * Source files for this documentation
 
-  * `Seth <https://github.com/hyperledger/sawtooth-seth>`_:
+  * `Sawtooth PBFT <https://github.com/hyperledger/sawtooth-pbft>`_:
+    Use PBFT consensus with Sawtooth
+
+  * `Sawtooth Sabre <https://github.com/hyperledger/sawtooth-sabre>`_:
+    Run on-chain smart contracts executed in a WebAssembly virtual machine
+
+  * `Sawtooth Seth <https://github.com/hyperledger/sawtooth-seth>`_:
     Deploy Ethereum Virtual Machine (EVM) smart contracts to Sawtooth
 
   * `Sawtooth Marketplace <https://github.com/hyperledger/sawtooth-marketplace>`_:

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -71,9 +71,22 @@ your own transaction family. These transaction families are available in the
   The family name is ``xo``.
   The transaction processor is ``xo-tp-{language}``.
 
+The following transaction families run on top of the Sawtooth platform:
+
+* `Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>`__:
+  Implements on-chain smart contracts that are executed in a WebAssembly (WASM)
+  virtual machine.
+  This transaction family is in the
+  `sawtooth-sabre <https://github.com/hyperledger/sawtooth-sabre>`__ repository.
+
+* `Sawtooth Seth Transaction Family <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>`__:
+  Supports running Ethereum Virtual Machine (EVM) smart contracts on Sawtooth.
+  This transaction family is in the
+  `sawtooth-seth <https://github.com/hyperledger/sawtooth-seth>`__ repository.
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 1
+   :caption: Contents
 
    transaction_family_specifications/settings_transaction_family.rst
    transaction_family_specifications/identity_transaction_family.rst
@@ -82,6 +95,8 @@ your own transaction family. These transaction families are available in the
    transaction_family_specifications/xo_transaction_family.rst
    transaction_family_specifications/validator_registry_transaction_family.rst
    transaction_family_specifications/smallbank_transaction_family.rst
+   Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>
+   Sawtooth Seth Transaction Family <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -1,6 +1,6 @@
-*************************************
-Validator Registry Transaction Family
-*************************************
+******************************************
+PoET Validator Registry Transaction Family
+******************************************
 
 Overview
 =========


### PR DESCRIPTION
- Add PBFT, Sabre, and Seth links to core docs
    
- Make consistency-related content changes for PoET, etc. (for clear/consistent titles, TOC presentation, and things like that)

- Fix issues found when adding the external doc links  