### PR TITLE
Fix pbft-engine executable name in App Dev Guide

### DIFF
--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -292,7 +292,7 @@ to start each component.
 
      .. code-block:: console
 
-        $ sudo -u sawtooth sawtooth-pbft-engine -vv --connect tcp://localhost:5050
+        $ sudo -u sawtooth pbft-engine -vv --connect tcp://localhost:5050
 
    * For PoET:
 


### PR DESCRIPTION
For a Sawtooth consensus engine, the executable name does not start
with "sawtooth" (except for PoET, which is sawtooth-poet-engine).

Signed-off-by: Anne Chenette <chenette@bitwise.io>