### PR TITLE
Fix adding batches to the publisher's pending queue

### DIFF
--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -482,10 +482,12 @@ impl SyncBlockPublisher {
         };
 
         if permission_check {
-            state.pending_batches.append(batch.clone());
-            if let Some(ref mut candidate_block) = state.candidate_block {
-                if candidate_block.can_add_batch() {
-                    candidate_block.add_batch(batch);
+            // If the batch is already in the pending queue, don't do anything further
+            if state.pending_batches.append(batch.clone()) {
+                if let Some(ref mut candidate_block) = state.candidate_block {
+                    if candidate_block.can_add_batch() {
+                        candidate_block.add_batch(batch);
+                    }
                 }
             }
         }
@@ -781,10 +783,12 @@ impl PendingBatchesPool {
         self.ids = HashSet::new();
     }
 
-    pub fn append(&mut self, batch: Batch) {
-        if !self.contains(&batch.header_signature) {
-            self.ids.insert(batch.header_signature.clone());
+    pub fn append(&mut self, batch: Batch) -> bool {
+        if self.ids.insert(batch.header_signature.clone()) {
             self.batches.push(batch);
+            true
+        } else {
+            false
         }
     }
 

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -471,17 +471,30 @@ impl SyncBlockPublisher {
         for observer in &state.batch_observers {
             observer.notify_batch_pending(&batch);
         }
-        let permission_check = {
+
+        // Batch can be added if the signer is authorized and the batch isn't already committed
+        let can_add_batch = {
             let gil = Python::acquire_gil();
             let py = gil.python();
-            self.permission_verifier
+
+            let permission_check = self
+                .permission_verifier
                 .call_method(py, "is_batch_signer_authorized", (batch.clone(),), None)
                 .expect("PermissionVerifier has no method is_batch_signer_authorized")
                 .extract(py)
-                .expect("PermissionVerifier.is_batch_signer_authorized did not return bool")
+                .expect("PermissionVerifier.is_batch_signer_authorized did not return bool");
+
+            let batch_already_committed: bool = self
+                .batch_committed
+                .call(py, (batch.header_signature.clone(),), None)
+                .expect("batch_committed could not be called")
+                .extract(py)
+                .expect("batch_committed did not return bool");
+
+            permission_check && !batch_already_committed
         };
 
-        if permission_check {
+        if can_add_batch {
             // If the batch is already in the pending queue, don't do anything further
             if state.pending_batches.append(batch.clone()) {
                 if let Some(ref mut candidate_block) = state.candidate_block {


### PR DESCRIPTION
Updates the way the block publisher accepts batches and adds them to its pending queue:
- Don't add a batch to the candidate block if the batch was already in the pending queue
- Don't add a batch to the pending queue if the batch is already committed
- Don't notify batch observers unless the batch is new (not already committed, not already in the pending queue)