### PR TITLE
Fix GossipBlockResponseSignatureVerifier seen_cache

### DIFF
--- a/validator/sawtooth_validator/gossip/signature_verifier.py
+++ b/validator/sawtooth_validator/gossip/signature_verifier.py
@@ -204,7 +204,7 @@ class GossipBlockResponseSignatureVerifier(Handler):
                          block.header_signature)
             return HandlerResult(status=HandlerStatus.DROP)
 
-        self._seen_cache = TimedCache()
+        self._seen_cache[block.header_signature] = None
         return HandlerResult(status=HandlerStatus.PASS)
 
 


### PR DESCRIPTION
The self.seen_cache was been recreated everytime a block was
valid. Instead the block's header signature should be added
to the timed_cache so if a duplicate is recieved it can
be properly dropped.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>