### PR TITLE
Add intkey cli to sawtooth-shell docker image

### DIFF
--- a/docker/sawtooth-shell
+++ b/docker/sawtooth-shell
@@ -39,6 +39,7 @@ RUN apt-get install -y -q \
 RUN apt-get install -y -q \
     python3-cbor \
     python3-colorlog \
+    python3-sawtooth-intkey \
     python3-sawtooth-sdk \
     python3-secp256k1 \
     python3-toml \


### PR DESCRIPTION
intkey is installed in the images created by docker-compose-installed
and in the images published to dockerhub. This commit adds intkey to the
shell generated by docker-compose.yaml for use in future testing
routines

Signed-off-by: Richard Berg <rberg@bitwise.io>