### PR TITLE
Rename sawtooth-shell in pbft docker-compose file

### DIFF
--- a/docker/compose/sawtooth-default-pbft.yaml
+++ b/docker/compose/sawtooth-default-pbft.yaml
@@ -172,7 +172,7 @@ services:
 
 # -------------=== shell ===-------------
 
-  sawtooth-shell:
+  shell:
     image: hyperledger/sawtooth-shell:1.1
     container_name: sawtooth-shell-default
     volumes:


### PR DESCRIPTION
All the other docker-compose files use the name shell for the container
named sawtooth-shell-default, this change makes the PBFT docker-compose
file consistent with the others.

Signed-off-by: Richard Berg <rberg@bitwise.io>