### PR TITLE
1-1 BACKPORT: Add more specific exclude paths for bandit

### DIFF
--- a/bin/run_bandit
+++ b/bin/run_bandit
@@ -23,14 +23,16 @@ directories="
     cli/tests
     families/settings/tests
     integration
+    integration/sawtooth_integration/tests/*
     rest_api/build
     rest_api/tests
-    sdk/python/build
-    sdk/python/sawtooth_processor_test
+    sdk/python/build/lib/sawtooth_processor_test/*
+    sdk/python/sawtooth_processor_test/*
     signing/build
     signing/tests
     validator/build
     validator/tests
+    validator/tests/test_config/*
 "
 
 if [ ! -d "$top_dir/build" ]; then


### PR DESCRIPTION
Workaround for bug reported here: https://github.com/PyCQA/bandit/issues/488

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>