### PR TITLE
1-1 BACKPORT: Avoid duplicate peering request from same endpoint

### DIFF
--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -217,7 +217,14 @@ class Gossip:
                 peer
         """
         with self._lock:
+            # If an endpoint is already peered with different connection id
+            # do not allow another peering request.
             if len(self._peers) < self._maximum_peer_connectivity:
+                if endpoint in self._peers.values():
+                    raise PeeringException(
+                        "The requested endpoint is registered already as "
+                        "a peer.")
+
                 self._peers[connection_id] = endpoint
                 self._topology.set_connection_status(connection_id,
                                                      PeerStatus.PEER)


### PR DESCRIPTION
Example Scenario: If there are three validators A, B and C.
These are configured such that A has B and C as peers,
B has C and A as peers, C has A and B as peers.
Every node initiates an outbound connection to the nodes
configured as their peers.

A peering request is sent when connection is established
successfully. With the above configuration the nodes may have
duplicate peers.

The default number of maximum number of peers is set to 10.
With above configuration, the limit may exceed soon with more
number of peers. Most of which are duplicate peering connections.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>