### PR TITLE
Use native Rust commit store in Publisher

### DIFF
--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -139,14 +139,12 @@ class BlockPublisher(OwnedPointer):
     """
 
     def __init__(self,
+                 block_store,
                  block_manager,
                  transaction_executor,
-                 batch_committed,
-                 transaction_committed,
                  state_view_factory,
                  block_sender,
                  batch_sender,
-                 chain_head,
                  identity_signer,
                  data_dir,
                  config_dir,
@@ -157,18 +155,14 @@ class BlockPublisher(OwnedPointer):
         Initialize the BlockPublisher object
 
         Args:
+            block_store (:obj: `BlockStore`): A BlockStore instance
             block_manager (:obj:`BlockManager`): A BlockManager instance
             transaction_executor (:obj:`TransactionExecutor`): A
                 TransactionExecutor instance.
-            batch_committed (fn(batch_id) -> bool): A function for checking if
-                a batch is committed.
-            transaction_committed (fn(transaction_id) -> bool): A function for
-                checking if a transaction is committed.
             state_view_factory (:obj:`NativeStateViewFactory`):
                 NativeStateViewFactory for read-only state views.
             block_sender (:obj:`BlockSender`): The BlockSender instance.
             batch_sender (:obj:`BatchSender`): The BatchSender instance.
-            chain_head (:obj:`BlockWrapper`): The initial chain head.
             chain_head_lock (:obj:`RLock`): The chain head lock.
             identity_signer (:obj:`Signer`): Cryptographic signer for signing
                 blocks
@@ -181,18 +175,17 @@ class BlockPublisher(OwnedPointer):
         """
         super(BlockPublisher, self).__init__('block_publisher_drop')
 
-        if chain_head is not None:
-            chain_head = BlockWrapper.wrap(chain_head)
+        if block_store.chain_head is not None:
+            chain_head = BlockWrapper.wrap(block_store.chain_head)
             chain_head_block = chain_head.block
         else:
             chain_head_block = None
 
         self._to_exception(PY_LIBRARY.call(
             'block_publisher_new',
+            block_store.pointer,
             block_manager.pointer,
             ctypes.py_object(transaction_executor),
-            ctypes.py_object(batch_committed),
-            ctypes.py_object(transaction_committed),
             state_view_factory.pointer,
             ctypes.py_object(block_sender),
             ctypes.py_object(batch_sender),

--- a/validator/sawtooth_validator/server/core.py
+++ b/validator/sawtooth_validator/server/core.py
@@ -320,14 +320,12 @@ class Validator:
             signer=identity_signer)
 
         block_publisher = BlockPublisher(
+            block_store=block_store,
             block_manager=block_manager,
             transaction_executor=transaction_executor,
-            transaction_committed=block_store.has_transaction,
-            batch_committed=block_store.has_batch,
             state_view_factory=native_state_view_factory,
             block_sender=block_sender,
             batch_sender=batch_sender,
-            chain_head=block_store.chain_head,
             identity_signer=identity_signer,
             data_dir=data_dir,
             config_dir=config_dir,

--- a/validator/tests/test_journal/block_tree_manager.py
+++ b/validator/tests/test_journal/block_tree_manager.py
@@ -128,14 +128,12 @@ class BlockTreeManager:
                 "commit_store")
 
         self.block_publisher = BlockPublisher(
+            block_store=self.block_store,
             block_manager=self.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            transaction_committed=self.block_store.has_transaction,
-            batch_committed=self.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.block_sender,
-            chain_head=chain_head.block,
             identity_signer=self.identity_signer,
             data_dir=None,
             config_dir=None,

--- a/validator/tests/test_journal/tests.py
+++ b/validator/tests/test_journal/tests.py
@@ -122,16 +122,12 @@ class TestBlockPublisher(unittest.TestCase):
         self.permission_verifier = MockPermissionVerifier()
 
         self.publisher = BlockPublisher(
+            block_store=self.block_tree_manager.block_store,
             block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            transaction_committed=(
-                self.block_tree_manager.block_store.has_transaction
-            ),
-            batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -294,17 +290,13 @@ class TestBlockPublisher(unittest.TestCase):
 
         mock_batch_injector_factory.create_injectors.return_value = []
         self.publisher = BlockPublisher(
+            block_store=self.block_tree_manager.block_store,
             block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(
                 batch_execution_result=False),
-            transaction_committed=(
-                self.block_tree_manager.block_store.has_transaction
-            ),
-            batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -336,16 +328,12 @@ class TestBlockPublisher(unittest.TestCase):
             {addr: value})
 
         self.publisher = BlockPublisher(
+            block_store=self.block_tree_manager.block_store,
             block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            transaction_committed=(
-                self.block_tree_manager.block_store.has_transaction
-            ),
-            batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -393,16 +381,12 @@ class TestBlockPublisher(unittest.TestCase):
         injected_batch = self.make_batch()
 
         self.publisher = BlockPublisher(
+            block_store=self.block_tree_manager.block_store,
             block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            transaction_committed=(
-                self.block_tree_manager.block_store.has_transaction
-            ),
-            batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,
@@ -441,16 +425,12 @@ class TestBlockPublisher(unittest.TestCase):
         batch2 = self.make_batch(txn_count=1)
 
         self.publisher = BlockPublisher(
+            block_store=self.block_tree_manager.block_store,
             block_manager=self.block_tree_manager.block_manager,
             transaction_executor=MockTransactionExecutor(),
-            transaction_committed=(
-                self.block_tree_manager.block_store.has_transaction
-            ),
-            batch_committed=self.block_tree_manager.block_store.has_batch,
             state_view_factory=self.state_view_factory,
             block_sender=self.block_sender,
             batch_sender=self.batch_sender,
-            chain_head=self.block_tree_manager.chain_head.block,
             identity_signer=self.block_tree_manager.identity_signer,
             data_dir=None,
             config_dir=None,


### PR DESCRIPTION
Updates the block publisher to use the native CommitStore for checking
committed transactions and batches rather than using the Python FFI.

Signed-off-by: Logan Seeley <seeley@bitwise.io>