### PR TITLE
Docs: Add PBFT steps to K8s network procedure

### DIFF
--- a/docs/source/_includes/about-nw-each-node-runs.inc
+++ b/docs/source/_includes/about-nw-each-node-runs.inc
@@ -1,15 +1,26 @@
-Each node in this Sawtooth network runs a validator, a REST API, a consensus
-engine, and the following transaction processors:
+Each node in this Sawtooth network runs a :term:`validator`, a :term:`REST API`,
+a consensus engine, and the following
+:term:`transaction processors<transaction processor>`:
 
 * :doc:`Settings <../transaction_family_specifications/settings_transaction_family>`
-  (``settings-tp``)
-* :doc:`Identity <../transaction_family_specifications/identity_transaction_family>`
-  (``identity-tp``)
+  (``settings-tp``): Handles Sawtooth's on-chain configuration settings. The
+  Settings transaction processor (or an equivalent) is required for all Sawtooth
+  networks.
+
 * :doc:`IntegerKey <../transaction_family_specifications/integerkey_transaction_family>`
-  (``intkey-tp-python``) -- optional, but used to test basic Sawtooth
-  functionality
+  (``intkey-tp-python``): Demonstrates basic Sawtooth functionality. The
+  associated ``intkey`` client includes shell commands to perform integer-based
+  transactions.
+
+* :doc:`XO <../transaction_family_specifications/xo_transaction_family>`
+  (``sawtooth-xo-tp-python``: Simple application for playing a game of
+  tic-tac-toe on the blockchain. The assocated ``xo`` client provides shell
+  commands to define players and play a game. XO is described in a later
+  section, :doc:`intro_xo_transaction_family`.
+
 * (PoET only) :doc:`PoET Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
-  (``poet-validator-registry-tp``)
+  (``poet-validator-registry-tp``): Configures PoET consensus and handles a
+  network with multiple nodes.
 
 .. important::
 

--- a/docs/source/_includes/about-sawtooth-networks.inc
+++ b/docs/source/_includes/about-sawtooth-networks.inc
@@ -8,6 +8,10 @@ set of Docker containers, or Kubernetes pod) is a Sawtooth node that runs one
 validator, an optional REST API, a consensus engine, and a set of transaction
 processors.
 
+The first node creates the :term:`genesis block`, which specifies the initial
+on-chain settings for the network. The other nodes access those settings when
+they join the network.
+
 .. note::
 
    The example environment includes the Sawtooth REST API on all validator

--- a/docs/source/app_developers_guide/docker_test_network.rst
+++ b/docs/source/app_developers_guide/docker_test_network.rst
@@ -4,21 +4,30 @@ Using Docker for a Sawtooth Test Network
 ========================================
 
 This procedure describes how to use Docker to create a network of five Sawtooth
-nodes for an application development environment, using either PBFT or PoET
-consensus. (Devmode consensus is not recommended for a network.)
+nodes for an application development environment. Each node is a set of Docker
+containers that runs a validator and related Sawtooth components.
 
-.. include:: ../_includes/pbft-vs-poet-cfg.inc
+.. note::
+
+   For a single-node environment, see :doc:`docker`.
+
+This procedure guides you through the following tasks:
+
+ * Downloading the Sawtooth Docker Compose file
+ * Starting the Sawtooth network with `docker-compose`
+ * Checking process status
+ * Configuring the allowed transaction types (optional)
+ * Connecting to the Sawtooth shell container and confirming network
+   functionality
+ * Stopping Sawtooth and resetting the Docker environment
 
 
 .. _about-sawtooth-nw-env-docker-label:
 
-About the Sawtooth Network Environment
---------------------------------------
+About the Docker Sawtooth Network Environment
+---------------------------------------------
 
-Each Sawtooth node runs a validator and related Sawtooth components. The first
-node creates the genesis block, which specifies the on-chain network
-configuration settings. The other nodes access those settings when they join the
-network.
+This test environment is a network of five Sawtooth nodes.
 
 .. figure:: ../images/appdev-environment-multi-node.*
    :width: 100%
@@ -28,7 +37,15 @@ network.
 .. include:: ../_includes/about-nw-each-node-runs.inc
 
 Like the :doc:`single-node test environment <docker>`, this environment uses
-parallel transaction processing and static peering.
+parallel transaction processing and static peering. However, it uses a different
+consensus algorithm (Devmode consensus is not recommended for a network). You
+can choose either PBFT or PoET consensus.
+
+.. include:: ../_includes/pbft-vs-poet-cfg.inc
+
+The first node creates the `genesis block`, which specifies the on-chain
+settings for the network configuration. The other nodes access those settings
+when they join the network.
 
 
 .. _prereqs-multi-docker-label:
@@ -65,11 +82,12 @@ Step 1: Download the Docker Compose File
 
 Download the Docker Compose file for a multiple-node network.
 
-* For PBFT: Download
+* For PBFT, download
   `sawtooth-default-pbft.yaml <./sawtooth-default-pbft.yaml>`_
 
-* For PoET: Download
+* For PoET, download
   `sawtooth-default-poet.yaml <./sawtooth-default-poet.yaml>`_
+
 
 Step 2: Start the Sawtooth Network
 ----------------------------------
@@ -256,7 +274,7 @@ By default, a validator accepts transactions from any transaction processor.
 However, Sawtooth allows you to limit the types of transactions that can be
 submitted.
 
-In this step, you will configure the validator network to accept transactions
+In this step, you will configure the Sawtooth network to accept transactions
 only from the transaction processors running in the example environment.
 Transaction-type restrictions are an on-chain setting, so this configuration
 change is made on one node, then applied to all other nodes.
@@ -265,9 +283,6 @@ The :doc:`Settings transaction processor
 <../transaction_family_specifications/settings_transaction_family>`
 handles on-chain configuration settings. You will use the ``sawset`` command to
 create and submit a batch of transactions containing the configuration change.
-
-Use the following steps to create and submit a batch containing the new on-chain
-setting.
 
 1. Connect to the first validator container (``sawtooth-validator-default-0``).
    The next command requires the validator key that was generated in that
@@ -331,32 +346,14 @@ setting.
 
    The output should be similar to this example:
 
-   * For PBFT:
+   .. code-block:: console
 
-     .. code-block:: console
-
-        sawtooth.consensus.algorithm.name: pbft
-        sawtooth.consensus.algorithm.version: 0.1
-        sawtooth.consensus.pbft.members=["0242fcde86373d0aa376055fc6...
-        sawtooth.publisher.max_batches_per_block=1200
-        sawtooth.settings.vote.authorized_keys: 0242fcde86373d0aa376...
-        sawtooth.validator.transaction_families: [{"family": "intkey...
-
-   * For PoET:
-
-     .. code-block:: console
-
-        sawtooth.consensus.algorithm.name: PoET
-        sawtooth.consensus.algorithm.version: 0.1
-        sawtooth.poet.initial_wait_time: 15
-        sawtooth.poet.report_public_key_pem: -----BEGIN PUBLIC KEY-----
-        MIIBIjANBgkqhki...
-        sawtooth.poet.target_wait_time: 5
-        sawtooth.poet.valid_enclave_basenames: b785c58b77152cbe7fd55ee3...
-        sawtooth.poet.valid_enclave_measurements: c99f21955e38dbb03d2ca...
-        sawtooth.publisher.max_batches_per_block: 100
-        sawtooth.settings.vote.authorized_keys: 036631291bbe87c3c9dde22...
-        sawtooth.validator.transaction_families: [{"family": "intkey", ...
+      sawtooth.consensus.algorithm.name: {name}
+      sawtooth.consensus.algorithm.version: {version}
+      ...
+      sawtooth.publisher.max_batches_per_block=1200
+      sawtooth.settings.vote.authorized_keys: 0242fcde86373d0aa376...
+      sawtooth.validator.transaction_families: [{"family": "intkey...
 
 Step 6: Stop the Sawtooth Network (Optional)
 --------------------------------------------

--- a/docs/source/app_developers_guide/kubernetes_test_network.rst
+++ b/docs/source/app_developers_guide/kubernetes_test_network.rst
@@ -3,90 +3,72 @@
 Using Kubernetes for a Sawtooth Test Network
 ============================================
 
-This procedure explains how to create a Hyperledger Sawtooth network with
-`Kubernetes <https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/>`__.
-This environment uses `Minikube <https://kubernetes.io/docs/setup/minikube/>`_
-to deploy Sawtooth as a containerized application in a local Kubernetes cluster
-inside a virtual machine (VM) on your computer.
+This procedure describes how to use `Kubernetes <https://kubernetes.io/>`__
+to create a network of five Sawtooth nodes for an application development
+environment. Each node is a Kubernetes pod containing a set of containers for a
+validator and related Sawtooth components.
 
 .. note::
 
-   This environment has five Sawtooth validator nodes. For a single-node
-   environment, see :doc:`installing_sawtooth`.
+   For a single-node environment, see :doc:`installing_sawtooth`.
 
-This procedure walks you through the following tasks:
+This procedure guides you through the following tasks:
 
- * Installing ``kubectl`` and Minikube
+ * Installing ``kubectl`` and ``minikube``
  * Starting Minikube
+ * Downloading the Sawtooth configuration file
  * Starting Sawtooth in a Kubernetes cluster
  * Connecting to the Sawtooth shell containers
- * Verifying network and blockchain functionality
+ * Confirming network and blockchain functionality
+ * Configuring the allowed transaction types (optional)
  * Stopping Sawtooth and deleting the Kubernetes cluster
+
 
 About the Kubernetes Sawtooth Network Environment
 -------------------------------------------------
 
-This environment is a network of five Sawtooth node. Each node has a
-:term:`validator`, a :term:`REST API`, and four
-:term:`transaction processors<transaction processor>`. This environment uses
-:ref:`PoET mode consensus <dynamic-consensus-label>`,
-:doc:`parallel transaction processing <../architecture/scheduling>`,
-and static peering (all-to-all)
+This test environment is a network of five Sawtooth nodes.
+This environment uses `Minikube <https://kubernetes.io/docs/setup/minikube/>`_
+to deploy Sawtooth as a containerized application in a local Kubernetes cluster
+inside a virtual machine (VM) on your computer.
+
+The Kubernetes cluster has a pod for each Sawtooth node. On each pod, there are
+containers for each Sawtooth component. The Sawtooth nodes are connected in
+an all-to-all peering relationship.
 
 .. figure:: ../images/appdev-environment-multi-node-kube.*
    :width: 100%
    :align: center
    :alt: Kubernetes: Sawtooth network with five nodes
 
-The Kubernetes cluster has a pod for each Sawtooth node. On each pod, there are
-containers for each Sawtooth component. The Sawtooth nodes are connected in
-an all-to-all peering relationship.
+.. include:: ../_includes/about-nw-each-node-runs.inc
 
-After the cluster is running, you can use the `Kubernetes dashboard
-<https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/>`_
-to view pod status, container names, Sawtooth log files, and more.
+Like the :doc:`single-node test environment <kubernetes>`, this environment uses
+parallel transaction processing and static peering. However, it uses a different
+consensus algorithm (Devmode consensus is not recommended for a network). You
+can choose either PBFT or PoET consensus.
 
-This example environment includes the following transaction processors:
+.. include:: ../_includes/pbft-vs-poet-cfg.inc
 
- * :doc:`Settings <../transaction_family_specifications/settings_transaction_family>`
-   handles Sawtooth's on-chain settings. The Settings transaction processor,
-   ``settings-tp``, is required for this environment.
-
- * :doc:`PoET Validator Registry <../transaction_family_specifications/validator_registry_transaction_family>`
-   configures PoET consensus and handles a network with multiple validators.
-
- * :doc:`IntegerKey <../transaction_family_specifications/integerkey_transaction_family>`
-   is a basic application (also called transaction family) that introduces
-   Sawtooth functionality. The ``sawtooth-intkey-tp-python`` transaction
-   processor works with the ``int-key`` client, which has shell commands to
-   perform integer-based transactions.
-
- * :doc:`XO <../transaction_family_specifications/xo_transaction_family>`
-   is a simple application for playing a game of tic-tac-toe on the blockchain.
-   The ``sawtooth-xo-tp-python`` transaction processor works with the ``xo``
-   client, which has shell commands to define players and play a game.
-   XO is described in a later tutorial.
-
-.. note::
-
-   Sawtooth provides the Settings transaction processor as a reference
-   implementation. In a production environment, you must always run the
-   Settings transaction processor or an equivalent that supports the
-   :doc:`Sawtooth methodology for storing on-chain configuration settings
-   <../transaction_family_specifications/settings_transaction_family>`.
+The first node creates the genesis block, which specifies the initial on-chain
+settings for the network configuration. The other nodes access those settings
+when they join the network.
 
 
 Prerequisites
 -------------
 
-This application development environment requires
-`kubectl <https://kubernetes.io/docs/concepts/overview/object-management-kubectl/overview/>`_
-and
-`Minikube <https://kubernetes.io/docs/setup/minikube/>`_ with a supported VM
-hypervisor, such as VirtualBox.
+* This environment requires `kubectl <https://kubernetes.io/docs/concepts/>`__
+  and
+  `minikube <https://kubernetes.io/docs/setup/minikube/>`_ with a supported VM
+  hypervisor, such as `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_.
+
+* If you created a :doc:`single-node Kubernetes environment <kubernetes>` that
+  is still running, shut it down and delete the Minikube cluster, VM, and
+  associated files. For more information, see :ref:`stop-sawtooth-kube-label`.
 
 
-Step 1: Install kubectl and Minikube
+Step 1: Install kubectl and minikube
 ------------------------------------
 
 This step summarizes the Kubernetes installation procedures. For more
@@ -94,8 +76,7 @@ information, see the
 `Kubernetes documentation <https://kubernetes.io/docs/tasks/>`_.
 
 1. Install a virtual machine (VM) hypervisor such as VirtualBox, VMWare,
-   KVM-QEMU, or Hyperkit. The steps in this procedure assume
-   `VirtualBox <https://www.virtualbox.org/wiki/Downloads>`_ (the default).
+   KVM-QEMU, or Hyperkit. This procedure assumes that you're using VirtualBox.
 
 #. Install the ``kubectl`` command as described in the Kubernetes document
    `Install kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_.
@@ -132,67 +113,175 @@ information, see the
         && chmod +x minikube && sudo mv minikube /usr/local/bin/
 
 
-Step 2: Start and Test Minikube
--------------------------------
-
-This step summarizes the procedure to start Minikube and test basic
-functionality. If you have problems, see the Kubernetes document
-`Running Kubernetes Locally via Minikube
-<https://kubernetes.io/docs/setup/minikube/>`_.
+Step 2: Start Minikube
+----------------------
 
 1. Start Minikube.
 
    .. code-block:: console
 
       $ minikube start
+      Starting local Kubernetes vX.X.X cluster...
+      ...
+      Kubectl is now configured to use the cluster.
+      Loading cached images from config file.
 
-#. Start Minikube's "Hello, World" test cluster, ``hello-minikube``.
+2. (Optional) Test basic Minikube functionality.
 
-   .. code-block:: console
+   If you have problems, see the Kubernetes document
+   `Running Kubernetes Locally via Minikube
+   <https://kubernetes.io/docs/setup/minikube/>`_.
 
-      $ kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
+   a. Start Minikube's "Hello, World" test cluster, ``hello-minikube``.
 
-      $ kubectl expose deployment hello-minikube --type=NodePort
+      .. code-block:: console
 
-#. Check the list of pods.
+         $ kubectl run hello-minikube --image=k8s.gcr.io/echoserver:1.10 --port=8080
 
-   .. code-block:: console
+         $ kubectl expose deployment hello-minikube --type=NodePort
 
-      $ kubectl get pods
+   #. Check the list of pods.
 
-   After the pod is up and running, the output of this command should display a
-   pod starting with ``hello-minikube...``.
+      .. code-block:: console
 
-#. Run a ``curl`` test to the cluster.
+         $ kubectl get pods
 
-   .. code-block:: none
+      After the cluster is up and running, the output of this command should
+      display a pod starting with ``hello-minikube...``.
 
-      $ curl $(minikube service hello-minikube --url)
+   #. Run a ``curl`` test to the cluster.
 
-#. Remove the ``hello-minikube`` cluster.
+      .. code-block:: none
 
-   .. code-block:: console
+         $ curl $(minikube service hello-minikube --url)
 
-      $ kubectl delete services hello-minikube
+   #. Remove the ``hello-minikube`` cluster.
 
-      $ kubectl delete deployment hello-minikube
+      .. code-block:: console
+
+         $ kubectl delete services hello-minikube
+
+         $ kubectl delete deployment hello-minikube
 
 
 Step 3: Download the Sawtooth Configuration File
 ------------------------------------------------
 
-Download the Kubernetes configuration (kubeconfig) file for a Sawtooth network,
-`sawtooth-kubernetes-default-poet.yaml <./sawtooth-kubernetes-default-poet.yaml>`_.
+Download the Kubernetes configuration (kubeconfig) file for a Sawtooth network.
 
-This kubeconfig file creates a Sawtooth network with five pods, each running a
-Sawtooth validator node. The pods are numbered from 0 to 4.
+* For PBFT, download
+  `sawtooth-kubernetes-default-pbft.yaml <./sawtooth-kubernetes-default-pbft.yaml>`_
 
-The configuration file also specifies the container images to download (from
+* For PoET, download
+  `sawtooth-kubernetes-default-poet.yaml <./sawtooth-kubernetes-default-poet.yaml>`_
+
+The kubeconfig file creates a Sawtooth network with five pods, each running a
+Sawtooth node. It also specifies the container images to download (from
 DockerHub) and the network settings needed for the containers to communicate
 correctly.
 
 
-Step 4: Start the Sawtooth Cluster
+Step 4: (PBFT Only) Configure Keys for the Kubernetes Pods
+----------------------------------------------------------
+
+.. important::
+
+   Skip this step if you are using PoET consensus.
+
+For a network using PBFT consensus, the initial member list must be specified
+in the genesis block. This step generates public and private validator keys for
+each pod in the network, then creates a Kubernetes ConfigMap so that the
+Sawtooth network can use these keys when it starts.
+
+1. Change your working directory to the same directory where you saved the
+   configuration file.
+
+#. Download the following files:
+
+   * `sawtooth-create-pbft-keys.yaml <https://github.com/hyperledger/sawtooth-core/blob/master/docker/kubernetes/sawtooth-create-pbft-keys.yaml>`__
+
+   * `pbft-keys-configmap.yaml <https://github.com/hyperledger/sawtooth-core/blob/master/docker/kubernetes/pbft-keys-configmap.yaml>`__
+
+   Save these files in the same directory where you saved
+   ``sawtooth-kubernetes-default-pbft.yaml...`` (in the previous step).
+
+#. Use the following command to generate the required keys.
+
+   .. code-block:: console
+
+      $ kubectl apply -f sawtooth-create-pbft-keys.yaml
+      job.batch/pbft-keys created
+
+#. Get the full name of the ``pbft-keys`` pod.
+
+   .. code-block:: console
+
+      $ kubectl get pods |grep pbft-keys
+
+#. Display the keys, then copy them for the next step. In the following command,
+   replace ``pbft-keys-xxxxx`` with the name of this pod.
+
+   .. code-block:: console
+
+      $ kubectl log pbft-keys-xxxxx
+
+   The output will resemble this example:
+
+   .. code-block:: console
+
+      pbft0priv: 028de9ced7ae7c58f1c4b8bb84a8cbf9378eb5943948d2dd6f493d0e7f3cadf3
+      pbft0pub: 036c14100c00188f0fe8e686d577f74f35032f97f10d78764f3ec910472f157c15
+      pbft1priv: c3e91eac9f8ccebc4d25977b69dc7137e4cf5fc6356a79c36802e712a49fd4b7
+      pbft1pub: 02554eddb36a2d0abcb7b51cd2316b213ebe030328cd949ebc105d061e8b6de5b5
+      pbft2priv: d34d4133fc830556beb8c642f31db4f082773c557b4108ec409871a10d60d2f4
+      pbft2pub: 03a86840dc802e19ea64b130d26f1ab7100f923396d3151ddedc76560bbdf2f778
+      pbft3priv: b8c8c79f7c8fe89eae18a805a836e23ad415b014822c60ac244a14c4df2e9429
+      pbft3pub: 02a87d1a87ed54cd467d1628a601e780ddc70a6718e4b98407f3d70bb88e8a1ee0
+      pbft4priv: 6499688038b519bfc99564978918ce31d74aa758380852608481c7cc1f779483
+      pbft4pub: 03186440394f4a447509874095a14550bc1b1821555560f0851a5f3549c8138ac2
+
+#. Edit ``pbft-keys-configmap.yaml`` to add the keys from the previous step.
+
+   .. code-block:: console
+
+      $ vim pbft-keys-configmap.yaml
+
+   Locate the "blank" key lines under ``data:`` and replace them with the keys
+   that you copied from in previous step.
+
+   Make sure that the YAML format is correct. The result should look like this
+   example:
+
+   .. code-block:: console
+
+      ...
+
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: keys-config
+      data:
+        pbft0priv: 028de9ced7ae7c58f1c4b8bb84a8cbf9378eb5943948d2dd6f493d0e7f3cadf3
+        pbft0pub: 036c14100c00188f0fe8e686d577f74f35032f97f10d78764f3ec910472f157c15
+        pbft1priv: c3e91eac9f8ccebc4d25977b69dc7137e4cf5fc6356a79c36802e712a49fd4b7
+        pbft1pub: 02554eddb36a2d0abcb7b51cd2316b213ebe030328cd949ebc105d061e8b6de5b5
+        pbft2priv: d34d4133fc830556beb8c642f31db4f082773c557b4108ec409871a10d60d2f4
+        pbft2pub: 03a86840dc802e19ea64b130d26f1ab7100f923396d3151ddedc76560bbdf2f778
+        pbft3priv: b8c8c79f7c8fe89eae18a805a836e23ad415b014822c60ac244a14c4df2e9429
+        pbft3pub: 02a87d1a87ed54cd467d1628a601e780ddc70a6718e4b98407f3d70bb88e8a1ee0
+        pbft4priv: 6499688038b519bfc99564978918ce31d74aa758380852608481c7cc1f779483
+        pbft4pub: 03186440394f4a447509874095a14550bc1b1821555560f0851a5f3549c8138ac2
+
+#. Apply the ConfigMap so that the Sawtooth network can use these keys in the
+   next step.
+
+   .. code-block:: console
+
+      $ kubectl apply -f pbft-keys-configmap.yaml
+      configmap/keys-config created
+
+
+Step 5: Start the Sawtooth Cluster
 ----------------------------------
 
 .. note::
@@ -201,48 +290,88 @@ Step 4: Start the Sawtooth Cluster
    generating keys and creating a genesis block. To learn about the full
    Sawtooth startup process, see :doc:`ubuntu`.
 
-Use these steps to start the Sawtooth network:
+Use these steps to start the Sawtooth network.
 
 1. Change your working directory to the same directory where you saved the
-   configuration file.
+   ``sawtooth-kubernetes-default-...`` configuration file.
 
-#. Make sure that Minikube is running.
+#. Start Sawtooth as a local Kubernetes cluster.
 
-   .. code-block:: console
+   * For PBFT:
 
-      $ minikube status
-      minikube: Running
-      cluster: Running
-      kubectl: Correctly Configured: pointing to minikube-vm at 192.168.99.100
+     .. code-block:: console
 
-   If necessary, start it with ``minikube start``.
+        $ kubectl apply -f sawtooth-kubernetes-default-pbft.yaml
+        deployment.extensions/pbft-0 created
+        service/sawtooth-0 created
+        deployment.extensions/pbft-1 created
+        service/sawtooth-1 created
+        deployment.extensions/pbft-2 created
+        service/sawtooth-2 created
+        deployment.extensions/pbft-3 created
+        service/sawtooth-3 created
+        deployment.extensions/pbft-4 created
+        service/sawtooth-4 created
 
-#. Start Sawtooth in a local Kubernetes cluster.
+   * For PoET:
 
-   .. _restart-kube-label:
+     .. code-block:: console
 
-   .. code-block:: console
+        $ kubectl apply -f sawtooth-kubernetes-default-poet.yaml
+        deployment.extensions/sawtooth-0 created
+        service/sawtooth-0 created
+        deployment.extensions/sawtooth-1 created
+        service/sawtooth-1 created
+        deployment.extensions/sawtooth-2 created
+        service/sawtooth-2 created
+        deployment.extensions/sawtooth-3 created
+        service/sawtooth-3 created
+        deployment.extensions/sawtooth-4 created
+        service/sawtooth-4 created
 
-      $ kubectl apply -f sawtooth-kubernetes-default-poet.yaml
-      deployment.extensions/sawtooth-0 created
-      service/sawtooth-0 created
-      deployment.extensions/sawtooth-1 created
-      service/sawtooth-1 created
-      deployment.extensions/sawtooth-2 created
-      service/sawtooth-2 created
-      deployment.extensions/sawtooth-3 created
-      service/sawtooth-3 created
-      deployment.extensions/sawtooth-4 created
-      service/sawtooth-4 created
+3. This Sawtooth network has five pods, numbered from 0 to 4, each running a
+   Sawtooth node. You can use the ``kubectl`` command to list the pods and get
+   information about each pod.
+
+   #. Display the list of pods.
+
+      .. code-block:: console
+
+         $ kubectl get pods
+         NAME                     READY     STATUS             RESTARTS   AGE
+         pod-0-aaaaaaaaaa-vvvvv   5/8       ContainerCreating  0          21m
+         pod-1-bbbbbbbbbb-wwwww   5/8       ContainerCreating  0          21m
+         pod-2-ccccccccc-xxxxx    5/8       ContainerCreating  0          21m
+         pod-3-dddddddddd-yyyyy   5/8       Pending            0          21m
+         pod-4-eeeeeeeeee-zzzzz   5/8       Pending            0          21m
+
+      Wait until each pod is ready before continuing.
+
+   #. You can specify a pod name to display the containers (Sawtooth components)
+      for that pod.
+
+      In the following command, replace ``pod-N-xxxxxxxxxx-yyyyy``  with a
+      pod name.
+
+      .. code-block:: console
+
+         $ kubectl get pods pod-N-xxxxxxxxxx-yyyyy -o jsonpath={.spec.containers[*].name}
+         sawtooth-intkey-tp-python sawtooth-pbft-engine sawtooth-rest-api sawtooth-settings-tp sawtooth-shell sawtooth-smallbank-tp-go sawtooth-validator sawtooth-xo-tp-python
+
+      Note that each pod has a shell container named ``sawtooth-shell``. You
+      will connect to the shell containers in later steps.
 
 #. (Optional) Start the Minikube dashboard.
 
-   .. code-block:: console
 
       $ minikube dashboard
 
    This command opens the dashboard in your default browser. The overview page
-   shows the Sawtooth deployment, pods, and replica sets.
+   includes workload status, deployments, pods, and Sawtooth services. The
+   Logs viewer (on the Pods page) shows the Sawtooth log files. For more
+   information, see
+   `Web UI (Dashboard) <https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/>`__
+   in the Kubernetes documentation.
 
 .. important::
 
@@ -256,22 +385,26 @@ Use these steps to start the Sawtooth network:
 
 .. _confirm-func-kube-label:
 
-Step 5: Confirm Network and Blockchain Functionality
+Step 6: Confirm Network and Blockchain Functionality
 ----------------------------------------------------
 
 1. Connect to the shell container on the first pod.
 
-     .. code-block:: none
+   In the following command, replace ``pod-0-xxxxxxxxxx-yyyyy`` with the
+   name of the first pod, as shown by ``kubectl get pods``.
 
-        $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-0/{print $1}') --container sawtooth-shell -- bash
+   .. code-block:: none
 
-        root@sawtooth-0#
+      $ kubectl exec -it pod-0-xxxxxxxxxx-yyyyy --container sawtooth-shell -- bash
+
+      root@sawtooth-0#
 
    .. note::
 
       In this procedure, the prompt ``root@sawtooth-0#`` marks the commands that should
-      be run on the Sawtooth node in pod 0. (The actual prompt is similar to
-      ``root@sawtooth-0-5ff6d9d578-5w45k:/#``.)
+      be run on the Sawtooth node in pod 0. The actual prompt is similar to
+      ``root@pbft-0-dabbad0000-5w45k:/#`` (for PBFT) or
+      ``root@sawtooth-0-f0000dd00d-sw33t:/#`` (for PoET).
 
 #. Display the list of blocks on the Sawtooth blockchain.
 
@@ -289,23 +422,24 @@ Step 5: Confirm Network and Blockchain Functionality
         0    0fb3ebf6fdc5eef8af600eccc8d1aeb3d2488992e17c124b03083f3202e3e6b9182e78fef696f5a368844da2a81845df7c3ba4ad940cee5ca328e38a0f0e7aa0  3     11    034aad...
 
    Block 0 is the :term:`genesis block`. The other two blocks contain
-   transactions for on-chain settings, such as setting PoET consensus.
+   transactions for on-chain settings.
 
 #. In a separate terminal window, connect to a different pod (such as pod 1) and
    verify that it has joined the Sawtooth network.
 
+   In the following command, replace ``pod-1-xxxxxxxxxx-yyyyy`` with the
+   name of the pod, as shown by ``kubectl get pods``.
+
      .. code-block:: none
 
-        $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-1/{print $1}') --container sawtooth-shell -- bash
+        $ kubectl exec -it pod-1-xxxxxxxxxx-yyyyy --container sawtooth-shell -- bash
 
         root@sawtooth-1#
 
-   .. note::
+    The prompt ``root@sawtooth-1#`` marks the commands that should be run on
+    the Sawtooth node in this pod.
 
-      The prompt ``root@sawtooth-1#`` marks the commands that should be run on
-      the Sawtooth node in pod 1.
-
-#. Display the list of blocks on the second pod.
+#. Display the list of blocks on the pod.
 
      .. code-block:: none
 
@@ -321,29 +455,39 @@ Step 5: Confirm Network and Blockchain Functionality
         1    4d7b3a2e6411e5462d94208a5bb83b6c7652fa6f4c2ada1aa98cabb0be34af9d28cf3da0f8ccf414aac2230179becade7cdabbd0976c4846990f29e1f96000d6  1     1     034aad...
         0    0fb3ebf6fdc5eef8af600eccc8d1aeb3d2488992e17c124b03083f3202e3e6b9182e78fef696f5a368844da2a81845df7c3ba4ad940cee5ca328e38a0f0e7aa0  3     11    034aad...
 
-#. (Optional) You can repeat the previous two steps on the other pods to verify
-   that they have the same block list. To connect to a different pod, replace
-   the `N` (in ``sawtooth-N``) in the following command with the pod number.
-   command:
+#. (Optional) You can run the following Sawtooth commands from any shell
+   container to show the other nodes on the network.
 
-     .. code-block:: none
+   In the following commands, replace ``pod-N-xxxxxxxxxx-yyyyy`` with the
+   name of the pod, as shown by ``kubectl get pods``.
 
-        $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-N/{print $1}') --container sawtooth-shell -- bash
+   a. Connect to any shell container.
 
-#. (Optional) You can also connect to the shell container of any pod, and
-   run the following Sawtooth commands to show the other nodes on the network.
+      .. code-block:: none
 
-   a. Run ``sawtooth peer list`` to show the peers of a particular node.
+         $ kubectl exec -it pod-N-xxxxxxxxxx-yyyyy --container sawtooth-shell -- bash
 
-   b. Run ``sawnet peers list`` to display a complete graph of peers on the
+         root@sawtooth-N#
+
+   #. Run ``sawtooth peer list`` to show the peers of a particular node.
+
+      .. code-block:: console
+
+         root@sawtooth-N# sawtooth peer list
+
+   #. Run ``sawnet peers list`` to display a complete graph of peers on the
       network (available in Sawtooth release 1.1 and later).
+
+      .. code-block:: console
+
+         root@sawtooth-N# sawnet peers list
 
 #. You can submit a transaction on one Sawtooth node, then look for the results
    of that transaction on another node.
 
-   a. From the shell container on pod 0, use the ``intkey set`` command to
-      submit a transaction on the first validator node. This example sets a key
-      named ``MyKey`` to the value 999.
+   a. From the shell container one pod (such as pod 0), use the ``intkey set``
+      command to submit a transaction on the first node. This example sets
+      a key named ``MyKey`` to the value 999.
 
         .. code-block:: console
 
@@ -354,7 +498,7 @@ Step 5: Confirm Network and Blockchain Functionality
              }
 
    b. From the shell container on a different pod (such as pod 1), check that
-      the value has been changed on that validator node.
+      the value has been changed on that node.
 
         .. code-block:: console
 
@@ -366,65 +510,78 @@ Step 5: Confirm Network and Blockchain Functionality
    available in the kubeconfig file or on a pod's page on the Kubernetes
    dashboard.
 
-   The following example connects to pod 3's PoET Validator Registry container
-   (``sawtooth-poet-validator-registry-tp``), then displays the list of running
-   process.
+   The following example connects to the Settings transaction processor
+   container (``sawtooth-settings-tp``) on pod 3, then displays the list of
+   running process. Replace ``pod-3-xxxxxxxxxx-yyyyy`` with the name of the
+   pod, as shown by ``kubectl get pods``.
 
    .. code-block:: console
 
-      $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-3/{print $1}') --container sawtooth-poet-validator-registry-tp -- bash
+      $ kubectl exec -it pod-3-xxxxxxxxxx-yyyyy --container sawtooth-settings-tp -- bash
 
       root@sawtooth-3# ps --pid 1 fw
         PID TTY      STAT   TIME COMMAND
-          1 ?        Ssl    0:02 /usr/bin/python3 /usr/bin/poet-validator-registry-tp -vv -C tcp://sawtooth-3-5bd565ff45-2klm7:4004
+          1 ?        Ssl    0:02 /usr/bin/python3 /usr/bin/settings-tp -vv -C tcp://sawtooth-3-5bd565ff45-2klm7:4004
 
 At this point, your environment is ready for experimenting with Sawtooth.
 
-For more ways to test basic functionality, see the Kubernetes section of
-"Setting Up a Sawtooth Application Development Environment".
+.. tip::
 
-* To use Sawtooth client commands to view block information and check state
-  data, see :ref:`sawtooth-client-kube-label`.
+   For more ways to test basic functionality, see :doc:`kubernetes`. For
+   example:
 
-* For information on the Sawtooth logs, see :ref:`examine-logs-kube-label`.
+   * To use Sawtooth client commands to view block information and check state
+     data, see :ref:`sawtooth-client-kube-label`.
+
+   * For information on the Sawtooth logs, see :ref:`examine-logs-kube-label`.
 
 
 .. _configure-txn-procs-kube-label:
 
-Step 6. Configure the Allowed Transaction Types (Optional)
+Step 7. Configure the Allowed Transaction Types (Optional)
 ----------------------------------------------------------
 
 By default, a validator accepts transactions from any transaction processor.
 However, Sawtooth allows you to limit the types of transactions that can be
 submitted.
 
-In this step, you will configure the validator network to accept transactions
-only from the four transaction processors in the example environment:
-IntegerKey, Settings, XO, and Validator Registry. Transaction-type restrictions
-are an on-chain setting, so this configuration change is applied to all
-validators.
+In this step, you will configure the Sawtooth network to accept transactions
+only from the transaction processors running in the example environment.
+Transaction-type restrictions are an on-chain setting, so this configuration
+change is made on one node, then applied to all other nodes.
 
 The :doc:`Settings transaction processor
 <../transaction_family_specifications/settings_transaction_family>`
-handles on-chain configuration settings. You can use the ``sawset`` command to
+handles on-chain configuration settings. You will use the ``sawset`` command to
 create and submit a batch of transactions containing the configuration change.
 
-Use the following steps to create and submit a batch containing the new setting.
+1. Connect to the validator container of the first node. The next command
+   requires the validator key that was generated in that container.
 
-1. Connect to the validator container of the first node
-   (``sawtooth-0-{xxxxxxxx}``). The next command requires the validator key that
-   was generated in that container.
+   Replace ``pod-0-xxxxxxxxxx-yyyyy`` with the name of the first pod, as
+   shown by ``kubectl get pods``.
 
    .. code-block:: console
 
-      $ kubectl exec -it $(kubectl get pods | awk '/sawtooth-0/{print $1}') --container sawtooth-validator -- bash
+      $ kubectl exec -it pod-0-xxxxxxxxxx-yyyyy --container sawtooth-validator -- bash
       root@sawtooth-0#
 
-#. Run the following command from the validator container:
+#. Run the following command from the validator container to specify the
+   allowed transaction families.
 
-   .. code-block:: console
+   * For PBFT:
 
-      root@sawtooth-0# sawset proposal create --key /etc/sawtooth/keys/validator.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]'
+     .. code-block:: console
+
+        root@sawtooth-0# sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+        sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}]'
+
+   * For PoET:
+
+     .. code-block:: console
+
+        root@sawtooth-0# sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+        sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]'
 
    This command sets ``sawtooth.validator.transaction_families`` to a JSON array
    that specifies the family name and version of each allowed transaction
@@ -436,7 +593,10 @@ Use the following steps to create and submit a batch containing the new setting.
 
    * You can use the Kubernetes dashboard to view this log message:
 
-     a. From the Overview page, scroll to the list of pods and click on any pod
+     a. Run ``minikube dashboard`` to start the Kubernetes dashboard, if
+        necessary.
+
+     #. From the Overview page, scroll to the list of pods and click on any pod
         name.
 
      #. On the pod page, click :guilabel:`LOGS` (in the top right).
@@ -447,8 +607,9 @@ Use the following steps to create and submit a batch containing the new setting.
         .. code-block:: none
 
            [2018-09-05 20:07:41.903 DEBUG    core] received message of type: TP_PROCESS_REQUEST
+
    * You can also connect to the ``sawtooth-settings-tp`` container on any pod,
-     then examine ``/var/log/sawtooth/logs/settings-{xxxxxxx}-debug.log``. (Each
+     then examine ``/var/log/sawtooth/logs/settings-xxxxxxx-debug.log``. (Each
      Settings log file has a unique string in the name.) The messages will
      resemble this example:
 
@@ -458,7 +619,9 @@ Use the following steps to create and submit a batch containing the new setting.
          .
          .
         [20:07:58.039 [MainThread] core DEBUG] received message of type: TP_PROCESS_REQUEST
-        [20:07:58.190 [MainThread] handler INFO] Setting setting sawtooth.validator.transaction_families changed from None to [{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]
+        [20:07:58.190 [MainThread] handler INFO] Setting setting
+        sawtooth.validator.transaction_families changed from None to [{"family":
+        "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"xo", "version":"1.0"}, ...
 
 #. Run the following command to check the setting change. You can use any
    container, such as a shell or another validator container.
@@ -471,23 +634,17 @@ Use the following steps to create and submit a batch containing the new setting.
 
    .. code-block:: console
 
-      sawtooth.consensus.algorithm.name: PoET
-      sawtooth.consensus.algorithm.version: 0.1
-      sawtooth.poet.initial_wait_time: 15
-      sawtooth.poet.key_block_claim_limit: 100000
-      sawtooth.poet.report_public_key_pem: -----BEGIN PUBL...
-      sawtooth.poet.target_wait_time: 15
-      sawtooth.poet.valid_enclave_basenames: b785c58b77152cb...
-      sawtooth.poet.valid_enclave_measurements: c99f21955e38dbb...
-      sawtooth.poet.ztest_minimum_win_count: 100000
+      sawtooth.consensus.algorithm.name: {name}
+      sawtooth.consensus.algorithm.version: {version}
+      ...
       sawtooth.publisher.max_batches_per_block: 200
-      sawtooth.settings.vote.authorized_keys: 03e27504580fa15...
-      sawtooth.validator.transaction_families: [{"family": "in...
+      sawtooth.settings.vote.authorized_keys: 03e27504580fa15da431...
+      sawtooth.validator.transaction_families: [{"family": "intkey...
 
 
 .. _stop-sawtooth-kube2-label:
 
-Step 7: Stop the Sawtooth Kubernetes Cluster
+Step 8: Stop the Sawtooth Kubernetes Cluster
 --------------------------------------------
 
 Use the following commands to stop and reset the Sawtooth network.
@@ -505,19 +662,37 @@ Use the following commands to stop and reset the Sawtooth network.
 #. Stop Sawtooth and delete the pods. Run the following command from the same
    directory where you saved the configuration file.
 
-   .. code-block:: console
+   * For PBFT:
 
-      $ kubectl delete -f sawtooth-kubernetes-default-poet.yaml
-      deployment.extensions "sawtooth-0" deleted
-      service "sawtooth-0" deleted
-      deployment.extensions "sawtooth-1" deleted
-      service "sawtooth-1" deleted
-      deployment.extensions "sawtooth-2" deleted
-      service "sawtooth-2" deleted
-      deployment.extensions "sawtooth-3" deleted
-      service "sawtooth-3" deleted
-      deployment.extensions "sawtooth-4" deleted
-      service "sawtooth-4" deleted
+     .. code-block:: console
+
+        $ kubectl delete -f sawtooth-kubernetes-default-pbft.yaml
+        deployment.extensions "pbft-0" deleted
+        service "sawtooth-0" deleted
+        deployment.extensions "pbft-1" deleted
+        service "sawtooth-1" deleted
+        deployment.extensions "pbft-2" deleted
+        service "sawtooth-2" deleted
+        deployment.extensions "pbft-3" deleted
+        service "sawtooth-3" deleted
+        deployment.extensions "pbft-4" deleted
+        service "sawtooth-4" deleted
+
+   * For PoET:
+
+     .. code-block:: console
+
+        $ kubectl delete -f sawtooth-kubernetes-default-poet.yaml
+        deployment.extensions "sawtooth-0" deleted
+        service "sawtooth-0" deleted
+        deployment.extensions "sawtooth-1" deleted
+        service "sawtooth-1" deleted
+        deployment.extensions "sawtooth-2" deleted
+        service "sawtooth-2" deleted
+        deployment.extensions "sawtooth-3" deleted
+        service "sawtooth-3" deleted
+        deployment.extensions "sawtooth-4" deleted
+        service "sawtooth-4" deleted
 
 #. Stop the Minikube cluster.
 


### PR DESCRIPTION
This PR updates "Using Kubernetes for a Sawtooth Test Network" in the App Dev Guide
to add PBFT steps and related information (intro material, overviews, links, etc.) 
alongside the existing PoET steps.
 
It also contains changes to make the Docker, Ubuntu, and Kubernetes procedures consistent.
