### PR TITLE
Add libprotobuf17 as a dependency for validator and rest_api

### DIFF
--- a/rest_api/Dockerfile
+++ b/rest_api/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y -q \
     python3-sawtooth-sdk
 
 RUN apt-get install -y -q \
+    libprotobuf17 \
     python3-aiodns \
     python3-aiohttp \
     python3-colorlog \

--- a/rest_api/stdeb.cfg
+++ b/rest_api/stdeb.cfg
@@ -1,2 +1,2 @@
 [DEFAULT]
-Depends3: ca-certificates
+Depends3: ca-certificates, libprotobuf17

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y -q \
     python3-sawtooth-sdk
 
 RUN apt-get install -y -q \
+    libprotobuf17 \
     libssl-dev \
     openssl \
     pkg-config \

--- a/validator/stdeb.cfg
+++ b/validator/stdeb.cfg
@@ -1,2 +1,2 @@
 [DEFAULT]
-Depends3: libpython3-dev, openssl, libssl-dev
+Depends3: libpython3-dev, openssl, libssl-dev, libprotobuf17


### PR DESCRIPTION
python3-protobuf:3.6.1 no longer depends on this package so it
is necessary to require it this way.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>