### PR TITLE
Remove the use of IntkeyMessageFactory in Tests

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -192,6 +192,8 @@ test_battleship() {
 test_validator() {
     run_docker_test ./validator/tests/unit_validator.yaml
     copy_coverage .coverage.validator
+    run_docker_test test_two_families
+    copy_coverage .coverage.test_two_families
     run_docker_test test_events_and_receipts
     copy_coverage .coverage.test_events_and_receipts
     run_docker_test test_namespace_restriction

--- a/bin/run_tests
+++ b/bin/run_tests
@@ -194,8 +194,6 @@ test_validator() {
     copy_coverage .coverage.validator
     run_docker_test test_two_families
     copy_coverage .coverage.test_two_families
-    run_docker_test test_events_and_receipts
-    copy_coverage .coverage.test_events_and_receipts
     run_docker_test test_namespace_restriction
     copy_coverage .coverage.namespace_restriction
     run_docker_test test_state_verifier --timeout 30

--- a/integration/sawtooth_integration/docker/test_two_families.yaml
+++ b/integration/sawtooth_integration/docker/test_two_families.yaml
@@ -37,7 +37,6 @@ services:
 
   intkey-tp-python:
     image: hyperledger/sawtooth-intkey-tp-python:nightly
-      - $SAWTOOTH_CORE:/project/sawtooth-core
     expose:
       - 4004
     depends_on:
@@ -134,4 +133,5 @@ services:
         test_two_families.TestTwoFamilies
     stop_signal: SIGKILL
     environment:
-      PYTHONPATH: "/project/sawtooth-core/integration"
+      PYTHONPATH: "/project/sawtooth-core/validator:\
+        /project/sawtooth-core/integration"

--- a/integration/sawtooth_integration/tests/test_block_info_injector.py
+++ b/integration/sawtooth_integration/tests/test_block_info_injector.py
@@ -19,14 +19,25 @@ import json
 import urllib.request
 import urllib.error
 import base64
+import hashlib
+import random
 
-from sawtooth_intkey.intkey_message_factory import IntkeyMessageFactory
+import cbor
+
+from sawtooth_signing import create_context
+from sawtooth_signing import CryptoFactory
 
 from sawtooth_validator.journal.block_info_injector \
     import CONFIG_ADDRESS
 from sawtooth_validator.journal.block_info_injector \
     import create_block_address
 from sawtooth_validator.protobuf import block_info_pb2
+from sawtooth_validator.protobuf.transaction_pb2 import Transaction
+from sawtooth_validator.protobuf.transaction_pb2 import TransactionHeader
+
+from sawtooth_validator.protobuf.batch_pb2 import Batch
+from sawtooth_validator.protobuf.batch_pb2 import BatchList
+from sawtooth_validator.protobuf.batch_pb2 import BatchHeader
 
 from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 
@@ -34,6 +45,14 @@ from sawtooth_integration.tests.integration_tools import wait_for_rest_apis
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 WAIT = 300
+
+INTKEY_ADDRESS_PREFIX = hashlib.sha512(
+    'intkey'.encode('utf-8')).hexdigest()[0:6]
+
+
+def make_intkey_address(name):
+    return INTKEY_ADDRESS_PREFIX + hashlib.sha512(
+        name.encode('utf-8')).hexdigest()[-64:]
 
 
 def get_blocks():
@@ -78,9 +97,62 @@ def submit_request(request):
     return json.loads(response)
 
 
-def make_batches(keys):
-    imf = IntkeyMessageFactory()
-    return [imf.create_batch([('set', k, 0)]) for k in keys]
+def make_batches(signer, keys):
+    return [create_batch(signer, [('set', k, 0)]) for k in keys]
+
+
+def create_batch(signer, triples):
+    transactions = [
+        create_transaction(signer, verb, name, value)
+        for verb, name, value in triples
+    ]
+
+    txn_signatures = [txn.header_signature for txn in transactions]
+
+    header = BatchHeader(
+        signer_public_key=signer.get_public_key().as_hex(),
+        transaction_ids=txn_signatures
+    ).SerializeToString()
+
+    signature = signer.sign(header)
+
+    batch = Batch(
+        header=header,
+        transactions=transactions,
+        header_signature=signature)
+
+    batch_list = BatchList(batches=[batch])
+
+    return batch_list.SerializeToString()
+
+
+def create_transaction(signer, verb, name, value):
+    payload = cbor.dumps({'Verb': verb, 'Name': name, 'Value': value},
+                         sort_keys=True)
+
+    addresses = [make_intkey_address(name)]
+
+    nonce = hex(random.randint(0, 2**64))
+
+    txn_pub_key = signer.get_public_key().as_hex()
+    header = TransactionHeader(
+        signer_public_key=txn_pub_key,
+        family_name="intkey",
+        family_version="1.0",
+        inputs=addresses,
+        outputs=addresses,
+        dependencies=[],
+        payload_sha512=hashlib.sha512(payload).hexdigest(),
+        batcher_public_key=signer.get_public_key().as_hex(),
+        nonce=nonce
+    )
+
+    signature = signer.sign(header.SerializeToString())
+
+    return Transaction(
+        header=header.SerializeToString(),
+        payload=payload,
+        header_signature=signature)
 
 
 class TestBlockInfoInjector(unittest.TestCase):
@@ -93,7 +165,11 @@ class TestBlockInfoInjector(unittest.TestCase):
         each block that is created by submitting intkey batches and then
         confirming that block info batches are in the final state.
         """
-        batches = make_batches('abcd')
+        context = create_context('secp256k1')
+        signer = CryptoFactory(context).new_signer(
+            context.new_random_private_key())
+
+        batches = make_batches(signer, 'abcd')
 
         # Assert all block info transactions are committed
         for i, batch in enumerate(batches):


### PR DESCRIPTION
Remove the dependency on the python SDK to avoid the collisions of thegenerated protobuf classes from the essentially the same source.

This replaces the use of the IntkeyMessageFactory with direct creation of intkey transactions using the protobuf classes in the `sawtooth_validator` package.