### PR TITLE
Disambiguate last on LmdbDatabaseReaderCursor

### DIFF
--- a/validator/src/database/lmdb.rs
+++ b/validator/src/database/lmdb.rs
@@ -213,14 +213,14 @@ pub struct LmdbDatabaseReaderCursor<'a> {
 }
 
 impl<'a> LmdbDatabaseReaderCursor<'a> {
-    pub fn first(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+    pub fn seek_first(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
         self.cursor
             .first(&self.access)
             .ok()
             .map(|(key, value): (&[u8], &[u8])| (Vec::from(key), Vec::from(value)))
     }
 
-    pub fn last(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
+    pub fn seek_last(&mut self) -> Option<(Vec<u8>, Vec<u8>)> {
         self.cursor
             .last(&self.access)
             .ok()

--- a/validator/src/journal/commit_store.rs
+++ b/validator/src/journal/commit_store.rs
@@ -108,9 +108,9 @@ impl CommitStore {
     fn read_chain_head_id_from_block_num_index(
         reader: &DatabaseReader,
     ) -> Result<Vec<u8>, DatabaseError> {
-        let cursor = reader.index_cursor("index_block_num")?;
+        let mut cursor = reader.index_cursor("index_block_num")?;
         let (_, val) = cursor
-            .last()
+            .seek_last()
             .ok_or_else(|| DatabaseError::NotFoundError("No chain head".into()))?;
         Ok(val)
     }


### PR DESCRIPTION
Disambiguate the use of `last` on `LmdbDatabaseReaderCursor` between its own method and that of Iterator. This commit renames `LmdbDatabaseReaderCursor`'s methods to `seek_first` and `seek_last` to differentiate the meaning.

This fixes the performance regression that occurs with `get_chain_head`.