### PR TITLE
Add new About Dynamic Consensus topic; clean up terms

### DIFF
--- a/docs/source/_includes/consensus-node-reqs.inc
+++ b/docs/source/_includes/consensus-node-reqs.inc
@@ -10,7 +10,7 @@
        because it is crash fault tolerant), which is a version of PoET-SGX
        consensus that runs on any processor.
 
-  - :term:`Devmode consensus <dev mode consensus>` has no minimum requirement,
+  - :term:`Devmode consensus` has no minimum requirement,
     but it is not recommended for multiple-node test networks or production
     networks. Devmode is a light-weight consensus that is intended for
     short-term testing on a single node or a very small network (two or three

--- a/docs/source/app_developers_guide/docker.rst
+++ b/docs/source/app_developers_guide/docker.rst
@@ -98,7 +98,7 @@ Download the Docker Compose file for the Sawtooth environment,
 This example Compose file defines the process for constructing a simple
 Sawtooth environment with following containers:
 
-* A single validator using dev mode consensus
+* A single validator using Devmode consensus
 * A REST API connected to the validator
 * The Settings transaction processor (``sawtooth-settings``)
 * The IntegerKey transaction processor (``intkey-tp-python``)

--- a/docs/source/app_developers_guide/kubernetes.rst
+++ b/docs/source/app_developers_guide/kubernetes.rst
@@ -187,7 +187,7 @@ Download the Kubernetes configuration file for a single-node environment:
 This file defines the process for constructing a one-node Sawtooth environment
 with following containers:
 
-* A single validator using :ref:`dev mode consensus <dynamic-consensus-label>`
+* A single validator using :term:`Devmode consensus`
 * A REST API connected to the validator
 * The Settings transaction processor (``sawtooth-settings``)
 * The IntegerKey transaction processor (``intkey-tp-python``)

--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -22,6 +22,9 @@ This procedure guides you through the following tasks:
  * Confirming network functionality
  * Configuring the allowed transaction types (optional)
 
+For information on Sawtooth :term:`dynamic consensus` or to learn how to change
+the consensus type, see :doc:`/sysadmin_guide/about_dynamic_consensus`.
+
 .. note::
 
    These instructions have been tested on Ubuntu 16.04 only.

--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -310,8 +310,9 @@ necessary transaction processors must be running.
 If any transactions in the genesis block set or change settings, Sawtooth
 requires the `Sawtooth Settings transaction processor <../cli/settings-tp>`_
 or an equivalent implementation.
-For example, if the genesis block configures PoET consensus, this transaction
-processor is handles the transactions with PoET settings.
+For example, the genesis block specifies the :term:`consensus engine` and
+related settings, so the Settings transaction processor is required to handle
+the transactions with these settings.
 
 When the genesis block is committed, the consensus settings are stored in
 state. All subsequent blocks are processed with the configured consensus

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -21,14 +21,12 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
   Consensus
     Process of reaching agreement among a group of participants (nodes on a
     Sawtooth network), some of which could be faulty or malicious. Sawtooth
-    supports many types of consensus algorithms. See also
-    :term:`Dynamic consensus`.
+    supports many types of consensus algorithms with the :term:`Dynamic
+    consensus` feature.
 
   Consensus API
-    Interface that allows a *consensus engine* to interact with the validator
-    in order to handle consensus functionality in a separate process. The
-    Sawtooth consensus API supports a wide variety of consensus algorithms on a
-    Sawtooth network.
+    Interface that allows a `consensus engine` to interact with the validator
+    in order to handle consensus functionality in a separate process.
 
   Consensus engine
     Sawtooth component that provides consensus-specific functionality for a
@@ -38,11 +36,12 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
   Core
     See :term:`Sawtooth core`.
 
-  Dev mode consensus
+  Devmode consensus
+    (Formerly "dev mode consensus".)
     Simple random-leader consensus algorithm that can be used to test a
-    transaction processor on a single Sawtooth node. (Dev mode is short for
-    "developer mode".) Dev mode is not recommended for a multiple-node network;
-    it should not be used for production.
+    transaction processor on a single Sawtooth node. (Devmode is short for
+    "developer mode".) Devmode consensus is not recommended for a multiple-node
+    network; it should not be used for production.
 
   Distributed ledger
     See :term:`Blockchain`.
@@ -139,7 +138,7 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
       a Trusted Execution Environment. PoET simulator is also called *PoET/CFT*
       because it is crash fault tolerant, not Byzantine fault tolerant.
 
-  Raft
+  Raft consensus
     Leader-based consensus algorithm that is designed for small networks with
     a restricted membership. Raft is crash fault tolerant, not Byzantine fault
     tolerant, and has finality (does not fork). For more information, see

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -189,6 +189,8 @@ network. Sawtooth currently includes consensus engines for these algorithms:
       testing a transaction processor. Devmode is not recommended for
       multi-node networks and should not be used for production.
 
+For more information, see :doc:`/sysadmin_guide/about_dynamic_consensus`.
+
 .. _sample-transaction-families-label:
 
 Sample Transaction Families

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -127,8 +127,8 @@ contracts can be deployed to Sawtooth using the Seth transaction family.
 
 .. _dynamic-consensus-label:
 
-Dynamic Consensus Algorithms
-----------------------------
+Dynamic Consensus
+-----------------
 
 In a blockchain, consensus is the process of building agreement among a group
 of participants in a network. Algorithms for achieving consensus with
@@ -184,9 +184,9 @@ network. Sawtooth currently includes consensus engines for these algorithms:
       is a leader-based consensus algorithm that provides crash fault tolerance
       for a small network with restricted membership.
 
-    * Dev mode (short for "developer mode")
+    * Devmode (short for "developer mode")
       is a simplified random-leader algorithm that is useful for developing and
-      testing a transaction processor. Dev mode is not recommended for
+      testing a transaction processor. Devmode is not recommended for
       multi-node networks and should not be used for production.
 
 .. _sample-transaction-families-label:

--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -13,15 +13,16 @@ on a Ubuntu system for proof-of-concept or production use in a Sawtooth network.
   with PoET consensus on a system with |Intel (R)| Software Guard Extensions
   (SGX).
 
-This guide also includes optional procedures to
-:doc:`restrict transaction types <sysadmin_guide/setting_allowed_txns>`,
-:doc:`set up a REST API proxy <sysadmin_guide/rest_auth_proxy>`,
-and :doc:`configure user, client, and validator permissions
-<sysadmin_guide/configuring_permissions>`.
+This guide also includes optional administration procedures, such as how to
+:doc:`restrict transaction types <sysadmin_guide/setting_allowed_txns>`;
+:doc:`configure user, client, and validator permissions
+<sysadmin_guide/configuring_permissions>`; and
+:doc:`display Sawtooth metrics with Grafana <sysadmin_guide/grafana_configuration>`.
 
-The last two sections in this guide explain how to
-:doc:`display Sawtooth metrics with Grafana <sysadmin_guide/grafana_configuration>`
-and :doc:`use Sawtooth configuration files <sysadmin_guide/configuring_sawtooth>`.
+Other sections in this guide summarize
+:doc:`dynamic consensus settings <sysadmin_guide/about_dynamic_consensus>`
+and explain how to
+:doc:`use Sawtooth configuration files <sysadmin_guide/configuring_sawtooth>`.
 
 .. toctree::
    :maxdepth: 2
@@ -31,8 +32,9 @@ and :doc:`use Sawtooth configuration files <sysadmin_guide/configuring_sawtooth>
    sysadmin_guide/setting_allowed_txns
    sysadmin_guide/rest_auth_proxy
    sysadmin_guide/configuring_permissions
-   sysadmin_guide/pbft_adding_removing_node.rst
    sysadmin_guide/grafana_configuration
+   sysadmin_guide/about_dynamic_consensus
+   sysadmin_guide/pbft_adding_removing_node.rst
    sysadmin_guide/configuring_sawtooth
 
 

--- a/docs/source/sysadmin_guide/about_dynamic_consensus.rst
+++ b/docs/source/sysadmin_guide/about_dynamic_consensus.rst
@@ -1,0 +1,315 @@
+.. _about-dynamic-consensus-label:
+
+***********************
+About Dynamic Consensus
+***********************
+
+Sawtooth :term:`dynamic consensus` lets you choose from a variety of consensus
+algorithms for the network.
+
+* Each consensus type has a :term:`consensus engine` that communicates with the
+  validator through the :term:`consensus API`. Each node in the network must run
+  the same consensus engine.
+
+* The validator listens for the consensus engine on the `consensus endpoint`
+  (by default, ``tcp://127.0.0.1:5050``). For more information, see
+  :doc:`/sysadmin_guide/off_chain_settings`.
+
+* The consensus type is controlled by the on-chain settings
+  ``sawtooth.consensus.algorithm.name`` and
+  ``sawtooth.consensus.algorithm.version``. These settings are required.
+
+The rest of this topic summarizes how to configure consensus and lists the
+settings and requirements for each supported consensus type:
+:ref:`PBFT <pbft-consensus-label>`,
+:ref:`PoET <poet-consensus-label>`,
+:ref:`Raft <raft-consensus-label>`, and
+:ref:`Devmode <devmode-consensus-label>`.
+
+.. note::
+
+   **Compatibility with Sawtooth 1.0**:
+   Sawtooth provides defaults for backward compatibility with previous versions
+   of Sawtooth (1.0 and earlier), when Devmode and PoET were the only supported
+   consensus algorithms.
+
+   * If ``sawtooth.consensus.algorithm.version`` is not set, the default version
+     is ``0.1``.
+
+   * If ``sawtooth.consensus.algorithm.name`` is not set, Sawtooth checks for
+     the deprecated setting ``sawtooth.consensus.algorithm``. If this setting
+     exists, Sawtooth uses the specified consensus.
+
+   * Otherwise, Sawtooth uses Devmode consensus.
+
+   **Important:** In release 1.1 and later, a consensus engine is always
+   required. The same consensus engine must be running on all nodes in the
+   network.
+
+
+Configuring Consensus for a New Network
+=======================================
+
+To configure the initial consensus, create a consensus proposal for the
+:term:`genesis block`, then start the consensus engine and any transaction
+processors that are required by that consensus type.
+
+1. The administrator of the first node uses the command ``sawset proposal
+   create`` to specify the consensus settings in the genesis block.
+   See :doc:`/sysadmin_guide/setting_up_sawtooth_poet-sim` for this procedure.
+
+#. On each node, the administrator installs and starts the consensus engine and
+   any transaction processors required for consensus (such as PoET Validator
+   Registry). See :doc:`/sysadmin_guide/systemd` for this procedure.
+
+When each node joins the network, it reads the on-chain consensus settings, then
+starts using the consensus engine to process blocks.
+
+
+Changing Consensus on a Running Network
+=======================================
+
+To change to a different consensus, start the new consensus engine on all nodes,
+plus any transaction processors that are required by that consensus type. Then
+submit a consensus change proposal.
+
+.. note::
+
+   Administrators should coordinate the change to a new consensus. For some
+   consensus types, the network could slow or become stalled if some nodes have
+   not started the new consensus engine.
+
+1. If the network has forked, stop all nodes except the one with the preferred
+   blocks.
+
+#. Each administrator installs and starts the new consensus engine and any
+   related transaction processors. See :doc:`/sysadmin_guide/installation` and
+   :doc:`/sysadmin_guide/systemd` for these procedures.
+
+#. One administrator uses the command ``sawset proposal create`` to submit a
+   transaction with the new on-chain consensus settings. For an example, see
+   :doc:`creating_genesis_block` or :ref:`config-validator-for-PoET-SGX-label`.
+
+   .. important::
+
+      This node or user must have permission to change on-chain settings.
+      Usually, the node that created the genesis block has the appropriate
+      permissions.  For more information, see
+      :ref:`config-onchain-txn-perm-label`.
+
+   When the block containing this transaction is committed, the network changes
+   to the new consensus.
+
+#. For each node, do not stop the previous consensus engine (and any related
+   transaction processors) until the node has processed all the blocks that
+   were submitted using the previous consensus.
+
+#. If a new node joins the network, it must run both consensus engines and all
+   related transaction processors. The original consensus is required to process
+   the first set of blocks.
+
+
+.. _pbft-consensus-label:
+
+PBFT Consensus
+==============
+
+:term:`Sawtooth PBFT <PBFT consensus>` is a voting-based, non-forking
+consensus algorithm with finality that provides Byzantine Fault Tolerance
+(BFT). PBFT is best for small, consortium-style networks that do not require
+open membership. For more information, see the
+`PBFT documentation <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>`__.
+
+Requirements:
+
+* A PBFT network must have at least four nodes.
+
+* The genesis block must include the validator public keys of all nodes in the
+  initial network.
+
+* Each node must install the PBFT consensus engine package,
+  ``sawtooth-pbft-engine``.
+
+* Each node must run the PBFT consensus engine:
+
+  * Service: ``sawtooth-pbft-engine.service``
+  * Executable: ``pbft-engine``
+
+  For more information, see :doc:`/sysadmin_guide/systemd`. (To start the
+  consensus engine on the command line, see
+  :ref:`start-sawtooth-first-node-label`).
+
+* Specify static peering when starting each validator. Use the ``--peering``
+  option when starting the validator (see :doc:`/cli/sawtooth-validator`) or
+  set the off-chain ``peers`` setting in the ``validator.toml`` configuration
+  file (see :doc:`configuring_sawtooth`).
+
+* Use these on-chain settings to configure PBFT consensus:
+
+  .. code-block:: none
+
+     sawtooth.consensus.algorithm.name=pbft
+     sawtooth.consensus.algorithm.version=[VERSION]
+     sawtooth.consensus.pbft.members=[VAL1KEY,VAL2KEY,...,VALnKEY]
+
+  See :doc:`/sysadmin_guide/creating_genesis_block` for more information on the
+  version and validator public keys for the PBFT member list .
+
+* For optional PBFT consensus settings, see
+  `Configuring PBFT <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/configuring-pbft.html>`__
+  in the PBFT documentation.
+
+
+.. _poet-consensus-label:
+
+PoET Consensus
+==============
+
+:term:`PoET <PoET consensus>` is a Nakamoto-style (lottery) consensus algorithm
+that is designed to support large production networks with open or
+consortium-style membership. For more information, see
+:doc:`/architecture/poet`.
+
+Sawtooth provides two versions of PoET consensus: *PoET SGX* (also called
+PoET BFT) and *PoET simulator* (also called PoET CFT). For more information,
+see :ref:`dynamic-consensus-label`.
+
+  .. important::
+
+     To learn which versions of Sawtooth support PoET SGX consensus, see
+     :doc:`/sysadmin_guide/configure_sgx` in the System Administrator's Guide.
+
+Requirements:
+
+* A PoET network must have at least three nodes, but is designed for larger
+  networks.
+
+* Each node must install the PoET consensus engine package,
+  ``python3-sawtooth-poet-engine``.
+
+* Each node must run the PoET consensus engine:
+
+  * Service: ``sawtooth-poet-engine.service``
+  * Executable: ``poet-engine``
+
+* Each node in the network must also run the PoET Validator Registry transaction
+  processor (included in the ``sawtooth`` package):
+
+  * Service: ``sawtooth-poet-validator-registry-tp.service``
+  * Executable: ``sawtooth-poet-validator-registry-tp``
+
+* Use these on-chain settings for the PoET consensus engine:
+
+  .. code-block:: none
+
+     sawtooth.consensus.algorithm.name=PoET
+     sawtooth.consensus.algorithm.version=0.1
+     sawtooth.poet.report_public_key_pem="$(cat * /etc/sawtooth/simulator_rk_pub.pem)"
+     sawtooth.poet.valid_enclave_measurements=$(poet enclave measurement)
+     sawtooth.poet.valid_enclave_basenames=$(poet enclave basename)
+
+* For a PoET test network with less than 10 or 12 nodes, disable the
+  defense-in-depth tests with these settings:
+
+  .. code-block:: none
+
+     sawtooth.poet.block_claim_delay=1
+     sawtooth.poet.key_block_claim_limit= 100000
+     sawtooth.poet.ztest_minimum_win_count=999999999
+
+
+.. _raft-consensus-label:
+
+Raft Consensus
+==============
+
+:term:`Sawtooth Raft <Raft consensus>` provides a simple consensus algorithm
+that is easy to understand.  It is leader-based, crash fault tolerant, and
+does not fork. For more information, see the
+`Raft documentation <https://sawtooth.hyperledger.org/docs/raft/nightly/master/>`__.
+
+.. note::
+
+   Sawtooth Raft is currently a prototype (not yet released). For more
+   information, see the
+   `sawtooth-raft <https://github.com/hyperledger/sawtooth-raft>`__ repository.
+
+Requirements:
+
+* Each node must install the Raft consensus engine package,
+  ``sawtooth-raft-engine``.
+
+* Each node must run the Raft consensus engine:
+
+  * Service: ``sawtooth-raft-engine.service``
+  * Executable: ``raft-engine``
+
+  For more information, see :doc:`/sysadmin_guide/systemd`. (To start the
+  consensus engine on the command line, see
+  :ref:`start-sawtooth-first-node-label`).
+
+* Specify static peering when starting each validator. Use the ``--peering``
+  option when starting the validator (see :doc:`/cli/sawtooth-validator`) or
+  set the off-chain ``peers`` setting in the ``validator.toml`` configuration
+  file (see :doc:`configuring_sawtooth`).
+
+* Use these on-chain settings for Raft consensus:
+
+  .. code-block:: none
+
+     sawtooth.consensus.algorithm.name=raft
+     sawtooth.consensus.algorithm.version=[VERSION]
+     sawtooth.consensus.raft.peers=[VAL1KEY,VAL2KEY,...,VALnKEY]
+
+  For the version number, see the ``Cargo.toml`` file. Use only the first two
+  digits (for example, `0.1`).
+
+  For ``VALxKEY``, specify the validator public key of each node in the network.
+
+* For other on-chain settings for Raft, see
+  `Optional Settings <https://sawtooth.hyperledger.org/docs/raft/nightly/master/configuring_deploying.html#on-chain-settings>`__
+  in the Raft documentation.
+
+
+.. _devmode-consensus-label:
+
+Devmode Consensus
+=================
+
+Devmode uses a simplified random-leader algorithm. It is intended for testing
+a transaction processor with a single Sawtooth node. Do not use Devmode for a
+production network.
+
+Requirements:
+
+* The node must install the Devmode consensus engine package,
+  ``sawtooth-devmode-engine-rust``.
+
+* The node must run the Devmode consensus engine ``devmode-engine-rust``.
+  For example:
+
+  .. code-block:: console
+
+     $ sudo -u sawtooth devmode-engine-rust -vv --connect tcp://localhost:5050
+
+  For more information, see :doc:`/app_developers_guide/installing_sawtooth`.
+
+* Use these on-chain settings for the Devmode consensus engine:
+
+  .. code-block:: none
+
+     sawtooth.consensus.algorithm.name=Devmode
+     sawtooth.consensus.algorithm.version=0.1
+
+  Optional settings control how long a validator should wait before attempting
+  to publish a block. If one (or both) of these options is a nonzero value,
+  the Devmode algorithm picks a random value between the maximum and minimum.
+
+  * ``sawtooth.consensus.max_wait_time``: Maximum wait time, in seconds.
+    The default is 0 (no wait).
+  * ``sawtooth.consensus.min_wait_time``: Minimum wait time, in seconds.
+    The default is 0 (no wait).
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -174,6 +174,8 @@ attestation service.
 `Click here <https://software.intel.com/formfill/sgx-onboarding>`_ for the
 registration form.
 
+.. _config-validator-for-PoET-SGX-label:
+
 Configure the Validator for PoET-SGX
 ------------------------------------
 

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -29,6 +29,8 @@ change on-chain settings and how many votes are required for a settings change.
    transaction processors can submit transactions. For more information, see
    "Setting the Allowed Transaction Types (Optional)".
 
+.. _transactor-key-permissioning-label:
+
 Transactor Key Permissioning
 ============================
 

--- a/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
+++ b/docs/source/sysadmin_guide/setting_up_sawtooth_poet-sim.rst
@@ -13,12 +13,16 @@ Sawtooth PBFT consensus or PoET simulator consensus.
   without a Trusted Execution Environment (TEE). Sawtooth PoET requires a
   minimum of three nodes, but works best with at least four or five nodes.
 
-.. note::
+For more information on the supported consensus types, or to learn how to change
+the consensus later, see :doc:`about_dynamic_consensus`.
 
-   For the procedure to configure Sawtooth with PoET SGX consensus on a system
-   with |Intel (R)| Software Guard Extensions (SGX), see :doc:`configure_sgx`.
+  .. note::
+
+     For the procedure to configure Sawtooth with PoET SGX consensus on a system
+     with |Intel (R)| Software Guard Extensions (SGX), see :doc:`configure_sgx`.
 
 .. |Intel (R)| unicode:: Intel U+00AE .. registered copyright symbol
+
 
 Use this set of procedures to create the first Sawtooth node in a network or to
 add a new node to an existing network.  Note that some procedures are performed


### PR DESCRIPTION
Add new topic "About Dynamic Consensus"
- Summarizes admin tasks for setting consensus in a new network
   and for changing consensus on a running network.
- For each consensus type, lists requirements and on-chain settings
- Adds links to this topic from the Introduction, App Dev Guide (Ubuntu network
   procedure) and Sys Admin Guide
- Documents consensus backwards compatibility - includes information about
   consensus defaults                                                            
 
Clean up consensus terms in Sawtooth docs
- Change "dev mode" to "Devmode" to match the consensus engine name
- Make other terms consistent and coherent (in the glossary and elsewhere)