### PR TITLE
Finalize the schedule on Cancel of the Candidate block

### DIFF
--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -107,6 +107,7 @@ impl CandidateBlock {
     }
 
     pub fn cancel(&mut self) {
+        self.scheduler.finalize(false).unwrap();
         self.scheduler.cancel().unwrap();
     }
 


### PR DESCRIPTION
When a candidate block is cancelled, it needs to finalize the schedule, as well as cancel it, so that the contexts are correctly cleaned up.

This addresses a minor memory leak of contexts.

Additionally,

Reduce cloning of transaction and batch results.