### PR TITLE
Hard code sdk dependency in cli 1-2

### DIFF
--- a/cli/stdeb.cfg
+++ b/cli/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+Depends3: python3-sawtooth-sdk


### PR DESCRIPTION
python3-sawtooth-sdk is sporadically missing from sawtooth-cli deb
package, the change in the PR hard codes it in.

Signed-off-by: Richard Berg <rberg@bitwise.io>