### PR TITLE
Fix error: change chmod to chown in SysAdmin Guide

### DIFF
--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -491,7 +491,7 @@ restrict permissions on ``validator.toml`` to protect the network private key.
 .. code-block:: console
 
     $ sudo chown root:sawtooth /etc/sawtooth/validator.toml
-    $ sudo chown 640 /etc/sawtooth/validator.toml
+    $ sudo chmod 640 /etc/sawtooth/validator.toml
 
 .. _rest-api-config:
 

--- a/docs/source/sysadmin_guide/off_chain_settings.rst
+++ b/docs/source/sysadmin_guide/off_chain_settings.rst
@@ -230,7 +230,7 @@ Additional steps specify the peers for this node, change the scheduler type
    .. code-block:: console
 
       $ sudo chown root:sawtooth /etc/sawtooth/validator.toml
-      $ sudo chown 640 /etc/sawtooth/validator.toml
+      $ sudo chmod 640 /etc/sawtooth/validator.toml
 
 #. Finally, restart the validator to activate the configuration changes.
 


### PR DESCRIPTION
Correct the command that restricts file permissions for validator.toml
in two sections of the System Administrator's Guide:

- Setting Up a Sawtooth Network / Changing Off-chain Settings with Configuration
  Files / Configure the Validator

- Using Sawtooth with PoET-SGX / Change the Validator Config File

Signed-off-by: Anne Chenette <chenette@bitwise.io>