### PR TITLE
1-2 backport: Improve consensus backwards compatibility

### DIFF
--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -79,10 +79,17 @@ message ConsensusStateEntry {
 
 // Sent to connect with the validator
 message ConsensusRegisterRequest {
+  message Protocol {
+    string name = 1;
+    string version = 2;
+  }
+
   // The name of this consensus engine
   string name = 1;
   // The version of this consensus engine
   string version = 2;
+  // Any additional name/version pairs the consensus engine supports
+  repeated Protocol additional_protocols = 3;
 }
 
 message ConsensusRegisterResponse {

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -136,8 +136,8 @@ class ConsensusRegisterActivateHandler(Handler):
 
     def handle(self, connection_id, message_content):
         # If this is the configured consensus engine, make it active. This is
-        # necessary for setting the active engine on genesis and when the
-        # configured engine is changed to an engine that is not registered yet
+        # necessary for setting the active engine when the configured engine is
+        # changed to an engine that is not registered yet
         request = consensus_pb2.ConsensusRegisterRequest()
 
         try:

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -115,12 +115,20 @@ class ConsensusRegisterHandler(ConsensusServiceHandler):
         self._proxy = proxy
 
     def handle_request(self, request, response, connection_id):
-        self._proxy.register(request.name, request.version, connection_id)
+        if request.additional_protocols is not None:
+            additional_protocols = \
+                [(p.name, p.version) for p in request.additional_protocols]
+        else:
+            additional_protocols = []
+
+        self._proxy.register(
+            request.name, request.version, additional_protocols, connection_id)
 
         LOGGER.info(
-            "Consensus engine registered: %s %s",
+            "Consensus engine registered: %s %s (additional protocols: %s)",
             request.name,
-            request.version)
+            request.version,
+            request.additional_protocols)
 
         return HandlerStatus.RETURN_AND_PASS
 
@@ -146,7 +154,14 @@ class ConsensusRegisterActivateHandler(Handler):
             LOGGER.exception("Unable to decode ConsensusRegisterRequest")
             return HandlerResult(status=HandlerResult.DROP)
 
-        self._proxy.activate_if_configured(request.name, request.version)
+        if request.additional_protocols is not None:
+            additional_protocols = \
+                [(p.name, p.version) for p in request.additional_protocols]
+        else:
+            additional_protocols = []
+
+        self._proxy.activate_if_configured(
+            request.name, request.version, additional_protocols)
 
         return HandlerResult(status=HandlerStatus.PASS)
 

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -366,18 +366,23 @@ def get_configured_engine(block, settings_view_factory):
     conf_version = settings_view.get_setting(
         'sawtooth.consensus.algorithm.version')
 
-    # Fallback to devmode if nothing else is set
-    name = "Devmode"
-    version = "0.1"
-
-    # If name and version settings aren't set, check for PoET
-    if conf_name is None or conf_version is None:
-        algorithm = settings_view.get_setting('sawtooth.consensus.algorithm')
-        if algorithm and (algorithm.lower() == 'poet'):
-            name = "PoET"
-    # Otherwise use name and version settings
-    else:
-        name = conf_name
+    # For backwards compatibility with 1.0:
+    # - Use version "0.1" if sawtooth.consensus.algorithm.version is unset
+    # - Use sawtooth.consensus.algorithm if sawtooth.consensus.algorithm.name
+    #   is unset
+    # - Use "Devmode" if sawtooth.consensus.algorithm is unset
+    if conf_version is not None:
         version = conf_version
+    else:
+        version = "0.1"
+
+    if conf_name is not None:
+        name = conf_name
+    else:
+        algorithm = settings_view.get_setting('sawtooth.consensus.algorithm')
+        if algorithm is not None:
+            name = algorithm
+        else:
+            name = "Devmode"
 
     return name, version

--- a/validator/tests/test_consensus/tests.py
+++ b/validator/tests/test_consensus/tests.py
@@ -30,7 +30,7 @@ class TestHandlers(unittest.TestCase):
         result = handler.handle('mock-id', request.SerializeToString())
         response = result.message_out
         self.assertEqual(response.status, handler.response_class.OK)
-        self.mock_proxy.register.assert_called_with('', '', 'mock-id')
+        self.mock_proxy.register.assert_called_with('', '', [], 'mock-id')
 
     def test_consensus_send_to_handler(self):
         handler = handlers.ConsensusSendToHandler(self.mock_proxy)
@@ -413,7 +413,8 @@ class MockBlockManager:
 
 class MockConsensusRegistry(Mock):
     def get_active_engine_info(self):
-        return EngineInfo('mock-id', 'mock-name', 'mock-version')
+        return EngineInfo('mock-id', 'mock-name', 'mock-version',
+                          [('alt-protocol-name', 'alt-protocol-version')])
 
     def is_active_engine_id(self, engine_id):
         return True


### PR DESCRIPTION
Backport of #2130

Adds a list of additional protocols (name/version pairs) that a consensus engine can support. Also updates how consensus engine name/version settings are inferred for backwards compatibility.