### PR TITLE
1-2 backport: Doc: Add Java + Swift links; improve org and content

### DIFF
--- a/docs/source/api_references.rst
+++ b/docs/source/api_references.rst
@@ -2,10 +2,13 @@
 SDK and API References
 **********************
 
+Sawtooth SDK References:
+
+.. include:: sdks.rst
+
 .. toctree::
    :maxdepth: 2
 
-   sdks.rst
    rest_api.rst
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/app_developers_guide/go_sdk.rst
+++ b/docs/source/app_developers_guide/go_sdk.rst
@@ -13,6 +13,7 @@ transaction family, XO, using the Sawtooth Go SDK.
    go_sdk_import.rst
    ../_autogen/sdk_TP_tutorial_go
    ../_autogen/sdk_submit_tutorial_go
+   ../sdk_go
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/javascript_sdk.rst
+++ b/docs/source/app_developers_guide/javascript_sdk.rst
@@ -12,6 +12,7 @@ transaction family, XO, using the Sawtooth JavaScript SDK.
    sdk_prerequisites
    ../_autogen/sdk_TP_tutorial_js
    ../_autogen/sdk_submit_tutorial_js
+   ../sdk_javascript
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/no_sdk.rst
+++ b/docs/source/app_developers_guide/no_sdk.rst
@@ -2,21 +2,20 @@
 Development Without an SDK
 **************************
 
-*Hyperledger Sawtooth* provides SDKs in a variety of languages to abstract away
-a great deal of complexity and simplify developing applications for the
-platform. The recommended way to work with Sawtooth is through one of these
-SDKs wherever possible. However, if there is no SDK for your language of
-choice, the SDK is missing some functionality, or you just want a deeper
-understanding of what is going on underneath the hood, this guide will cover
-developing for Sawtooth *without* the help of an SDK.
+Hyperledger Sawtooth provides SDKs in a variety of languages to handle
+a great deal of complexity and simplify developing applications for this
+platform. The recommended way to work with Sawtooth is through
+:doc:`one of these SDKs <using_the_sdks>`. However, if there is no SDK for your
+language of choice, if the SDK is missing functionality, or if you want a deeper
+understanding of what is going on underneath the hood, use this guide to learn
+how to develop a Sawtooth application without the help of an SDK.
 
 .. note::
 
-   In addition to an overview of the underlying concepts, each guide includes
-   copious code examples in *Python 3*. This is intended simply as a concrete
-   demonstration in a common readable language. The material covered should
-   apply to almost any language, and actual Python development should typically
-   happen with the :doc:`Python SDK <python_sdk>`.
+   This guide uses Python 3 for the code examples, because Python 3 provides a
+   concrete demonstration in a common, readable language. The information in
+   these examples applies to almost any language. Note that actual Python
+   development should typically use the :doc:`Python SDK <python_sdk>`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/app_developers_guide/python_sdk.rst
+++ b/docs/source/app_developers_guide/python_sdk.rst
@@ -13,6 +13,7 @@ transaction family, XO, using the Sawtooth Python SDK.
    python_sdk_install.rst
    ../_autogen/sdk_TP_tutorial_python
    ../_autogen/sdk_submit_tutorial_python
+   ../sdk_python
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/rust_sdk.rst
+++ b/docs/source/app_developers_guide/rust_sdk.rst
@@ -12,6 +12,7 @@ transaction family, XO, using the Sawtooth Rust SDK.
     sdk_prerequisites
     ./rust_sdk_import.rst
     ../_autogen/sdk_TP_tutorial_rust
+    ../sdk_rust
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/app_developers_guide/sdk_table.rst
+++ b/docs/source/app_developers_guide/sdk_table.rst
@@ -1,6 +1,36 @@
-**************
-Available SDKs
-**************
+*************************
+Summary of Available SDKs
+*************************
+
+The Sawtooth SDKs are in the following repositories:
+
+* C++:
+  `hyperledger/sawtooth-sdk-cxx
+  <https://github.com/hyperledger/sawtooth-sdk-cxx>`__
+
+* Go:
+  `hyperledger/sawtooth-sdk-go
+  <https://github.com/hyperledger/sawtooth-sdk-go>`__
+
+* Java:
+  `hyperledger/sawtooth-sdk-java
+  <https://github.com/hyperledger/sawtooth-sdk-java>`__
+
+* JavaScript:
+  `hyperledger/sawtooth-sdk-javascript
+  <https://github.com/hyperledger/sawtooth-sdk-javascript>`__
+
+* Python:
+  `hyperledger/sawtooth-sdk-python
+  <https://github.com/hyperledger/sawtooth-sdk-python>`__
+
+* Rust:
+  `hyperledger/sawtooth-sdk-rust
+  <https://github.com/hyperledger/sawtooth-sdk-rust>`__
+
+* Swift:
+  `hyperledger/sawtooth-sdk-swift
+  <https://github.com/hyperledger/sawtooth-sdk-swift>`__
 
 The following table summarizes the Sawtooth SDKs. It shows the feature completeness,
 API stability, and maturity level for the client signing, transaction
@@ -11,17 +41,19 @@ processors, and state delta features.
 +            +-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
 |            | Complete? | Stable API? | Maturity | Complete? | Stable API? | Maturity | Complete? | Stable API? | Maturity |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| Python     | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   1      | |yes|     | |yes|       | 1        |
+| Python     | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   1      | |yes|     | |yes|       |  1       |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| Go         | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   1      | |yes|     | |yes|       | 1        |
+| Go         | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   1      | |yes|     | |yes|       |  1       |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| JavaScript | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   2      | |yes|     | |yes|       | 2        |
+| JavaScript | |yes|     | |yes|       |   1      | |yes|     | |yes|       |   2      | |yes|     | |yes|       |  2       |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| Rust       | |yes|     |             |   1      | |yes|     |             |   1      | |yes|     |             | 1        |
+| Rust       | |yes|     |             |   1      | |yes|     |             |   1      | |yes|     |             |  1       |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| Java       |           |             |   3      |           |             |   3      |           |             | 3        |
+| Java       |           |             |   3      |           |             |   3      |           |             |  3       |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
-| C++        |           |             |   3      |           |             |   3      |           |             | 3        |
+| C++        |           |             |   3      |           |             |   3      |           |             |  3       |
++------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
+| Swift      |           |             |   3      | N/A       | N/A         |  N/A     | N/A       | N/A         | N/A      |
 +------------+-----------+-------------+----------+-----------+-------------+----------+-----------+-------------+----------+
 
 A stable API means that the Sawtooth development team is committed to backward
@@ -34,31 +66,6 @@ The Maturity column shows the general maturity level of each feature:
   2.  Community support only (core maintainers do not update these SDKs)
   3.  Experimental: Might have known issues and future API changes
 
-The available SDKs are in the following repositories:
-
-* Python:
-  `https://github.com/hyperledger/sawtooth-sdk-python/
-  <https://github.com/hyperledger/sawtooth-sdk-python>`_
-
-* Rust:
-  `https://github.com/hyperledger/sawtooth-sdk-rust
-  <https://github.com/hyperledger/sawtooth-sdk-rust>`_
-
-* Go:
-  `https://github.com/hyperledger/sawtooth-sdk-go
-  <https://github.com/hyperledger/sawtooth-sdk-go>`_
-
-* JavaScript:
-  `https://github.com/hyperledger/sawtooth-sdk-javascript
-  <https://github.com/hyperledger/sawtooth-sdk-javascript>`_
-
-* Java:
-  `https://github.com/hyperledger/sawtooth-sdk-java
-  <https://github.com/hyperledger/sawtooth-sdk-java>`_
-
-* C++:
-  `https://github.com/hyperledger/sawtooth-sdk-cxx
-  <https://github.com/hyperledger/sawtooth-sdk-cxx>`_
 
 .. |yes| unicode:: U+2713 .. checkmark
 

--- a/docs/source/app_developers_guide/using_the_sdks.rst
+++ b/docs/source/app_developers_guide/using_the_sdks.rst
@@ -3,16 +3,20 @@ Using the Sawtooth SDKs
 ***********************
 
 Sawtooth provides SDKs in several languages to help with application
-development.
+development. See :doc:`sdk_table` for links to the SDK repositories,
+as well as information on the maturity level of each SDK.
+The rest of this section has tutorials for the fully supported SDKs.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    sdk_table.rst
    go_sdk
+   Using the Java SDK: sawtooth-java-sdk documentation <https://sawtooth.hyperledger.org/docs/sdk-java/nightly/master/>
    javascript_sdk
    python_sdk
    rust_sdk
+   Using the Swift SDK: sawtooth-swift-sdk documentation <https://sawtooth.hyperledger.org/docs/sdk-swift/nightly/master/>
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sdk_go.rst
+++ b/docs/source/sdk_go.rst
@@ -1,0 +1,15 @@
+====================
+Go SDK API Reference
+====================
+
+The Go SDK Reference is available only in the
+`sawtooth-sdk-go source code <https://github.com/hyperledger/sawtooth-sdk-go>`__.
+
+  .. tip::
+
+     Use `godoc <https://godoc.org/golang.org/x/tools/cmd/godoc>`_  to extract
+     and build the Go SDK reference.
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sdk_javascript.rst
+++ b/docs/source/sdk_javascript.rst
@@ -1,0 +1,13 @@
+============================
+JavaScript SDK API Reference
+============================
+
+- `Transaction Processor
+  <https://sawtooth.hyperledger.org/docs/sdk-javascript/nightly/master/module-processor.html>`__
+
+- `Signing
+  <https://sawtooth.hyperledger.org/docs/sdk-javascript/nightly/master/module-signing.html>`__
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sdk_python.rst
+++ b/docs/source/sdk_python.rst
@@ -1,0 +1,13 @@
+========================
+Python SDK API Reference
+========================
+
+- `Transaction Processor
+  <https://sawtooth.hyperledger.org/docs/sdk-python/nightly/master/sdks/python_sdk/processor.html>`__
+
+- `Signing
+  <https://sawtooth.hyperledger.org/docs/sdk-python/nightly/master/sdks/python_sdk/sawtooth_signing.html>`__
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sdk_rust.rst
+++ b/docs/source/sdk_rust.rst
@@ -1,0 +1,14 @@
+======================
+Rust SDK API Reference
+======================
+
+- `Transaction Processor
+  <https://sawtooth.hyperledger.org/docs/sdk-rust/nightly/master/sawtooth_sdk/processor/index.html>`__
+
+- `Signing
+  <https://sawtooth.hyperledger.org/docs/sdk-rust/nightly/master/sawtooth_sdk/signing/index.html>`__
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/
+

--- a/docs/source/sdks.rst
+++ b/docs/source/sdks.rst
@@ -1,46 +1,13 @@
-=======================
-Sawtooth SDK References
-=======================
+.. toctree::
+   :maxdepth: 2
 
-
-Python
-------
-
-- `Transaction Processor
-  <https://sawtooth.hyperledger.org/docs/sdk-python/nightly/master/sdks/python_sdk/processor.html>`__
-
-- `Signing
-  <https://sawtooth.hyperledger.org/docs/sdk-python/nightly/master/sdks/python_sdk/sawtooth_signing.html>`__
-
-Go
---
-
-The Go SDK Reference is available only in the
-`sawtooth-sdk-go source code <https://github.com/hyperledger/sawtooth-sdk-go>`__.
-
-  .. tip::
-
-     Use `godoc <https://godoc.org/golang.org/x/tools/cmd/godoc>`_  to extract
-     and build the Go SDK reference.
-
-Javascript
-----------
-
-- `Transaction Processor
-  <https://sawtooth.hyperledger.org/docs/sdk-javascript/nightly/master/module-processor.html>`__
-
-- `Signing
-  <https://sawtooth.hyperledger.org/docs/sdk-javascript/nightly/master/module-signing.html>`__
-
-Rust
-----
-
-- `Transaction Processor
-  <https://sawtooth.hyperledger.org/docs/sdk-rust/nightly/master/sawtooth_sdk/processor/index.html>`__
-
-- `Signing
-  <https://sawtooth.hyperledger.org/docs/sdk-rust/nightly/master/sawtooth_sdk/signing/index.html>`__
-
+   Go <sdk_go>
+   Java <https://sawtooth.hyperledger.org/docs/sdk-java/nightly/master/sdk_api_ref.html>
+   JavaScript <sdk_javascript>
+   Python <sdk_python>
+   Rust <sdk_rust>
+   Swift <https://sawtooth.hyperledger.org/docs/sdk-swift/nightly/master/sdk_api_ref.html>
 
 .. Licensed under Creative Commons Attribution 4.0 International License
 .. https://creativecommons.org/licenses/by/4.0/
+


### PR DESCRIPTION
Backport of #2151 

This PR updates the SDK-related topics in the App Dev Guide and SDK and API Reference:

- Add Java + Swift links to SDK topics; edit topics to streamline and clarify

- Fix SDK doc org: clean up + make consistent

It also contains changes to improve the intro and note for "Development Without an SDK".