### PR TITLE
Doc: Fix terms for node, network, and PoET Validator Registry

### DIFF
--- a/docs/source/_includes/about-network-bind-endpoint-strings.inc
+++ b/docs/source/_includes/about-network-bind-endpoint-strings.inc
@@ -31,11 +31,11 @@ along with additional information about the interfaces. For example:
 This example output shows that ``eth0`` is a network interface that has access
 to the Internet. In this case, you could use one of the following:
 
-* If you would like the validator node to accept connections from other
-  validator nodes on the network behind ``eth0``, you could specify a
+* If you would like the validator to accept connections from other
+  nodes on the network behind ``eth0``, you could specify a
   network bind string such as ``tcp://eth0:8800``.
 
-* If you would like the validator node to accept only connections from local
+* If you would like the validator to accept only connections from local
   Sawtooth components, you could specify the component bind string
   ``tcp://lo:4004``. Note that this is equivalent to ``tcp://127.0.0.1:4004``.
 
@@ -51,13 +51,13 @@ About the public endpoint string
 The correct value for your public endpoint string depends on your network
 configuration.
 
-* If this network is for development purposes and all of the validator nodes
+* If this network is for development purposes and all of the nodes
   will be on the same local network, the IP address returned by ``ifconfig``
   should work as your public endpoint string.
 
 * If part of your network is behind a NAT or firewall, or if you want to start
   up a public network on the Internet, you must determine the correct routable
-  values for all the validator nodes in your network.
+  values for all the nodes in your network.
 
   Determining these values for a distributed or production network is an
   advanced networking topic that is beyond the scope of this guide. Contact your

--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -8,7 +8,7 @@ genesis block also includes the keys for the other nodes in the initial network.
 
 .. important::
 
-   Use this procedure **only** for the first validator node on a Sawtooth
+   Use this procedure **only** for the first node on a Sawtooth
    network. Skip this procedure for a node that will join an existing network.
 
 1. Ensure that the required user and validator keys exist on this node:

--- a/docs/source/_includes/sawtooth-settings-list-pbft.inc
+++ b/docs/source/_includes/sawtooth-settings-list-pbft.inc
@@ -2,7 +2,7 @@
   ``sawtooth.consensus.pbft.members`` lists the validator public keys of all
   PBFT member nodes on the network.
 
-  a. Connect to the first validator node (the one that created the genesis
+  a. Connect to the first node (the one that created the genesis
      block).
 
   #. Display the on-chain settings.

--- a/docs/source/_includes/testing-rest-api.inc
+++ b/docs/source/_includes/testing-rest-api.inc
@@ -7,7 +7,7 @@
   .. note::
 
      The Sawtooth environment described this guide runs a local REST API on
-     each validator node. For a node that is not running a local REST API,
+     each node. For a node that is not running a local REST API,
      replace ``localhost:8008`` with the externally advertised IP address and
      port.
 

--- a/docs/source/app_developers_guide/aws.rst
+++ b/docs/source/app_developers_guide/aws.rst
@@ -4,7 +4,7 @@ Using AWS for a Single Sawtooth Node
 
 This tutorial explains how to set up Hyperledger Sawtooth for application
 development using the Amazon Elastic Compute Cloud (Amazon EC2) service.
-It shows you how to launch an instance of a Sawtooth validator node from the
+It shows you how to launch an instance of a Sawtooth node from the
 `Amazon Web Services (AWS) Marketplace <https://aws.amazon.com/marketplace/pp/B075TKQCC2>`_,
 then walks you through the following tasks:
 
@@ -85,7 +85,7 @@ For more information, see the Amazon guide
       * To access the REST API remotely, add an inbound rule to allow TCP
         traffic on port 8008.
 
-      * To communicate with another validator node, add an inbound rule to
+      * To communicate with another node, add an inbound rule to
         allow TCP traffic on port 8800.
 
       For information on editing the security group rules, see Amazon's

--- a/docs/source/app_developers_guide/kubernetes.rst
+++ b/docs/source/app_developers_guide/kubernetes.rst
@@ -11,7 +11,7 @@ inside a virtual machine (VM) on your computer.
 
 .. note::
 
-   This environment has one Sawtooth validator node. For a
+   This environment has one Sawtooth node. For a
    multiple-node environment, see :doc:`creating_sawtooth_network`.
 
 This procedure walks you through the following tasks:

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -166,8 +166,8 @@ Step 4: Create the Genesis Block
 ================================
 
 Because this is a new network, you must create a genesis block (the first block
-on the distributed ledger). This step is done only for the first validator node
-on the network. Validator nodes that join an existing network do not create
+on the distributed ledger). This step is done only for the first node
+on the network. Nodes that join an existing network do not create
 a genesis block.
 
 The genesis block contains initial values that are necessary when a Sawtooth

--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -69,7 +69,7 @@ Prerequisites
   described in :doc:`ubuntu`, stop Sawtooth and delete all blockchain data
   and logs from that node.
 
-  1. If the first validator node is running, stop the Sawtooth components
+  1. If the first node is running, stop the Sawtooth components
      (validator, REST API, consensus engine, and transaction processors),
      as described in :ref:`stop-sawtooth-ubuntu-label`.
 
@@ -82,7 +82,7 @@ Prerequisites
      new keys, delete the ``.priv`` and ``.pub`` files from
      ``/home/yourname/.sawtooth/keys/`` and ``/etc/sawtooth/keys/``.
 
-* Gather networking information: For each validator node that will be on your
+* Gather networking information: For each node that will be on your
   network, gather the following information.
 
   * **Component bind string**: Where this validator will listen for incoming
@@ -91,12 +91,12 @@ Prerequisites
     ``tcp://127.0.0.1:4004``.
 
   * **Network bind string**: Where this validator will listen for incoming
-    communication from other validator nodes (also called peers). You will set
+    communication from other nodes (also called peers). You will set
     this value with ``--bind network`` when starting the validator.  Default:
     ``tcp://127.0.0.1:8800``.
 
   * **Public endpoint string**: The address that other peers should use to
-    find this validator node. You will set this value with ``--endpoint`` when
+    find the validator on this node. You will set this value with ``--endpoint`` when
     starting the validator. You will also specify this value in the peers list
     when starting a validator on another node. Default: ``tcp://127.0.0.1:8800``.
 
@@ -106,7 +106,7 @@ Prerequisites
     ``tcp://127.0.0.1:5050``.
 
   * **Peers list**: The addresses that this validator should use to connect to
-    the other validator nodes (peers); that is, the public endpoint strings of
+    the other nodes (peers); that is, the public endpoint strings of
     those nodes. You will set this value with ``--peers`` when starting the
     validator. Default: none.
 
@@ -378,7 +378,7 @@ Use the procedure in :ref:`start-sawtooth-first-node-label`.
    network to fail.
 
    Start the same transaction processors that are running on the first
-   validator node. For example, if you chose not to start ``intkey-tp-python``
+   node. For example, if you chose not to start ``intkey-tp-python``
    and ``xo-tp-python`` on the first node, do not start them on the other nodes.
 
 When each node's validator fully starts, it will peer with the other running
@@ -396,9 +396,9 @@ For the remaining steps, multiple nodes in the network must be running.
       * PoET requires at least three nodes.
 
 1. To check whether peering has occurred on the network, submit a peers query
-   to the REST API on the first validator node.
+   to the REST API on the first node.
 
-   Open a terminal window on the first validator node and run the following
+   Open a terminal window on the first node and run the following
    command.
 
      .. code-block:: console
@@ -407,7 +407,7 @@ For the remaining steps, multiple nodes in the network must be running.
 
    .. note::
 
-      This environment runs a local REST API on each validator node. For
+      This environment runs a local REST API on each node. For
       a node that is not running a local REST API, you must replace
       ``localhost:8008`` with the externally advertised IP address and
       port.  (Non-default values are set with the ``--bind`` option when
@@ -426,7 +426,7 @@ For the remaining steps, multiple nodes in the network must be running.
           "link": "http://rest-api:8008/peers"
         }
 
-#. Run the following Sawtooth commands on a validator node to show the other
+#. Run the following Sawtooth commands on a node to show the other
    nodes on the network.
 
    a. Run ``sawtooth peer list`` to show the peers of a particular node.
@@ -436,20 +436,20 @@ For the remaining steps, multiple nodes in the network must be running.
 
 #. Verify that transactions are being processed correctly.
 
-   a. Submit a transaction to the REST API on the first validator node. This
+   a. Submit a transaction to the REST API on the first node. This
       example sets a key named ``MyKey`` to the value 999.
 
-      Run the following command in a terminal window on the first validator node.
+      Run the following command in a terminal window on the first node.
 
       .. code-block:: console
 
          $ intkey set MyKey 999
 
-   #. Watch for this transaction to appear on the other validator node. The
+   #. Watch for this transaction to appear on the other node. The
       following command requests the value of ``MyKey`` from the REST API on the
-      that validator node.
+      that node.
 
-      Open a terminal window on another validator node to run the following
+      Open a terminal window on another node to run the following
       command.
 
 

--- a/docs/source/architecture/journal.rst
+++ b/docs/source/architecture/journal.rst
@@ -2,7 +2,7 @@
 Journal
 *******
 
-The `journal` is the group of validator components that work together to handle
+The `journal` is the group of validator subcomponents that work together to handle
 batches and proposed blocks. These components are responsible for completing
 published blocks, publishing batches into blocks to extend the chain, and
 validating proposed blocks to determine if they should be considered for the new
@@ -195,7 +195,7 @@ block-creation process that is described in the
 :doc:`previous Journal sections <journal>`.
 
 A genesis block (the root of a blockchain) is required to bootstrap a new
-Sawtooth validator network with on-chain settings such as the desired consensus
+Sawtooth network with on-chain settings such as the desired consensus
 algorithm, any deployment-specific configuration settings, and any
 application-specific transactions that are needed at genesis time.
 

--- a/docs/source/architecture/permissioning_requirement.rst
+++ b/docs/source/architecture/permissioning_requirement.rst
@@ -12,9 +12,9 @@ Sawtooth divides permissioning into two general groups:
   - `Transactor key permissioning` controls who can submit transactions and
     batches, based on signing keys.
   - `Validator key permissioning` controls which nodes are allowed to
-    establish connections to the validator network.
+    establish connections to the Sawtooth network.
 
-This chapter summarizes the types of validator networks, then lists the
+This chapter summarizes the types of Sawtooth networks, then lists the
 capability requirements for these permissioning groups. Each requirement has
 a short description, the network scenario the requirement supports, and
 associated `user stories`. User stories are short statements about a requirement
@@ -26,8 +26,8 @@ and network-wide on-chain permissioning.
 
 - Local configuration allows a validator to limit who is allowed to submit
   batches and transactions directly to that validator. This is useful, for
-  example, if a company is running its own validator and wishes to allow only
-  members of that company to submit transactions.
+  example, if a company is running its own Sawtooth node and wishes to allow
+  only members of that company to submit transactions.
 
 - On-chain configuration allows a Sawtooth network to enforce consistent
   permissioning rules. For example, in validator key permissioning, all the
@@ -61,7 +61,7 @@ Client
 
 Policy
   Set of DENY and PERMIT rules that can be used to permission the
-  access to the validator network and which transactors can participate on the
+  access to the Sawtooth network and which transactors can participate on the
   network.
 
 Transaction
@@ -106,12 +106,12 @@ Network Operator
   modifying on-chain roles.
 
 Sysadmin
-  System administrator; a person who installs and configures the validator
-  software and configures the validator software using config files. The
+  System administrator; a person who installs and configures a Sawtooth
+  node using config files. The
   role of sysadmin does not include activities that modify on-chain settings.
 
-Validator Network Scenarios
-===========================
+Sawtooth Network Scenarios
+==========================
 
 Sawtooth is designed to support public, consortium, and private networks.
 The following network scenarios are used in the discussion of capability
@@ -122,14 +122,14 @@ requirements to illustrate when each requirement would be useful.
   allowed to sign batches and transactions.
 
 - Consortium network:
-  In a consortium network, only specific validators are allowed to join the
-  validator network and participate in consensus. However, the network allows
+  In a consortium network, only specific nodes are allowed to join the
+  Sawtooth network and participate in consensus. However, the network allows
   any client, transaction processor, or event subscriber to connect to a
   validator and accept batches and transactions signed by all transactors.
 
 - Private Network:
-  In a private network, only specific validators are allowed to join the
-  validator network and participate in consensus. The validators in the network
+  In a private network, only specific nodes are allowed to join the
+  Sawtooth network and participate in consensus. The validators in the network
   accept only connections from specific clients. The validators also control
   whether the client is allowed to submit batches and query specific address
   prefixes in state. Only specific transaction processors and event subscribers
@@ -146,11 +146,11 @@ scenario.
 +--------------------+--------------------------------------------------------+
 | Public Network     | - Allow all batch signers to submit batches            |
 |                    | - Allow all transaction signers to submit transactions |
-|                    | - Allow all nodes to join the validator network        |
+|                    | - Allow all nodes to join the Sawtooth network         |
 +--------------------+--------------------------------------------------------+
 | Consortium Network | - Allow all batch signers to submit batches            |
 |                    | - Allow all transaction signers to submit transactions |
-|                    | - Allow only specific nodes to join the validator      |
+|                    | - Allow only specific nodes to join the Sawtooth       |
 |                    |   network                                              |
 |                    | - Allow only specific nodes to participate in consensus|
 |                    | - Support policy-based transactor permissioning        |
@@ -158,7 +158,7 @@ scenario.
 | Private Network    | - Allow only specific batch signers to submit batches  |
 |                    | - Allow only specific transaction signers to submit    |
 |                    |   transactions                                         |
-|                    | - Allow only specific nodes to join the validator      |
+|                    | - Allow only specific nodes to join the Sawtooth       |
 |                    |   network                                              |
 |                    | - Allow only specific nodes to participate in consensus|
 |                    | - Restrict the type of transactions transactors can    |
@@ -205,7 +205,7 @@ Allow all batch signers to submit batches
 |                    |   validator to accept batches signed by any batch      |
 |                    |   signer.                                              |
 |                    | - A network operator can configure the                 |
-|                    |   validator network to accept batches signed by any    |
+|                    |   Sawtooth network to accept batches signed by any     |
 |                    |   batch signer.                                        |
 +--------------------+--------------------------------------------------------+
 
@@ -222,7 +222,7 @@ Allow only specific batch signers to submit batches
 |                    | validator receives a batch that was signed by a batch  |
 |                    | signer whose public key is not allowed, that batch     |
 |                    | is dropped. Batches are also checked                   |
-|                    | before block validation. If the validator network      |
+|                    | before block validation. If the Sawtooth network       |
 |                    | permits a given batch signer, the validator accepts    |
 |                    | batches signed by that batch signer from peers,        |
 |                    | regardless of its local configuration.                 |
@@ -231,7 +231,7 @@ Allow only specific batch signers to submit batches
 |                    |   validator to accept batches signed only by predefined|
 |                    |   batch signers.                                       |
 |                    | - A network operator can configure the                 |
-|                    |   whole validator network to only accept batches from  |
+|                    |   whole Sawtooth network to only accept batches from   |
 |                    |   specific batch signers.                              |
 +--------------------+--------------------------------------------------------+
 
@@ -256,7 +256,7 @@ Allow all transaction signers to submit transactions
 |                    |   validator to accept transactions signed by any       |
 |                    |   transaction signer.                                  |
 |                    | - A network operator can configure the                 |
-|                    |   whole validator network to accept transactions signed|
+|                    |   whole Sawtooth network to accept transactions signed |
 |                    |   by any batch signer.                                 |
 +--------------------+--------------------------------------------------------+
 
@@ -274,7 +274,7 @@ Allow only specific transaction signers to submit transactions
 |                    | a transaction that was signed by a transaction signer  |
 |                    | whose public key is not allowed, that transaction      |
 |                    | should be dropped. Transactions should also be checked |
-|                    | during block validation. If the validator network      |
+|                    | during block validation. If the Sawtooth network       |
 |                    | permits a given transaction signer, the validator will |
 |                    | accept transactions signed by that transaction signer  |
 |                    | from peers, regardless of its local configuration.     |
@@ -283,7 +283,7 @@ Allow only specific transaction signers to submit transactions
 |                    |   validator to accept transactions signed only by      |
 |                    |   predefined transaction signers.                      |
 |                    | - A network operator can configure the                 |
-|                    |   whole validator network to accept batches only from  |
+|                    |   whole Sawtooth network to accept batches only from   |
 |                    |   specific transaction signers.                        |
 +--------------------+--------------------------------------------------------+
 
@@ -302,7 +302,7 @@ Restrict the type of transactions transactors can sign
 |                    | by the transaction family logic.                       |
 +--------------------+--------------------------------------------------------+
 | User Stories       | - A network operator can configure the                 |
-|                    |   whole validator network to only accept transactions  |
+|                    |   whole Sawtooth network to only accept transactions   |
 |                    |   that were signed by allowed transaction signers for a|
 |                    |   specific transaction family.                         |
 +--------------------+--------------------------------------------------------+
@@ -323,7 +323,7 @@ Support policy-based transactor permissioning
 |                    |   that are signed by transactors that are allowed by   |
 |                    |   predefined locally stored policies.                  |
 |                    | - A network operator can configure the                 |
-|                    |   whole validator network to accept only transactions  |
+|                    |   whole Sawtooth network to accept only transactions   |
 |                    |   and batches that are signed by transactor that are   |
 |                    |   allowed by defined policies.                         |
 +--------------------+--------------------------------------------------------+
@@ -331,13 +331,13 @@ Support policy-based transactor permissioning
 Validator Key Permissioning
 ===========================
 
-Validator key permissioning is performed on the basis of a validator node’s
+Validator key permissioning is performed on the basis of a validator’s
 public signing key.
 
 The following tables describe the design of each capability for validator
 key permissioning.
 
-Allow all nodes to join the validator network
+Allow all nodes to join the Sawtooth network
 ---------------------------------------------
 
 +--------------------+--------------------------------------------------------+
@@ -345,11 +345,11 @@ Allow all nodes to join the validator network
 |                    | - Consortium - NO                                      |
 |                    | - Private - NO                                         |
 +--------------------+--------------------------------------------------------+
-| Description        | The validator network can be configured to             |
-|                    | allow all validator nodes to join the network. This    |
+| Description        | The Sawtooth network can be configured to              |
+|                    | allow all nodes to join the network. This              |
 |                    | means that every validator on the network should accept|
 |                    | the node as a peer, regardless of its public key.      |
-|                    | The validator nodes are also able to                   |
+|                    | The nodes are also able to                             |
 |                    | participate in consensus and communicate over the      |
 |                    | gossip protocol. The node must still go through        |
 |                    | the authorization procedure defined by the validator   |
@@ -358,11 +358,11 @@ Allow all nodes to join the validator network
 |                    | rejected.                                              |
 +--------------------+--------------------------------------------------------+
 | User Stories       | - A network operator can configure the                 |
-|                    |   validator network to accept all nodes that wish to   |
+|                    |   Sawtooth network to accept all nodes that wish to    |
 |                    |   connect, regardless of the node’s public key.        |
 +--------------------+--------------------------------------------------------+
 
-Allow only specific nodes to join the validator network
+Allow only specific nodes to join the Sawtooth network
 -------------------------------------------------------
 
 +--------------------+--------------------------------------------------------+
@@ -370,7 +370,7 @@ Allow only specific nodes to join the validator network
 |                    | - Consortium - YES                                     |
 |                    | - Private - YES                                        |
 +--------------------+--------------------------------------------------------+
-| Description        | The validator network can be configured to             |
+| Description        | The Sawtooth network can be configured to              |
 |                    | only allow nodes to join the network if the node's     |
 |                    | public key is permitted. In other words, if a validator|
 |                    | receives a connection request from a node, and the     |
@@ -378,7 +378,7 @@ Allow only specific nodes to join the validator network
 |                    | connection is rejected.                                |
 +--------------------+--------------------------------------------------------+
 | User Stories       | - A network operator can configure the                 |
-|                    |   validator network to only accept connections from    |
+|                    |   Sawtooth network to only accept connections from     |
 |                    |   nodes with specific public keys.                     |
 +--------------------+--------------------------------------------------------+
 
@@ -390,7 +390,7 @@ Allow only specific nodes to participate in consensus
 |                    | - Consortium - YES                                     |
 |                    | - Private - YES                                        |
 +--------------------+--------------------------------------------------------+
-| Description        | The validator network can be configured to             |
+| Description        | The Sawtooth network can be configured to              |
 |                    | only allow specific nodes to participate in consensus. |
 |                    | This is separate from any restrictions enforced by the |
 |                    | consensus algorithm. The nodes that are not allowed to |
@@ -398,7 +398,7 @@ Allow only specific nodes to participate in consensus
 |                    | are not allowed to publish blocks.                     |
 +--------------------+--------------------------------------------------------+
 | User Stories       | - A network operator can configure the                 |
-|                    |   validator network to only allow certain nodes to     |
+|                    |   Sawtooth network to only allow certain nodes to      |
 |                    |   participate in consensus.                            |
 +--------------------+--------------------------------------------------------+
 

--- a/docs/source/architecture/poet.rst
+++ b/docs/source/architecture/poet.rst
@@ -97,7 +97,7 @@ EPID
 EPID Pseudonym
   Pseudonym of an SGX platform used in linkable quotes.  It is
   part of the IAS attestation response according to IAS API specifications. It
-  is computed as a function of the service Basename (validator network in our
+  is computed as a function of the service Basename (Sawtooth network in our
   case) and the device's EPID private key.
 
 PPK, PSK
@@ -343,7 +343,7 @@ following sign-up procedure:
    \textnormal{ENC.generateSignUpData(OPKhash)}` The ``report_data`` (512 bits)
    field in the report body includes the SHA256 digest of (OPKhash | PPK).
 #. Ask SGX Quoting Enclave (QE) for linkable quote on the report (using the
-   validator network's Basename).
+   Sawtooth network's Basename).
 #. If Self Attestation is enabled in IAS API: request attestation of linkable
    quote and PSE manifest to IAS. The AEP sent to IAS must contain:
 

--- a/docs/source/architecture/poet.rst
+++ b/docs/source/architecture/poet.rst
@@ -55,7 +55,7 @@ PoET essentially works as follows:
 
 #. Another function, such as “CheckTimer”, verifies that the timer
    was created by the enclave. If the timer has expired, this function
-   creates an attestation that can be used to verify that validator did
+   creates an attestation that can be used to verify that the validator did
    wait the allotted time before claiming the leadership role.
 
 The PoET leader election algorithm meets the criteria for a good lottery
@@ -97,7 +97,7 @@ EPID
 EPID Pseudonym
   Pseudonym of an SGX platform used in linkable quotes.  It is
   part of the IAS attestation response according to IAS API specifications. It
-  is computed as a function of the service Basename (Sawtooth network in our
+  is computed as a function of the service Basename (Sawtooth network, in our
   case) and the device's EPID private key.
 
 PPK, PSK
@@ -378,9 +378,9 @@ The server side of the validator runs the following sign-up procedure:
       digest of the most recently committed block. It may be that the sender has
       not seen :math:`WaitCertId_{n}` yet and could be sending
       :math:`WaitCertId_{n'}` where :math:`n'<n`. In this case the sender should
-      be urged to updated his/her view of the ledger by appending the new blocks
+      be urged to updated the view of the ledger by appending the new blocks
       and retry. It could also happen that the receiving validator has not seen
-      :math:`WaitCertId_{n}` in which case he/she should try to update his/her
+      :math:`WaitCertId_{n}` in which case it should try to update the
       view of the ledger and verify again.
    #. Verify MRENCLAVE value within quote is equal to PoET\_MRENCLAVE (there
       could be more than one allowed value).
@@ -425,7 +425,7 @@ Election Phase
 --------------
 
 Assume the identifier of the most recent valid block is :math:`WaitCertId_{n}`.
-Broadcast messages are signed by a validator with his/her PPK. To participate in
+Broadcast messages are signed by a validator with its PPK. To participate in
 the election phase a validator runs the following procedure on the client side:
 
 1. Start the PoET SGX enclave: ENC.
@@ -440,7 +440,7 @@ the election phase a validator runs the following procedure on the client side:
    (waitCertificate, signature, block, OPK, PPK) where block is the transaction
    block identified by blockDigest.
 
-On the server side a validator waits for incoming (waitCertificate, signature,
+On the server side, a validator waits for incoming (waitCertificate, signature,
 block, OPK, PPK) tuples. When one is received the following validity checks are
 performed:
 
@@ -485,8 +485,8 @@ validator could perform on other validators' EPID keys  at any time.
 
 #. **Asynchronous sign-up quote verification** A validator can (at any time) ask
    IAS for attestation on a quote that another validator used to sign-up to
-   check if his/her EPID key has been revoked since. If so the returned AVR will
-   indicate that the key is revoked. A validator who obtains such an AVR from
+   check if its EPID key has been revoked since. If so, the returned AVR will
+   indicate that the key is revoked. A validator that obtains such an AVR from
    IAS can broadcast it in a blacklisting transaction, so that all the
    validators can check the veracity of the AVR and proceed with the
    blacklisting. To limit the use of blacklisting transactions as a means to
@@ -496,10 +496,10 @@ validator could perform on other validators' EPID keys  at any time.
    * A certain number of participation tokens needs to be burned to commit a
      blacklisting transaction.
 
-   * A validator can commit a blacklisting transaction only once he/she wins one
+   * A validator can commit a blacklisting transaction only once it wins one
      or more elections.
 
-   * A validator who commits a certain number of non-legit blacklisting
+   * A validator that commits a certain number of non-legit blacklisting
      transactions is blacklisted.
 
 Security Considerations
@@ -518,7 +518,7 @@ Security Considerations
    arbitrarily win elections cannot affect the correctness of the system, but
    can hinder progress by publishing void transactions. This problem is
    mitigated by limiting the frequency with which a validator (identified by
-   his/her PPK) can win elections in a given time frame (see z-test
+   its PPK) can win elections in a given time frame (see z-test
    documentation).
 
 #. **WaitTimer duration manipulation:**
@@ -547,7 +547,7 @@ Security Considerations
       validator does not have control over the resulting :math:`WaitCertId_{n}`.
       A validator winning an election could otherwise try different blockDigest
       input values to createWaitCertificate and broadcast the WaitCertificate
-      whose :math:`WaitCertId_{n}` results in the lowest duration of his/her
+      whose :math:`WaitCertId_{n}` results in the lowest duration of its
       next WaitTimer.
 
    #. The call ``createWaitTimer()`` in step 1 of the election phase (client
@@ -562,8 +562,8 @@ Security Considerations
       user from creating multiple WaitCertificates (each with a different nonce)
       resulting in different WaitCertId digests without re-creating a WaitTimer
       (and waiting for its duration) each time. It follows that as long as the
-      duration of WaitTimer is not too small a malicious validator who wins the
-      current election has very limited control over the duration of his/hers
+      duration of WaitTimer is not too small, a malicious validator that wins the
+      current election has very limited control over the duration of its
       next WaitTimer.
 
    #. The check on the Monotonic Counter value guarantees only one enclave

--- a/docs/source/architecture/scheduling.rst
+++ b/docs/source/architecture/scheduling.rst
@@ -132,9 +132,9 @@ determined using these inputs/outputs declarations.
    implementations can enforce specific inputs/outputs requirements to
    provide an incentive for correct client behavior.
 
-The parallel scheduler calculates predecessors using a Merkle-Radix tree with nodes
-addressable by state addresses or namespaces. This tree is called the
-predecessor tree. Input declarations are considered reads, with output
+The parallel scheduler calculates predecessors using a Merkle-Radix tree with
+nodes that are addressable by state addresses or namespaces. This tree is called
+the "predecessor tree". Input declarations are considered reads, with output
 declarations considered writes.  By keeping track of readers and writers within
 nodes of the tree, predecessors for a transaction can be quickly determined.
 

--- a/docs/source/architecture/scheduling.rst
+++ b/docs/source/architecture/scheduling.rst
@@ -57,7 +57,7 @@ Block Publisher
 ---------------
 
 The Block Publisher is responsible for creating new candidate blocks.  As
-batches are received by the validator (from clients or other validator nodes),
+batches are received by the validator (from clients or other Sawtooth nodes),
 they are added to the Block Publisher's pending queue.  Only valid transactions
 will be added to the next candidate block.  For timeliness, batches are added
 to a scheduler as they are added to the pending queue; thus, transactions are

--- a/docs/source/architecture/validator_network.rst
+++ b/docs/source/architecture/validator_network.rst
@@ -1,6 +1,6 @@
-*****************
-Validator Network
-*****************
+****************
+Sawtooth Network
+****************
 
 The network layer is responsible for communication between validators in a
 Sawtooth network, including performing initial connectivity, peer discovery,
@@ -52,7 +52,7 @@ States
 ======
 
 Sawtooth defines three states related to the connection between any two
-validator nodes:
+nodes:
 
 - Unconnected
 - Connected - A connection is a required prerequisite for peering.
@@ -216,7 +216,7 @@ Network Permissioning
 =====================
 The Sawtooth
 :doc:`permissioning design <../architecture/permissioning_requirement>`
-allows the validator network to
+allows the network to
 limit the nodes that are able to connect to it. The permissioning rules
 determine the roles a connection is able to play on the network. The roles
 control the types of messages that can be sent and received over a given
@@ -232,7 +232,7 @@ from their identity signing key. Permission verifiers examine incoming
 messages against the policy and the current configuration and either permit,
 drop, or respond with an error. In certain cases, the connection will be
 forcibly closed -- for example, if a node is not allowed to connect to the
-validator network.
+network.
 
 The following describes the procedure for establishing a new connection with
 the validator. The procedure supports implementing different authorization

--- a/docs/source/cli/sawtooth-validator.rst
+++ b/docs/source/cli/sawtooth-validator.rst
@@ -42,7 +42,7 @@ validator.
   - If set to ``dynamic``, any static peers will be processed first,
     before starting the topology buildout starting, then the URLs
     specified by ``--seeds`` will be used for the initial connection
-    to the validator network.
+    to the Sawtooth network.
 
 - Use ``--scheduler`` to set the scheduler type to ``serial`` or
   ``parallel``. Note that both scheduler types result in the same

--- a/docs/source/cli/sawtooth.rst
+++ b/docs/source/cli/sawtooth.rst
@@ -19,8 +19,8 @@
 sawtooth
 ********
 
-The ``sawtooth`` command is the usual way to interact with validators or
-validator networks.
+The ``sawtooth`` command is the usual way to interact with Sawtooth validators
+and networks.
 
 This command has a multi-level structure. It starts with the base call to
 ``sawtooth``. Next is a top-level subcommand such as ``block`` or ``state``.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -93,7 +93,7 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
 
   Node
     Participant in Sawtooth network. Each node runs a single validator, a
-    REST API, and one or more transaction processors.
+    REST API, a consensus engine, and one or more transaction processors.
 
   Off-chain setting
     Setting or value that is stored locally, rather than on the blockchain.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -62,7 +62,7 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
   Global state
     Database that stores a local (validator-specific) record of transactions for
     the blockchain. Sawtooth represents state in a single instance of a
-    Merkle-Radix tree on each validator node.  For more information, see
+    Merkle-Radix tree on each Sawtooth node.  For more information, see
     :doc:`architecture/global_state`.
 
   Identity
@@ -209,7 +209,10 @@ This glossary defines Hyperledger Sawtooth terms and concepts.
     Component responsible for validating batches of transactions, combining
     them into blocks, maintaining consensus with the Sawtooth network,
     and coordinating communication between clients, transaction processors, and
-    other validator nodes.
+    other validators on the network.
+
+  Validator node
+    See :term:`node`.
 
   XO
     Sample transaction family that demonstrates basic transactions by playing

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -277,16 +277,16 @@ lines of output showing that the SGX enclave has been initialized:
       Changes the version of the consensus algorithm to 0.1.
 
     ``sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)"``
-      Adds the public key that the validator registry transaction processor uses
+      Adds the public key that the PoET Validator Registry transaction processor uses
       to verify attestation reports.
 
     ``sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement)``
       Adds the enclave measurement for your enclave to the blockchain for the
-      validator registry transaction processor to use to check signup information.
+      PoET Validator Registry transaction processor to use to check signup information.
 
     ``sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename)``
       Adds the enclave basename for your enclave to the blockchain for the
-      validator registry transaction processor to use to check signup information.
+      PoET Validator Registry transaction processor to use to check signup information.
 
     ``sawtooth.poet.enclave_module_name``
       Specifies the name of the Python module that implements the PoET enclave.

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -223,9 +223,11 @@ Create validator keys:
 
     $ sudo sawadm keygen
 
-.. note::  If you're configuring multiple validators, the steps below are
-    required for the first validator only.  For additional validators, you
-    can skip the rest of this procedure. Continue with :ref:`val-config`.
+.. note::
+
+   If you're configuring multiple Sawtooth nodes, the following steps are
+   required for the first node only.  For the other nodes, you
+   can skip the rest of this procedure; continue with :ref:`val-config`.
 
 Become the ``sawtooth`` user and change to ``/tmp``.
 In the following commands, the prompt ``[sawtooth@system]`` shows the commands
@@ -369,7 +371,7 @@ Add the following content to the file:
     # Advertised network endpoint URL.
     endpoint = "tcp://[external interface]:[port]"
 
-    # Uri(s) to connect to in order to initially connect to the validator network,
+    # URI(s) to connect to in order to initially connect to the Sawtooth network,
     # in the format tcp://hostname:port. This is not needed in static peering mode
     # and defaults to None.
     seeds = ["tcp://[seed address 1]:[port]",

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -40,7 +40,7 @@ two different methods for defining the transactors that a validator will accept.
 
 The first method is configuring a validator to only accept batches and
 transactions from predefined transactors that are loaded from a local validator
-config file. Once the validator is configured the list of allowed transactors
+config file. Once the validator is configured, the list of allowed transactors
 is immutable while the validator is running. This set of permissions are only
 enforced when receiving a batch from a connected client, but not when receiving
 a batch from a peer on the network.
@@ -104,7 +104,7 @@ additional ``PERMIT_KEY`` or ``DENY_KEY`` lines.
 .. note::
 
    A policy file implicitly ends with the rule ``DENY_KEY *``, which denies
-   all transactors or validators who are not explicitly specified in a
+   all transactors or validators that are not explicitly specified in a
    ``PERMIT_KEY`` rule. For example, if a transactor policy file contains a
    single rule that permits one transactor, it is implicitly denying all
    other transactors.

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -233,7 +233,7 @@ are allowed to sign transactions and batches on the system.
 Validator Key Permissioning
 ===========================
 
-Sawtooth allows the validator network to
+Sawtooth allows the network to
 limit the nodes that are able to connect to it. The permissioning rules
 determine the roles a connection is able to play on the network. These roles
 control the types of messages that can be sent and received over a given
@@ -247,7 +247,7 @@ from its identity signing key. Permission verifiers examine incoming
 messages against the policy and the current configuration and either permit,
 drop, or respond with an error. In certain cases, the connection will be
 forcibly closed -- such as if a node is not allowed to connect to the
-validator network.
+network.
 
 This on-chain approach allows the whole network to change its policies at the
 same time while the network is live, instead of relying on a startup
@@ -256,14 +256,14 @@ configuration.
 Configuring Authorization
 -------------------------
 The Identity namespace stores roles as key-value pairs, where the key is a role
-name and the value is a policy. Validator network permissioning roles use
+name and the value is a policy. Sawtooth network permissioning roles use
 the following pattern:
 
 .. code-block:: none
 
   network[.SUB_ROLE] = POLICY_NAME
 
-where network is the name of the role to be used for validator network
+where ``network`` is the name of the role to be used for network-wide validator
 permissioning. POLICY_NAME refers to the name of a policy that is set in the
 Identity namespace. The policy defines the public keys that are allowed to
 participate in that role. The policy is made up of PERMIT_KEY and DENY_KEY
@@ -299,7 +299,7 @@ will be rejected. For more information, please look at the
 
 Network Roles
 -------------
-The following is the suggested high-level role for on-chain validator network
+The following is the suggested high-level role for on-chain network
 permissioning.
 
 ``default``:
@@ -310,7 +310,7 @@ permissioning.
   is ``PERMIT_KEY *`` (permit all).
 
 ``network``:
-  If a validator receives a peer request from a node whose public key is not
+  If a validator receives a peer request from a node whose validator public key is not
   permitted by the policy, the message will be dropped, an
   ``AuthorizationViolation`` will be returned, and the connection will be closed.
 
@@ -331,7 +331,7 @@ permissioning.
 
 ``network.consensus``:
   If a validator receives a ``GossipMessage`` that contains a new block published
-  by a node whose public key is not permitted by the policy, the message will
+  by a node whose validator public key is not permitted by the policy, the message will
   be dropped, an ``AuthorizationViolation`` will be returned, and the connection
   will be closed.
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -55,7 +55,7 @@ The ``validator.toml`` configuration file has the following options:
 
   Dynamic peering first processes any static peers, starts topology buildouts,
   then uses the URLs specified by the seeds option for the initial connection
-  to the validator network.
+  to the Sawtooth network.
 
   .. code-block:: none
 
@@ -75,7 +75,7 @@ The ``validator.toml`` configuration file has the following options:
 - ``seeds`` = [``URI``]
 
   (Dynamic peering only.) Specifies the URI or URIs for the initial connection
-  to the validator network.  Specify multiple URIs in a comma-separated list;
+  to the Sawtooth network.  Specify multiple URIs in a comma-separated list;
   each URI must be enclosed in double quotes.  Default: none.
 
   Note that this option is not needed in static peering mode.

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -43,7 +43,7 @@ The ``validator.toml`` configuration file has the following options:
 
 - ``peering = "{static,dynamic}"``
 
-  Specifies the type of peering approach the validator should take: static
+  Specifies the type of peering the validator should use: static
   or dynamic.  Default: ``static``.
 
   Static peering attempts to peer only with the candidates provided with the

--- a/docs/source/sysadmin_guide/off_chain_settings.rst
+++ b/docs/source/sysadmin_guide/off_chain_settings.rst
@@ -149,7 +149,7 @@ Additional steps specify the peers for this node, change the scheduler type
          peers = ["tcp://node1:8800", "tcp://node2:8800", "tcp://node3:8800"]
 
    #. (Dynamic peering only). Find the ``seeds`` setting, which specifies the
-      peers to use for the initial connection to the validator network.
+      peers to use for the initial connection to the Sawtooth network.
       This setting is ignored for static peering.
 
       Replace the default address and port (``host1:8800``) with the values for

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -41,6 +41,7 @@ accepted transaction types to those from this network's transaction processors
 
         $ sudo sawset proposal create --key /etc/sawtooth/keys/validator.priv \
         sawtooth.validator.transaction_families='[{"family":"sawtooth_identity", "version":"1.0"}, {"family":"intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}]'
+
    * For PoET:
 
      .. code-block:: console

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -18,7 +18,7 @@ block with this transaction. Note that the
 :doc:`Settings transaction processor <../transaction_family_specifications/settings_transaction_family>`
 is required to handle on-chain configuration settings.
 
-In this procedure, you will configure the validator network to limit the
+In this procedure, you will configure the Sawtooth network to limit the
 accepted transaction types to those from this network's transaction processors
 (as started in :doc:`systemd`).
 

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -31,7 +31,8 @@ your own transaction family. These transaction families are available in the
   The family name is ``intkey``.
   The transaction processor is ``intkey-tp-{language}``.
 
-* The :doc:`/transaction_family_specifications/validator_registry_transaction_family`
+* The :doc:`PoET Validator Registry transaction
+  family </transaction_family_specifications/validator_registry_transaction_family>`
   provides a way to add new validators to the network. It is used by the PoET
   consensus algorithm implementation to keep track of other validators.
 

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -8,7 +8,7 @@ Overview
 The validator registry transaction family provides a way to add new validators
 to the network.
 
-The validator's information is used by poet_consensus to verify that when a
+The validator's information is used by PoET consensus to verify that when a
 validator tries to claim a block it is following the block claiming policies of
 PoET consensus. For example, the Z policy will refuse blocks from a validator
 if it has already claimed a disproportionate amount of blocks compared to the
@@ -17,14 +17,14 @@ claim blocks, after being added to the registry or updating their information,
 until a certain number of blocks are claimed by other participants. The number
 of blocks claimed since signup can be found by checking the current block number
 against the block number that is stored in the validator information when the
-validator registry information has either been added or updated. And finally the K
-policy requires new signup information to be sent to the validator registry
-after it has claimed a maximum number of block. If the validator is not found
-in the validator registry the block will be rejected since there is no way to
-validate.
+validator registry information has either been added or updated. And, finally,
+the K policy requires new signup information to be sent to the validator registry
+after it has claimed a maximum number of blocks. If the validator is not found
+in the validator registry, the block will be rejected, since there is no way to
+validate it.
 
-Currently the number of blocks claimed by a specific validator is stored within
-the poet_consensus, not within the validator registry.
+Currently, the number of blocks claimed by a specific validator is stored within
+the PoET consensus engine, not within the validator registry.
 
 
 State
@@ -104,15 +104,16 @@ to the validator registry. This check is necessary because if the number of
 blocks that must be waited on is greater than the number of validators minus
 one, it is possible for the network to get into a state where nobody can
 publish blocks because the validators are all waiting for more blocks to be
-committed or their signup information to be added to a block.
+committed or for their signup information to be added to a block.
 
-Validator registry transaction would not be able to be done at the same time as
-any other transaction as an update to the ValidatorMap is necessary. However all
-other transaction that need to access the state set by the validator registry,
-can be done in parallel since it will only be a read and  the statics for each
-validator is stored in the poet_enclave. If this was changed so that the stats
-were stored in the validator registry this would require a write to state every
-time a block is published and would reduce the ability for parallelism.
+A validator registry transaction cannot be done at the same time as
+any other transaction, because an update to the ValidatorMap is necessary.
+However, all other transactions that need to access the state set by the
+validator registry can be done in parallel, since it will only be a read and the
+statics for each validator is stored in the poet_enclave. If this was changed so
+that the stats were stored in the validator registry, this would require a write
+to state every time a block is published and would reduce the ability for
+parallelism.
 
 Addressing
 ----------
@@ -224,7 +225,7 @@ transaction is rejected and a invalid transaction response is returned.
 If the transaction is deemed to be valid, the validator_id is used to find
 the address where the validator_info should be stored. Store the serialized
 ValidatorInfo protocol buffer in state at the address as mentioned above. If
-this validator is new (not updating its SignUpInfo), the validator’s id needs
+this validator is new (not updating its SignUpInfo), the validator’s ID needs
 to be added to the validator_map.
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/validator_registry_transaction_family.rst
@@ -5,8 +5,8 @@ PoET Validator Registry Transaction Family
 Overview
 =========
 
-The validator registry transaction family provides a way to add new validators
-to the network.
+The PoET Validator Registry transaction family provides a way to add new validators
+to a network using :term:`PoET consensus`.
 
 The validator's information is used by PoET consensus to verify that when a
 validator tries to claim a block it is following the block claiming policies of
@@ -30,8 +30,8 @@ the PoET consensus engine, not within the validator registry.
 State
 =====
 This section describes in detail how validator information, including
-identification and signup data, is stored and addressed using the validator
-registry transaction family.
+identification and signup data, is stored and addressed using the PoET Validator
+Registry transaction family.
 
 The following protocol buffers definition defines the validator info:
 
@@ -121,11 +121,11 @@ Addressing
 When a validator’s signup info is registered or updated it should be accessed
 using the following algorithm:
 
-Addresses for the validator registry transaction family are set by adding
-sha256 hash of the validator's id to the validator registry namespace. The
-namespace for the validator registry will be the first 6 characters of the
-sha256  hash of the string “validator_registry”, which is “6a4372” For example,
-the validator signup info of a validator with the id “validator_id” could be
+Addresses for the PoET Validator Registry transaction family are set by adding
+sha256 hash of the validator's ID to the PoET Validator Registry namespace. The
+namespace for this transaction family is the first 6 characters of the
+sha256 hash of the string “validator_registry”, which is “6a4372” For example,
+the validator signup info of a validator with the ID “validator_id” could be
 set like this:
 
 .. code-block:: pycon
@@ -144,7 +144,7 @@ following address:
 
 Transaction Payload
 ===================
-Validator registry transaction family payloads are defined by the following
+PoET Validator Registry transaction family payloads are defined by the following
 protocol buffers code:
 
 .. code-block:: protobuf
@@ -174,7 +174,7 @@ Transaction Header
 Inputs and Outputs
 ------------------
 
-The inputs for validator registry family transactions must include:
+The inputs for PoET Validator Registry family transactions must include:
 
 * the address of *validator_id*
 * the address of *validator_map*
@@ -182,7 +182,7 @@ The inputs for validator registry family transactions must include:
 * the address of *sawtooth.poet.valid_enclave_measurement*
 * the address of *sawtooth.poet.valid_enclave_basenames*
 
-The outputs for validator registry family transactions must include:
+The outputs for PoET Validator Registry family transactions must include:
 
 * the address of *validator_id*
 * the address of *validator_map*


### PR DESCRIPTION
- Change "validator node" to "Sawtooth node" (or just "node").

- Change "validator network" to "Sawtooth network" or "validator", depending on context.

- Change "Validator Registry" (TP/TF name) to "PoET Validator Registry".

Also fix typos and wording problems noticed when making these changes.

