### PR TITLE
Doc: Add Identity info and steps to App Dev network procs

### DIFF
--- a/docs/source/_includes/about-nw-each-node-runs.inc
+++ b/docs/source/_includes/about-nw-each-node-runs.inc
@@ -7,6 +7,11 @@ a consensus engine, and the following
   Settings transaction processor (or an equivalent) is required for all Sawtooth
   networks.
 
+* :doc:`Identity <../transaction_family_specifications/identity_transaction_family>`
+  (``identity-tp``): Handles permissions for other components in the network.
+  The Identity transaction processor (or an equivalent) is required to change
+  permissions such as the allowed transaction types.
+
 * :doc:`IntegerKey <../transaction_family_specifications/integerkey_transaction_family>`
   (``intkey-tp-python``): Demonstrates basic Sawtooth functionality. The
   associated ``intkey`` client includes shell commands to perform integer-based

--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -295,6 +295,10 @@ to start each component.
 
    .. code-block:: console
 
+      $ sudo -u sawtooth identity-tp -v
+
+   .. code-block:: console
+
       $ sudo -u sawtooth intkey-tp-python -v
 
    .. code-block:: console

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -14,9 +14,13 @@ This setting, ``sawtooth.validator.transaction_families``, improves the
 Sawtooth network's security by ignoring any unrecognized transaction processors.
 It is an on-chain setting, which means that the change is submitted on one node;
 the other nodes in the network apply the settings change when they receive the
-block with this transaction. Note that the
+block with this transaction.
+
+The :doc:`Identity transaction processor <../transaction_family_specifications/identity_transaction_family>`
+(or an equivalent) is required to change permissions such as the allowed
+transaction types. The
 :doc:`Settings transaction processor <../transaction_family_specifications/settings_transaction_family>`
-is required to handle on-chain configuration settings.
+(or an equivalent) is required to handle the on-chain configuration settings.
 
 In this procedure, you will configure the validator network to limit the
 accepted transaction types to those from this network's transaction processors

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -16,15 +16,14 @@ your own transaction family. These transaction families are available in the
   is an extensible role- and policy-based system for defining permissions in a
   way that can be used by other Sawtooth components.
   The family name is ``sawtooth_identity``;
-  the associated transaction processor is ``identity-tp`` (see
-  :doc:`/cli/identity-tp`).
+  the associated transaction processor is ``identity-tp``.
 
 * The :doc:`/transaction_family_specifications/integerkey_transaction_family`
   (also called "intkey") simply sets, increments, and decrements the value of
   entries stored in a state dictionary.
-  The :doc:`intkey command </cli/intkey>` command provides an example CLI client.
+  The :doc:`intkey command </cli/intkey>` provides an example CLI client.
 
-  intkey is available in several languages, including Go, Java, and JavaScript
+  IntegerKey is available in several languages, including Go, Java, and JavaScript
   (Node.js); see the ``sawtooth-sdk-{language}`` repositories under
   ``examples``.
 


### PR DESCRIPTION
The Identity TP is required to set the allowed transaction types (as described in the last section of the Ubuntu NW procedure).
    
- Add Identity to the list of TPs in the app dev network environment
    
- Add step to start identity-tp with the other TPs

Also fix typos in the Transaction Family Specification introduction.
