### PR TITLE
1-2 backport: Add owner+perm info to sysadmin config file topics

### DIFF
--- a/docs/source/sysadmin_guide/configuring_sawtooth/cli_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/cli_configuration.rst
@@ -20,7 +20,8 @@ configuration file.
 An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/cli/cli.toml.example``. To create a CLI configuration
 file, download this example file to the config directory and name it
-``cli.toml``.
+``cli.toml``. Set the ownership and permissions to owner ``root``,
+group ``sawtooth``, and permissions ``640``.
 
 The example file shows the format of the ``url`` option. To use it,
 uncomment the line and replace the default value with the actual

--- a/docs/source/sysadmin_guide/configuring_sawtooth/identity_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/identity_tp_configuration.rst
@@ -18,9 +18,10 @@ file.
 An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/families/identity/sawtooth_identity/packaging/identity.toml.example``.
 To create an Identity transaction processor configuration file, download this
-example file to the config directory and name it ``identity.toml``. Then edit
-the file to change the example configuration options as necessary for your
-system.
+example file to the config directory and name it ``identity.toml``.
+Set the ownership and permissions to owner ``root``, group ``sawtooth``, and
+permissions ``640``. Then edit the file to change the example configuration
+options as necessary for your system.
 
 The ``identity.toml`` configuration file has the following option:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/path_configuration_file.rst
@@ -17,8 +17,10 @@ path for application data.
 
 An example file is in ``/etc/sawtooth/path.toml.example``. To create a path
 configuration file, copy the example file to the config directory and name it
-``path.toml``. Then edit the file to change the example configuration options as
-necessary for your system.
+``path.toml``. Important: Copy with ``cp -a`` to preserve the file's ownership
+and permissions (or change after copying to owner ``root``, group ``sawtooth``,
+and permissions ``640``). Then edit the file to change the example configuration
+options as necessary for your system.
 
 This file configures the following settings:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.rst
@@ -17,8 +17,10 @@ in the configuration file.
 An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/consensus/poet/sgx/packaging/poet_enclave_sgx.toml.example``.
 To create a PoET SGX enclave configuration file, download this example file to
-the config directory and name it ``poet_enclave_sgx.toml``. Then edit the file
-to change the example configuration options as necessary for your system.
+the config directory and name it ``poet_enclave_sgx.toml``. Set the ownership
+and permissions to owner ``root``, group ``sawtooth``, and permissions ``640``.
+Then edit the file to change the example configuration options as necessary for
+your system.
 
 .. note::
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/rest_api_configuration_file.rst
@@ -18,8 +18,10 @@ in the configuration file.
 An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/rest_api/packaging/rest_api.toml.example``.
 To create a REST API configuration file, download this example file to the
-config directory and name it ``rest_api.toml``. Then edit the file to change the
-example configuration options as necessary for your system.
+config directory and name it ``rest_api.toml``. Set the ownership and
+permissions to owner ``root``, group ``sawtooth``, and permissions ``640``.
+Then edit the file to change the example configuration options as necessary for
+your system.
 
 The ``rest_api.toml`` configuration file has the following options:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/settings_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/settings_tp_configuration.rst
@@ -18,9 +18,10 @@ file.
 An example configuration file is in the ``sawtooth-core`` repository at
 ``/sawtooth-core/families/settings/packaging/settings.toml.example``.
 To create a Settings transaction processor configuration file, download this
-example file to the config directory and name it ``settings.toml``. Then edit
-the file to change the example configuration options as necessary for your
-system.
+example file to the config directory and name it ``settings.toml``. Set the
+ownership and permissions to owner ``root``, group ``sawtooth``, and
+permissions ``640``. Then edit the file to change the example configuration
+options as necessary for your system.
 
 The ``settings.toml`` configuration file has the following option:
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/validator_configuration_file.rst
@@ -19,8 +19,10 @@ setting in the configuration file.
 
 An example configuration file is in ``/etc/sawtooth/validator.toml.example``.
 To create a validator configuration file, copy the example file to the config
-directory and name it ``validator.toml``. Then edit the file to change the
-example configuration options as necessary for your system.
+directory and name it ``validator.toml``. Important: Copy with ``cp -a`` to
+preserve the file's ownership and permissions (or change after copying to
+owner ``root``, group ``sawtooth``, and permissions ``640``). Then edit the file
+to change the example configuration options as necessary for your system.
 
 .. note::
 

--- a/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
+++ b/docs/source/sysadmin_guide/configuring_sawtooth/xo_tp_configuration.rst
@@ -18,8 +18,10 @@ file.
 An example configuration file is in the ``sawtooth-sdk-python`` repository at
 ``https://github.com/hyperledger/sawtooth-sdk-python/blob/master/examples/xo_python/packaging/xo.toml.example``.
 To create a XO transaction processor configuration file, download this example
-file to the config directory and name it ``xo.toml``. Then edit the file
-to change the example configuration options as necessary for your system.
+file to the config directory and name it ``xo.toml``. Set the ownership and
+permissions to owner ``root``, group ``sawtooth``, and permissions ``640``.
+Then edit the file to change the example configuration options as necessary for
+your system.
 
 The ``xo.toml`` configuration file has the following option:
 

--- a/docs/source/sysadmin_guide/log_configuration.rst
+++ b/docs/source/sysadmin_guide/log_configuration.rst
@@ -56,6 +56,8 @@ validator or REST API, put a log configuration file in the config directory
 Sawtooth provides an example log configuration file in
 ``/etc/sawtooth/log_config.toml.example``. To create a log configuration file,
 copy the example file to the config directory and name it ``log_config.toml``.
+Copy with ``cp -a`` to preserve the file's ownership and permissions (or change
+after copying to owner ``root``, group ``sawtooth``, and permissions ``640``).
 
 Each transaction processor can define its own config file. The name of
 this file is determined by the author. The transaction processors included in


### PR DESCRIPTION
Backport of #2157 

Add info on the required/recommended ownership and permissions for config files: Owner root, group sawtooth, and permissions 640.

Signed-off-by: Anne Chenette <chenette@bitwise.io>