### PR TITLE
1-2 backport: Update note on PoET SGX support to include 1.2

### DIFF
--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -4,9 +4,8 @@ Using Sawtooth with PoET-SGX
 
 .. note::
 
-   PoET-SGX is currently not compatible with Sawtooth 1.1. Users looking to
-   leverage PoET-SGX should remain on Sawtooth 1.0. PoET-SGX is being upgraded
-   to be made compatible with 1.1 and will be released before the end of 2018.
+   PoET-SGX is currently not compatible with Sawtooth 1.1 or later.
+   Users looking to leverage PoET-SGX should remain on Sawtooth 1.0.
 
 This procedure describes how to install, configure, and run Hyperledger Sawtooth
 with PoET simulator consensus on a system with |Intel (R)| Software Guard


### PR DESCRIPTION
Changed "1.1" to "1.1 or later". Also removed statement that PoET-SGX would be supported in Sawtooth 1.1.

Signed-off-by: Anne Chenette <chenette@bitwise.io>