### PR TITLE
Doc: Clean up top-level TOC (remove external doc links)

### DIFF
--- a/docs/source/_includes/about-sawtooth-networks.inc
+++ b/docs/source/_includes/about-sawtooth-networks.inc
@@ -27,6 +27,11 @@ they join the network.
 
 A Sawtooth network has the following requirements:
 
+* Each node must run the same :term:`consensus engine`. The procedures in this
+  guide show you how to configure :term:`PBFT <PBFT consensus>` or
+  :term:`PoET <PoET consensus>` consensus. For more information, see
+  :doc:`/sysadmin_guide/about_dynamic_consensus`.
+
 * Each node must run the same set of transaction processors as all other nodes
   in the network.
 

--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -35,12 +35,6 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth PBFT{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Sawtooth PBFT consensus{% endtrans %}</span></p>
 
-  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth Sabre{% endtrans %}</a><br/>
-    <span class="linkdescr">{% trans %}write on-chain smart contracts with the Sawtooth Sabre transaction family{% endtrans %}</span></p>
-
-  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth Seth{% endtrans %}</a><br/>
-    <span class="linkdescr">{% trans %}support EVM smart contracts with the Sawtooth Seth transaction family{% endtrans %}</span></p>
-
   <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Community{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}join the conversation{% endtrans %}</span></p>
 

--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -32,9 +32,6 @@
   <p class="biglink"><a class="biglink" href="{{ pathto("cli") }}">{% trans %}CLI Command Reference{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Sawtooth commands{% endtrans %}</span></p>
 
-  <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Sawtooth PBFT{% endtrans %}</a><br/>
-    <span class="linkdescr">{% trans %}learn about Sawtooth PBFT consensus{% endtrans %}</span></p>
-
   <p class="biglink"><a class="biglink" href="{{ pathto("community") }}">{% trans %}Community{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}join the conversation{% endtrans %}</span></p>
 

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -12,8 +12,6 @@ Table of Contents
    api_references.rst
    cli.rst
    Sawtooth PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>
-   Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>
-   Sawtooth Seth Transaction Family <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>
    community.rst
    glossary.rst
 

--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -11,7 +11,6 @@ Table of Contents
    sysadmin_guide.rst
    api_references.rst
    cli.rst
-   Sawtooth PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>
    community.rst
    glossary.rst
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -196,10 +196,13 @@ For more information, see :doc:`/sysadmin_guide/about_dynamic_consensus`.
 Sample Transaction Families
 ---------------------------
 
-In Sawtooth, the data model and transaction language are implemented
-in a :term:`transaction family<Transaction family>`. While we expect users to
-build custom transaction families that reflect the unique requirements of their
-ledgers, we provide several core transaction families as models\:
+In a Sawtooth application, the data model and transaction language are
+implemented in a :term:`transaction family<Transaction family>`, which runs
+on a Sawtooth node as a :term:`transaction processor`.
+
+While most application developers will build custom transaction families
+that reflect the unique requirements of their ledgers, Sawtooth provides
+several core transaction families as models\:
 
     * IntegerKey - Used for testing deployed ledgers.
 
@@ -220,12 +223,12 @@ Additional transaction families provide models for specific areas\:
     * BlockInfo - Provides a methodology for storing information
       about a configurable number of historic blocks.
 
-The following projects provide smart-contract functionality for the Sawtooth
+Other Hyperledger projects provide smart-contract functionality for the Sawtooth
 platform\:
 
     * `Sawtooth Sabre <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>`__ -
       Implements on-chain smart contracts that are executed in a WebAssembly
-      (WASM) virtual machine
+      (WASM) virtual machine.
 
     * `Sawtooth Seth <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>`__ -
       Supports running Ethereum Virtual Machine (EVM) smart contracts on Sawtooth


### PR DESCRIPTION
The doc links for PBFT, Sabre, and Seth are already in the relevant topics.  Including them as top-level TOC links didn't fit with the Sawtooth doc organization. 

This PR also fixes and clarifies text related to these external docs.