### PR TITLE
Update doc notes - tested on 18.04/Bionic only

### DIFF
--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -3,8 +3,8 @@ Using Ubuntu for a Single Sawtooth Node
 *********************************************
 
 This procedure explains how to set up Hyperledger Sawtooth for application
-development on Ubuntu 16.04. It shows you how to install Sawtooth on Ubuntu,
-then walks you through the following tasks:
+development on Ubuntu 18.04 (Bionic). It shows you how to install Sawtooth on
+Ubuntu, then walks you through the following tasks:
 
  * Generating a user key
  * Generating a root key
@@ -67,7 +67,7 @@ for each Sawtooth component and one to use for client commands.
 Prerequisites
 =============
 
-This Sawtooth development environment requires Ubuntu 16.04.
+This Sawtooth development environment requires Ubuntu 18.04 (Bionic).
 
 
 Step 1: Install Sawtooth

--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -27,7 +27,7 @@ the consensus type, see :doc:`/sysadmin_guide/about_dynamic_consensus`.
 
 .. note::
 
-   These instructions have been tested on Ubuntu 16.04 only.
+   These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 
 .. _about-sawtooth-nw-env-label:

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -276,7 +276,7 @@ included example :term:`transaction families<Transaction family>`, as
 well as to any transaction families you might write yourself.
 
 Sawtooth validators can be run from pre-built Docker containers, installed
-natively using Ubuntu 16.04, or launched in AWS from the AWS Marketplace.
+natively using Ubuntu, or launched in AWS from the AWS Marketplace.
 
 To get started, see :doc:`/app_developers_guide/installing_sawtooth`.
 

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -18,7 +18,7 @@ algorithm, such as PoET, see :doc:`setting_up_sawtooth_network`.
 
 .. note::
 
-   These instructions have been tested on Ubuntu 16.04 only.
+   These instructions have been tested with Sawtooth 1.0 on Ubuntu 16.04 only.
 
 
 Prerequisites

--- a/docs/source/sysadmin_guide/configuring_permissions.rst
+++ b/docs/source/sysadmin_guide/configuring_permissions.rst
@@ -4,7 +4,7 @@ Configuring Validator and Transactor Permissions
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 This section describes the validator and transactor permissions in Hyperledger
 Sawtooth.

--- a/docs/source/sysadmin_guide/creating_genesis_block.rst
+++ b/docs/source/sysadmin_guide/creating_genesis_block.rst
@@ -4,7 +4,7 @@ Creating the Genesis Block
 
 .. note::
 
-   These instructions have been tested on Ubuntu 16.04 only.
+   These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 **Prerequisites**:
 

--- a/docs/source/sysadmin_guide/generating_keys.rst
+++ b/docs/source/sysadmin_guide/generating_keys.rst
@@ -4,7 +4,7 @@ Generating User and Validator Keys
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 .. include:: ../_includes/generate-keys.inc
 

--- a/docs/source/sysadmin_guide/grafana_configuration.rst
+++ b/docs/source/sysadmin_guide/grafana_configuration.rst
@@ -4,7 +4,7 @@ Using Grafana to Display Sawtooth Metrics
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 This procedure describes how to display Sawtooth metrics with
 `Grafana <https://grafana.com>`__, using

--- a/docs/source/sysadmin_guide/installation.rst
+++ b/docs/source/sysadmin_guide/installation.rst
@@ -4,7 +4,7 @@ Installing Hyperledger Sawtooth
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 This procedure describes how to install Hyperledger Sawtooth on a Ubuntu system
 for proof-of-concept or production use in a Sawtooth network.

--- a/docs/source/sysadmin_guide/off_chain_settings.rst
+++ b/docs/source/sysadmin_guide/off_chain_settings.rst
@@ -4,7 +4,7 @@ Changing Off-chain Settings with Configuration Files
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 This procedure explains how to create and use Sawtooth configuration files to
 change the following Sawtooth settings:

--- a/docs/source/sysadmin_guide/rest_auth_proxy.rst
+++ b/docs/source/sysadmin_guide/rest_auth_proxy.rst
@@ -4,7 +4,7 @@ Using a Proxy Server to Authorize the REST API
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 The Sawtooth REST API is designed to be a lightweight shim on top of internal
 communications. When the REST API receives a request, it passes that request to

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -4,7 +4,7 @@ Setting the Allowed Transaction Types (Optional)
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 By default, a validator accepts transactions from any transaction processor.
 However, Sawtooth allows you to limit the types of transactions that can be

--- a/docs/source/sysadmin_guide/systemd.rst
+++ b/docs/source/sysadmin_guide/systemd.rst
@@ -4,7 +4,7 @@ Running Sawtooth as a Service
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 When you installed Sawtooth with ``apt-get``, ``systemd`` units were added for
 the Sawtooth components (validator, REST API, transaction processors, and

--- a/docs/source/sysadmin_guide/testing_sawtooth.rst
+++ b/docs/source/sysadmin_guide/testing_sawtooth.rst
@@ -3,7 +3,7 @@ Testing Sawtooth Functionality
 
 .. note::
 
-    These instructions have been tested on Ubuntu 16.04 only.
+    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
 
 **Test a single node**
 


### PR DESCRIPTION
Change the notes "tested on Ubuntu 16.04 only" to the Chime version: "tested on Ubuntu 18.04 (Bionic) only".

Also change the PoET-SGX procedure's note to say "tested with Sawtooth 1.0 on Ubuntu 16.04 only."