### PR TITLE
1-2 only: Change PBFT + Sabre doc links: nightly -> latest

### DIFF
--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -31,7 +31,7 @@ management, consensus, transaction scheduling, permissioning, and more.
    architecture/permissioning_requirement
    architecture/injecting_batches_block_validation_rules
    architecture/events_and_transactions_receipts
-   PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/architecture.html>
+   PBFT Consensus <https://sawtooth.hyperledger.org/docs/pbft/releases/latest/architecture.html>
    PoET 1.0 Consensus <architecture/poet>
 
 .. Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -151,7 +151,7 @@ transaction or two.
 The Sawtooth consensus API supports a wide variety of consensus algorithms on a
 network. Sawtooth currently includes consensus engines for these algorithms:
 
-    * `Sawtooth PBFT <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>`__
+    * `Sawtooth PBFT <https://sawtooth.hyperledger.org/docs/pbft/releases/latest/>`__
       (Practical Byzantine Fault Tolerance) is a voting-based consensus
       algorithm that provides Byzantine fault tolerance with finality.
       Sawtooth PBFT extends the
@@ -223,7 +223,7 @@ Additional transaction families provide models for specific areas\:
 The following projects provide smart-contract functionality for the Sawtooth
 platform\:
 
-    * `Sawtooth Sabre <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>`__ -
+    * `Sawtooth Sabre <https://sawtooth.hyperledger.org/docs/sabre/releases/latest/>`__ -
       Implements on-chain smart contracts that are executed in a WebAssembly
       (WASM) virtual machine
 

--- a/docs/source/sysadmin_guide/about_dynamic_consensus.rst
+++ b/docs/source/sysadmin_guide/about_dynamic_consensus.rst
@@ -118,7 +118,7 @@ PBFT Consensus
 consensus algorithm with finality that provides Byzantine Fault Tolerance
 (BFT). PBFT is best for small, consortium-style networks that do not require
 open membership. For more information, see the
-`PBFT documentation <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/>`__.
+`PBFT documentation <https://sawtooth.hyperledger.org/docs/pbft/releases/latest/>`__.
 
 Requirements:
 
@@ -156,7 +156,7 @@ Requirements:
   version and validator public keys for the PBFT member list .
 
 * For optional PBFT consensus settings, see
-  `Configuring PBFT <https://sawtooth.hyperledger.org/docs/pbft/nightly/master/configuring-pbft.html>`__
+  `Configuring PBFT <https://sawtooth.hyperledger.org/docs/pbft/releases/latest/configuring-pbft.html>`__
   in the PBFT documentation.
 
 

--- a/docs/source/transaction_family_specifications.rst
+++ b/docs/source/transaction_family_specifications.rst
@@ -73,7 +73,7 @@ your own transaction family. These transaction families are available in the
 
 The following transaction families run on top of the Sawtooth platform:
 
-* `Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>`__:
+* `Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/releases/latest/>`__:
   Implements on-chain smart contracts that are executed in a WebAssembly (WASM)
   virtual machine.
   This transaction family is in the
@@ -95,7 +95,7 @@ The following transaction families run on top of the Sawtooth platform:
    transaction_family_specifications/xo_transaction_family.rst
    transaction_family_specifications/validator_registry_transaction_family.rst
    transaction_family_specifications/smallbank_transaction_family.rst
-   Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/nightly/master/>
+   Sawtooth Sabre Transaction Family <https://sawtooth.hyperledger.org/docs/sabre/releases/latest/>
    Sawtooth Seth Transaction Family <https://sawtooth.hyperledger.org/docs/seth/nightly/master/>
 
 .. Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
Change PBFT and Sabre 1.2 doc links from nightly/master to release/latest.

Signed-off-by: Anne Chenette <chenette@bitwise.io>