### PR TITLE
Update docs for 1.0 pbft algorithm version

### DIFF
--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -72,10 +72,8 @@ genesis block also includes the keys for the other nodes in the initial network.
         --key /etc/sawtooth/keys/validator.priv \
         -o config-consensus.batch \
         sawtooth.consensus.algorithm.name=pbft \
-        sawtooth.consensus.algorithm.version=VERSION \
+        sawtooth.consensus.algorithm.version=1.0 \
         sawtooth.consensus.pbft.members='["VAL1KEY","VAL2KEY",...,"VALnKEY"]'
-
-     Replace ``VERSION`` with the PBFT version number.
 
        .. tip::
 

--- a/docs/source/sysadmin_guide/about_dynamic_consensus.rst
+++ b/docs/source/sysadmin_guide/about_dynamic_consensus.rst
@@ -149,7 +149,7 @@ Requirements:
   .. code-block:: none
 
      sawtooth.consensus.algorithm.name=pbft
-     sawtooth.consensus.algorithm.version=[VERSION]
+     sawtooth.consensus.algorithm.version=1.0
      sawtooth.consensus.pbft.members=["VAL1KEY","VAL2KEY",...,"VALnKEY"]
 
   .. note::

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -74,7 +74,7 @@ accepted transaction types to those from this network's transaction processors
      .. code-block:: console
 
         sawtooth.consensus.algorithm.name=pbft
-        sawtooth.consensus.algorithm.version=0.1
+        sawtooth.consensus.algorithm.version=1.0
         sawtooth.consensus.pbft.members="03e27504580fa15...
         sawtooth.publisher.max_batches_per_block: 200
         sawtooth.settings.vote.authorized_keys: 03e27504580fa15...


### PR DESCRIPTION
The files where I updated VERSION to 1.0 had version numbers in the examples for the other consensus engines.

Signed-off-by: Richard Berg <rberg@bitwise.io>