### PR TITLE
Add a trace message while waiting for TP registration

### DIFF
--- a/validator/sawtooth_validator/execution/processor_manager.py
+++ b/validator/sawtooth_validator/execution/processor_manager.py
@@ -149,6 +149,9 @@ class ProcessorManager:
             None
         """
         with self._condition:
+            if processor_type not in self:
+                LOGGER.info("waiting for processor type %s to register",
+                            processor_type)
             self._condition.wait_for(lambda: (
                 processor_type in self
                 or self._cancelled_event.is_set()))


### PR DESCRIPTION
Add a trace to identify the case where transaction is
scheduled for execution and there's no TP registered
which can execute the transaction.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>