### PR TITLE
Add description to smallbank workload Cargo.toml

### DIFF
--- a/perf/smallbank_workload/Cargo.toml
+++ b/perf/smallbank_workload/Cargo.toml
@@ -17,6 +17,7 @@ name = "sawtooth-smallbank-workload"
 version = "0.1.0"
 build = "build.rs"
 authors = ["Intel Corporation"]
+description = "Workload generator for Sawtooth Smallbank"
 
 [dependencies]
 sawtooth-sdk = "0.3"


### PR DESCRIPTION
Old description
`Description: [generated from Rust crate sawtooth-smallbank-workload]`
New description
`Description: Workload generator for Sawtooth Smallbank`

Signed-off-by: Richard Berg <rberg@bitwise.io>