### PR TITLE
Doc: Fix format of tip; improve info order

### DIFF
--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -75,17 +75,17 @@ genesis block also includes the keys for the other nodes in the initial network.
         sawtooth.consensus.algorithm.version=1.0 \
         sawtooth.consensus.pbft.members='["VAL1KEY","VAL2KEY",...,"VALnKEY"]'
 
-       .. tip::
-
-          The PBFT version number is in the file ``sawtooth-pbft/Cargo.toml``
-          as ``version = "{major}.{minor}.{patch}"``. Use only the first two
-          digits (major and minor release numbers); omit the patch number.
-          For example, if the version is 1.0.3, use ``1.0`` for this setting.
-
      Replace ``"VAL1KEY","VAL2KEY","VAL3KEY",...,"VALnKEY"`` with the validator public
      keys of all the nodes (including this node). This information is in the
      file ``/etc/sawtooth/keys/validator.pub`` on each node. Be sure to use
      single quotes and double quotes correctly, as shown in the example.
+
+     .. tip::
+
+        The PBFT version number is in the file ``sawtooth-pbft/Cargo.toml``
+        as ``version = "{major}.{minor}.{patch}"``. Use only the first two
+        digits (major and minor release numbers); omit the patch number.
+        For example, if the version is 1.0.3, use ``1.0`` for this setting.
 
    * For PoET:
 


### PR DESCRIPTION
Correct the indent so that the tip is formatted correctly.

Also move the tip after the info about replacing the VALxKEY strings, because
the tip is less important (the example shows the current version number).

Signed-off-by: Anne Chenette <chenette@bitwise.io>