### PR TITLE
1-2 Backport: Add description to intkey workload Cargo.toml

### DIFF
--- a/perf/intkey_workload/Cargo.toml
+++ b/perf/intkey_workload/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sawtooth-intkey-workload"
 version = "0.1.0"
 authors = ["Intel Corporation"]
+description = "Workload generator for Sawtooth Intkey"
 
 [[bin]]
 name = "intkey-workload"


### PR DESCRIPTION
Back port of #2205 
Signed-off-by: Richard Berg <rberg@bitwise.io>