### PR TITLE
Correct metric for "chain head moved"

### DIFF
--- a/docker/grafana/dashboards/dashboard.json
+++ b/docker/grafana/dashboards/dashboard.json
@@ -638,7 +638,7 @@
                   "type": "fill"
                 }
               ],
-              "measurement": "sawtooth_validator.block_validator.BlockValidator.chain_head_moved_to_fork_count",
+              "measurement": "sawtooth_validator.chain.ChainController.chain_head_moved_to_fork_count",
               "orderByTime": "ASC",
               "policy": "default",
               "refId": "A",


### PR DESCRIPTION
The metric for "chain_head_moved_to_fork_count" moved from being under
the BlockValidator to the ChainController.  This commit corrects the
default grafana dashboard to display this data.

Signed-off-by: Peter Schwarz <pschwarz@bitwise.io>