### PR TITLE
1-2 Backport: Docs: Fix settings + key info, add auth user proc

### DIFF
--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -46,7 +46,9 @@ genesis block also includes the keys for the other nodes in the initial network.
       You must use the same key for the ``sawset proposal create`` commands
       in the following steps. In theory, some of these commands could use a
       different key, but configuring multiple keys is a complicated process
-      that is not shown in this procedure.
+      that is not shown in this procedure. For more information, see
+      :doc:`/sysadmin_guide/adding_authorized_users`.
+
 
 #. Create a batch to initialize the consensus settings.
 

--- a/docs/source/_includes/create-genesis-block.inc
+++ b/docs/source/_includes/create-genesis-block.inc
@@ -15,8 +15,8 @@ genesis block also includes the keys for the other nodes in the initial network.
 
    .. code-block:: console
 
-      $ ls ~/.sawtooth/keys/
-      {yourname}.priv    {yourname}.pub
+      $ ls $HOME/.sawtooth/keys/
+      my_key.priv    my_key.pub
 
       $ ls /etc/sawtooth/keys/
       validator.priv   validator.pub
@@ -24,43 +24,29 @@ genesis block also includes the keys for the other nodes in the initial network.
    If these key files do not exist, create them as described in the previous
    step.
 
-#. Become the ``sawtooth`` user. Otherwise, you must preface each command with
-   ``sudo -u sawtooth``.
-
-   .. code-block:: console
-
-      $ sudo -u sawtooth -s
-      [sawtooth@system]$
-
-   In the following commands, the prompt ``[sawtooth@system]`` shows the
-   commands that must be executed as the ``sawtooth`` user.
-
 #. Change to a writable directory such as ``/tmp``.
 
    .. code-block:: console
 
-      [sawtooth@system]$ cd /tmp
+      $ cd /tmp
 
 #. Create a batch with a settings proposal for the genesis block.
 
    .. code-block:: console
 
-      [sawtooth@system]$ sawset genesis \
-      --key /etc/sawtooth/keys/validator.priv \
+      $ sawset genesis --key $HOME/.sawtooth/keys/my_key.priv \
       -o config-genesis.batch
 
-   This command authorizes this key (the validator key on this node) to change
-   Sawtooth settings. You must use the same key for the following commands in
-   this procedure. Also, any later commands to change on-chain Sawtooth settings
-   must specify this key.
+   This command authorizes you to set and change Sawtooth settings. The
+   settings changes will take effect after the validator and Settings
+   transaction processor have started.
 
    .. note::
 
-      This procedure uses the same validator key for all commands that require a
-      key. In theory, some of these commands could use a different key, but
-      configuring multiple keys is a complicated process. Describing how to use
-      multiple keys to create the genesis block is outside the scope of this
-      guide.
+      You must use the same key for the ``sawset proposal create`` commands
+      in the following steps. In theory, some of these commands could use a
+      different key, but configuring multiple keys is a complicated process
+      that is not shown in this procedure.
 
 #. Create a batch to initialize the consensus settings.
 
@@ -68,8 +54,7 @@ genesis block also includes the keys for the other nodes in the initial network.
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawset proposal create \
-        --key /etc/sawtooth/keys/validator.priv \
+        $ sawset proposal create --key $HOME/.sawtooth/keys/my_key.priv \
         -o config-consensus.batch \
         sawtooth.consensus.algorithm.name=pbft \
         sawtooth.consensus.algorithm.version=1.0 \
@@ -91,8 +76,7 @@ genesis block also includes the keys for the other nodes in the initial network.
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawset proposal create \
-        --key /etc/sawtooth/keys/validator.priv \
+        $ sawset proposal create --key $HOME/.sawtooth/keys/my_key.priv \
         -o config-consensus.batch \
         sawtooth.consensus.algorithm.name=PoET \
         sawtooth.consensus.algorithm.version=0.1 \
@@ -105,10 +89,9 @@ genesis block also includes the keys for the other nodes in the initial network.
       This is a complicated command. Here's an explanation of the options and
       arguments:
 
-      ``--key /etc/sawtooth/keys/validator.priv``
-       Signs the proposal with this node's validator key. Only this key can be
-       used to change on-chain settings. For more information, see
-       :doc:`../sysadmin_guide/configuring_permissions`.
+      ``--key $HOME/.sawtooth/keys/my_key.priv``
+       Signs the proposal with your private key. Only this key can be
+       used to change on-chain settings.
 
       ``-o config-consensus.batch``
        Wraps the consensus proposal transaction in a batch named
@@ -142,12 +125,13 @@ genesis block also includes the keys for the other nodes in the initial network.
        Validator Registry uses this value to check signup information.
 
 #. (PoET only) Create a batch to register the first Sawtooth node with the PoET
-   Validator Registry transaction processor. Without this command, the validator
-   would not be able to publish any blocks.
+   Validator Registry transaction processor, using the validator's private key.
+   Without this command, the validator would not be able to publish any blocks.
+
 
    .. code-block:: console
 
-      [sawtooth@system]$ poet registration create --key /etc/sawtooth/keys/validator.priv -o poet.batch
+      $ poet registration create --key /etc/sawtooth/keys/validator.priv -o poet.batch
 
 #. (Optional) Create a batch to configure other consensus settings.
 
@@ -155,8 +139,7 @@ genesis block also includes the keys for the other nodes in the initial network.
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawset proposal create \
-        --key /etc/sawtooth/keys/validator.priv \
+        $ sawset proposal create --key $HOME/.sawtooth/keys/my_key.priv \
         -o pbft-settings.batch \
         SETTING-NAME=VALUE \
         ... \
@@ -170,8 +153,7 @@ genesis block also includes the keys for the other nodes in the initial network.
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawset proposal create \
-        --key /etc/sawtooth/keys/validator.priv \
+        $ sawset proposal create --key $HOME/.sawtooth/keys/my_key.priv \
         -o poet-settings.batch \
         sawtooth.poet.target_wait_time=5 \
         sawtooth.poet.initial_wait_time=25 \
@@ -180,26 +162,25 @@ genesis block also includes the keys for the other nodes in the initial network.
      .. note::
 
         This example shows the default PoET settings.
+        For more information, see the `Hyperledger Sawtooth Settings
+        FAQ <https://sawtooth.hyperledger.org/faq/settings/>`__.
 
-     For more information, see the `Hyperledger Sawtooth Settings
-     FAQ <https://sawtooth.hyperledger.org/faq/settings/>`__.
-
-#. Combine the separate batches into a single genesis batch that will be
-   committed in the genesis block.
+#. As the sawtooth user, combine the separate batches into a single genesis
+   batch that will be committed in the genesis block.
 
    * For PBFT:
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawadm genesis config-genesis.batch \
-        config-consensus.batch pbft-settings.batch
+        $ sudo -u sawtooth sawadm genesis \
+        config-genesis.batch config-consensus.batch pbft-settings.batch
 
    * For PoET:
 
      .. code-block:: console
 
-        [sawtooth@system]$ sawadm genesis config-genesis.batch \
-        config-consensus.batch poet.batch poet-settings.batch
+        $ sudo -u sawtooth sawadm genesis \
+        config-genesis.batch config-consensus.batch poet.batch poet-settings.batch
 
    You’ll see some output indicating success:
 
@@ -217,13 +198,7 @@ genesis block also includes the keys for the other nodes in the initial network.
       genesis`` will fail if they are not present in one of the batches unless
       the ``--ignore-required-settings`` flag is used.
 
-#. When this command finishes, the genesis block is complete. Log out of the
-   ``sawtooth`` account.
-
-   .. code-block:: console
-
-      [sawtooth@system]$ exit
-      $
+When this command finishes, the genesis block is complete.
 
 The settings in the genesis block will be available after the first node has
 started and the genesis block has been committed.

--- a/docs/source/_includes/generate-keys.inc
+++ b/docs/source/_includes/generate-keys.inc
@@ -4,13 +4,20 @@
    When you create the genesis block on the first node, you will need the
    validator keys for at least three other nodes.
 
-1.  Generate your user key for Sawtooth.
+1. Generate your user key for Sawtooth.
 
-    .. code-block:: console
+   .. code-block:: console
 
-       $ sawtooth keygen my_key
-       writing file: /home/yourname/.sawtooth/keys/my_key.priv
-       writing file: /home/yourname/.sawtooth/keys/my_key.pub
+      $ sawtooth keygen my_key
+      writing file: /home/yourname/.sawtooth/keys/my_key.priv
+      writing file: /home/yourname/.sawtooth/keys/my_key.pub
+
+   .. note::
+
+      This command specifies ``my_key`` as the base name for the key files,
+      to be consistent with the key name that is used in some example Docker and
+      Kubernetes files. By default (when no key name is specified), the
+      ``sawtooth keygen`` command uses your user name.
 
 #. Generate the key for the validator, which runs as root.
 

--- a/docs/source/_includes/generate-keys.inc
+++ b/docs/source/_includes/generate-keys.inc
@@ -8,9 +8,9 @@
 
     .. code-block:: console
 
-       $ sawtooth keygen
-       writing file: /home/yourname/.sawtooth/keys/yourname.priv
-       writing file: /home/yourname/.sawtooth/keys/yourname.pub
+       $ sawtooth keygen my_key
+       writing file: /home/yourname/.sawtooth/keys/my_key.priv
+       writing file: /home/yourname/.sawtooth/keys/my_key.pub
 
 #. Generate the key for the validator, which runs as root.
 

--- a/docs/source/app_developers_guide/docker_test_network.rst
+++ b/docs/source/app_developers_guide/docker_test_network.rst
@@ -284,6 +284,13 @@ The :doc:`Settings transaction processor
 handles on-chain configuration settings. You will use the ``sawset`` command to
 create and submit a batch of transactions containing the configuration change.
 
+.. important::
+
+   You **must** run this procedure from the first validator container, because
+   the example Docker Compose file uses the first validator's key to create and
+   sign the genesis block. (At this point, only the key used to create the
+   genesis block can change on-chain settings.)
+
 1. Connect to the first validator container (``sawtooth-validator-default-0``).
    The next command requires the validator key that was generated in that
    container.

--- a/docs/source/app_developers_guide/docker_test_network.rst
+++ b/docs/source/app_developers_guide/docker_test_network.rst
@@ -289,7 +289,9 @@ create and submit a batch of transactions containing the configuration change.
    You **must** run this procedure from the first validator container, because
    the example Docker Compose file uses the first validator's key to create and
    sign the genesis block. (At this point, only the key used to create the
-   genesis block can change on-chain settings.)
+   genesis block can change on-chain settings.) For more information, see
+   :doc:`/sysadmin_guide/adding_authorized_users`.
+
 
 1. Connect to the first validator container (``sawtooth-validator-default-0``).
    The next command requires the validator key that was generated in that

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -144,6 +144,12 @@ previous step.
    writing file: /home/yourname/.sawtooth/keys/my_key.priv
    writing file: /home/yourname/.sawtooth/keys/my_key.pub
 
+.. note::
+
+   This command specifies ``my_key`` as the base name for the key files, to be
+   consistent with the key name that is used in the example Docker and
+   Kubernetes files. By default (when no key name is specified), the
+   ``sawtooth keygen`` command uses your user name.
 
 .. _generate-root-key-ubuntu:
 

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -138,11 +138,11 @@ Step 2: Generate a User Key
 Generate your user key for Sawtooth, using the same terminal window as the
 previous step.
 
-   .. code-block:: console
+.. code-block:: console
 
-      user@validator$ sawtooth keygen
-      writing file: /home/yourname/.sawtooth/keys/yourname.priv
-      writing file: /home/yourname/.sawtooth/keys/yourname.pub
+   user@validator$ sawtooth keygen my_key
+   writing file: /home/yourname/.sawtooth/keys/my_key.priv
+   writing file: /home/yourname/.sawtooth/keys/my_key.pub
 
 
 .. _generate-root-key-ubuntu:
@@ -176,50 +176,60 @@ for users who are authorized to set and change configuration settings.
 
 Use the same terminal window as the previous step.
 
-#. Create a settings proposal (as a batch of transactions) that authorizes you
-   to set and change configuration settings. By default (if no options are
-   specified), the ``sawset genesis`` command uses the key of the current user
-   (you). Execute these commands in a directory writable by user sawtooth (such as ``/tmp``).
+1. Change to a writable directory such as ``/tmp``.
 
    .. code-block:: console
 
       user@validator$ cd /tmp
-      user@validator$ sudo -u sawtooth sawset genesis -k /etc/sawtooth/keys/validator.priv
-      Generated config-genesis.batch
 
-    This settings proposal will change authorized keys in the setting
-    ``sawtooth.settings.vote.authorized_keys``. The change will take effect
-    after the validator and Settings transaction processor have started.
-
-#. Create a settings proposal to initialize the Devmode consensus engine settings. This command sets the consensus algorithm to Devmode.
+#. Create a batch with a settings proposal for the genesis
+   block.
 
    .. code-block:: console
 
-      user@validator$ sudo -u sawtooth sawset proposal create \
-         -k /etc/sawtooth/keys/validator.priv \
-         sawtooth.consensus.algorithm.name=Devmode \
-         sawtooth.consensus.algorithm.version=0.1 -o config.batch
+      user@validator$ sawset genesis --key $HOME/.sawtooth/keys/my_key.priv
+      Generated config-genesis.batch
+
+   This command authorizes you to set and change Sawtooth settings. The
+   settings changes will take effect after the validator and Settings
+   transaction processor have started.
+
+   .. important::
+
+      You must use the same key for the ``sawset proposal create`` command in
+      the next step.
+
+#. Create another settings proposal to initialize the Devmode consensus engine
+   settings. This command sets the consensus algorithm to Devmode.
+
+   .. code-block:: console
+
+      user@validator$ sawset proposal create \
+      --key $HOME/.sawtooth/keys/my_key.priv \
+      sawtooth.consensus.algorithm.name=Devmode \
+      sawtooth.consensus.algorithm.version=0.1 -o config.batch
 
    .. note::
 
       The ``sawtooth.consensus.algorithm.name`` and
       ``sawtooth.consensus.algorithm.version`` settings are required; ``sawadm
-      genesis`` will fail if they are not present in one of the batches unless
+      genesis`` will fail if they are not present in one of the batches, unless
       the ``--ignore-required-settings`` flag is used.
 
-#. Combine the previously created batches into a single genesis batch that will be committed in the genesis block:
+#. As the sawtooth user, combine the previously created batches into a single
+   genesis batch that will be committed in the genesis block.
 
    .. code-block:: console
 
-     user@validator$ sudo -u sawtooth sawadm genesis config-genesis.batch config.batch
-     Processing config-genesis.batch...
-     Processing config.batch...
-     Generating /var/lib/sawtooth/genesis.batch
+      user@validator$ sudo -u sawtooth sawadm genesis config-genesis.batch config.batch
+      Processing config-genesis.batch...
+      Processing config.batch...
+      Generating /var/lib/sawtooth/genesis.batch
 
    .. note::
 
       The ``-u sawtooth`` option refers to the sawtooth user,
-      not the sawtooth command.
+      not the ``sawtooth`` command.
 
 
 .. _start-validator-ubuntu-label:
@@ -229,7 +239,8 @@ Step 5: Start the Validator
 
 Use the same terminal window as the previous step.
 
-#. Start a validator that listens locally on the default ports.
+1. As the sawtooth user, start a validator that listens locally on the default
+   ports.
 
    .. code-block:: console
 
@@ -248,7 +259,7 @@ Use the same terminal window as the previous step.
       [2018-03-14 15:53:34.909 INFO     cli] sawtooth-validator (Hyperledger Sawtooth) version 1.0.1
       [2018-03-14 15:53:34.909 INFO     path] Skipping path loading from non-existent config file: /etc/sawtooth/path.toml
       [2018-03-14 15:53:34.910 INFO     validator] Skipping validator config loading from non-existent config file: /etc/sawtooth/validator.toml
-      [2018-03-14 15:53:34.911 INFO     keys] Loading signing key: /etc/sawtooth/keys/validator.priv
+      [2018-03-14 15:53:34.911 INFO     keys] Loading signing key: /home/username/.sawtooth/keys/my_key.priv
       [2018-03-14 15:53:34.912 INFO     cli] config [path]: config_dir = "/etc/sawtooth"; config [path]: key_dir = "/etc/sawtooth/keys"; config [path]: data_dir = "/var/lib/sawtooth"; config [path]: log_dir = "/var/log/sawtooth"; config [path]: policy_dir = "/etc/sawtooth/policy"
       [2018-03-14 15:53:34.913 WARNING  cli] Network key pair is not configured, Network communications between validators will not be authenticated or encrypted.
       [2018-03-14 15:53:34.914 DEBUG    core] global state database file is /var/lib/sawtooth/merkle-00.lmdb
@@ -285,7 +296,7 @@ Step 6: Start the Devmode Consensus Engine
 
    .. code-block:: console
 
-       user@consensus$ sudo -u sawtooth devmode-engine-rust -vv --connect tcp://localhost:5050
+      user@consensus$ sudo -u sawtooth devmode-engine-rust -vv --connect tcp://localhost:5050
 
    The consensus terminal window displays verbose log messages showing the
    Devmode engine connecting to and registering with the validator.

--- a/docs/source/app_developers_guide/ubuntu_test_network.rst
+++ b/docs/source/app_developers_guide/ubuntu_test_network.rst
@@ -133,8 +133,8 @@ Use these steps on each system to install Hyperledger Sawtooth.
 
 .. _appdev-multinode-keys-label:
 
-Step 2: Create User and Validator Keys on All Nodes
----------------------------------------------------
+Step 2: Create User and Validator Keys
+--------------------------------------
 
 .. note::
 
@@ -153,8 +153,8 @@ they join the network.
 
 **Prerequisites**:
 
-* If you are reusing an existing node, ensure that you have deleted blockchain
-  data before continuing (as described in :ref:`the Ubuntu section's
+* If you are reusing an existing node, make sure that you have deleted the
+  blockchain data before continuing (as described in :ref:`the Ubuntu section's
   prerequisites <prereqs-multi-ubuntu-label>`).
 
 * For PBFT, the genesis block requires the validator keys for at least four
@@ -162,7 +162,7 @@ they join the network.
   installed Sawtooth and generated keys on the other nodes, perform
   :ref:`Step 1 <appdev-multinode-install-label>` and
   :ref:`Step 2 <appdev-multinode-keys-label>`
-  on those nodes, then gather the keys nodes from
+  on those nodes, then gather the public keys from
   ``/etc/sawtooth/keys/validator.pub`` on each node.
 
 .. include:: ../_includes/create-genesis-block.inc

--- a/docs/source/sysadmin_guide.rst
+++ b/docs/source/sysadmin_guide.rst
@@ -30,6 +30,7 @@ and explain how to
    sysadmin_guide/setting_up_sawtooth_network
    sysadmin_guide/configure_sgx
    sysadmin_guide/setting_allowed_txns
+   sysadmin_guide/adding_authorized_users
    sysadmin_guide/rest_auth_proxy
    sysadmin_guide/configuring_permissions
    sysadmin_guide/grafana_configuration

--- a/docs/source/sysadmin_guide/adding_authorized_users.rst
+++ b/docs/source/sysadmin_guide/adding_authorized_users.rst
@@ -1,0 +1,89 @@
+**********************************************
+Adding Authorized Users for Settings Proposals
+**********************************************
+
+Sawtooth supports on-chain settings to configure validator behavior, consensus,
+permissions, and more. The Settings transaction processor (or an equivalent)
+handles these on-chain settings.
+The on-chain setting ``sawtooth.settings.vote.authorized_keys`` contains the
+public keys of validators and users who are allowed to propose and vote on
+settings changes.
+
+By default, settings changes are restricted to the owner of the private key used
+to create the genesis block, as specified by the ``--key privatekeyfile`` option
+for the ``sawswet genesis`` command. The associated public key is stored in
+``sawtooth.settings.vote.authorized_keys`` when the genesis block is created.
+
+If the validator key was used to create the genesis block, we **strongly**
+recommend adding one or more user keys to this setting. Otherwise, if the first
+node becomes unavailable, no settings changes can be made.
+
+This procedure describes how to add a user key to
+``sawtooth.settings.vote.authorized_keys``.
+
+1. Log into the Sawtooth node that has your private key file.
+
+   .. important::
+
+      If the genesis block was created with the first validator's key, and
+      no user keys are authorized to change settings, you **must** run this
+      procedure on the same node that created the genesis block. The
+      ``sawset proposal create`` command requires the private validator key
+      that was generated on that node.
+
+#. Make sure that the Settings transaction processor (or an equivalent) and the
+   REST API are running, as described in :doc:`systemd`.
+
+#. Display the existing setting.
+
+   .. code-block:: console
+
+      $ sawtooth settings list sawtooth.settings.vote.authorized_keys
+
+   The output will resemble this example:
+
+   .. code-block:: console
+
+      sawtooth.settings.vote.authorized_keys: 0276023d4f7323103db8d8683a4b7bc1eae1f66...
+
+   If you want to add a key to the existing list, copy the key strings for the
+   next step.
+
+#. Add the new user's public key to the list of those allowed to change
+   settings.
+
+   .. code-block:: none
+
+     $ sawset proposal create --key {PRIVATE-KEY} \
+     sawtooth.settings.vote.authorized_keys='{OLDLIST},{NEWKEY}'
+
+   .. note::
+
+      * For ``{PRIVATE-KEY}``, specify the path to your private key file (or the
+        validator's private key file, if it was used to create the genesis
+        block).
+
+      * For ``{OLDLIST}``, use the list of existing keys from step 2.
+        To delete a key, omit it from this list.
+
+      * For ``{NEWKEY}``, use the public key of the user you want to add.
+
+#. To see the changed setting, run ``sawtooth settings list`` again.
+
+   .. code-block:: console
+
+      $ sawtooth settings list sawtooth.settings.vote.authorized_keys
+
+   Check that the new user key appears on the list.
+
+**About proposal voting**
+
+Each settings change must receive a certain amount of votes in order to be
+accepted. By default, only one vote is required, and the settings proposal
+contains an automatic "yes" vote from the user (or validator) who submitted
+the proposal. For information on configuring more complex voting schemes,
+see :doc:`/transaction_family_specifications/settings_transaction_family`.
+
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/sysadmin_guide/pbft_adding_removing_node.rst
+++ b/docs/source/sysadmin_guide/pbft_adding_removing_node.rst
@@ -16,8 +16,9 @@ Adding a PBFT Node
 ==================
 
 To add a new node to an existing PBFT network, you will install and configure
-the node, start it and wait for it to catch up with the rest of the network,
-then update ``sawtooth.consensus.pbft.members`` on an existing node.
+the node, start it and wait for it to catch up with the rest of the network.
+Next, the administrator of an existing node will update
+``sawtooth.consensus.pbft.members``.
 
 You can add several nodes at the same time.
 
@@ -49,36 +50,35 @@ You can add several nodes at the same time.
    :ref:`sawtooth block list <sawtooth-block-list-label>` to check on the
    new node's progress.
 
-#. Copy the new node's public validator key for use in the next step.
+#. Send the new node's public validator key to the administrator who will update
+   ``sawtooth.consensus.pbft.members``. Use this command to display the public
+   validator key:
 
    .. code-block:: console
 
       $ cat /etc/sawtooth/keys/validator.pub
 
-   This step assumes that the validator key is stored in the default location,
-   ``/etc/sawtooth/keys``. If not, use the location specified by the ``key_dir``
-   setting (see :doc:`configuring_sawtooth/path_configuration_file`).
+   This command assumes that the validator key is stored in the default
+   location, ``/etc/sawtooth/keys``. If not, use the location specified by the
+   ``key_dir`` setting (see
+   :doc:`configuring_sawtooth/path_configuration_file`).
 
-#. On an existing member node, update ``sawtooth.consensus.pbft.members`` to
-   include the public validator key of the new node.
+#. An authorized user must update the on-chain setting
+   ``sawtooth.consensus.pbft.members`` to include the public validator key of
+   the new node.
 
-   Run the following steps on a node that has permission to change on-chain
-   settings; that is, a node whose validator key is listed in
-   ``sawtooth.identity.allowed_keys``.
+   a. Log into an existing member node as a user who has permission to change
+      on-chain settings (by default, the owner of the private key used to create
+      the genesis block). For more information, see
+      :doc:`/sysadmin_guide/adding_authorized_users`.
 
-   .. Tip::
-
-      Usually, the node that created the genesis block is listed in
-      ``sawtooth.identity.allowed_keys``. Note that this list can include user
-      keys as well as validator keys, so that changes can be made by an
-      administrator from any node. For more information, see
-      :ref:`config-onchain-txn-perm-label`.
-
-   a. List the current PBFT member nodes:
+   #. List the current PBFT member nodes:
 
       .. code-block:: console
 
          $ sawtooth settings list --filter sawtooth.consensus.pbft.members
+
+      Copy the list of validator keys to use in the next step.
 
    #. Submit a transaction that specifies the new list of all PBFT member nodes
       (the previous list plus the new node's key).
@@ -100,37 +100,48 @@ You can add several nodes at the same time.
 
       If there are no errors, this change will be committed to the blockchain.
 
-#. When all nodes have detected the change and updated their local copy of the
-   member list, the new member node begins to participate in the PBFT network.
+When all nodes have detected the change and updated their local copy of the
+member list, the new member node begins to participate in the PBFT network.
 
 .. _removing-a-pbft-node-label:
 
 Removing a PBFT Node
 ====================
 
-To remove an existing node from a PBFT network, you will delete the node's
-validator key from  the ``sawtooth.consensus.pbft.members`` setting, then shut
-down the removed node. You can delete several nodes at the same time.
+To remove an existing node from a PBFT network, an authorized user will delete
+the node's validator key from  the ``sawtooth.consensus.pbft.members`` setting.
+
+You can delete several nodes at the same time.
 
 .. note::
 
    PBFT consensus requires a network with at least four nodes. A network with
    fewer than four nodes will fail.
 
-1. Update ``sawtooth.consensus.pbft.members`` to no longer include the
-   validator public key of the node you want to remove.
+1. Send the node's public validator key to the administrator who will update
+   ``sawtooth.consensus.pbft.members``. On the node you want to remove, use this
+   command to display the public validator key:
 
-   Run the following steps on a node or as a user that has permission to change
-   on-chain settings. For more information, see the tip in
-   :ref:`adding-a-pbft-node-label`.
+   .. code-block:: console
 
-   a. List the current PBFT member nodes:
+      $ cat /etc/sawtooth/keys/validator.pub
+
+#. An authorized user must update the on-chain setting
+   ``sawtooth.consensus.pbft.members`` to delete the public validator key of
+   the node to be removed.
+
+   a. Log into an existing member node as a user who has permission to change
+      on-chain settings (by default, the owner of the private key used to create
+      the genesis block). For more information, see
+      :doc:`/sysadmin_guide/adding_authorized_users`.
+
+   #. List the current PBFT member nodes:
 
       .. code-block:: console
 
          $ sawtooth settings list --filter sawtooth.consensus.pbft.members
 
-   #. Submit a transaction that specifies the new list of all PBFT member nodes
+   #. Submit a transaction that specifies the new list of PBFT member nodes
       (the previous list, minus the key of the node or nodes to be removed).
 
       .. Important::
@@ -157,7 +168,7 @@ down the removed node. You can delete several nodes at the same time.
 
       $ sawtooth settings list --filter sawtooth.consensus.pbft.members
 
-   .. note::
+   .. Important::
 
       Until the settings change is committed on all nodes, the removed node is
       considered part of the network. If the node is shut down too soon, it

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -2,10 +2,6 @@
 Setting the Allowed Transaction Types (Optional)
 ************************************************
 
-.. note::
-
-    These instructions have been tested on Ubuntu 18.04 (Bionic) only.
-
 By default, a validator accepts transactions from any transaction processor.
 However, Sawtooth allows you to limit the types of transactions that can be
 submitted.
@@ -22,31 +18,37 @@ In this procedure, you will configure the Sawtooth network to limit the
 accepted transaction types to those from this network's transaction processors
 (as started in :doc:`systemd`).
 
-.. important::
+1. Log into the node with your public/private key files.
 
-   For the environment described in this guide, you  **must** run this procedure
-   on the same node that created the genesis block, because the ``sawset
-   proposal create`` command requires the validator key that was generated on
-   that node.
+   .. important::
 
-#. Open a terminal window on the "genesis node" (the Sawtooth node that created
-   the genesis block in a previous procedure).
+      If the genesis block was created with the first validator's key, and there
+      are no other authorized users, you **must** run this procedure on the same
+      node that created the genesis block, because the
+      ``sawset proposal create`` command requires the private validator key
+      from that node.
 
-#. Use the ``sawset`` command to create and submit a batch of transactions that
-   changes the allowed transaction types.
+#. Use the ``sawset proposal create`` command to create and submit a batch of
+   transactions that changes the allowed transaction types.
+
+   .. note::
+
+      For ``{PRIVATE-KEY}``, specify the path to the private key file for an
+      authorized user or validator, such as the key used to create the genesis
+      block.
 
    * For PBFT:
 
      .. code-block:: console
 
-        $ sudo sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+        $ sudo sawset proposal create --key {PRIVATE-KEY} \
         sawtooth.validator.transaction_families='[{"family":"sawtooth_identity", "version":"1.0"}, {"family":"intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}]'
 
    * For PoET:
 
      .. code-block:: console
 
-        $ sudo sawset proposal create --key /etc/sawtooth/keys/validator.priv \
+        $ sudo sawset proposal create --key {PRIVATE-KEY} \
         sawtooth.validator.transaction_families='[{"family":"sawtooth_identity", "version":"1.0"}, {"family":"intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family":"sawtooth_validator_registry", "version":"1.0"}]'
 
    This command sets ``sawtooth.validator.transaction_families`` to a JSON array

--- a/docs/source/sysadmin_guide/setting_allowed_txns.rst
+++ b/docs/source/sysadmin_guide/setting_allowed_txns.rst
@@ -22,11 +22,11 @@ accepted transaction types to those from this network's transaction processors
 
    .. important::
 
-      If the genesis block was created with the first validator's key, and there
-      are no other authorized users, you **must** run this procedure on the same
-      node that created the genesis block, because the
-      ``sawset proposal create`` command requires the private validator key
-      from that node.
+      If the genesis block was created with the first validator's key,
+      and there are no other :doc:`authorized users <adding_authorized_users>`,
+      you **must** run this procedure on the same node that created the genesis
+      block, because the ``sawset proposal create`` command requires the private
+      validator key from that node.
 
 #. Use the ``sawset proposal create`` command to create and submit a batch of
    transactions that changes the allowed transaction types.
@@ -35,7 +35,9 @@ accepted transaction types to those from this network's transaction processors
 
       For ``{PRIVATE-KEY}``, specify the path to the private key file for an
       authorized user or validator, such as the key used to create the genesis
-      block.
+      block. For more information, see
+      :doc:`/sysadmin_guide/adding_authorized_users`.
+
 
    * For PBFT:
 

--- a/docs/source/transaction_family_specifications/settings_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/settings_transaction_family.rst
@@ -19,10 +19,10 @@ families is used by the transaction processing platform.
 In addition, pluggable components such as transaction family implementations
 can use the settings during their execution.
 
-This design supports two authorization options: a) a single authorized key
-which can make changes, and b) multiple authorized keys.  In the case of
-multiple keys, a percentage of votes signed by the keys is required to make a
-change.
+This design supports two authorization options: a single authorized key
+that can make changes and multiple authorized keys.  In the case of
+multiple keys, a configuration setting controls how many nodes must vote to
+make a change.
 
 .. note::
 
@@ -63,7 +63,7 @@ The Settings transaction family uses the following settings for its own configur
 +-------------------------------------------+------------------------------------------------------------------------------+
 | Setting (Settings)                        | Value Description                                                            |
 +===========================================+==============================================================================+
-| sawtooth.settings.vote.authorized_keys    | List of public keys allowed to vote                                          |
+| sawtooth.settings.vote.authorized_keys    | List of public keys allowed to propose and vote on settings changes          |
 +-------------------------------------------+------------------------------------------------------------------------------+
 | sawtooth.settings.vote.approval_threshold | Minimum number of votes required to accept or reject a proposal (default: 1) |
 +-------------------------------------------+------------------------------------------------------------------------------+


### PR DESCRIPTION
Backport of #2212 

- Change the Ubuntu single- and multi-node procedures to use the user's private key for the genesis block instead of the validator key. Also change the user key name to "my_key" (to match the k8s environment) and clarify the key required for settings change proposals.

- In other procedures, make the key-related info more generic and clarify the validator key information.

- In the Settings transaction family spec, clarify the definition of sawtooth.settings.vote.authorized_keys and add info about voting.

- Add new procedure to the Sys Admin Guide for changing the authorized users in sawtooth.settings.vote.authorized_keys, "Adding Adding Authorized Users for Settings Proposals".

- Update "Adding and Removing a PBFT Node" to clarify settings-related info and steps.
