### PR TITLE
Add ready blocks to processing

### DIFF
--- a/validator/src/journal/block_scheduler.rs
+++ b/validator/src/journal/block_scheduler.rs
@@ -201,7 +201,9 @@ impl<B: BlockStatusStore> BlockSchedulerState<B> {
 
         for blk in &ready {
             self.pending.remove(&blk.header_signature);
+            self.processing.insert(blk.header_signature.clone());
         }
+
         self.update_gauges();
         ready
     }


### PR DESCRIPTION
When calling `done` on the `BlockScheduler`, add the next set of blocks (the immediate successor blocks), if any, to the `processing` list.

This corrects an issue where the blocks are scheduled again due to not being marked as in-process via the above mechanism.