### PR TITLE
Remove fetch tags from jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,12 +75,6 @@ pipeline {
             }
         }
 
-        stage('Fetch Tags') {
-            steps {
-                sh 'git fetch --tag'
-            }
-        }
-
         stage('Build Lint Requirements') {
             steps {
                 sh 'docker-compose -f docker/compose/run-lint.yaml build'


### PR DESCRIPTION
This command was added as a workaround for a bug in JJB where tags were
not checked out, this has been fixed so this is no longer needed.

Signed-off-by: Richard Berg <rberg@bitwise.io>