### PR TITLE
Docs: Add Missing Documentation About Installing GNU Privacy Guard

### DIFF
--- a/docs/source/_includes/install-sawtooth.inc
+++ b/docs/source/_includes/install-sawtooth.inc
@@ -6,6 +6,8 @@
 
      .. code-block:: console
 
+        $ sudo apt-get update
+        $ sudo apt-get install gnupg -y
         $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
         $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe'
 
@@ -23,6 +25,8 @@
 
      .. code-block:: console
 
+        $ sudo apt-get update
+        $ sudo apt-get install gnupg -y
         $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
         $ sudo apt-add-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic universe'
 

--- a/docs/source/app_developers_guide/ubuntu.rst
+++ b/docs/source/app_developers_guide/ubuntu.rst
@@ -89,6 +89,8 @@ stable or nightly.  We recommend using the stable repository.
 
      .. code-block:: console
 
+       user@validator$ sudo apt-get update
+       user@validator$ sudo apt-get install gnupg -y
        user@validator$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
        user@validator$ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe'
        user@validator$ sudo apt-get update
@@ -103,6 +105,8 @@ stable or nightly.  We recommend using the stable repository.
 
      .. code-block:: console
 
+        user@validator$ sudo apt-get update
+        user@validator$ sudo apt-get install gnupg -y
         user@validator$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 44FC67F19B2466EA
         user@validator$ sudo apt-add-repository "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe"
         user@validator$ sudo apt-get update

--- a/docs/source/sysadmin_guide/configure_sgx.rst
+++ b/docs/source/sysadmin_guide/configure_sgx.rst
@@ -151,6 +151,8 @@ Install Sawtooth
 
 .. code-block:: console
 
+    $ sudo apt-get update
+    $ sudo apt-get install gnupg -y
     $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
     $ sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu/chime/stable bionic universe'
     $ sudo apt-get update


### PR DESCRIPTION
Add missing Documentation in the sysadmin guide and app dev guide about
the requirement to install GNU Privacy Guard package gnupg2 before
using `apt-key` .

Signed-off-by: danintel <daniel.anderson@intel.com>