### PR TITLE
1-2 BACKPORT: Fix versioning of packaged Rust components

### DIFF
--- a/adm/Dockerfile-installed-bionic
+++ b/adm/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/adm
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== admin tools docker build ===-------------
 FROM ubuntu:bionic

--- a/adm/Dockerfile-installed-xenial
+++ b/adm/Dockerfile-installed-xenial
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/adm
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== admin tools docker build ===-------------
 FROM ubuntu:xenial

--- a/families/block_info/Dockerfile-installed-bionic
+++ b/families/block_info/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project/sawtooth-core
 
 WORKDIR /project/sawtooth-core/families/block_info/sawtooth_block_info
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== block-info rust docker build ===-------------
 FROM ubuntu:bionic

--- a/families/block_info/Dockerfile-installed-xenial
+++ b/families/block_info/Dockerfile-installed-xenial
@@ -42,8 +42,9 @@ COPY . /project/sawtooth-core
 
 WORKDIR /project/sawtooth-core/families/block_info/sawtooth_block_info
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== block-info rust docker build ===-------------
 FROM ubuntu:xenial

--- a/families/identity/Dockerfile-installed-bionic
+++ b/families/identity/Dockerfile-installed-bionic
@@ -47,8 +47,9 @@ COPY . /project
 
 WORKDIR /project/families/identity/sawtooth_identity/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
  # -------------=== identity docker build ===-------------
 FROM ubuntu:bionic

--- a/families/identity/Dockerfile-installed-xenial
+++ b/families/identity/Dockerfile-installed-xenial
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/families/identity/sawtooth_identity
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
  # -------------=== identity docker build ===-------------
 FROM ubuntu:xenial

--- a/families/settings/Dockerfile-installed-bionic
+++ b/families/settings/Dockerfile-installed-bionic
@@ -44,8 +44,9 @@ COPY . /project
 
 WORKDIR /project/families/settings/sawtooth_settings
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== settings docker build ===-------------
 FROM ubuntu:bionic

--- a/families/settings/Dockerfile-installed-xenial
+++ b/families/settings/Dockerfile-installed-xenial
@@ -45,8 +45,9 @@ COPY . /project
 
 WORKDIR /project/families/settings/sawtooth_settings
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== settings rust docker build ===-------------
 FROM ubuntu:xenial

--- a/families/smallbank/smallbank_rust/Dockerfile-installed-bionic
+++ b/families/smallbank/smallbank_rust/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/families/smallbank/smallbank_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== smallbank rust docker build ===-------------
 FROM ubuntu:bionic

--- a/families/smallbank/smallbank_rust/Dockerfile-installed-xenial
+++ b/families/smallbank/smallbank_rust/Dockerfile-installed-xenial
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/families/smallbank/smallbank_rust/
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== smallbank rust docker build ===-------------
 FROM ubuntu:xenial

--- a/perf/intkey_workload/Dockerfile-installed-bionic
+++ b/perf/intkey_workload/Dockerfile-installed-bionic
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/perf/intkey_workload
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== intkey workload docker build ===-------------
 FROM ubuntu:bionic

--- a/perf/intkey_workload/Dockerfile-installed-xenial
+++ b/perf/intkey_workload/Dockerfile-installed-xenial
@@ -43,8 +43,9 @@ COPY . /project
 
 WORKDIR /project/perf/intkey_workload
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== intkey workload docker build ===-------------
 FROM ubuntu:xenial

--- a/perf/smallbank_workload/Dockerfile-installed-bionic
+++ b/perf/smallbank_workload/Dockerfile-installed-bionic
@@ -82,8 +82,9 @@ COPY . /project
 
 WORKDIR /project/perf/smallbank_workload
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== smallbank workload docker build ===-------------
 FROM ubuntu:bionic

--- a/perf/smallbank_workload/Dockerfile-installed-xenial
+++ b/perf/smallbank_workload/Dockerfile-installed-xenial
@@ -79,8 +79,9 @@ COPY . /project
 
 WORKDIR /project/perf/smallbank_workload
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(../../bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(../../bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== smallbank workload docker build ===-------------
 FROM ubuntu:xenial


### PR DESCRIPTION
The behavior of cargo-deb was changed to generate version numbers with
tildes instead of dashes. This is causing newly built packages to sort
below older releases.

https://github.com/mmstick/cargo-deb/pull/102

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>