### PR TITLE
Only validate block on request from consensus

### DIFF
--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -372,6 +372,12 @@ class ConsensusCheckBlocksNotifier(Handler):
                 self._consensus_notifier.notify_block_valid(block_id)
             elif block_status == BlockStatus.Invalid:
                 self._consensus_notifier.notify_block_invalid(block_id)
+            elif block_status == BlockStatus.Unknown:
+                # No need to worry about unknown block, this is checked in the
+                # previous handler.
+                self._proxy.validate_block(block_id)
+            elif block_status == BlockStatus.Missing:
+                LOGGER.error("Missing block: %s", block_id)
 
         return HandlerResult(status=HandlerStatus.PASS)
 

--- a/validator/sawtooth_validator/consensus/handlers.py
+++ b/validator/sawtooth_validator/consensus/handlers.py
@@ -378,6 +378,10 @@ class ConsensusCheckBlocksNotifier(Handler):
                 self._proxy.validate_block(block_id)
             elif block_status == BlockStatus.Missing:
                 LOGGER.error("Missing block: %s", block_id)
+            elif block_status == BlockStatus.InValidation:
+                # Block is already being validated, notification will be sent
+                # when it's complete
+                pass
 
         return HandlerResult(status=HandlerStatus.PASS)
 

--- a/validator/sawtooth_validator/consensus/proxy.py
+++ b/validator/sawtooth_validator/consensus/proxy.py
@@ -219,6 +219,14 @@ class ConsensusProxy:
         except KeyError as key_error:
             raise UnknownBlock(key_error.args[0])
 
+    def validate_block(self, block_id):
+        """Instruct the chain controller to validate the given block."""
+        try:
+            block = next(self._block_manager.get([block_id]))
+        except StopIteration as stop_iteration:
+            raise UnknownBlock(stop_iteration.args[0])
+        self._chain_controller.validate_block(block)
+
     def commit_block(self, block_id):
         try:
             block = next(self._block_manager.get([block_id.hex()]))

--- a/validator/sawtooth_validator/journal/block_wrapper.py
+++ b/validator/sawtooth_validator/journal/block_wrapper.py
@@ -23,11 +23,16 @@ class BlockStatus(IntEnum):
     """
         The status of a block as the journal is concerned.
     """
-    Unknown = 0  # Block is present but not yet validated
-    Invalid = 1  # Block failed block validation.
-    Valid = 2  # Block has been validated and id valid to appear in a chain.
-    Missing = 3  # we know about the block, possibly by a successor, but
-    # we do not have it.
+    # Block is present but not yet validated
+    Unknown = 0
+    # Block failed block validation.
+    Invalid = 1
+    # Block has been validated and id valid to appear in a chain.
+    Valid = 2
+    # We know about the block, possibly by a successor, but we do not have it.
+    Missing = 3
+    # The block is currently being validated
+    InValidation = 4
 
 
 class BlockWrapper:

--- a/validator/sawtooth_validator/journal/chain.py
+++ b/validator/sawtooth_validator/journal/chain.py
@@ -94,6 +94,11 @@ class ChainController(OwnedPointer):
         payload = block.SerializeToString()
         _libexec(name, self.pointer, payload, len(payload))
 
+    def validate_block(self, block):
+        self._chain_controller_block_ffi_fn(
+            'chain_controller_validate_block',
+            block)
+
     def ignore_block(self, block):
         self._chain_controller_block_ffi_fn(
             'chain_controller_ignore_block',

--- a/validator/src/journal/block_wrapper.rs
+++ b/validator/src/journal/block_wrapper.rs
@@ -27,6 +27,7 @@ pub enum BlockStatus {
     Invalid = 1,
     Valid = 2,
     Missing = 3,
+    InValidation = 5,
 }
 
 impl Default for BlockStatus {

--- a/validator/src/journal/block_wrapper_ffi.rs
+++ b/validator/src/journal/block_wrapper_ffi.rs
@@ -56,6 +56,9 @@ impl ToPyObject for BlockStatus {
             BlockStatus::Missing => PY_BLOCK_STATUS
                 .getattr(py, "Missing")
                 .expect("No BlockStatus.Missing"),
+            BlockStatus::InValidation => PY_BLOCK_STATUS
+                .getattr(py, "InValidation")
+                .expect("No BlockStatus.InValidation"),
         }
     }
 }
@@ -67,6 +70,7 @@ impl<'source> FromPyObject<'source> for BlockStatus {
             1 => BlockStatus::Invalid,
             2 => BlockStatus::Valid,
             3 => BlockStatus::Missing,
+            5 => BlockStatus::InValidation,
             _ => BlockStatus::Unknown,
         })
     }

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -523,6 +523,24 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
     }
 
     pub fn validate_block(&self, block: &Block) {
+        // If there is already a result for this block, no need to validate it
+        if self
+            .block_validation_results
+            .get(&block.header_signature)
+            .is_some()
+        {
+            return;
+        }
+
+        // Create block validation result, maked as in-validation
+        self.block_validation_results.insert(BlockValidationResult {
+            block_id: block.header_signature.clone(),
+            execution_results: vec![],
+            num_transactions: 0,
+            status: BlockStatus::InValidation,
+        });
+
+        // Submit for validation
         let sender = self.validation_result_sender.as_ref().expect(
             "Attempted to submit block for validation before starting the chain controller",
         );

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -539,7 +539,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
         // Drop Ref-C: Consensus is not interested in this block anymore
         match state.block_references.remove(&block.header_signature) {
             Some(_) => info!("Ignored block {}", block),
-            None => warn!(
+            None => debug!(
                 "Could not ignore block {}; consensus has already decided on it",
                 &block.header_signature
             ),
@@ -559,7 +559,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                     .fail_block(&block.header_signature);
                 info!("Failed block {}", block);
             }
-            None => warn!(
+            None => debug!(
                 "Could not fail block {}; consensus has already decided on it",
                 &block.header_signature
             ),

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -728,8 +728,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                 // Move Ref-C: Consensus has decided this block should become the new chain
                 // head, so the ChainController will maintain ownership of this ext. ref until a
                 // new chain head replaces it.
-                // Drop Ref-C: The ext. ref. of the old chain head is dropped here since it's
-                // superceded by the new chain head.
                 state.chain_head = Some(
                     state
                         .block_references

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -231,6 +231,12 @@ macro_rules! chain_controller_block_ffi {
     }
 }
 
+chain_controller_block_ffi!(
+    chain_controller_validate_block,
+    validate_block,
+    block,
+    &block
+);
 chain_controller_block_ffi!(chain_controller_ignore_block, ignore_block, block, &block);
 chain_controller_block_ffi!(chain_controller_fail_block, fail_block, block, &block);
 chain_controller_block_ffi!(chain_controller_commit_block, commit_block, block, block);


### PR DESCRIPTION
Updates the validator:
- Send a block to consensus as soon as it's created/received.
- Wait for a check_blocks() request from consensus to validate the
block.
- Send a BlockValid/BlockInvalid update to consensus when the block has
finished validating.

This was the original intent for consensus API behavior, and it allows
consensus to prioritize which blocks are considered.

Signed-off-by: Logan Seeley <seeley@bitwise.io>

This PR has been verified using the devmode liveness test.