### PR TITLE
Revert "Remove futures from _SendReceive after a certain timeout."

### DIFF
--- a/validator/sawtooth_validator/networking/future.py
+++ b/validator/sawtooth_validator/networking/future.py
@@ -135,20 +135,18 @@ class FutureCollection:
                 "no such correlation id: {}".format(correlation_id))
 
     def remove_expired(self):
-        with self._lock:
-            correlation_ids = [
-                correlation_id
-                for correlation_id, future
-                in self._futures.items()
-                if future.is_expired()
-            ]
-            for correlation_id in correlation_ids:
-                self._futures[correlation_id].timer_stop()
-                del self._futures[correlation_id]
+        correlation_ids = [
+            correlation_id
+            for correlation_id, future
+            in self._futures.items()
+            if future.is_expired()
+        ]
+        for correlation_id in correlation_ids:
+            self._futures[correlation_id].timer_stop()
+            del self._futures[correlation_id]
 
     def clean(self):
-        with self._lock:
-            correlation_ids = list(self._futures.keys())
-            for correlation_id in correlation_ids:
-                self._futures[correlation_id].timer_stop()
-                del self._futures[correlation_id]
+        correlation_ids = list(self._futures.keys())
+        for correlation_id in correlation_ids:
+            self._futures[correlation_id].timer_stop()
+            del self._futures[correlation_id]


### PR DESCRIPTION
This reverts commits ca131d586c7e798f831559335f0768ab1cdeb037 and 7693dfc3fb5f4acbbb1cd92cf730fba7a38a98fc.

In 1.2 testing, the expired future feature added post 1.1 was causing network instability
with dynamic peering.

Signed-off-by: James Mitchell <mitchell@bitwise.io>