### PR TITLE
Change libexec style for selected calls based on perf testing results

### DIFF
--- a/validator/sawtooth_validator/ffi.py
+++ b/validator/sawtooth_validator/ffi.py
@@ -82,7 +82,7 @@ def prepare_string_result():
 def from_rust_string(string_ptr, string_len, string_cap):
     # pylint: disable=invalid-slice-index
     py_bytes = bytes(string_ptr[:string_len.value])
-    LIBRARY.call(
+    PY_LIBRARY.call(
         "ffi_reclaim_string",
         string_ptr,
         string_len,
@@ -104,7 +104,7 @@ def prepare_vec_result(pointer_type=ctypes.c_uint8):
 def from_rust_vec(vec_ptr, vec_len, vec_cap):
     # pylint: disable=invalid-slice-index
     py_bytes = bytes(vec_ptr[:vec_len.value])
-    LIBRARY.call(
+    PY_LIBRARY.call(
         "ffi_reclaim_vec",
         vec_ptr,
         vec_len,

--- a/validator/sawtooth_validator/journal/block_store.py
+++ b/validator/sawtooth_validator/journal/block_store.py
@@ -59,6 +59,10 @@ def _libexec(name, *args):
     _check_error(ffi.LIBRARY.call(name, *args))
 
 
+def _pylibexec(name, *args):
+    _check_error(ffi.PY_LIBRARY.call(name, *args))
+
+
 class _PutEntry(ctypes.Structure):
     _fields_ = [('block_bytes', ctypes.c_char_p),
                 ('block_bytes_len', ctypes.c_size_t)]
@@ -87,25 +91,23 @@ class BlockStore(ffi.OwnedPointer):
 
     def _get_data_by_num(self, object_id, ffi_fn_name):
         (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
-        _libexec(
-            ffi_fn_name,
-            self.pointer,
-            ctypes.c_ulonglong(object_id),
-            ctypes.byref(vec_ptr),
-            ctypes.byref(vec_len),
-            ctypes.byref(vec_cap))
+        _pylibexec(ffi_fn_name,
+                   self.pointer,
+                   ctypes.c_ulonglong(object_id),
+                   ctypes.byref(vec_ptr),
+                   ctypes.byref(vec_len),
+                   ctypes.byref(vec_cap))
 
         return ffi.from_rust_vec(vec_ptr, vec_len, vec_cap)
 
     def _get_data_by_id(self, object_id, ffi_fn_name):
         (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()
-        _libexec(
-            ffi_fn_name,
-            self.pointer,
-            ctypes.c_char_p(object_id.encode()),
-            ctypes.byref(vec_ptr),
-            ctypes.byref(vec_len),
-            ctypes.byref(vec_cap))
+        _pylibexec(ffi_fn_name,
+                   self.pointer,
+                   ctypes.c_char_p(object_id.encode()),
+                   ctypes.byref(vec_ptr),
+                   ctypes.byref(vec_len),
+                   ctypes.byref(vec_cap))
 
         return ffi.from_rust_vec(vec_ptr, vec_len, vec_cap)
 
@@ -136,11 +138,10 @@ class BlockStore(ffi.OwnedPointer):
 
     def _contains_id(self, object_id, fn_name):
         contains = ctypes.c_bool(False)
-        _libexec(
-            fn_name,
-            self.pointer,
-            ctypes.c_char_p(object_id.encode()),
-            ctypes.byref(contains))
+        _pylibexec(fn_name,
+                   self.pointer,
+                   ctypes.c_char_p(object_id.encode()),
+                   ctypes.byref(contains))
         return contains.value
 
     def __contains__(self, block_id):

--- a/validator/sawtooth_validator/journal/publisher.py
+++ b/validator/sawtooth_validator/journal/publisher.py
@@ -64,7 +64,7 @@ class IncomingBatchSender(OwnedPointer):
         self._ptr = sender_ptr
 
     def send(self, item):
-        res = PY_LIBRARY.call(
+        res = LIBRARY.call(
             "incoming_batch_sender_send",
             self._ptr,
             ctypes.py_object(item))
@@ -302,7 +302,7 @@ class BlockPublisher(OwnedPointer):
         return has
 
     def initialize_block(self, block):
-        self._py_call('initialize_block', ctypes.py_object(block))
+        self._call('initialize_block', ctypes.py_object(block))
 
     def summarize_block(self, force=False):
         (vec_ptr, vec_len, vec_cap) = ffi.prepare_vec_result()


### PR DESCRIPTION
These commits change the libexec style from python style to c-style (and vise versa) for selected calls based on performance testing method timings. Generally, the preference is to hold the python GIL (via pylibexec) for frequent, fast FFI calls, and to release the GIL (via libexec) for slow FFI calls.