### PR TITLE
Remove gossip duplicate and broadcast existence checks

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -48,6 +48,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
     python3-aiohttp \
     python3-async-timeout \
     python3-bitcoin \
+    python3-cachetools \
     python3-cbor \
     python3-cchardet \
     python3-colorlog \

--- a/ci/sawtooth-shell-installed
+++ b/ci/sawtooth-shell-installed
@@ -32,6 +32,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/ap
     openssl \
     pkg-config \
     python3 \
+    python3-cachetools \
     python3-dev \
     python3-grpcio \
     python3-grpcio-tools \

--- a/docker/lint
+++ b/docker/lint
@@ -26,6 +26,7 @@ RUN apt-get install -y -q \
     git \
     python3 \
     python3-aiohttp \
+    python3-cachetools \
     python3-cbor \
     python3-colorlog \
     python3-cryptography-vectors \

--- a/docker/sawtooth-debug-python
+++ b/docker/sawtooth-debug-python
@@ -39,6 +39,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
     python3-aiopg \
     python3-async-timeout \
     python3-bitcoin \
+    python3-cachetools \
     python3-cbor \
     python3-cchardet \
     python3-colorlog \

--- a/docker/sawtooth-shell
+++ b/docker/sawtooth-shell
@@ -37,6 +37,7 @@ RUN apt-get install -y -q \
     python3-protobuf
 
 RUN apt-get install -y -q \
+    python3-cachetools \
     python3-cbor \
     python3-colorlog \
     python3-sawtooth-intkey \

--- a/integration/sawtooth_integration/docker/integration-tests.dockerfile
+++ b/integration/sawtooth_integration/docker/integration-tests.dockerfile
@@ -26,6 +26,7 @@ RUN apt-get install -y -q \
     apt-transport-https \
     curl \
     python3-aiohttp \
+    python3-cachetools \
     python3-cbor \
     python3-colorlog \
     python3-cov-core \

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get install -y -q \
     libssl-dev \
     openssl \
     pkg-config \
+    python3-cachetools \
     python3-cbor \
     python3-colorlog \
     python3-cryptography>=1.7.1 \

--- a/validator/Dockerfile-installed-bionic
+++ b/validator/Dockerfile-installed-bionic
@@ -32,6 +32,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/ap
     openssl \
     pkg-config \
     python3 \
+    python3-cachetools \
     python3-dev \
     python3-grpcio \
     python3-grpcio-tools \

--- a/validator/Dockerfile-installed-xenial
+++ b/validator/Dockerfile-installed-xenial
@@ -29,6 +29,7 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/bumper/nightly xenial universe" >> 
     openssl \
     pkg-config \
     python3 \
+    python3-cachetools \
     python3-dev \
     python3-grpcio \
     python3-grpcio-tools \

--- a/validator/sawtooth_validator/gossip/gossip_handlers.py
+++ b/validator/sawtooth_validator/gossip/gossip_handlers.py
@@ -219,9 +219,10 @@ class GossipConsensusHandler(Handler):
 
 
 class GossipBroadcastHandler(Handler):
-    def __init__(self, gossip, completer):
+    def __init__(self, gossip):
         self._gossip = gossip
-        self._completer = completer
+        self._cache = LRUCache(maxsize=4096)
+        self._lock = Lock()
 
     def handle(self, connection_id, message_content):
         obj, tag, ttl = message_content
@@ -234,19 +235,22 @@ class GossipBroadcastHandler(Handler):
             # Do not forward message if it has reached its time to live limit
             return HandlerResult(status=HandlerStatus.PASS)
 
+        with self._lock:
+            if obj.header_signature in self._cache:
+                return HandlerResult(status=HandlerStatus.PASS)
+
+            self._cache[obj.header_signature] = True
+
         if tag == GossipMessage.BATCH:
-            # If we already have this batch, don't forward it
-            if not self._completer.get_batch(obj.header_signature):
-                self._gossip.broadcast_batch(obj, exclude, time_to_live=ttl)
+            self._gossip.broadcast_batch(obj, exclude, time_to_live=ttl)
         elif tag == GossipMessage.BLOCK:
-            # If we already have this block, don't forward it
-            if not self._completer.get_block(obj.header_signature):
-                self._gossip.broadcast_block(obj, exclude, time_to_live=ttl)
+            self._gossip.broadcast_block(obj, exclude, time_to_live=ttl)
         elif tag == GossipMessage.CONSENSUS:
-            # We do not want to forward consensus messages
             pass
         else:
-            LOGGER.info("received %s, not BATCH or BLOCK or CONSENSUS", tag)
+            LOGGER.info("received %s, not BATCH or "
+                        "BLOCK or CONSENSUS", tag)
+
         return HandlerResult(status=HandlerStatus.PASS)
 
 

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -207,7 +207,7 @@ def add(
 
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_MESSAGE,
-        GossipMessageDuplicateHandler(completer, has_block, has_batch),
+        GossipMessageDuplicateHandler(),
         thread_pool)
 
     # GOSSIP_MESSAGE ) Verify Network Permissions

--- a/validator/sawtooth_validator/server/network_handlers.py
+++ b/validator/sawtooth_validator/server/network_handlers.py
@@ -258,7 +258,7 @@ def add(
     # should occur
     dispatcher.add_handler(
         validator_pb2.Message.GOSSIP_MESSAGE,
-        GossipBroadcastHandler(gossip=gossip, completer=completer),
+        GossipBroadcastHandler(gossip=gossip),
         thread_pool)
 
     # GOSSIP_MESSAGE ) Send message to completer

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -53,6 +53,7 @@ setup(
     url='https://github.com/hyperledger/sawtooth-core',
     packages=find_packages(),
     install_requires=[
+        "cachetools",
         "cbor>=0.1.23",
         "colorlog",
         "protobuf",

--- a/validator/stdeb.cfg
+++ b/validator/stdeb.cfg
@@ -1,2 +1,2 @@
 [DEFAULT]
-Depends3: libpython3-dev, openssl, libssl-dev
+Depends3: libpython3-dev, openssl, libssl-dev, python3-cachetools

--- a/validator/tests/test_duplicate_handler/tests.py
+++ b/validator/tests/test_duplicate_handler/tests.py
@@ -31,13 +31,12 @@ class TestDuplicateHandler(unittest.TestCase):
         self.completer = MockCompleter()
         self.chain = MockChainController()
         self.publisher = MockPublisher()
-        self.handler = GossipMessageDuplicateHandler(
-            self.completer, self.chain.has_block, self.publisher.has_batch)
+        self.handler = GossipMessageDuplicateHandler()
 
     def test_no_block(self):
         """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
+        Test that if the block has not been received recently,
+        the gossip message is passed.
         """
         block = Block(header_signature="Block1")
         handler_status = self.handler.handle(
@@ -46,54 +45,34 @@ class TestDuplicateHandler(unittest.TestCase):
 
     def test_no_batch(self):
         """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
+        Test that if the batch has not been received recently,
+        the gossip message is passed.
         """
         batch = Batch(header_signature="Batch1")
         handler_status = self.handler.handle(
             "connection_id", (batch, GossipMessage.BATCH, 2))
         self.assertEqual(handler_status.status, HandlerStatus.PASS)
 
-    def test_completer_has_block(self):
+    def test_recent_block(self):
         """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
+        Test that if the block has been received recently,
+        the gossip message is dropped.
         """
         block = Block(header_signature="Block1")
-        self.completer.add_block("Block1")
+        handler_status = self.handler.handle(
+            "connection_id", (block, GossipMessage.BLOCK, 2))
         handler_status = self.handler.handle(
             "connection_id", (block, GossipMessage.BLOCK, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)
 
-    def test_completer_has_batch(self):
+    def test_recent_batch(self):
         """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
+        Test that if the batch has been received recently,
+        the gossip message is dropped.
         """
         batch = Batch(header_signature="Batch1")
-        self.completer.add_batch("Batch1")
         handler_status = self.handler.handle(
             "connection_id", (batch, GossipMessage.BATCH, 2))
-        self.assertEqual(handler_status.status, HandlerStatus.DROP)
-
-    def test_chain_has_block(self):
-        """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
-        """
-        block = Block(header_signature="Block1")
-        self.chain.add_block("Block1")
-        handler_status = self.handler.handle(
-            "connection_id", (block, GossipMessage.BLOCK, 2))
-        self.assertEqual(handler_status.status, HandlerStatus.DROP)
-
-    def test_publisher_has_block(self):
-        """
-        Test that if the block does not exist yet in the completer or the
-        chain controller, the gossip message is passed.
-        """
-        batch = Batch(header_signature="Batch1")
-        self.publisher.add_batch("Batch1")
         handler_status = self.handler.handle(
             "connection_id", (batch, GossipMessage.BATCH, 2))
         self.assertEqual(handler_status.status, HandlerStatus.DROP)

--- a/validator/tests/validator-tests.dockerfile
+++ b/validator/tests/validator-tests.dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y -q \
     openssl \
     pkg-config \
     python3-aiohttp \
+    python3-cachetools \
     python3-cbor \
     python3-colorlog \
     python3-cryptography-vectors \


### PR DESCRIPTION
In a gossip network, often multiple duplicate messages arrive from peers in short order. Previously, the duplicate handler was performing an existence check (has_block, has_batch) against the completer. Since the completer likely does not process the first message by the time the last duplicate is seen, the completer's "caches" were not filled, resulting in a high volume of block store calls (resulting in "not in" results to the duplicate handler). This change moves to an LRU cache of message signature headers managed by the handler itself. This should allow the duplicate handler to behave as expected (dropping short-term duplicates) without excessive existence check calls.

In sawtooth, message broadcasting occurs prior to the message being passed to the completer. Previously, the broadcast handler was performing an existence check against the completer to determine if re-broadcasting was required. This resulted in a completer "cache" check and a block store existence check for an initial message, despite the fact that the completer could not have handled the message yet (as it comes after broadcast in the dispatch list). To exacerbate matters, if duplicate messages are passed to the broadcast handler in short order, the completer checks would still return "not in", and the messages would be broadcast multiple times to peers. This change moves to an LRU cache of message header signatures managed by the handler itself.