### PR TITLE
Add IPV6 tests to run_tests script

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -23,6 +23,7 @@ MODULE_LIST="
     settings
     identity
     block_info
+    ipv6
     battleship
     validator
     rust_sdk
@@ -144,6 +145,9 @@ main() {
                 integration)
                     test_integration
                     ;;
+                ipv6)
+                    test_ipv6
+                    ;;
                 deployment)
                     test_deployment
                     ;;
@@ -178,6 +182,11 @@ test_settings() {
 test_identity() {
   run_docker_test ./families/identity/tests/test_tp_identity.yaml
   copy_coverage .coverage.identity
+}
+
+test_ipv6() {
+    run_docker_test ./integration/sawtooth_integration/docker/test_ipv6.yaml
+    copy_coverage .coverage.ipv6
 }
 
 test_block_info() {


### PR DESCRIPTION
This commit enables the IPV6 test by default in the run_tests script.
docker-compose creates an IPV6 network even if IPV6 is not enabled
globally in Docker, so this will not cause failures where its not enabled.

Signed-off-by: Richard Berg <rberg@bitwise.io>