### PR TITLE
[1.1 Backport] Fix default connector port in devmode consensus engine

### DIFF
--- a/sdk/examples/devmode_rust/src/main.rs
+++ b/sdk/examples/devmode_rust/src/main.rs
@@ -46,7 +46,7 @@ fn main() {
 
     let endpoint = matches
         .value_of("connect")
-        .unwrap_or("tcp://localhost:5005");
+        .unwrap_or("tcp://localhost:5050");
 
     let console_log_level;
     match matches.occurrences_of("verbose") {


### PR DESCRIPTION
Validator will default listen on 5050 port, make example devmode
to connect on 5050 instead of 5005.

This is a backport of https://github.com/hyperledger/sawtooth-core/pull/1966 to 1.1 branch

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>