### PR TITLE
Add libsawtooth and stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@
 
 /integration/**/__pycache__/
 
+/libsawtooth/target/
+/libsawtooth/Cargo.lock
+
 /rest_api/build/
 /rest_api/sawtooth_rest_api/protobuf/
 /rest_api/**/__pycache__/

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -21,5 +21,6 @@ license = "Apache-2.0"
 
 [features]
 default = []
-experimental = ["stores"]
+experimental = ["btree-store", "stores"]
+btree-store = ["stores"]
 stores = []

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -20,13 +20,15 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+lmdb-zero = { version = "0.4", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
 transact = "0.1"
 
 [features]
 default = []
-experimental = ["btree-store", "receipt-store", "redis-store", "stores"]
+experimental = ["btree-store", "lmdb-store", "receipt-store", "redis-store", "stores"]
 btree-store = ["stores"]
+lmdb-store = ["lmdb-zero", "stores"]
 receipt-store = ["stores"]
 redis-store = ["redis", "stores"]
 stores = []

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -21,4 +21,5 @@ license = "Apache-2.0"
 
 [features]
 default = []
-experimental = []
+experimental = ["stores"]
+stores = []

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -19,8 +19,12 @@ authors = ["Cargill Incorporated"]
 edition = "2018"
 license = "Apache-2.0"
 
+[dependencies]
+transact = "0.1"
+
 [features]
 default = []
-experimental = ["btree-store", "stores"]
+experimental = ["btree-store", "receipt-store", "stores"]
 btree-store = ["stores"]
+receipt-store = ["stores"]
 stores = []

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -20,11 +20,13 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
+redis = { version = "0.13.0", default-features = false, optional = true }
 transact = "0.1"
 
 [features]
 default = []
-experimental = ["btree-store", "receipt-store", "stores"]
+experimental = ["btree-store", "receipt-store", "redis-store", "stores"]
 btree-store = ["stores"]
 receipt-store = ["stores"]
+redis-store = ["redis", "stores"]
 stores = []

--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2019 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "sawtooth"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
+license = "Apache-2.0"
+
+[features]
+default = []
+experimental = []

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -11,3 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#[cfg(feature = "stores")]
+pub mod store;

--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -1,0 +1,125 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::fmt::Debug;
+
+use super::{OrderedStore, OrderedStoreError};
+
+/// A BTreeMap-backed implementation of the `OrderedStore` trait that provides an in-memory,
+/// ordered key/value store.
+#[derive(Default)]
+pub struct BTreeOrderedStore<K: Ord, V, I: Ord> {
+    // The main store contains the index of the entry so it can be mapped back to the index store
+    main_store: BTreeMap<K, (V, I)>,
+    index_store: BTreeMap<I, K>,
+}
+
+impl<K: Ord, V, I: Ord> BTreeOrderedStore<K, V, I> {
+    pub fn new() -> Self {
+        Self {
+            main_store: BTreeMap::default(),
+            index_store: BTreeMap::default(),
+        }
+    }
+}
+
+impl<K: Ord + Clone + Debug + 'static, V: Clone + 'static, I: Ord + Clone + Debug + 'static>
+    OrderedStore<K, V, I> for BTreeOrderedStore<K, V, I>
+{
+    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+        Ok(self
+            .index_store
+            .get(idx)
+            .and_then(|key| self.main_store.get(key).map(|(val, _)| val).cloned()))
+    }
+
+    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+        Ok(self.main_store.get(key).map(|(val, _)| val).cloned())
+    }
+
+    fn count(&self) -> Result<u64, OrderedStoreError> {
+        Ok(self
+            .main_store
+            .iter()
+            .count()
+            .try_into()
+            .map_err(|err| OrderedStoreError::Internal(Box::new(err)))?)
+    }
+
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        Ok(Box::new(
+            self.index_store
+                .iter()
+                .map(|(_, key)| self.main_store.get(key).map(|(val, _)| val).cloned())
+                .collect::<Option<Vec<_>>>()
+                .ok_or_else(|| {
+                    OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                })?
+                .into_iter(),
+        ))
+    }
+
+    fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
+        if self.main_store.contains_key(&key) {
+            return Err(OrderedStoreError::ValueAlreadyExistsForKey(Box::new(key)));
+        }
+        if self.index_store.contains_key(&idx) {
+            return Err(OrderedStoreError::ValueAlreadyExistsAtIndex(Box::new(idx)));
+        }
+
+        self.index_store.insert(idx.clone(), key.clone());
+        self.main_store.insert(key, (value, idx));
+
+        Ok(())
+    }
+
+    fn remove_by_index(&mut self, idx: &I) -> Result<Option<(K, V)>, OrderedStoreError> {
+        Ok(if let Some(key) = self.index_store.remove(idx) {
+            let val = self
+                .main_store
+                .remove(&key)
+                .map(|(val, _)| val)
+                .ok_or_else(|| {
+                    OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                })?;
+            Some((key, val))
+        } else {
+            None
+        })
+    }
+
+    fn remove_by_key(&mut self, key: &K) -> Result<Option<(V, I)>, OrderedStoreError> {
+        Ok(if let Some((val, index)) = self.main_store.remove(key) {
+            self.index_store.remove(&index);
+            Some((val, index))
+        } else {
+            None
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::store::tests::test_u8_ordered_store;
+
+    /// Verify that the `BTreeOrderedStore` passes the u8 ordered store test.
+    #[test]
+    fn u8_btree_store() {
+        test_u8_ordered_store(Box::new(BTreeOrderedStore::new()))
+    }
+}

--- a/libsawtooth/src/store/error.rs
+++ b/libsawtooth/src/store/error.rs
@@ -1,0 +1,55 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub enum OrderedStoreError {
+    InitializationFailed(String),
+    Internal(Box<dyn Error>),
+    StoreCorrupted(String),
+    ValueAlreadyExistsAtIndex(Box<dyn Debug>),
+    ValueAlreadyExistsForKey(Box<dyn Debug>),
+}
+
+impl Error for OrderedStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InitializationFailed(_) => None,
+            Self::Internal(err) => Some(&**err),
+            Self::StoreCorrupted(_) => None,
+            Self::ValueAlreadyExistsForKey(_) => None,
+            Self::ValueAlreadyExistsAtIndex(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for OrderedStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::InitializationFailed(err) => {
+                write!(f, "failed to initialize ordered store: {}", err)
+            }
+            Self::Internal(err) => write!(f, "internal error occurred: {}", err),
+            Self::StoreCorrupted(err) => write!(f, "ordered store is corrupted: {}", err),
+            Self::ValueAlreadyExistsForKey(key) => {
+                write!(f, "value already exists for key: {:?}", key)
+            }
+            Self::ValueAlreadyExistsAtIndex(idx) => {
+                write!(f, "value already exists at index: {:?}", idx)
+            }
+        }
+    }
+}

--- a/libsawtooth/src/store/error.rs
+++ b/libsawtooth/src/store/error.rs
@@ -17,6 +17,7 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 pub enum OrderedStoreError {
+    BytesParsingFailed(String),
     InitializationFailed(String),
     Internal(Box<dyn Error>),
     StoreCorrupted(String),
@@ -27,6 +28,7 @@ pub enum OrderedStoreError {
 impl Error for OrderedStoreError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::BytesParsingFailed(_) => None,
             Self::InitializationFailed(_) => None,
             Self::Internal(err) => Some(&**err),
             Self::StoreCorrupted(_) => None,
@@ -39,6 +41,7 @@ impl Error for OrderedStoreError {
 impl std::fmt::Display for OrderedStoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            Self::BytesParsingFailed(err) => write!(f, "failed to parse from bytes: {}", err),
             Self::InitializationFailed(err) => {
                 write!(f, "failed to initialize ordered store: {}", err)
             }

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -1,0 +1,349 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::convert::TryInto;
+use std::fmt::Debug;
+use std::path::Path;
+use std::sync::Arc;
+
+use lmdb_zero as lmdb;
+use lmdb_zero::error::LmdbResultExt;
+
+use super::{AsBytes, FromBytes, OrderedStore, OrderedStoreError};
+
+const DEFAULT_SIZE: usize = 1 << 40; // 1024 ** 4
+const NUM_DBS: u32 = 3; // main DB, index-to-key DB, and key-to-index DB
+
+impl From<lmdb::Error> for OrderedStoreError {
+    fn from(err: lmdb::Error) -> Self {
+        Self::Internal(Box::new(err))
+    }
+}
+
+/// An LMDB-backed implementation of the `OrderedStore` trait that provides a persistent, ordered
+/// key/value store.
+pub struct LmdbOrderedStore {
+    env: Arc<lmdb::Environment>,
+    // The main DB stores the (key, value) pairs
+    main_db: Arc<lmdb::Database<'static>>,
+    // The index-to-key DB stores the (index, key) mapping to support interacting with indexes
+    index_to_key_db: Arc<lmdb::Database<'static>>,
+    // The key-to-index DB stores the (key, index) mapping to support removing by key
+    key_to_index_db: Arc<lmdb::Database<'static>>,
+}
+
+impl LmdbOrderedStore {
+    pub fn new(filepath: &Path, size: Option<usize>) -> Result<Self, OrderedStoreError> {
+        let flags = lmdb::open::MAPASYNC
+            | lmdb::open::WRITEMAP
+            | lmdb::open::NORDAHEAD
+            | lmdb::open::NOSUBDIR;
+
+        let filepath_str = filepath.to_str().ok_or_else(|| {
+            OrderedStoreError::InitializationFailed(format!("invalid filepath: {:?}", filepath))
+        })?;
+
+        let mut builder = lmdb::EnvBuilder::new().map_err(|err| {
+            OrderedStoreError::InitializationFailed(format!(
+                "failed to initialize environment builder: {}",
+                err
+            ))
+        })?;
+        builder.set_maxdbs(NUM_DBS).map_err(|err| {
+            OrderedStoreError::InitializationFailed(format!("failed to set MAX_DBS: {}", err))
+        })?;
+        builder
+            .set_mapsize(size.unwrap_or(DEFAULT_SIZE))
+            .map_err(|err| {
+                OrderedStoreError::InitializationFailed(format!("failed to set MAP_SIZE: {}", err))
+            })?;
+
+        let env = Arc::new(unsafe {
+            builder.open(filepath_str, flags, 0o600).map_err(|err| {
+                OrderedStoreError::InitializationFailed(format!("database not found: {}", err))
+            })
+        }?);
+
+        let main_db = Arc::new(
+            lmdb::Database::open(
+                env.clone(),
+                Some("main"),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+            )
+            .map_err(|err| {
+                OrderedStoreError::InitializationFailed(format!(
+                    "failed to open main database: {}",
+                    err
+                ))
+            })?,
+        );
+
+        let index_to_key_db = Arc::new(
+            lmdb::Database::open(
+                env.clone(),
+                Some("index_to_key"),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+            )
+            .map_err(|err| {
+                OrderedStoreError::InitializationFailed(format!(
+                    "failed to open index-to-key database: {:?}",
+                    err
+                ))
+            })?,
+        );
+
+        let key_to_index_db = Arc::new(
+            lmdb::Database::open(
+                env.clone(),
+                Some("key_to_index"),
+                &lmdb::DatabaseOptions::new(lmdb::db::CREATE),
+            )
+            .map_err(|err| {
+                OrderedStoreError::InitializationFailed(format!(
+                    "failed to open key-to-index database: {:?}",
+                    err
+                ))
+            })?,
+        );
+
+        Ok(LmdbOrderedStore {
+            env,
+            main_db,
+            index_to_key_db,
+            key_to_index_db,
+        })
+    }
+}
+
+impl<
+        K: Clone + Debug + AsBytes + FromBytes + 'static,
+        V: Clone + AsBytes + FromBytes + 'static,
+        I: Clone + Debug + Ord + AsBytes + FromBytes + 'static,
+    > OrderedStore<K, V, I> for LmdbOrderedStore
+{
+    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let access = txn.access();
+
+        Ok(
+            match access
+                .get::<_, [u8]>(&self.index_to_key_db, &idx.as_bytes())
+                .to_opt()?
+            {
+                Some(key) => access
+                    .get::<_, [u8]>(&self.main_db, key)
+                    .to_opt()?
+                    .map(|val| V::from_bytes(val))
+                    .transpose()
+                    .map_err(OrderedStoreError::BytesParsingFailed)?,
+                None => None,
+            },
+        )
+    }
+
+    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let access = txn.access();
+
+        Ok(access
+            .get::<_, [u8]>(&self.main_db, &key.as_bytes())
+            .to_opt()?
+            .map(|val| V::from_bytes(val))
+            .transpose()
+            .map_err(OrderedStoreError::BytesParsingFailed)?)
+    }
+
+    fn count(&self) -> Result<u64, OrderedStoreError> {
+        Ok(lmdb::ReadTransaction::new(self.env.clone())?
+            .db_stat(&self.main_db)?
+            .entries
+            .try_into()
+            .map_err(|err| OrderedStoreError::Internal(Box::new(err)))?)
+    }
+
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let access = txn.access();
+        let mut index_cursor = txn.cursor(self.index_to_key_db.clone())?;
+
+        let index_iter = lmdb::CursorIter::new(
+            lmdb::MaybeOwned::Borrowed(&mut index_cursor),
+            &access,
+            |c, a| c.first(a),
+            lmdb::Cursor::next::<[u8], [u8]>,
+        )?;
+
+        Ok(Box::new(
+            index_iter
+                .map(|res| {
+                    res.map_err(|err| OrderedStoreError::Internal(Box::new(err)))
+                        .and_then(|(_, key)| {
+                            access
+                                .get::<_, [u8]>(&self.main_db, key)
+                                .map_err(|err| OrderedStoreError::Internal(Box::new(err)))
+                                .and_then(|val| {
+                                    V::from_bytes(val)
+                                        .map_err(OrderedStoreError::BytesParsingFailed)
+                                })
+                        })
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter(),
+        ))
+    }
+
+    fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
+        let txn = lmdb::WriteTransaction::new(self.env.clone())?;
+
+        {
+            let mut access = txn.access();
+
+            if access
+                .get::<_, [u8]>(&self.main_db, &key.as_bytes())
+                .to_opt()?
+                .is_some()
+            {
+                return Err(OrderedStoreError::ValueAlreadyExistsForKey(Box::new(key)));
+            }
+            if access
+                .get::<_, [u8]>(&self.index_to_key_db, &idx.as_bytes())
+                .to_opt()?
+                .is_some()
+            {
+                return Err(OrderedStoreError::ValueAlreadyExistsAtIndex(Box::new(idx)));
+            }
+
+            access.put(
+                &self.main_db,
+                &key.as_bytes(),
+                &value.as_bytes(),
+                lmdb::put::NOOVERWRITE,
+            )?;
+            access.put(
+                &self.index_to_key_db,
+                &idx.as_bytes(),
+                &key.as_bytes(),
+                lmdb::put::NOOVERWRITE,
+            )?;
+            access.put(
+                &self.key_to_index_db,
+                &key.as_bytes(),
+                &idx.as_bytes(),
+                lmdb::put::NOOVERWRITE,
+            )?;
+        }
+
+        txn.commit()?;
+
+        Ok(())
+    }
+
+    fn remove_by_index(&mut self, idx: &I) -> Result<Option<(K, V)>, OrderedStoreError> {
+        let txn = lmdb::WriteTransaction::new(self.env.clone())?;
+
+        let kv_option = {
+            let mut access = txn.access();
+
+            if let Some(key) = access
+                .get::<_, [u8]>(&self.index_to_key_db, &idx.as_bytes())
+                .to_opt()?
+                .map(Vec::from)
+            {
+                let val = access
+                    .get::<_, [u8]>(&self.main_db, &key)
+                    .to_opt()?
+                    .ok_or_else(|| {
+                        OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                    })
+                    .and_then(|val| {
+                        V::from_bytes(val).map_err(OrderedStoreError::BytesParsingFailed)
+                    })?;
+
+                access.del_key(&self.main_db, &key)?;
+                access.del_key(&self.index_to_key_db, &idx.as_bytes())?;
+                access.del_key(&self.key_to_index_db, &key)?;
+
+                let key = K::from_bytes(&key).map_err(OrderedStoreError::BytesParsingFailed)?;
+
+                Some((key, val))
+            } else {
+                None
+            }
+        };
+
+        txn.commit()?;
+
+        Ok(kv_option)
+    }
+
+    fn remove_by_key(&mut self, key: &K) -> Result<Option<(V, I)>, OrderedStoreError> {
+        let txn = lmdb::WriteTransaction::new(self.env.clone())?;
+
+        let vi_option = {
+            let mut access = txn.access();
+
+            if let Some(idx) = access
+                .get::<_, [u8]>(&self.key_to_index_db, &key.as_bytes())
+                .to_opt()?
+                .map(Vec::from)
+            {
+                let val = access
+                    .get::<_, [u8]>(&self.main_db, &key.as_bytes())
+                    .to_opt()?
+                    .ok_or_else(|| {
+                        OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                    })
+                    .and_then(|val| {
+                        V::from_bytes(val).map_err(OrderedStoreError::BytesParsingFailed)
+                    })?;
+
+                access.del_key(&self.main_db, &key.as_bytes())?;
+                access.del_key(&self.index_to_key_db, &idx)?;
+                access.del_key(&self.key_to_index_db, &key.as_bytes())?;
+
+                let idx = I::from_bytes(&idx).map_err(OrderedStoreError::BytesParsingFailed)?;
+
+                Some((val, idx))
+            } else {
+                None
+            }
+        };
+
+        txn.commit()?;
+
+        Ok(vi_option)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::store::tests::test_u8_ordered_store;
+
+    /// Verify that the `LmdbOrderedStore` passes the u8 ordered store test.
+    #[test]
+    fn u8_lmdb_store() {
+        let mut temp_db_path = std::env::temp_dir();
+        let thread_id = std::thread::current().id();
+        temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
+
+        test_u8_ordered_store(Box::new(
+            LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+                .expect("Failed to create LMDB ordered store"),
+        ));
+
+        std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+    }
+}

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "btree-store")]
+pub mod btree;
 mod error;
 
 pub use error::OrderedStoreError;

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -15,6 +15,8 @@
 #[cfg(feature = "btree-store")]
 pub mod btree;
 mod error;
+#[cfg(feature = "receipt-store")]
+pub mod receipt_store;
 
 pub use error::OrderedStoreError;
 

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -1,0 +1,113 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+pub use error::OrderedStoreError;
+
+/// A key/vaue store that is indexed by a type with total ordering
+pub trait OrderedStore<K, V, I: Ord> {
+    /// Get the value at the index if it exists.
+    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError>;
+
+    /// Get the value by the specified key if it exists.
+    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError>;
+
+    /// Get the number of entries in the store.
+    fn count(&self) -> Result<u64, OrderedStoreError>;
+
+    /// Get an iterator of all values in the store.
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError>;
+
+    /// Insert the key,value pair at the index. If a value already exists for the key or index, an
+    /// error is returned.
+    fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError>;
+
+    /// Remove the value at the index and return the key,value pair if it exists.
+    fn remove_by_index(&mut self, idx: &I) -> Result<Option<(K, V)>, OrderedStoreError>;
+
+    /// Remove the value corresponding to the key and return the valu,index pair if it exists.
+    fn remove_by_key(&mut self, key: &K) -> Result<Option<(V, I)>, OrderedStoreError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that a basic `OrderedStore` (one that only stores `u8`s) works properly.
+    pub fn test_u8_ordered_store(mut store: Box<dyn OrderedStore<u8, u8, u8>>) {
+        assert_eq!(store.count().expect("Failed to get count"), 0);
+
+        store.insert(0, 0, 0).expect("Failed to perform insert");
+        store.insert(1, 1, 1).expect("Failed to perform insert");
+
+        assert_eq!(store.count().expect("Failed to get count"), 2);
+
+        assert_eq!(
+            store.get_by_index(&0).expect("Failed to get by index"),
+            Some(0)
+        );
+        assert_eq!(
+            store.get_by_index(&2).expect("Failed to get by index"),
+            None
+        );
+
+        assert_eq!(store.get_by_key(&1).expect("Failed to get by key"), Some(1));
+        assert_eq!(store.get_by_key(&2).expect("Failed to get by key"), None);
+
+        let mut iter = store.iter().expect("Failed to get iter");
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(1));
+        assert_eq!(iter.next(), None);
+
+        assert!(store.insert(0, 2, 2).is_err());
+        assert!(store.insert(2, 2, 0).is_err());
+
+        assert_eq!(
+            store
+                .remove_by_index(&2)
+                .expect("Failed to remove by index"),
+            None
+        );
+        assert_eq!(store.count().expect("Failed to get count"), 2);
+        assert_eq!(
+            store
+                .remove_by_index(&1)
+                .expect("Failed to remove by index"),
+            Some((1, 1))
+        );
+        assert_eq!(
+            store.get_by_index(&1).expect("Failed to get by index"),
+            None
+        );
+        assert_eq!(store.get_by_key(&1).expect("Failed to get by key"), None);
+        assert_eq!(store.count().expect("Failed to get count"), 1);
+
+        assert_eq!(
+            store.remove_by_key(&2).expect("Failed to remove by key"),
+            None
+        );
+        assert_eq!(store.count().expect("Failed to get count"), 1);
+        assert_eq!(
+            store.remove_by_key(&0).expect("Failed to remove by key"),
+            Some((0, 0))
+        );
+        assert_eq!(
+            store.get_by_index(&0).expect("Failed to get by index"),
+            None
+        );
+        assert_eq!(store.get_by_key(&0).expect("Failed to get by key"), None);
+        assert_eq!(store.count().expect("Failed to get count"), 0);
+    }
+}

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -15,6 +15,8 @@
 #[cfg(feature = "btree-store")]
 pub mod btree;
 mod error;
+#[cfg(feature = "lmdb-store")]
+pub mod lmdb;
 #[cfg(feature = "receipt-store")]
 pub mod receipt_store;
 #[cfg(feature = "redis-store")]

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -17,6 +17,8 @@ pub mod btree;
 mod error;
 #[cfg(feature = "receipt-store")]
 pub mod receipt_store;
+#[cfg(feature = "redis-store")]
+pub mod redis;
 
 pub use error::OrderedStoreError;
 

--- a/libsawtooth/src/store/receipt_store/error.rs
+++ b/libsawtooth/src/store/receipt_store/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::error::Error;
+
+use crate::store::OrderedStoreError;
+
+#[derive(Debug)]
+pub struct TransactionReceiptStoreError(OrderedStoreError);
+
+impl Error for TransactionReceiptStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl std::fmt::Display for TransactionReceiptStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "error in transaction receipt store: {}", self.0)
+    }
+}
+
+impl From<OrderedStoreError> for TransactionReceiptStoreError {
+    fn from(err: OrderedStoreError) -> Self {
+        Self(err)
+    }
+}

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -224,4 +224,20 @@ mod tests {
             crate::store::btree::BTreeOrderedStore::new(),
         )))
     }
+
+    /// Test that an LMDB-backed receipt store works properly.
+    #[cfg(feature = "lmdb-store")]
+    #[test]
+    fn lmdb_receipt_store() {
+        let mut temp_db_path = std::env::temp_dir();
+        let thread_id = std::thread::current().id();
+        temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
+
+        test_receipt_store(TransactionReceiptStore::new(Box::new(
+            crate::store::lmdb::LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+                .expect("Failed to create LMDB ordered store"),
+        )));
+
+        std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+    }
 }

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -1,0 +1,211 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+use transact::protocol::receipt::TransactionReceipt;
+
+use crate::store::OrderedStore;
+
+pub use self::error::TransactionReceiptStoreError;
+
+/// `TransactionReceiptStore` is a wrapper around an `OrderedStore` that stores
+/// `TransactionReceipt`s keyed by transaction IDs (`String`s) and indexed by `u64`s to provide
+/// ordering of transactions.
+pub struct TransactionReceiptStore(Box<dyn OrderedStore<String, TransactionReceipt, u64> + Send>);
+
+impl TransactionReceiptStore {
+    /// Create a new `TransactionReceiptStore` that is backed by the given `OrderedStore`.
+    pub fn new(store: Box<dyn OrderedStore<String, TransactionReceipt, u64> + Send>) -> Self {
+        Self(store)
+    }
+
+    /// Get the `TransactionReceipt` that matches the given transaction ID.
+    pub fn get_by_id(
+        &self,
+        id: String,
+    ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
+        Ok(self.0.get_by_key(&id)?)
+    }
+
+    /// Get the `TransactionReceipt` at the given index.
+    pub fn get_by_index(
+        &self,
+        idx: u64,
+    ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
+        Ok(self.0.get_by_index(&idx)?)
+    }
+
+    /// Get the number of `TransactionReceipt`s in the store.
+    pub fn count(&self) -> Result<u64, TransactionReceiptStoreError> {
+        Ok(self.0.count()?)
+    }
+
+    /// Get an iterator over all `TransactionReceipt`s in order.
+    pub fn iter(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = TransactionReceipt>>, TransactionReceiptStoreError> {
+        Ok(self.0.iter()?)
+    }
+
+    /// Add receipts to the end of the store.
+    pub fn append(
+        &mut self,
+        receipts: Vec<TransactionReceipt>,
+    ) -> Result<(), TransactionReceiptStoreError> {
+        for receipt in receipts {
+            self.0
+                .insert(receipt.transaction_id.clone(), receipt, self.count()?)?;
+        }
+        Ok(())
+    }
+
+    /// Remove the `TransactionReceipt` with the given ID.
+    pub fn remove_by_id(
+        &mut self,
+        id: String,
+    ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
+        Ok(self.0.remove_by_key(&id)?.map(|(val, _)| val))
+    }
+
+    /// Remove the `TransactionReceipt` at the given index.
+    pub fn remove_by_index(
+        &mut self,
+        idx: u64,
+    ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
+        Ok(self.0.remove_by_index(&idx)?.map(|(_, val)| val))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that a receipt store works properly.
+    fn test_receipt_store(mut receipt_store: TransactionReceiptStore) {
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 0);
+
+        let receipt1 = TransactionReceipt {
+            state_changes: vec![],
+            events: vec![],
+            data: vec![],
+            transaction_id: "ab".into(),
+        };
+        let receipt2 = TransactionReceipt {
+            state_changes: vec![],
+            events: vec![],
+            data: vec![],
+            transaction_id: "cd".into(),
+        };
+
+        receipt_store
+            .append(vec![receipt1.clone(), receipt2.clone()])
+            .expect("Failed to append");
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 2);
+
+        assert_eq!(
+            receipt_store
+                .get_by_index(0)
+                .expect("Failed to get by index"),
+            Some(receipt1.clone())
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_index(2)
+                .expect("Failed to get by index"),
+            None
+        );
+
+        assert_eq!(
+            receipt_store
+                .get_by_id(receipt1.transaction_id.clone())
+                .expect("Failed to get by id"),
+            Some(receipt1.clone())
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_id("01".into())
+                .expect("Failed to get by id"),
+            None
+        );
+
+        let mut iter = receipt_store.iter().expect("Failed to get iter");
+        assert_eq!(iter.next(), Some(receipt1.clone()));
+        assert_eq!(iter.next(), Some(receipt2.clone()));
+        assert_eq!(iter.next(), None);
+
+        assert_eq!(
+            receipt_store
+                .remove_by_index(2)
+                .expect("Failed to remove by index"),
+            None
+        );
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 2);
+        assert_eq!(
+            receipt_store
+                .remove_by_index(1)
+                .expect("Failed to remove by index"),
+            Some(receipt2.clone()),
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_index(1)
+                .expect("Failed to get by index"),
+            None
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_id(receipt2.transaction_id.clone())
+                .expect("Failed to get by id"),
+            None
+        );
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 1);
+
+        assert_eq!(
+            receipt_store
+                .remove_by_id("ef".into())
+                .expect("Failed to remove by id"),
+            None
+        );
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 1);
+        assert_eq!(
+            receipt_store
+                .remove_by_id(receipt1.transaction_id.clone())
+                .expect("Failed to remove by id"),
+            Some(receipt1.clone()),
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_index(0)
+                .expect("Failed to get by index"),
+            None
+        );
+        assert_eq!(
+            receipt_store
+                .get_by_id(receipt1.transaction_id.clone())
+                .expect("Failed to get by id"),
+            None
+        );
+        assert_eq!(receipt_store.count().expect("Failed to get count"), 0);
+    }
+
+    /// Test that a BTree-backed receipt store works properly.
+    #[cfg(feature = "btree-store")]
+    #[test]
+    fn btree_receipt_store() {
+        test_receipt_store(TransactionReceiptStore::new(Box::new(
+            crate::store::btree::BTreeOrderedStore::new(),
+        )))
+    }
+}

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -15,10 +15,26 @@
 mod error;
 
 use transact::protocol::receipt::TransactionReceipt;
+use transact::protos::{FromBytes as ReceiptFromBytes, IntoBytes};
 
-use crate::store::OrderedStore;
+use crate::store::{AsBytes, FromBytes, OrderedStore};
 
 pub use self::error::TransactionReceiptStoreError;
+
+impl AsBytes for TransactionReceipt {
+    fn as_bytes(&self) -> Vec<u8> {
+        self.clone()
+            .into_bytes()
+            .expect("failed to serialize transaction receipt")
+    }
+}
+
+impl FromBytes for TransactionReceipt {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        <TransactionReceipt as ReceiptFromBytes<TransactionReceipt>>::from_bytes(bytes)
+            .map_err(|err| err.to_string())
+    }
+}
 
 /// `TransactionReceiptStore` is a wrapper around an `OrderedStore` that stores
 /// `TransactionReceipt`s keyed by transaction IDs (`String`s) and indexed by `u64`s to provide

--- a/libsawtooth/src/store/redis.rs
+++ b/libsawtooth/src/store/redis.rs
@@ -1,0 +1,153 @@
+// Copyright 2019 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cell::RefCell;
+use std::fmt::Debug;
+
+use redis::{Client, Commands, Connection, FromRedisValue, RedisError, ToRedisArgs};
+
+use super::{OrderedStore, OrderedStoreError};
+
+const MAIN_STORE: &str = "main";
+const INDEX_STORE: &str = "index";
+
+impl From<RedisError> for OrderedStoreError {
+    fn from(err: RedisError) -> Self {
+        Self::Internal(Box::new(err))
+    }
+}
+
+pub struct RedisOrderedStore {
+    conn: RefCell<Connection>,
+}
+
+impl RedisOrderedStore {
+    pub fn new(url: &str) -> Result<Self, OrderedStoreError> {
+        let conn = RefCell::new(
+            Client::open(url)
+                .map_err(|err| OrderedStoreError::InitializationFailed(err.to_string()))?
+                .get_connection()
+                .map_err(|err| OrderedStoreError::InitializationFailed(err.to_string()))?,
+        );
+        Ok(Self { conn })
+    }
+}
+
+impl<
+        K: Debug + FromRedisValue + ToRedisArgs + 'static,
+        V: FromRedisValue + ToRedisArgs + 'static,
+        I: Debug + Ord + FromRedisValue + ToRedisArgs + 'static,
+    > OrderedStore<K, V, I> for RedisOrderedStore
+{
+    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+        Ok(
+            match self
+                .conn
+                .borrow_mut()
+                .hget::<_, _, Option<K>>(INDEX_STORE, idx.to_redis_args())?
+            {
+                Some(key) => self.conn.borrow_mut().hget(MAIN_STORE, key)?,
+                None => None,
+            },
+        )
+    }
+
+    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+        Ok(self
+            .conn
+            .borrow_mut()
+            .hget(MAIN_STORE, key.to_redis_args())?)
+    }
+
+    fn count(&self) -> Result<u64, OrderedStoreError> {
+        Ok(self.conn.borrow_mut().hlen(MAIN_STORE)?)
+    }
+
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        let mut conn = self.conn.borrow_mut();
+
+        Ok(Box::new(
+            conn.hgetall::<_, Vec<K>>(INDEX_STORE)?
+                .into_iter()
+                .map(|key| conn.hget(MAIN_STORE, key.to_redis_args()))
+                .collect::<Result<Option<Vec<_>>, _>>()?
+                .ok_or_else(|| {
+                    OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                })?
+                .into_iter(),
+        ))
+    }
+
+    fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
+        if self
+            .conn
+            .borrow_mut()
+            .hexists(MAIN_STORE, key.to_redis_args())?
+        {
+            return Err(OrderedStoreError::ValueAlreadyExistsForKey(Box::new(key)));
+        }
+        if self
+            .conn
+            .borrow_mut()
+            .hexists(INDEX_STORE, idx.to_redis_args())?
+        {
+            return Err(OrderedStoreError::ValueAlreadyExistsAtIndex(Box::new(idx)));
+        }
+
+        self.conn
+            .borrow_mut()
+            .hset(INDEX_STORE, idx.to_redis_args(), key.to_redis_args())?;
+        self.conn.borrow_mut().hset(MAIN_STORE, key, (value, idx))?;
+
+        Ok(())
+    }
+
+    fn remove_by_index(&mut self, idx: &I) -> Result<Option<(K, V)>, OrderedStoreError> {
+        Ok(
+            if let Some(key) = self
+                .conn
+                .borrow_mut()
+                .hdel::<_, _, Option<K>>(INDEX_STORE, idx.to_redis_args())?
+            {
+                let val = self
+                    .conn
+                    .borrow_mut()
+                    .hdel::<_, _, Option<V>>(MAIN_STORE, key.to_redis_args())?
+                    .ok_or_else(|| {
+                        OrderedStoreError::StoreCorrupted("value missing from main store".into())
+                    })?;
+                Some((key, val))
+            } else {
+                None
+            },
+        )
+    }
+
+    fn remove_by_key(&mut self, key: &K) -> Result<Option<(V, I)>, OrderedStoreError> {
+        Ok(
+            if let Some((val, idx)) = self
+                .conn
+                .borrow_mut()
+                .hdel::<_, _, Option<(V, I)>>(MAIN_STORE, key.to_redis_args())?
+            {
+                self.conn
+                    .borrow_mut()
+                    .hdel(INDEX_STORE, idx.to_redis_args())?;
+                Some((val, idx))
+            } else {
+                None
+            },
+        )
+    }
+}


### PR DESCRIPTION
- Add the libsawtooth crate that will provide various components used by the Sawtooth validator.
- Add the `OrderedStore` trait, which defines an interface for a key/value store that is indexed by a type with total ordering.
- Add a BTreeMap-backed implementation of the `OrderedStore` trait for an in-memory ordered store.
- Add the `TransactionReceiptStore`, which is a wrapper around an `OrderedStore` that can be used to store transaction receipts, keyed by transaction IDs, in order.
- Add the `RedisOrderedStore` struct, which is an implementation of the `OrderedStore` trait that uses a redis database.
- Add the `LmdbOrderedStore`, which is an implementation of the `OrderedStore` trait that uses an LMDB database.