### PR TITLE
Add LmdbOrderedStoreIter for iterating over an LMDB ordered store

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -24,6 +24,7 @@ description = """\
 """
 
 [dependencies]
+log = "0.4"
 lmdb-zero = { version = "0.4", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
 transact = "0.1"

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[macro_use]
+extern crate log;
+
 #[cfg(feature = "stores")]
 pub mod store;

--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -15,20 +15,18 @@
 use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
 
 use super::{OrderedStore, OrderedStoreError};
 
-/// A BTreeMap-backed implementation of the `OrderedStore` trait that provides an in-memory,
-/// ordered key/value store.
-#[derive(Default)]
-pub struct BTreeOrderedStore<K: Ord, V, I: Ord> {
+struct BTreeOrderedStoreInternal<K, V, I> {
     // The main store contains the index of the entry so it can be mapped back to the index store
     main_store: BTreeMap<K, (V, I)>,
     index_store: BTreeMap<I, K>,
 }
 
-impl<K: Ord, V, I: Ord> BTreeOrderedStore<K, V, I> {
-    pub fn new() -> Self {
+impl<K: Ord, V, I: Ord> Default for BTreeOrderedStoreInternal<K, V, I> {
+    fn default() -> Self {
         Self {
             main_store: BTreeMap::default(),
             index_store: BTreeMap::default(),
@@ -36,22 +34,54 @@ impl<K: Ord, V, I: Ord> BTreeOrderedStore<K, V, I> {
     }
 }
 
-impl<K: Ord + Clone + Debug + 'static, V: Clone + 'static, I: Ord + Clone + Debug + 'static>
-    OrderedStore<K, V, I> for BTreeOrderedStore<K, V, I>
+/// A BTreeMap-backed implementation of the `OrderedStore` trait that provides an in-memory,
+/// ordered key/value store.
+#[derive(Default)]
+pub struct BTreeOrderedStore<K: Ord + Sync + Send, V: Sync + Send, I: Ord + Sync + Send> {
+    internal: Arc<Mutex<BTreeOrderedStoreInternal<K, V, I>>>,
+}
+
+impl<K: Ord + Sync + Send, V: Sync + Send, I: Ord + Sync + Send> BTreeOrderedStore<K, V, I> {
+    pub fn new() -> Self {
+        Self {
+            internal: Arc::new(Mutex::new(BTreeOrderedStoreInternal::default())),
+        }
+    }
+}
+
+impl<
+        K: Ord + Clone + Debug + Sync + Send + 'static,
+        V: Clone + Sync + Send + 'static,
+        I: Ord + Clone + Debug + Sync + Send + 'static,
+    > OrderedStore<K, V, I> for BTreeOrderedStore<K, V, I>
 {
     fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
-        Ok(self
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?;
+        Ok(internal
             .index_store
             .get(idx)
-            .and_then(|key| self.main_store.get(key).map(|(val, _)| val).cloned()))
+            .and_then(|key| internal.main_store.get(key).map(|(val, _)| val).cloned()))
     }
 
     fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
-        Ok(self.main_store.get(key).map(|(val, _)| val).cloned())
+        Ok(self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?
+            .main_store
+            .get(key)
+            .map(|(val, _)| val)
+            .cloned())
     }
 
     fn count(&self) -> Result<u64, OrderedStoreError> {
         Ok(self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?
             .main_store
             .iter()
             .count()
@@ -60,10 +90,15 @@ impl<K: Ord + Clone + Debug + 'static, V: Clone + 'static, I: Ord + Clone + Debu
     }
 
     fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        let internal = self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?;
         Ok(Box::new(
-            self.index_store
+            internal
+                .index_store
                 .iter()
-                .map(|(_, key)| self.main_store.get(key).map(|(val, _)| val).cloned())
+                .map(|(_, key)| internal.main_store.get(key).map(|(val, _)| val).cloned())
                 .collect::<Option<Vec<_>>>()
                 .ok_or_else(|| {
                     OrderedStoreError::StoreCorrupted("value missing from main store".into())
@@ -73,22 +108,31 @@ impl<K: Ord + Clone + Debug + 'static, V: Clone + 'static, I: Ord + Clone + Debu
     }
 
     fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
-        if self.main_store.contains_key(&key) {
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?;
+
+        if internal.main_store.contains_key(&key) {
             return Err(OrderedStoreError::ValueAlreadyExistsForKey(Box::new(key)));
         }
-        if self.index_store.contains_key(&idx) {
+        if internal.index_store.contains_key(&idx) {
             return Err(OrderedStoreError::ValueAlreadyExistsAtIndex(Box::new(idx)));
         }
 
-        self.index_store.insert(idx.clone(), key.clone());
-        self.main_store.insert(key, (value, idx));
+        internal.index_store.insert(idx.clone(), key.clone());
+        internal.main_store.insert(key, (value, idx));
 
         Ok(())
     }
 
     fn remove_by_index(&mut self, idx: &I) -> Result<Option<(K, V)>, OrderedStoreError> {
-        Ok(if let Some(key) = self.index_store.remove(idx) {
-            let val = self
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?;
+        Ok(if let Some(key) = internal.index_store.remove(idx) {
+            let val = internal
                 .main_store
                 .remove(&key)
                 .map(|(val, _)| val)
@@ -102,12 +146,18 @@ impl<K: Ord + Clone + Debug + 'static, V: Clone + 'static, I: Ord + Clone + Debu
     }
 
     fn remove_by_key(&mut self, key: &K) -> Result<Option<(V, I)>, OrderedStoreError> {
-        Ok(if let Some((val, index)) = self.main_store.remove(key) {
-            self.index_store.remove(&index);
-            Some((val, index))
-        } else {
-            None
-        })
+        let mut internal = self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?;
+        Ok(
+            if let Some((val, index)) = internal.main_store.remove(key) {
+                internal.index_store.remove(&index);
+                Some((val, index))
+            } else {
+                None
+            },
+        )
     }
 }
 

--- a/libsawtooth/src/store/error.rs
+++ b/libsawtooth/src/store/error.rs
@@ -20,6 +20,7 @@ pub enum OrderedStoreError {
     BytesParsingFailed(String),
     InitializationFailed(String),
     Internal(Box<dyn Error>),
+    LockPoisoned(String),
     StoreCorrupted(String),
     ValueAlreadyExistsAtIndex(Box<dyn Debug>),
     ValueAlreadyExistsForKey(Box<dyn Debug>),
@@ -31,6 +32,7 @@ impl Error for OrderedStoreError {
             Self::BytesParsingFailed(_) => None,
             Self::InitializationFailed(_) => None,
             Self::Internal(err) => Some(&**err),
+            Self::LockPoisoned(_) => None,
             Self::StoreCorrupted(_) => None,
             Self::ValueAlreadyExistsForKey(_) => None,
             Self::ValueAlreadyExistsAtIndex(_) => None,
@@ -46,6 +48,7 @@ impl std::fmt::Display for OrderedStoreError {
                 write!(f, "failed to initialize ordered store: {}", err)
             }
             Self::Internal(err) => write!(f, "internal error occurred: {}", err),
+            Self::LockPoisoned(err) => write!(f, "a lock was poisoned: {}", err),
             Self::StoreCorrupted(err) => write!(f, "ordered store is corrupted: {}", err),
             Self::ValueAlreadyExistsForKey(key) => {
                 write!(f, "value already exists for key: {:?}", key)

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -339,11 +339,15 @@ mod tests {
         let thread_id = std::thread::current().id();
         temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
 
-        test_u8_ordered_store(Box::new(
-            LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
-                .expect("Failed to create LMDB ordered store"),
-        ));
+        let test_result = std::panic::catch_unwind(|| {
+            test_u8_ordered_store(Box::new(
+                LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+                    .expect("Failed to create LMDB ordered store"),
+            ))
+        });
 
         std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+
+        assert!(test_result.is_ok());
     }
 }

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::fmt::Debug;
+use std::ops::Bound;
 use std::path::Path;
 use std::sync::Arc;
 
 use lmdb_zero as lmdb;
 use lmdb_zero::error::LmdbResultExt;
 
-use super::{AsBytes, FromBytes, OrderedStore, OrderedStoreError};
+use super::{AsBytes, FromBytes, OrderedStore, OrderedStoreError, OrderedStoreRange};
 
 const DEFAULT_SIZE: usize = 1 << 40; // 1024 ** 4
 const NUM_DBS: u32 = 3; // main DB, index-to-key DB, and key-to-index DB
+const ITER_CACHE_SIZE: usize = 64; // num of items at a time that are loaded into memory by iter
 
 impl From<lmdb::Error> for OrderedStoreError {
     fn from(err: lmdb::Error) -> Self {
@@ -173,34 +176,14 @@ impl<
     }
 
     fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
-        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
-        let access = txn.access();
-        let mut index_cursor = txn.cursor(self.index_to_key_db.clone())?;
-
-        let index_iter = lmdb::CursorIter::new(
-            lmdb::MaybeOwned::Borrowed(&mut index_cursor),
-            &access,
-            |c, a| c.first(a),
-            lmdb::Cursor::next::<[u8], [u8]>,
+        let iter: LmdbOrderedStoreIter<V, I> = LmdbOrderedStoreIter::new(
+            self.env.clone(),
+            self.index_to_key_db.clone(),
+            self.main_db.clone(),
+            None,
         )?;
 
-        Ok(Box::new(
-            index_iter
-                .map(|res| {
-                    res.map_err(|err| OrderedStoreError::Internal(Box::new(err)))
-                        .and_then(|(_, key)| {
-                            access
-                                .get::<_, [u8]>(&self.main_db, key)
-                                .map_err(|err| OrderedStoreError::Internal(Box::new(err)))
-                                .and_then(|val| {
-                                    V::from_bytes(val)
-                                        .map_err(OrderedStoreError::BytesParsingFailed)
-                                })
-                        })
-                })
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter(),
-        ))
+        Ok(Box::new(iter))
     }
 
     fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
@@ -326,6 +309,123 @@ impl<
     }
 }
 
+/// `LmdbOrderedStoreIter` is an iterator over entries in an LMDB ordered store. It uses an
+/// in-memory cache of items that it retrieves from the database using a cursor. The cache is
+/// refilled when it is emptied, and its size is defined by the ITER_CACHE_SIZE constant.
+///
+/// An optional `OrderedStoreRange` may be provided to get only a subset of entries from the
+/// database.
+struct LmdbOrderedStoreIter<V, I> {
+    txn: Arc<lmdb::ReadTransaction<'static>>,
+    index_to_key_db: Arc<lmdb::Database<'static>>,
+    main_db: Arc<lmdb::Database<'static>>,
+
+    cache: VecDeque<V>,
+    range: OrderedStoreRange<I>,
+}
+
+impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedStoreIter<V, I> {
+    fn new(
+        env: Arc<lmdb::Environment>,
+        index_to_key_db: Arc<lmdb::Database<'static>>,
+        main_db: Arc<lmdb::Database<'static>>,
+        range: Option<OrderedStoreRange<I>>,
+    ) -> Result<Self, OrderedStoreError> {
+        let mut iter = Self {
+            txn: Arc::new(lmdb::ReadTransaction::new(env)?),
+            index_to_key_db,
+            main_db,
+            cache: VecDeque::new(),
+            range: range.unwrap_or_else(|| (..).into()), // default to unbounded range
+        };
+
+        // Load initial values into the cache
+        if let Err(err) = iter.reload_cache() {
+            error!("Failed to load iterator's initial cache: {}", err);
+        }
+
+        Ok(iter)
+    }
+
+    fn reload_cache(&mut self) -> Result<(), String> {
+        let access = self.txn.access();
+        let mut index_cursor = self
+            .txn
+            .cursor(self.index_to_key_db.clone())
+            .map_err(|err| err.to_string())?;
+
+        // Set the cursor to the start of the range and get the first entry
+        let mut first_entry = Some(match &self.range.start {
+            Bound::Included(idx) => {
+                // Get the first entry >= idx; that will be the first entry.
+                index_cursor.seek_range_k::<[u8], [u8]>(&access, &idx.as_bytes())
+            }
+            Bound::Excluded(idx) => {
+                // Get the first entry >= idx. If that entry == idx, get the next entry since this
+                // is an exclusive bound.
+                match index_cursor.seek_range_k::<[u8], [u8]>(&access, &idx.as_bytes()) {
+                    // If this is the same as the range's index,
+                    Ok((found_idx, _)) if found_idx == idx.as_bytes().as_slice() => {
+                        index_cursor.next::<[u8], [u8]>(&access)
+                    }
+                    other => other,
+                }
+            }
+            Bound::Unbounded => {
+                // Starting from the beginning
+                index_cursor.first::<[u8], [u8]>(&access)
+            }
+        });
+
+        // Load up to ITER_CACHE_SIZE entries; stop if all entries have been read or if the end of
+        // the range is reached.
+        for _ in 0..ITER_CACHE_SIZE {
+            let next_entry = first_entry
+                .take()
+                .unwrap_or_else(|| index_cursor.next::<[u8], [u8]>(&access));
+            match next_entry {
+                Ok((idx, key)) => {
+                    let idx = I::from_bytes(idx).map_err(|err| err.to_string())?;
+                    // If this index is in the range, add the value to the cache; otherwise, exit.
+                    if !self.range.contains(&idx) {
+                        break;
+                    } else {
+                        self.cache.push_back(
+                            V::from_bytes(
+                                access
+                                    .get::<_, [u8]>(&self.main_db, key)
+                                    .map_err(|err| err.to_string())?,
+                            )
+                            .map_err(|err| err.to_string())?,
+                        );
+                        // Update the range start to reflect only what's left
+                        self.range.start = Bound::Excluded(idx);
+                    }
+                }
+                Err(lmdb::error::Error::Code(lmdb::error::NOTFOUND)) => break,
+                Err(err) => return Err(err.to_string()),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> Iterator
+    for LmdbOrderedStoreIter<V, I>
+{
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cache.is_empty() {
+            if let Err(err) = self.reload_cache() {
+                error!("Failed to load iterator's cache: {}", err);
+            }
+        }
+        self.cache.pop_front()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,9 +435,7 @@ mod tests {
     /// Verify that the `LmdbOrderedStore` passes the u8 ordered store test.
     #[test]
     fn u8_lmdb_store() {
-        let mut temp_db_path = std::env::temp_dir();
-        let thread_id = std::thread::current().id();
-        temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
+        let temp_db_path = get_temp_db_path();
 
         let test_result = std::panic::catch_unwind(|| {
             test_u8_ordered_store(Box::new(
@@ -349,5 +447,248 @@ mod tests {
         std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
 
         assert!(test_result.is_ok());
+    }
+
+    /// Verify that the `LmdbOrderedStoreIter` works properly with various ranges.
+    #[test]
+    fn iterator_with_ranges() {
+        let temp_db_path = get_temp_db_path();
+
+        let test_result = std::panic::catch_unwind(|| {
+            let mut store = LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+                .expect("Failed to create LMDB ordered store");
+
+            store.insert(1u8, 1u8, 1u8).expect("failed to add 1");
+            store.insert(2u8, 2u8, 2u8).expect("failed to add 2");
+            store.insert(3u8, 3u8, 3u8).expect("failed to add 3");
+            store.insert(4u8, 4u8, 4u8).expect("failed to add 4");
+            store.insert(5u8, 5u8, 5u8).expect("failed to add 5");
+
+            // Get all entries in iterator
+            let all_entries = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                None,
+            )
+            .expect("failed to create iter for all entries");
+
+            assert_eq!(
+                all_entries.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8],
+            );
+
+            // Get all entries starting at a certain point
+            let from_2 = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((2..).into()),
+            )
+            .expect("failed to create iter for entries from 2");
+
+            assert_eq!(from_2.collect::<Vec<_>>(), vec![2u8, 3u8, 4u8, 5u8]);
+
+            // Get all entries up to a certain point
+            let up_to_4 = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((..5).into()), // upper bound is exclusive
+            )
+            .expect("failed to create iter for entries up to 4");
+
+            assert_eq!(up_to_4.collect::<Vec<_>>(), vec![1u8, 2u8, 3u8, 4u8]);
+
+            // Get all entries between two points
+            let from_2_to_4 = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((2..5).into()), // upper bound is exclusive
+            )
+            .expect("failed to create iter for entries from 2 to 4");
+
+            assert_eq!(from_2_to_4.collect::<Vec<_>>(), vec![2u8, 3u8, 4u8]);
+
+            // Verify inclusive start, even if it's the first value
+            let from_1_inclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((1..).into()),
+            )
+            .expect("failed to create iter for entries from 1 (inclusive)");
+
+            assert_eq!(
+                from_1_inclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Verify inclusive start, even when the specified start index doesn't exist
+            let from_0_inclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((0..).into()),
+            )
+            .expect("failed to create iter for entries from 0 (inclusive)");
+
+            assert_eq!(
+                from_0_inclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Verify exclusive start, even if it's the first value
+            let from_1_exclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some(OrderedStoreRange {
+                    start: Bound::Excluded(1),
+                    end: Bound::Unbounded,
+                }),
+            )
+            .expect("failed to create iter for entries from 1 (exclusive)");
+
+            assert_eq!(
+                from_1_exclusive.collect::<Vec<_>>(),
+                vec![2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Verify exclusive start, even when the specified start index doesn't exist
+            let from_0_exclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((0..).into()),
+            )
+            .expect("failed to create iter for entries from 0 (exclusive)");
+
+            assert_eq!(
+                from_0_exclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Test inclusive end, even if it's the last value
+            let up_to_5_inclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some(std::ops::RangeToInclusive { end: 5 }.into()),
+            )
+            .expect("failed to create iter for entries up to 5 (inclusive)");
+
+            assert_eq!(
+                up_to_5_inclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Verify inclusive end, even when the specified end index doesn't exist
+            let up_to_6_inclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some(std::ops::RangeToInclusive { end: 6 }.into()),
+            )
+            .expect("failed to create iter for entries up to 6 (inclusive)");
+
+            assert_eq!(
+                up_to_6_inclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+
+            // Test exclusive end, even if it's the last value
+            let up_to_5_exclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((..5).into()),
+            )
+            .expect("failed to create iter for entries up to 5 (exclusive)");
+
+            assert_eq!(
+                up_to_5_exclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8]
+            );
+
+            // Verify exclusive end, even when the specified end index doesn't exist
+            let up_to_6_exclusive = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                Some((..6).into()),
+            )
+            .expect("failed to create iter for entries up to 6 (exclusive)");
+
+            assert_eq!(
+                up_to_6_exclusive.collect::<Vec<_>>(),
+                vec![1u8, 2u8, 3u8, 4u8, 5u8]
+            );
+        });
+
+        std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+
+        assert!(test_result.is_ok());
+    }
+
+    /// Verify that the `LmdbOrderedStoreIter` properly populates its cache with only
+    /// `ITER_CACHE_SIZE` items at a time, and that it is able to repopulate this cache as needed.
+    #[test]
+    fn iterator_large_db() {
+        let temp_db_path = get_temp_db_path();
+
+        let test_result = std::panic::catch_unwind(|| {
+            let mut store = LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+                .expect("Failed to create LMDB ordered store");
+
+            for i in 0..std::u8::MAX {
+                store.insert(i, i, i).expect("Failed to add u8");
+            }
+
+            let mut iter = LmdbOrderedStoreIter::<u8, u8>::new(
+                store.env.clone(),
+                store.index_to_key_db.clone(),
+                store.main_db.clone(),
+                None,
+            )
+            .expect("failed to create iter");
+
+            assert_eq!(iter.cache.len(), ITER_CACHE_SIZE);
+
+            for _ in 0..(ITER_CACHE_SIZE - 1) {
+                iter.next().expect("failed to get item");
+            }
+            assert_eq!(iter.cache.len(), 1);
+
+            let item63 = iter.next().expect("failed to get another item");
+            assert_eq!(item63, 63);
+            assert_eq!(iter.cache.len(), 0);
+
+            let item64 = iter
+                .next()
+                .expect("failed to get another item or reload the cache");
+            assert_eq!(item64, 64);
+            assert_eq!(iter.cache.len(), 63);
+
+            let remaining_items = iter.collect::<Vec<_>>();
+            assert_eq!(remaining_items.len(), (std::u8::MAX - 65) as usize);
+            assert_eq!(remaining_items.first().expect("no first"), &65);
+            assert_eq!(
+                remaining_items.last().expect("no last"),
+                &(std::u8::MAX - 1)
+            );
+        });
+
+        std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+
+        assert!(test_result.is_ok());
+    }
+
+    fn get_temp_db_path() -> std::path::PathBuf {
+        let mut temp_db_path = std::env::temp_dir();
+        let thread_id = std::thread::current().id();
+        temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
+        temp_db_path
     }
 }

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -39,7 +39,7 @@ pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     fn count(&self) -> Result<u64, OrderedStoreError>;
 
     /// Get an iterator of all values in the store.
-    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError>;
+    fn iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = V> + 'a>, OrderedStoreError>;
 
     /// Insert the key,value pair at the index. If a value already exists for the key or index, an
     /// error is returned.
@@ -218,10 +218,13 @@ mod tests {
         assert_eq!(store.get_by_key(&1).expect("Failed to get by key"), Some(1));
         assert_eq!(store.get_by_key(&2).expect("Failed to get by key"), None);
 
-        let mut iter = store.iter().expect("Failed to get iter");
-        assert_eq!(iter.next(), Some(0));
-        assert_eq!(iter.next(), Some(1));
-        assert_eq!(iter.next(), None);
+        assert_eq!(
+            store
+                .iter()
+                .expect("Failed to get iter")
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
 
         assert!(store.insert(0, 2, 2).is_err());
         assert!(store.insert(2, 2, 0).is_err());

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -28,7 +28,7 @@ use std::ops::{Bound, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, Rang
 pub use error::OrderedStoreError;
 
 /// A key/vaue store that is indexed by a type with total ordering
-pub trait OrderedStore<K, V, I: Ord> {
+pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     /// Get the value at the index if it exists.
     fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError>;
 

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -233,11 +233,18 @@ mod tests {
         let thread_id = std::thread::current().id();
         temp_db_path.push(format!("store-{:?}.lmdb", thread_id));
 
-        test_receipt_store(TransactionReceiptStore::new(Box::new(
-            crate::store::lmdb::LmdbOrderedStore::new(temp_db_path.as_path(), Some(1024 * 1024))
+        let test_result = std::panic::catch_unwind(|| {
+            test_receipt_store(TransactionReceiptStore::new(Box::new(
+                crate::store::lmdb::LmdbOrderedStore::new(
+                    temp_db_path.as_path(),
+                    Some(1024 * 1024),
+                )
                 .expect("Failed to create LMDB ordered store"),
-        )));
+            )))
+        });
 
         std::fs::remove_file(temp_db_path.as_path()).expect("Failed to remove temp DB file");
+
+        assert!(test_result.is_ok());
     }
 }

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -69,9 +69,10 @@ impl TransactionReceiptStore {
     }
 
     /// Get an iterator over all `TransactionReceipt`s in order.
-    pub fn iter(
-        &self,
-    ) -> Result<Box<dyn Iterator<Item = TransactionReceipt>>, TransactionReceiptStoreError> {
+    pub fn iter<'a>(
+        &'a self,
+    ) -> Result<Box<dyn Iterator<Item = TransactionReceipt> + 'a>, TransactionReceiptStoreError>
+    {
         Ok(self.0.iter()?)
     }
 
@@ -156,10 +157,13 @@ mod tests {
             None
         );
 
-        let mut iter = receipt_store.iter().expect("Failed to get iter");
-        assert_eq!(iter.next(), Some(receipt1.clone()));
-        assert_eq!(iter.next(), Some(receipt2.clone()));
-        assert_eq!(iter.next(), None);
+        assert_eq!(
+            receipt_store
+                .iter()
+                .expect("Failed to get iter")
+                .collect::<Vec<_>>(),
+            vec![receipt1.clone(), receipt2.clone()]
+        );
 
         assert_eq!(
             receipt_store


### PR DESCRIPTION
Add the `LmdbOrderedStoreIter` struct that is returned by the
`LmdbOrderedStore.iter()` method. This iterator loads items into an
in-memory cache as needed and provides an iterator over the values in
the ordered store. Additionally, it provides the option to specify a
range to get only a subset of items in the database.

Signed-off-by: Logan Seeley <seeley@bitwise.io>