### PR TITLE
Transaction receipt store range queries

### DIFF
--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -55,7 +55,7 @@ impl<
         I: Ord + Clone + Debug + Sync + Send + 'static,
     > OrderedStore<K, V, I> for BTreeOrderedStore<K, V, I>
 {
-    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
         let internal = self
             .internal
             .lock()
@@ -66,7 +66,7 @@ impl<
             .and_then(|key| internal.main_store.get(key).map(|(val, _)| val).cloned()))
     }
 
-    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
         Ok(self
             .internal
             .lock()

--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -77,6 +77,17 @@ impl<
             .cloned())
     }
 
+    fn get_index_by_key(&self, key: &K) -> Result<Option<I>, OrderedStoreError> {
+        Ok(self
+            .internal
+            .lock()
+            .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?
+            .main_store
+            .get(key)
+            .map(|(_, idx)| idx)
+            .cloned())
+    }
+
     fn count(&self) -> Result<u64, OrderedStoreError> {
         Ok(self
             .internal

--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -100,7 +100,7 @@ impl<
             .map_err(|err| OrderedStoreError::Internal(Box::new(err)))?)
     }
 
-    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         let internal = self
             .internal
             .lock()
@@ -121,7 +121,7 @@ impl<
     fn range_iter(
         &self,
         range: OrderedStoreRange<I>,
-    ) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    ) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         let internal = self
             .internal
             .lock()

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -186,6 +186,20 @@ impl<
         Ok(Box::new(iter))
     }
 
+    fn range_iter(
+        &self,
+        range: OrderedStoreRange<I>,
+    ) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        let iter: LmdbOrderedStoreIter<V, I> = LmdbOrderedStoreIter::new(
+            self.env.clone(),
+            self.index_to_key_db.clone(),
+            self.main_db.clone(),
+            Some(range),
+        )?;
+
+        Ok(Box::new(iter))
+    }
+
     fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {
         let txn = lmdb::WriteTransaction::new(self.env.clone())?;
 

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -131,8 +131,8 @@ impl LmdbOrderedStore {
 
 impl<
         K: Clone + Debug + AsBytes + FromBytes + 'static,
-        V: Clone + AsBytes + FromBytes + 'static,
-        I: Clone + Debug + Ord + AsBytes + FromBytes + 'static,
+        V: Clone + Send + AsBytes + FromBytes + 'static,
+        I: Clone + Debug + Ord + Send + AsBytes + FromBytes + 'static,
     > OrderedStore<K, V, I> for LmdbOrderedStore
 {
     fn get_value_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
@@ -187,7 +187,7 @@ impl<
             .map_err(|err| OrderedStoreError::Internal(Box::new(err)))?)
     }
 
-    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         let iter: LmdbOrderedStoreIter<V, I> = LmdbOrderedStoreIter::new(
             self.env.clone(),
             self.index_to_key_db.clone(),
@@ -201,7 +201,7 @@ impl<
     fn range_iter(
         &self,
         range: OrderedStoreRange<I>,
-    ) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    ) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         let iter: LmdbOrderedStoreIter<V, I> = LmdbOrderedStoreIter::new(
             self.env.clone(),
             self.index_to_key_db.clone(),
@@ -342,7 +342,7 @@ impl<
 /// An optional `OrderedStoreRange` may be provided to get only a subset of entries from the
 /// database.
 struct LmdbOrderedStoreIter<V, I> {
-    txn: Arc<lmdb::ReadTransaction<'static>>,
+    env: Arc<lmdb::Environment>,
     index_to_key_db: Arc<lmdb::Database<'static>>,
     main_db: Arc<lmdb::Database<'static>>,
 
@@ -358,7 +358,7 @@ impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedS
         range: Option<OrderedStoreRange<I>>,
     ) -> Result<Self, OrderedStoreError> {
         let mut iter = Self {
-            txn: Arc::new(lmdb::ReadTransaction::new(env)?),
+            env,
             index_to_key_db,
             main_db,
             cache: VecDeque::new(),
@@ -374,9 +374,9 @@ impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedS
     }
 
     fn reload_cache(&mut self) -> Result<(), String> {
-        let access = self.txn.access();
-        let mut index_cursor = self
-            .txn
+        let txn = lmdb::ReadTransaction::new(self.env.clone()).map_err(|err| err.to_string())?;
+        let access = txn.access();
+        let mut index_cursor = txn
             .cursor(self.index_to_key_db.clone())
             .map_err(|err| err.to_string())?;
 

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -167,6 +167,18 @@ impl<
             .map_err(OrderedStoreError::BytesParsingFailed)?)
     }
 
+    fn get_index_by_key(&self, key: &K) -> Result<Option<I>, OrderedStoreError> {
+        let txn = lmdb::ReadTransaction::new(self.env.clone())?;
+        let access = txn.access();
+
+        Ok(access
+            .get::<_, [u8]>(&self.key_to_index_db, &key.as_bytes())
+            .to_opt()?
+            .map(|idx| I::from_bytes(idx))
+            .transpose()
+            .map_err(OrderedStoreError::BytesParsingFailed)?)
+    }
+
     fn count(&self) -> Result<u64, OrderedStoreError> {
         Ok(lmdb::ReadTransaction::new(self.env.clone())?
             .db_stat(&self.main_db)?

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -135,7 +135,7 @@ impl<
         I: Clone + Debug + Ord + AsBytes + FromBytes + 'static,
     > OrderedStore<K, V, I> for LmdbOrderedStore
 {
-    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
         let txn = lmdb::ReadTransaction::new(self.env.clone())?;
         let access = txn.access();
 
@@ -155,7 +155,7 @@ impl<
         )
     }
 
-    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
         let txn = lmdb::ReadTransaction::new(self.env.clone())?;
         let access = txn.access();
 

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -41,6 +41,12 @@ pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     /// Get an iterator of all values in the store.
     fn iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = V> + 'a>, OrderedStoreError>;
 
+    /// Get an iterator over a range of values in the store.
+    fn range_iter<'a>(
+        &'a self,
+        range: OrderedStoreRange<I>,
+    ) -> Result<Box<dyn Iterator<Item = V> + 'a>, OrderedStoreError>;
+
     /// Insert the key,value pair at the index. If a value already exists for the key or index, an
     /// error is returned.
     fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError>;
@@ -224,6 +230,22 @@ mod tests {
                 .expect("Failed to get iter")
                 .collect::<Vec<_>>(),
             vec![0, 1]
+        );
+
+        assert_eq!(
+            store
+                .range_iter((1..).into())
+                .expect("Failed to get iter from 1")
+                .collect::<Vec<_>>(),
+            vec![1]
+        );
+
+        assert_eq!(
+            store
+                .range_iter((..1).into())
+                .expect("Failed to get iter up to 1")
+                .collect::<Vec<_>>(),
+            vec![0]
         );
 
         assert!(store.insert(0, 2, 2).is_err());

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -35,6 +35,9 @@ pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     /// Get the value by the specified key if it exists.
     fn get_value_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError>;
 
+    /// Get the index of the entry with the specified key if it exists.
+    fn get_index_by_key(&self, key: &K) -> Result<Option<I>, OrderedStoreError>;
+
     /// Get the number of entries in the store.
     fn count(&self) -> Result<u64, OrderedStoreError>;
 
@@ -240,6 +243,19 @@ mod tests {
 
         assert_eq!(
             store
+                .get_index_by_key(&1)
+                .expect("Failed to get index by key"),
+            Some(1)
+        );
+        assert_eq!(
+            store
+                .get_index_by_key(&2)
+                .expect("Failed to get index by key"),
+            None
+        );
+
+        assert_eq!(
+            store
                 .iter()
                 .expect("Failed to get iter")
                 .collect::<Vec<_>>(),
@@ -290,6 +306,12 @@ mod tests {
                 .expect("Failed to get value by key"),
             None
         );
+        assert_eq!(
+            store
+                .get_index_by_key(&1)
+                .expect("Failed to get index by key"),
+            None
+        );
         assert_eq!(store.count().expect("Failed to get count"), 1);
 
         assert_eq!(
@@ -311,6 +333,12 @@ mod tests {
             store
                 .get_value_by_key(&0)
                 .expect("Failed to get value by key"),
+            None
+        );
+        assert_eq!(
+            store
+                .get_index_by_key(&0)
+                .expect("Failed to get index by key"),
             None
         );
         assert_eq!(store.count().expect("Failed to get count"), 0);

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -30,10 +30,10 @@ pub use error::OrderedStoreError;
 /// A key/vaue store that is indexed by a type with total ordering
 pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     /// Get the value at the index if it exists.
-    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError>;
+    fn get_value_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError>;
 
     /// Get the value by the specified key if it exists.
-    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError>;
+    fn get_value_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError>;
 
     /// Get the number of entries in the store.
     fn count(&self) -> Result<u64, OrderedStoreError>;
@@ -213,16 +213,30 @@ mod tests {
         assert_eq!(store.count().expect("Failed to get count"), 2);
 
         assert_eq!(
-            store.get_by_index(&0).expect("Failed to get by index"),
+            store
+                .get_value_by_index(&0)
+                .expect("Failed to get value by index"),
             Some(0)
         );
         assert_eq!(
-            store.get_by_index(&2).expect("Failed to get by index"),
+            store
+                .get_value_by_index(&2)
+                .expect("Failed to get value by index"),
             None
         );
 
-        assert_eq!(store.get_by_key(&1).expect("Failed to get by key"), Some(1));
-        assert_eq!(store.get_by_key(&2).expect("Failed to get by key"), None);
+        assert_eq!(
+            store
+                .get_value_by_key(&1)
+                .expect("Failed to get value by key"),
+            Some(1)
+        );
+        assert_eq!(
+            store
+                .get_value_by_key(&2)
+                .expect("Failed to get value by key"),
+            None
+        );
 
         assert_eq!(
             store
@@ -265,10 +279,17 @@ mod tests {
             Some((1, 1))
         );
         assert_eq!(
-            store.get_by_index(&1).expect("Failed to get by index"),
+            store
+                .get_value_by_index(&1)
+                .expect("Failed to get value by index"),
             None
         );
-        assert_eq!(store.get_by_key(&1).expect("Failed to get by key"), None);
+        assert_eq!(
+            store
+                .get_value_by_key(&1)
+                .expect("Failed to get value by key"),
+            None
+        );
         assert_eq!(store.count().expect("Failed to get count"), 1);
 
         assert_eq!(
@@ -281,10 +302,17 @@ mod tests {
             Some((0, 0))
         );
         assert_eq!(
-            store.get_by_index(&0).expect("Failed to get by index"),
+            store
+                .get_value_by_index(&0)
+                .expect("Failed to get value by index"),
             None
         );
-        assert_eq!(store.get_by_key(&0).expect("Failed to get by key"), None);
+        assert_eq!(
+            store
+                .get_value_by_key(&0)
+                .expect("Failed to get value by key"),
+            None
+        );
         assert_eq!(store.count().expect("Failed to get count"), 0);
     }
 

--- a/libsawtooth/src/store/mod.rs
+++ b/libsawtooth/src/store/mod.rs
@@ -42,13 +42,13 @@ pub trait OrderedStore<K, V, I: Ord>: Sync + Send {
     fn count(&self) -> Result<u64, OrderedStoreError>;
 
     /// Get an iterator of all values in the store.
-    fn iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = V> + 'a>, OrderedStoreError>;
+    fn iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = V> + 'a + Send>, OrderedStoreError>;
 
     /// Get an iterator over a range of values in the store.
     fn range_iter<'a>(
         &'a self,
         range: OrderedStoreRange<I>,
-    ) -> Result<Box<dyn Iterator<Item = V> + 'a>, OrderedStoreError>;
+    ) -> Result<Box<dyn Iterator<Item = V> + 'a + Send>, OrderedStoreError>;
 
     /// Insert the key,value pair at the index. If a value already exists for the key or index, an
     /// error is returned.

--- a/libsawtooth/src/store/receipt_store/error.rs
+++ b/libsawtooth/src/store/receipt_store/error.rs
@@ -17,22 +17,31 @@ use std::error::Error;
 use crate::store::OrderedStoreError;
 
 #[derive(Debug)]
-pub struct TransactionReceiptStoreError(OrderedStoreError);
+pub enum TransactionReceiptStoreError {
+    IdNotFound, // used by the `iter_since_id` method if the given ID is not in the store
+    Internal(OrderedStoreError),
+}
 
 impl Error for TransactionReceiptStoreError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.0)
+        match self {
+            Self::IdNotFound => None,
+            Self::Internal(err) => Some(err),
+        }
     }
 }
 
 impl std::fmt::Display for TransactionReceiptStoreError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "error in transaction receipt store: {}", self.0)
+        match self {
+            Self::IdNotFound => write!(f, "id not found in the store"),
+            Self::Internal(err) => write!(f, "an internal error occurred: {}", err),
+        }
     }
 }
 
 impl From<OrderedStoreError> for TransactionReceiptStoreError {
     fn from(err: OrderedStoreError) -> Self {
-        Self(err)
+        Self::Internal(err)
     }
 }

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -41,11 +41,11 @@ impl FromBytes for TransactionReceipt {
 /// `TransactionReceiptStore` is a wrapper around an `OrderedStore` that stores
 /// `TransactionReceipt`s keyed by transaction IDs (`String`s) and indexed by `u64`s to provide
 /// ordering of transactions.
-pub struct TransactionReceiptStore(Box<dyn OrderedStore<String, TransactionReceipt, u64> + Send>);
+pub struct TransactionReceiptStore(Box<dyn OrderedStore<String, TransactionReceipt, u64>>);
 
 impl TransactionReceiptStore {
     /// Create a new `TransactionReceiptStore` that is backed by the given `OrderedStore`.
-    pub fn new(store: Box<dyn OrderedStore<String, TransactionReceipt, u64> + Send>) -> Self {
+    pub fn new(store: Box<dyn OrderedStore<String, TransactionReceipt, u64>>) -> Self {
         Self(store)
     }
 

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -73,8 +73,10 @@ impl TransactionReceiptStore {
     /// Get an iterator over all `TransactionReceipt`s in order.
     pub fn iter<'a>(
         &'a self,
-    ) -> Result<Box<dyn Iterator<Item = TransactionReceipt> + 'a>, TransactionReceiptStoreError>
-    {
+    ) -> Result<
+        Box<dyn Iterator<Item = TransactionReceipt> + 'a + Send>,
+        TransactionReceiptStoreError,
+    > {
         Ok(self.0.iter()?)
     }
 
@@ -82,8 +84,10 @@ impl TransactionReceiptStore {
     pub fn iter_since_id<'a>(
         &'a self,
         id: String,
-    ) -> Result<Box<dyn Iterator<Item = TransactionReceipt> + 'a>, TransactionReceiptStoreError>
-    {
+    ) -> Result<
+        Box<dyn Iterator<Item = TransactionReceipt> + 'a + Send>,
+        TransactionReceiptStoreError,
+    > {
         let idx = self
             .0
             .get_index_by_key(&id)?

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -52,7 +52,7 @@ impl TransactionReceiptStore {
         &self,
         id: String,
     ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
-        Ok(self.0.get_by_key(&id)?)
+        Ok(self.0.get_value_by_key(&id)?)
     }
 
     /// Get the `TransactionReceipt` at the given index.
@@ -60,7 +60,7 @@ impl TransactionReceiptStore {
         &self,
         idx: u64,
     ) -> Result<Option<TransactionReceipt>, TransactionReceiptStoreError> {
-        Ok(self.0.get_by_index(&idx)?)
+        Ok(self.0.get_value_by_index(&idx)?)
     }
 
     /// Get the number of `TransactionReceipt`s in the store.

--- a/libsawtooth/src/store/redis.rs
+++ b/libsawtooth/src/store/redis.rs
@@ -50,7 +50,7 @@ impl<
         I: Debug + Ord + FromRedisValue + ToRedisArgs + 'static,
     > OrderedStore<K, V, I> for RedisOrderedStore
 {
-    fn get_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_index(&self, idx: &I) -> Result<Option<V>, OrderedStoreError> {
         Ok(
             match self
                 .conn
@@ -68,7 +68,7 @@ impl<
         )
     }
 
-    fn get_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
+    fn get_value_by_key(&self, key: &K) -> Result<Option<V>, OrderedStoreError> {
         Ok(self
             .conn
             .lock()

--- a/libsawtooth/src/store/redis.rs
+++ b/libsawtooth/src/store/redis.rs
@@ -46,7 +46,7 @@ impl RedisOrderedStore {
 
 impl<
         K: Debug + FromRedisValue + ToRedisArgs + 'static,
-        V: FromRedisValue + ToRedisArgs + 'static,
+        V: Send + FromRedisValue + ToRedisArgs + 'static,
         I: Debug + Ord + FromRedisValue + ToRedisArgs + 'static,
     > OrderedStore<K, V, I> for RedisOrderedStore
 {
@@ -88,7 +88,7 @@ impl<
             .hlen(MAIN_STORE)?)
     }
 
-    fn iter(&self) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    fn iter(&self) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         let mut conn = self
             .conn
             .lock()
@@ -109,7 +109,7 @@ impl<
     fn range_iter(
         &self,
         _range: OrderedStoreRange<I>,
-    ) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+    ) -> Result<Box<dyn Iterator<Item = V> + Send>, OrderedStoreError> {
         unimplemented!()
     }
 

--- a/libsawtooth/src/store/redis.rs
+++ b/libsawtooth/src/store/redis.rs
@@ -76,6 +76,10 @@ impl<
             .hget(MAIN_STORE, key.to_redis_args())?)
     }
 
+    fn get_index_by_key(&self, _key: &K) -> Result<Option<I>, OrderedStoreError> {
+        unimplemented!()
+    }
+
     fn count(&self) -> Result<u64, OrderedStoreError> {
         Ok(self
             .conn

--- a/libsawtooth/src/store/redis.rs
+++ b/libsawtooth/src/store/redis.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use redis::{Client, Commands, Connection, FromRedisValue, RedisError, ToRedisArgs};
 
-use super::{OrderedStore, OrderedStoreError};
+use super::{OrderedStore, OrderedStoreError, OrderedStoreRange};
 
 const MAIN_STORE: &str = "main";
 const INDEX_STORE: &str = "index";
@@ -100,6 +100,13 @@ impl<
                 })?
                 .into_iter(),
         ))
+    }
+
+    fn range_iter(
+        &self,
+        _range: OrderedStoreRange<I>,
+    ) -> Result<Box<dyn Iterator<Item = V>>, OrderedStoreError> {
+        unimplemented!()
     }
 
     fn insert(&mut self, key: K, value: V, idx: I) -> Result<(), OrderedStoreError> {


### PR DESCRIPTION
Add a method for getting all receipts in the store since the receipt
with the given ID.

Signed-off-by: Logan Seeley <seeley@bitwise.io>