### PR TITLE
Fix typo in block info address calculation

### DIFF
--- a/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
+++ b/docs/source/transaction_family_specifications/blockinfo_transaction_family.rst
@@ -59,7 +59,7 @@ For example, in Python the address could be constructed with:
 
 .. code-block:: pycon
 
-  >>> '00b10c00' + hex(block_num)[2:].zfill(62))
+  >>> '00b10c00' + hex(block_num)[2:].zfill(62)
 
 BlockInfo
 ---------


### PR DESCRIPTION
Sorry my last PR https://github.com/hyperledger/sawtooth-core/pull/2269 was accidenetly closed. Now i signed my commit.