### PR TITLE
Doc : Fixed typo in kubernetes_test_network.rst

### DIFF
--- a/docs/source/app_developers_guide/kubernetes_test_network.rst
+++ b/docs/source/app_developers_guide/kubernetes_test_network.rst
@@ -223,7 +223,7 @@ Sawtooth network can use these keys when it starts.
 
    .. code-block:: console
 
-      $ kubectl log pbft-keys-xxxxx
+      $ kubectl logs pbft-keys-xxxxx
 
    The output will resemble this example:
 


### PR DESCRIPTION
Instead of `$ kubectl log pbft-keys-xxxxx`, it should be `$ kubectl logs pbft-keys-xxxxx`.