### PR TITLE
Fix a dead link in docs

### DIFF
--- a/docs/source/community/issue_tracking.rst
+++ b/docs/source/community/issue_tracking.rst
@@ -21,7 +21,7 @@ issues that will help you get involved right away. Log into
 `Linux Foundation Account <https://identity.linuxfoundation.org/>`_)
 and see the Sawtooth "help-wanted" list:
 
-https://jira.hyperledger.org/issues/?filter=10612
+https://jira.hyperledger.org/issues/?jql=labels+%3D+help-wanted
 
 
 How to Report an Issue


### PR DESCRIPTION
Fix a link to the list of issues labeled as `help-wanted` .