### PR TITLE
Update transact dependency to 0.2

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -27,7 +27,7 @@ description = """\
 log = "0.4"
 lmdb-zero = { version = "0.4", optional = true }
 redis = { version = "0.13.0", default-features = false, optional = true }
-transact = "0.1"
+transact = "0.2"
 
 [features]
 default = []

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -411,19 +411,16 @@ impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedS
                 .unwrap_or_else(|| index_cursor.next::<[u8], [u8]>(&access));
             match next_entry {
                 Ok((idx, key)) => {
-                    let idx = I::from_bytes(idx).map_err(|err| err.to_string())?;
+                    let idx = I::from_bytes(idx)?;
                     // If this index is in the range, add the value to the cache; otherwise, exit.
                     if !self.range.contains(&idx) {
                         break;
                     } else {
-                        self.cache.push_back(
-                            V::from_bytes(
-                                access
-                                    .get::<_, [u8]>(&self.main_db, key)
-                                    .map_err(|err| err.to_string())?,
-                            )
-                            .map_err(|err| err.to_string())?,
-                        );
+                        self.cache.push_back(V::from_bytes(
+                            access
+                                .get::<_, [u8]>(&self.main_db, key)
+                                .map_err(|err| err.to_string())?,
+                        )?);
                         // Update the range start to reflect only what's left
                         self.range.start = Bound::Excluded(idx);
                     }

--- a/libsawtooth/src/store/receipt_store/mod.rs
+++ b/libsawtooth/src/store/receipt_store/mod.rs
@@ -132,22 +132,22 @@ impl TransactionReceiptStore {
 mod tests {
     use super::*;
 
+    use transact::protocol::receipt::TransactionReceiptBuilder;
+
     /// Test that a receipt store works properly.
     fn test_receipt_store(mut receipt_store: TransactionReceiptStore) {
         assert_eq!(receipt_store.count().expect("Failed to get count"), 0);
 
-        let receipt1 = TransactionReceipt {
-            state_changes: vec![],
-            events: vec![],
-            data: vec![],
-            transaction_id: "ab".into(),
-        };
-        let receipt2 = TransactionReceipt {
-            state_changes: vec![],
-            events: vec![],
-            data: vec![],
-            transaction_id: "cd".into(),
-        };
+        let receipt1 = TransactionReceiptBuilder::new()
+            .valid()
+            .with_transaction_id("ab".into())
+            .build()
+            .expect("failed to build receipt1");
+        let receipt2 = TransactionReceiptBuilder::new()
+            .invalid()
+            .with_transaction_id("cd".into())
+            .build()
+            .expect("failed to build receipt2");
 
         receipt_store
             .append(vec![receipt1.clone(), receipt2.clone()])


### PR DESCRIPTION
transact v0.2 changes the `TransactionReceipt` protocol.

Signed-off-by: Logan Seeley <seeley@bitwise.io>