### PR TITLE
Upgrade pip during sawtooth-build-docs image build

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -92,6 +92,7 @@ RUN apt-get update && apt-get install -y -q \
     zip \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --upgrade pip \
     && pip3 install \
     sphinx==2.0.1 \
     sphinxcontrib-httpdomain \


### PR DESCRIPTION
An outdated version of pip was causing the 'zipp' package to fail during
installation.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>