### PR TITLE
[Backport 1.1] Parent not found when trying to delete & update simultaneously

### DIFF
--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -172,8 +172,7 @@ def do_batch_list(args):
         fmt.print_csv(headers, batches, parse_batch_row)
 
     elif args.format == 'json' or args.format == 'yaml':
-        data = [{k: d for k, d in zip(keys, parse_batch_row(b))}
-                for b in batches]
+        data = [dict(zip(keys, parse_batch_row(b))) for b in batches]
 
         if args.format == 'yaml':
             fmt.print_yaml(data)

--- a/cli/sawtooth_cli/batch.py
+++ b/cli/sawtooth_cli/batch.py
@@ -16,7 +16,7 @@
 import argparse
 import time
 
-from sys import maxsize
+import sys
 
 from sawtooth_cli import format_utils as fmt
 from sawtooth_cli.rest_client import RestClient
@@ -85,7 +85,7 @@ def add_batch_status_parser(subparsers, parent_parser):
     status_parser.add_argument(
         '--wait',
         nargs='?',
-        const=maxsize,
+        const=sys.maxsize,
         type=int,
         help='set time, in seconds, to wait for commit')
 
@@ -114,7 +114,7 @@ def add_batch_submit_parser(subparsers, parent_parser):
     submit_parser.add_argument(
         '--wait',
         nargs='?',
-        const=maxsize,
+        const=sys.maxsize,
         type=int,
         help='set time, in seconds, to wait for batches to commit')
 
@@ -282,4 +282,4 @@ def do_batch_submit(args):
         print('Wait timed out! Some batches have not yet been committed...')
         for batch_id, status in statuses[0].items():
             print('{}  {}'.format(batch_id, status))
-        exit(1)
+        sys.exit(1)

--- a/cli/sawtooth_cli/block.py
+++ b/cli/sawtooth_cli/block.py
@@ -116,8 +116,7 @@ def do_block(args):
             fmt.print_csv(headers, blocks, parse_block_row)
 
         elif args.format == 'json' or args.format == 'yaml':
-            data = [{k: d for k, d in zip(keys, parse_block_row(b))}
-                    for b in blocks]
+            data = [dict(zip(keys, parse_block_row(b)))for b in blocks]
 
             if args.format == 'yaml':
                 fmt.print_yaml(data)

--- a/cli/sawtooth_cli/identity.py
+++ b/cli/sawtooth_cli/identity.py
@@ -289,7 +289,7 @@ def _do_identity_policy_create(args):
             print('{:128.128}  {}'.format(
                 batch_id,
                 statuses[0]['status']))
-            exit(1)
+            sys.exit(1)
     else:
         raise AssertionError('No target for create set.')
 
@@ -406,7 +406,7 @@ def _do_identity_role_create(args):
             print('{:128.128}  {}'.format(
                 batch_id,
                 statuses[0]['status']))
-            exit(1)
+            sys.exit(1)
     else:
         raise AssertionError('No target for create set.')
 

--- a/cli/sawtooth_cli/state.py
+++ b/cli/sawtooth_cli/state.py
@@ -113,7 +113,7 @@ def do_state(args):
         elif args.format == 'json' or args.format == 'yaml':
             state_data = {
                 'head': head,
-                'data': [{k: d for k, d in zip(keys, parse_leaf_row(l, False))}
+                'data': [dict(zip(keys, parse_leaf_row(l, False)))
                          for l in leaves]}
 
             if args.format == 'yaml':

--- a/cli/sawtooth_cli/transaction.py
+++ b/cli/sawtooth_cli/transaction.py
@@ -89,7 +89,7 @@ def do_transaction(args):
             fmt.print_csv(headers, transactions, parse_txn_row)
 
         elif args.format == 'json' or args.format == 'yaml':
-            data = [{k: d for k, d in zip(keys, parse_txn_row(b, False))}
+            data = [dict(zip(keys, parse_txn_row(b, False)))
                     for b in transactions]
 
             if args.format == 'yaml':

--- a/cli/tests/test_config.py
+++ b/cli/tests/test_config.py
@@ -53,10 +53,14 @@ class TestConfigBatchlist(unittest.TestCase):
             return output
 
     def test_set_value_creates_batch_list(self):
-        subprocess.run(shlex.split(
-            'sawset proposal create -k {} -o {} x=1 y=1'.format(
-                self._priv_file,
-                os.path.join(self._temp_dir, 'myconfig.batch'))))
+        subprocess.run(
+            shlex.split(
+                'sawset proposal create -k {} -o {} x=1 y=1'.format(
+                    self._priv_file,
+                    os.path.join(self._temp_dir, 'myconfig.batch')
+                )
+            ), check=True
+        )
 
         batch_list = self._read_target_file_as(BatchList)
 

--- a/families/block_info/sawtooth_block_info/processor/handler.py
+++ b/families/block_info/sawtooth_block_info/processor/handler.py
@@ -189,7 +189,6 @@ class BlockInfoTransactionHandler(TransactionHandler):
 
         if sets:
             addresses = set(k for k, _ in sets)
-            addresses_set = set(context.set_state(
-                {k: v for k, v in sets}))
+            addresses_set = set(context.set_state(dict(sets)))
             if addresses != addresses_set:
                 raise InternalError("Failed to set addresses.")

--- a/integration/sawtooth_integration/tests/test_intkey_cli.py
+++ b/integration/sawtooth_integration/tests/test_intkey_cli.py
@@ -94,4 +94,6 @@ class TestInkeyCli(unittest.TestCase):
 def _send_command(command):
     return subprocess.run(
         shlex.split(
-            command))
+            command
+        ), check=True
+    )

--- a/integration/sawtooth_integration/tests/test_intkey_smoke.py
+++ b/integration/sawtooth_integration/tests/test_intkey_smoke.py
@@ -193,4 +193,4 @@ class IntkeyTestVerifier:
             in zip(self.verbs, self.initial, self.incdec)
         ]
 
-        return {word: val for word, val in zip(self.valid, expected_values)}
+        return dict(zip(self.valid, expected_values))

--- a/integration/sawtooth_integration/tests/test_peer_list.py
+++ b/integration/sawtooth_integration/tests/test_peer_list.py
@@ -114,8 +114,11 @@ class TestPeerList(unittest.TestCase):
         ])
 
         # make sure pretty-print option works
-        subprocess.run(shlex.split(
-            'sawnet peers list {} --pretty'.format(http_addresses)))
+        subprocess.run(
+            shlex.split(
+                'sawnet peers list {} --pretty'.format(http_addresses)
+            ), check=True
+        )
 
         sawnet_peers_output = json.loads(
             _run_peer_command(
@@ -128,8 +131,11 @@ class TestPeerList(unittest.TestCase):
             peers_list_expected)
 
         # run `sawnet peers graph`, but don't verify output
-        subprocess.run(shlex.split(
-            'sawnet peers graph {}'.format(http_addresses)))
+        subprocess.run(
+            shlex.split(
+                'sawnet peers graph {}'.format(http_addresses)
+            ), check=True
+        )
 
 
 def _get_peers(node_number, fmt='json'):

--- a/integration/sawtooth_integration/tests/test_two_families.py
+++ b/integration/sawtooth_integration/tests/test_two_families.py
@@ -263,4 +263,4 @@ class IntkeyTestVerifier:
             in zip(self.verbs, self.initial, self.incdec)
         ]
 
-        return {word: val for word, val in zip(self.valid, expected_values)}
+        return dict(zip(self.valid, expected_values))

--- a/integration/sawtooth_integration/tests/test_workload.py
+++ b/integration/sawtooth_integration/tests/test_workload.py
@@ -50,8 +50,11 @@ class TestWorkload(unittest.TestCase):
         # run workload for WORKLOAD_TIME seconds
         time.sleep(WORKLOAD_TIME)
 
-        subprocess.run(shlex.split(
-            'sawtooth block list --url {}'.format(self.client.url)))
+        subprocess.run(
+            shlex.split(
+                'sawtooth block list --url {}'.format(self.client.url)
+            ), check=True
+        )
 
         blocks = self.client.list_blocks()
 

--- a/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
+++ b/sdk/examples/intkey_python/sawtooth_intkey/processor/handler.py
@@ -170,7 +170,7 @@ def _do_set(name, value, state):
                 n=name,
                 v=state[name]))
 
-    updated = {k: v for k, v in state.items()}
+    updated = dict(state.items())
     updated[name] = value
 
     return updated
@@ -192,7 +192,7 @@ def _do_inc(name, value, state):
             'Verb is "inc", but result would be greater than {}'.format(
                 MAX_VALUE))
 
-    updated = {k: v for k, v in state.items()}
+    updated = dict(state.items())
     updated[name] = incd
 
     return updated
@@ -214,7 +214,7 @@ def _do_dec(name, value, state):
             'Verb is "dec", but result would be less than {}'.format(
                 MIN_VALUE))
 
-    updated = {k: v for k, v in state.items()}
+    updated = dict(state.items())
     updated[name] = decd
 
     return updated

--- a/sdk/python/tests/test_zmq_driver.py
+++ b/sdk/python/tests/test_zmq_driver.py
@@ -32,6 +32,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class MockEngine(Engine):
+    # Ignore invalid override pylint issues
+    # pylint: disable=invalid-overridden-method
     def __init__(self):
         self.updates = []
         self.exit = False

--- a/validator/sawtooth_validator/execution/context_manager.py
+++ b/validator/sawtooth_validator/execution/context_manager.py
@@ -526,7 +526,7 @@ class _ContextWriter(InstrumentedThread):
             if context_id_list_tuple is _SHUTDOWN_SENTINEL:
                 break
             c_id, inflated_address_list = context_id_list_tuple
-            inflated_value_map = {k: v for k, v in inflated_address_list}
+            inflated_value_map = dict(inflated_address_list)
             if c_id in self._contexts:
                 self._contexts[c_id].set_from_tree(inflated_value_map)
 

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -653,12 +653,12 @@ class ParallelScheduler(Scheduler):
                 if not result.is_valid:
                     batch_is_valid = False
                     break
-                else:
-                    txn_id = txn.header_signature
-                    if txn_id not in txns_added_predecessors:
-                        txns_added_predecessors.append(
-                            self._txn_predecessors[txn_id])
-                        contexts_from_batch.append(result.context_id)
+
+                txn_id = txn.header_signature
+                if txn_id not in txns_added_predecessors:
+                    txns_added_predecessors.append(
+                        self._txn_predecessors[txn_id])
+                    contexts_from_batch.append(result.context_id)
             if batch_is_valid:
                 contexts.extend(contexts_from_batch)
 

--- a/validator/sawtooth_validator/gossip/gossip.py
+++ b/validator/sawtooth_validator/gossip/gossip.py
@@ -659,15 +659,15 @@ class ConnectionManager(InstrumentedThread):
                             # Unable to peer with endpoint
                             to_remove.append(endpoint)
                             continue
-                        else:
-                            # At maximum retry threashold, increment count
-                            self._static_peer_status[endpoint] = \
-                                StaticPeerInfo(
-                                    time=time.time(),
-                                    retry_threshold=min(
-                                        static_peer_info.retry_threshold * 2,
-                                        MAXIMUM_STATIC_RETRY_FREQUENCY),
-                                    count=static_peer_info.count + 1)
+
+                        # At maximum retry threashold, increment count
+                        self._static_peer_status[endpoint] = \
+                            StaticPeerInfo(
+                                time=time.time(),
+                                retry_threshold=min(
+                                    static_peer_info.retry_threshold * 2,
+                                    MAXIMUM_STATIC_RETRY_FREQUENCY),
+                                count=static_peer_info.count + 1)
                     else:
                         self._static_peer_status[endpoint] = \
                             StaticPeerInfo(
@@ -803,22 +803,22 @@ class ConnectionManager(InstrumentedThread):
                     # has not finished the authorization (trust/challenge)
                     # process yet.
                     continue
-                elif conn_id in peers:
+                if conn_id in peers:
                     # connected and peered - we've already sent peer request
                     continue
-                else:
-                    # connected but not peered
-                    if endpoint in self._temp_endpoints:
-                        # Endpoint is not yet authorized, do not request peers
-                        continue
 
-                    try:
-                        self._network.send(
-                            validator_pb2.Message.GOSSIP_GET_PEERS_REQUEST,
-                            get_peers_request.SerializeToString(),
-                            conn_id)
-                    except ValueError:
-                        LOGGER.debug("Connection disconnected: %s", conn_id)
+                # connected but not peered
+                if endpoint in self._temp_endpoints:
+                    # Endpoint is not yet authorized, do not request peers
+                    continue
+
+                try:
+                    self._network.send(
+                        validator_pb2.Message.GOSSIP_GET_PEERS_REQUEST,
+                        get_peers_request.SerializeToString(),
+                        conn_id)
+                except ValueError:
+                    LOGGER.debug("Connection disconnected: %s", conn_id)
 
     def _attempt_to_peer_with_endpoint(self, endpoint):
         LOGGER.debug("Attempting to connect/peer with %s", endpoint)

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -31,8 +31,8 @@ class BlockPublisher(BlockPublisherInterface):
                  block_cache,
                  state_view_factory,
                  batch_publisher,
-                 config_dir,
                  data_dir,
+                 config_dir,
                  validator_id):
         super().__init__(block_cache,
                          state_view_factory,

--- a/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
+++ b/validator/sawtooth_validator/journal/consensus/genesis/genesis_consensus.py
@@ -27,6 +27,8 @@ class BlockPublisher(BlockPublisherInterface):
     `'Genesis'` and finalized as such.
     """
 
+    # pylint: disable=useless-super-delegation
+
     def __init__(self,
                  block_cache,
                  state_view_factory,

--- a/validator/sawtooth_validator/journal/genesis.py
+++ b/validator/sawtooth_validator/journal/genesis.py
@@ -154,7 +154,7 @@ class GenesisController:
 
         initial_state_root = self._context_manager.get_first_root()
 
-        genesis_batches = [batch for batch in genesis_data.batches]
+        genesis_batches = list(genesis_data.batches)
         if genesis_batches:
             scheduler = SerialScheduler(
                 self._context_manager.get_squash_handler(),
@@ -288,7 +288,7 @@ class GenesisController:
         receipts = []
         for result in results:
             receipt = transaction_receipt_pb2.TransactionReceipt()
-            receipt.data.extend([data for data in result.data])
+            receipt.data.extend(list(result.data))
             receipt.state_changes.extend(result.state_changes)
             receipt.events.extend(result.events)
             receipt.transaction_id = result.signature

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -953,7 +953,7 @@ class BatchListRequest(_ClientRequestHandler):
             head_id,
             request.batch_ids,
             self._block_store.get_batch,
-            lambda block: [a for a in block.batches])
+            lambda block: list(block.batches))
 
         if self.is_reverse(request.sorting, self._status.INVALID_SORT):
             batches.reverse()

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -228,6 +228,7 @@ impl MerkleDatabase {
         let mut path_map = HashMap::new();
 
         let mut deletions = HashSet::new();
+        let mut additions = HashSet::new();
 
         for (set_address, set_value) in set_items {
             let tokens = tokenize_address(set_address);
@@ -240,6 +241,9 @@ impl MerkleDatabase {
                 node.value = Some(set_value.to_vec());
             }
             path_map.extend(set_path_map);
+        }
+        for pkey in path_map.keys() {
+            additions.insert(pkey.clone());
         }
 
         for del_address in delete_items.iter() {
@@ -255,7 +259,7 @@ impl MerkleDatabase {
                 let remove_parent = {
                     let parent_node = path_map
                         .get_mut(parent_address)
-                        .expect("Path map not correctly generated");
+                        .expect("Path map not correctly generated or entry is deleted");
 
                     if let Some(old_hash_key) = parent_node.children.remove(path_branch) {
                         deletions.insert(old_hash_key);
@@ -264,7 +268,9 @@ impl MerkleDatabase {
                     parent_node.children.is_empty()
                 };
 
-                if remove_parent {
+                // there's no children to the parent node already in the tree, remove it from
+                // path_map if a new node doesn't have this as its parent
+                if remove_parent && !additions.contains(parent_address) {
                     // empty node delete it.
                     path_map.remove(parent_address);
                 } else {
@@ -279,7 +285,7 @@ impl MerkleDatabase {
                 if parent_address == "" {
                     let parent_node = path_map
                         .get_mut(parent_address)
-                        .expect("Path map not correctly generated");
+                        .expect("Path map not correctly generated or entry is deleted");
 
                     if let Some(old_hash_key) = parent_node.children.remove(path_branch) {
                         deletions.insert(old_hash_key);
@@ -306,7 +312,7 @@ impl MerkleDatabase {
                 let (parent_address, path_branch) = parent_and_branch(&path);
                 let mut parent = path_map
                     .get_mut(parent_address)
-                    .expect("Path map not correctly generated");
+                    .expect("Path map not correctly generated or entry is deleted");
                 if let Some(old_hash_key) = parent
                     .children
                     .insert(path_branch.to_string(), ::hex::encode(hash_key.clone()))
@@ -1043,6 +1049,98 @@ mod tests {
             let mut set_items = HashMap::new();
             // Perform some updates on the lower keys
             for &(_, ref key_hash) in key_hashes.iter() {
+                set_items.insert(key_hash.clone().to_string(), "2.0".as_bytes().to_vec());
+                values.insert(key_hash.clone().to_string(), "2.0".to_string());
+            }
+
+            // The first item below(e55420...89b9) shares a common prefix
+            // with the first in set_items(e55420...620c)
+            let delete_items = vec![
+                "e55420c026596ee643e26fd93927249ea28fb5f359ddbd18bc02562dc7e8dbc93e89b9"
+                    .to_string(),
+                "cc1370ce67aa16c89721ee947e9733b2a3d2460db5b0ea6410288f426ad8d8040ea641"
+                    .to_string(),
+                "d07e69664286712c3d268ca71464f2b3b2604346f833106f3e0f6a72276e57a16f3e0f"
+                    .to_string(),
+            ];
+
+            for hash in delete_items.iter() {
+                values.remove(hash);
+            }
+
+            let virtual_root = merkle_db.update(&set_items, &delete_items, true).unwrap();
+
+            // virtual root shouldn't match actual contents of tree
+            assert!(merkle_db.set_merkle_root(virtual_root.clone()).is_err());
+
+            let actual_root = merkle_db.update(&set_items, &delete_items, false).unwrap();
+            // the virtual root should be the same as the actual root
+            assert_eq!(virtual_root, actual_root);
+            assert_ne!(actual_root, merkle_db.get_merkle_root());
+
+            merkle_db.set_merkle_root(actual_root).unwrap();
+
+            for (address, value) in values {
+                assert_value_at_address(&merkle_db, &address, &value);
+            }
+
+            for address in delete_items {
+                assert!(merkle_db.get(&address).is_err());
+            }
+        })
+    }
+
+    #[test]
+    /// This test is similar to the update_same_address_space except that it will ensure that
+    /// there are no index errors in path_map within update function in case
+    /// there are addresses within set_items & delete_items which have a common
+    /// prefix (of any length), when trie doesn't have children to the parent node getting deleted.
+    ///
+    /// A Merkle trie is created with some initial values which is then updated
+    /// (set & delete).
+    fn merkle_trie_update_same_address_space_with_no_children() {
+        run_test(|merkle_path| {
+            let mut merkle_db = make_db(merkle_path);
+            let init_root = merkle_db.get_merkle_root();
+            let key_hashes = vec![
+                (
+                    "qwert",
+                    "c946ee72d38b8c51328f1a5f31eb5bd3300362ad0ca69dab54eff996775c7069216bda",
+                ),
+                (
+                    "zxcvb",
+                    "487a6a63c71c9b7b63146ef68858e5d010b4978fd70dda0404d4fad5e298ccc9a560eb",
+                ),
+                // matching prefix e55420, this will be deleted
+                (
+                    "yuiop",
+                    "e55420c026596ee643e26fd93927249ea28fb5f359ddbd18bc02562dc7e8dbc93e89b9",
+                ),
+                (
+                    "hjklk",
+                    "cc1370ce67aa16c89721ee947e9733b2a3d2460db5b0ea6410288f426ad8d8040ea641",
+                ),
+                (
+                    "bnmvc",
+                    "d07e69664286712c3d268ca71464f2b3b2604346f833106f3e0f6a72276e57a16f3e0f",
+                ),
+            ];
+            let mut values = HashMap::new();
+            for &(ref key, ref hashed) in key_hashes.iter() {
+                let new_root = merkle_db.set(&hashed, key.as_bytes()).unwrap();
+                values.insert(hashed.to_string(), key.to_string());
+                merkle_db.set_merkle_root(new_root).unwrap();
+            }
+            assert_ne!(init_root, merkle_db.get_merkle_root());
+
+            // matching prefix e55420, however this will be newly added and not set already in trie
+            let key_hash_to_be_inserted = vec![(
+                "asdfg",
+                "e5542002d3e2892516fa461cde69e05880609fbad3d38ab69435a189e126de672b620c",
+            )];
+            let mut set_items = HashMap::new();
+            // Perform some updates on the lower keys
+            for &(_, ref key_hash) in key_hash_to_be_inserted.iter() {
                 set_items.insert(key_hash.clone().to_string(), "2.0".as_bytes().to_vec());
                 values.insert(key_hash.clone().to_string(), "2.0".to_string());
             }

--- a/validator/tests/test_block_store/tests.py
+++ b/validator/tests/test_block_store/tests.py
@@ -267,7 +267,7 @@ class BlockStorePredecessorIteratorTest(unittest.TestCase):
         block_store = BlockStore(DictDatabase(
             indexes=BlockStore.create_index_configuration()))
 
-        self.assertEqual([], [b for b in block_store.get_predecessor_iter()])
+        self.assertEqual([], list(block_store.get_predecessor_iter()))
 
     def _create_chain(self, length):
         chain = []

--- a/validator/tests/test_context_manager/tests.py
+++ b/validator/tests/test_context_manager/tests.py
@@ -707,15 +707,14 @@ class TestContextManager(unittest.TestCase):
         )
         self.assertEqual(
             address_values,
-            [(a, v) for a, v in zip(test_addresses.writes, values1)]
+            list(zip(test_addresses.writes, values1))
         )
 
         # 3)
         values2 = [bytes(v.encode()) for v in test_addresses.outputs]
         self.context_manager.set(
             context_id=context_a,
-            address_value_list=[{a: v} for
-                                a, v in zip(test_addresses.outputs, values2)])
+            address_value_list=[dict(zip(test_addresses.outputs, values2))])
 
         # 4)
         context_id_a1 = self.context_manager.create_context(
@@ -730,9 +729,10 @@ class TestContextManager(unittest.TestCase):
             context_id=context_id_a1,
             address_list=list(test_addresses.outputs)
         )
+
         self.assertEqual(
             c_ida1_address_values,
-            [(a, v) for a, v in zip(test_addresses.outputs, values2)]
+            list(zip(test_addresses.outputs, values2))
         )
 
         # 6)
@@ -764,9 +764,9 @@ class TestContextManager(unittest.TestCase):
                 context_id_b,
                 list(test_addresses2.writes + test_addresses.outputs)
             ),
-            [(a, v) for a, v in zip(
+            list(zip(
                 test_addresses2.writes + test_addresses.outputs,
-                values3 + values2)]
+                values3 + values2))
         )
 
     def test_state_root_after_parallel_ctx(self):
@@ -1066,9 +1066,8 @@ class TestContextManager(unittest.TestCase):
 
         tree = MerkleDatabase(self.database_results)
         state_hash_from_1 = tree.update(
-            set_items={a: v for a, v in zip(outputs_1,
-                                            [bytes(i)
-                                             for i in range(len(outputs_1))])},
+            set_items=dict(zip(outputs_1,
+                               [bytes(i) for i in range(len(outputs_1))])),
             virtual=False)
 
         self.assertEqual(state_hash_from_1, sh1,

--- a/validator/tests/test_merkle_trie/tests.py
+++ b/validator/tests/test_merkle_trie/tests.py
@@ -107,10 +107,7 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
             for key, hashed in random.sample(key_hashes.items(), 50)
         }
         values.update(set_items)
-        delete_items = {
-            hashed
-            for hashed in random.sample(list(key_hashes.values()), 50)
-        }
+        delete_items = set(random.sample(list(key_hashes.values()), 50))
 
         # make sure there are no sets and deletes of the same key
         delete_items = delete_items - set_items.keys()
@@ -163,11 +160,11 @@ class TestSawtoothMerkleTrie(unittest.TestCase):
             [("010101", {"my_data": 1}),
              ("010202", {"my_data": 2}),
              ("010303", {"my_data": 3})],
-            [entry for entry in iter(self.trie)])
+            list(iter(self.trie)))
 
         # Test prefixed iteration
         self.assertEqual([("010202", {"my_data": 2})],
-                         [entry for entry in self.trie.leaves('0102')])
+                         list(iter(self.trie.leaves('0102'))))
 
     # assertions
     def assert_value_at_address(self, address, value, ishash=False):

--- a/validator/tests/test_receipt_store/tests.py
+++ b/validator/tests/test_receipt_store/tests.py
@@ -116,7 +116,7 @@ class TransactionReceiptGetRequestHandlerTest(unittest.TestCase):
         self.assertEqual(ClientReceiptGetResponse.OK,
                          response.message_out.status)
 
-        self.assertEqual([receipt], [r for r in response.message_out.receipts])
+        self.assertEqual([receipt], list(response.message_out.receipts))
 
         request = ClientReceiptGetRequest(
             transaction_ids=['unknown']).SerializeToString()

--- a/validator/tests/test_state_view/tests.py
+++ b/validator/tests/test_state_view/tests.py
@@ -62,7 +62,7 @@ class StateViewTest(unittest.TestCase):
 
         # test that the initial state view returns empty values
         self.assertEqual([], initial_state_view.addresses())
-        self.assertEqual({}, {k: v for k, v in initial_state_view.leaves('')})
+        self.assertEqual({}, dict(initial_state_view.leaves('')))
         with self.assertRaises(KeyError):
             initial_state_view.get('abcd')
 
@@ -78,4 +78,4 @@ class StateViewTest(unittest.TestCase):
         # Check that the values can be properly read back
         self.assertEqual('hello', next_state_view.get('abcd').decode())
         self.assertEqual({'abcd': 'hello'.encode()},
-                         {k: v for k, v in next_state_view.leaves('')})
+                         dict(next_state_view.leaves('')))


### PR DESCRIPTION
Transaction is submitted to handle simultaneous read and write
to multiple addresses in merkle tree.

"merkle_db_update" is called with both update items and delete
items. If update items have common parent with delete items,
and delete items remove common parent required by update items a
node is left to be added without a correct parent chain.
Processing delete items leaves behind the broken parent chain.

Solution: Remove parent node of item to be deleted only if its
path is not in parent chain of update items.

This is a backport from #2000 

There are also additional lint fix commits, some of which are cherry-pick from https://github.com/hyperledger/sawtooth-core/pull/2257