### PR TITLE
Add DecodedMerkleStateReader for state views

### DIFF
--- a/validator/src/state/state_view_factory.rs
+++ b/validator/src/state/state_view_factory.rs
@@ -16,7 +16,7 @@
  */
 use database::lmdb::LmdbDatabase;
 use state::error::StateDatabaseError;
-use state::merkle::MerkleDatabase;
+use state::merkle::{DecodedMerkleStateReader, MerkleDatabase};
 use state::StateReader;
 
 /// The StateViewFactory produces StateViews for a particular merkle root.
@@ -38,7 +38,10 @@ impl StateViewFactory {
         &self,
         state_root_hash: &str,
     ) -> Result<V, StateDatabaseError> {
-        let merkle_db = MerkleDatabase::new(self.state_database.clone(), Some(state_root_hash))?;
+        let merkle_db = DecodedMerkleStateReader::new(MerkleDatabase::new(
+            self.state_database.clone(),
+            Some(state_root_hash),
+        )?);
         Ok(V::from(Box::new(merkle_db)))
     }
 }


### PR DESCRIPTION
The python code wraps data in CBOR when added to state, and unwraps the values when read.  This reader provides the CBOR-decoded values to the rust implementations of `StateView` structs via a new implementation of the `StateReader`.
