### PR TITLE
Add proto generation to libsawtooth

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -28,6 +28,7 @@ hex = { version = "0.4", optional = true }
 log = "0.4"
 lmdb-zero = { version = "0.4", optional = true }
 openssl = { version = "0.10", optional = true }
+protobuf = "2"
 redis = { version = "0.13.0", default-features = false, optional = true }
 transact = "0.2"
 
@@ -54,3 +55,7 @@ receipt-store = ["stores"]
 redis-store = ["redis", "stores"]
 stores = []
 validator-internals = ["hex", "openssl"]
+
+[build-dependencies]
+protoc-rust = "2.0"
+glob = "0.2"

--- a/libsawtooth/build.rs
+++ b/libsawtooth/build.rs
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+extern crate glob;
+extern crate protoc_rust;
+
+use std::env;
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+use protoc_rust::Customize;
+
+fn main() {
+    // Generate protobuf files
+    let proto_src_files = glob_simple("./protos/*.proto");
+    println!("{:?}", proto_src_files);
+
+    let out_dir = env::var("OUT_DIR").expect("No OUT_DIR env variable");
+    let dest_path = Path::new(&out_dir).join("protos");
+    fs::create_dir_all(&dest_path).expect("Unable to create proto destination directory");
+
+    let mod_file_content = proto_src_files
+        .iter()
+        .map(|proto_file| {
+            let proto_path = Path::new(proto_file);
+            format!(
+                "pub mod {};",
+                proto_path
+                    .file_stem()
+                    .expect("Unable to extract stem")
+                    .to_str()
+                    .expect("Unable to extract filename")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut mod_file = File::create(dest_path.join("mod.rs")).unwrap();
+    mod_file
+        .write_all(mod_file_content.as_bytes())
+        .expect("Unable to write mod file");
+
+    protoc_rust::Codegen::new()
+        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .inputs(
+            &proto_src_files
+                .iter()
+                .map(|a| a.as_ref())
+                .collect::<Vec<&str>>(),
+        )
+        .includes(&["src", "protos"])
+        .customize(Customize::default())
+        .run()
+        .expect("unable to run protoc");
+}
+
+fn glob_simple(pattern: &str) -> Vec<String> {
+    glob::glob(pattern)
+        .expect("glob")
+        .map(|g| {
+            g.expect("item")
+                .as_path()
+                .to_str()
+                .expect("utf-8")
+                .to_owned()
+        })
+        .collect()
+}

--- a/libsawtooth/protos/batch.proto
+++ b/libsawtooth/protos/batch.proto
@@ -1,0 +1,51 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "batch_pb2";
+
+import "transaction.proto";
+
+message BatchHeader {
+    // Public key for the client that signed the BatchHeader
+    string signer_public_key = 1;
+
+    // List of transaction.header_signatures that match the order of
+    // transactions required for the batch
+    repeated string transaction_ids = 2;
+}
+
+message Batch {
+    // The serialized version of the BatchHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of the transactions that match the list of
+    // transaction_ids listed in the batch header
+    repeated Transaction transactions = 3;
+
+    // A debugging flag which indicates this batch should be traced through the
+    // system, resulting in a higher level of debugging output.
+    bool trace = 4;
+}
+
+message BatchList {
+    repeated Batch batches = 1;
+}

--- a/libsawtooth/protos/block.proto
+++ b/libsawtooth/protos/block.proto
@@ -1,0 +1,59 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "block_pb2";
+
+import "batch.proto";
+
+message BlockHeader {
+    // Block number in the chain
+    uint64 block_num = 1;
+
+    // The header_signature of the previous block that was added to the chain.
+    string previous_block_id = 2;
+
+    // Public key for the component internal to the validator that
+    // signed the BlockHeader
+    string signer_public_key = 3;
+
+    // List of batch.header_signatures that match the order of batches
+    // required for the block
+    repeated string batch_ids = 4;
+
+    // Bytes that are set and verified by the consensus algorithm used to
+    // create and validate the block
+    bytes consensus = 5;
+
+    // The state_root_hash should match the final state_root after all
+    // transactions in the batches have been applied, otherwise the block
+    // is not valid
+    string state_root_hash = 6;
+}
+
+message Block {
+    // The serialized version of the BlockHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // A list of batches. The batches may contain new batches that other
+    // validators may not have received yet, or they will be all batches needed
+    // for block validation when passed to the journal
+    repeated Batch batches = 3;
+}

--- a/libsawtooth/protos/consensus.proto
+++ b/libsawtooth/protos/consensus.proto
@@ -1,0 +1,546 @@
+// Copyright 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+// --== Data Structures ==--
+
+message ConsensusPeerMessageHeader {
+  // Public key for the component internal to the validator that
+  // signed the message
+  bytes signer_id = 1;
+
+  // The sha512 hash of the encoded message
+  bytes content_sha512 = 2;
+  // Interpretation is left to the consensus engine implementation
+  string message_type = 5;
+
+  // Used to identify the consensus engine that produced this message
+  string name = 3;
+  string version = 4;
+}
+
+// A consensus-related message sent between peers
+message ConsensusPeerMessage {
+  // The serialized version of the ConsensusPeerMessageHeader
+  bytes header = 1;
+
+  // The signature derived from signing the header
+  bytes header_signature = 3;
+
+  // The opaque payload to send to other nodes
+  bytes content = 2;
+}
+
+// All information about a block that is relevant to consensus
+message ConsensusBlock {
+  bytes block_id = 1;
+  bytes previous_id = 2;
+  // The id of peer that signed this block
+  bytes signer_id = 3;
+  uint64 block_num = 4;
+  bytes payload = 5;
+  // A summary of the contents of the block
+  bytes summary = 6;
+}
+
+// Information about a peer that is relevant to consensus
+message ConsensusPeerInfo {
+  // The unique id for this peer. This can be correlated with the signer id
+  // on consensus blocks.
+  bytes peer_id = 1;
+}
+
+// A settings key-value pair
+message ConsensusSettingsEntry {
+  string key = 1;
+  string value = 2;
+}
+
+// A state key-value pair
+message ConsensusStateEntry {
+  string address = 1;
+  bytes data = 2;
+}
+
+// --== Registration ==--
+
+// Sent to connect with the validator
+message ConsensusRegisterRequest {
+  message Protocol {
+    string name = 1;
+    string version = 2;
+  }
+
+  // The name of this consensus engine
+  string name = 1;
+  // The version of this consensus engine
+  string version = 2;
+  // Any additional name/version pairs the consensus engine supports
+  repeated Protocol additional_protocols = 3;
+}
+
+message ConsensusRegisterResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+  }
+
+  Status status = 1;
+
+  // Startup Info
+  ConsensusBlock chain_head = 2;
+  repeated ConsensusPeerInfo peers = 3;
+  ConsensusPeerInfo local_peer_info = 4;
+}
+
+// --== Notifications ==--
+
+// The following are notifications provided by the validator to the consensus
+// engine. An ack should be sent in response to all notifications.
+
+// - P2P -
+
+// A new peer was added
+message ConsensusNotifyPeerConnected {
+  ConsensusPeerInfo peer_info = 1;
+}
+
+// An existing peer was dropped
+message ConsensusNotifyPeerDisconnected {
+  bytes peer_id = 1;
+}
+
+// A new message was received from a peer
+message ConsensusNotifyPeerMessage {
+  // The message sent
+  ConsensusPeerMessage message = 1;
+  // The node that sent the message, not necessarily the node that created it
+  bytes sender_id = 2;
+}
+
+// - Blocks -
+
+// A new block was received and passed initial consensus validation
+message ConsensusNotifyBlockNew {
+  ConsensusBlock block = 1;
+}
+
+// This block can be committed successfully
+message ConsensusNotifyBlockValid {
+  bytes block_id = 1;
+}
+
+// This block cannot be committed successfully
+message ConsensusNotifyBlockInvalid {
+  bytes block_id = 1;
+}
+
+// This block has been committed
+message ConsensusNotifyBlockCommit {
+  bytes block_id = 1;
+}
+
+// The engine has been activated
+message ConsensusNotifyEngineActivated {
+  // Startup Info
+  ConsensusBlock chain_head = 1;
+  repeated ConsensusPeerInfo peers = 2;
+  ConsensusPeerInfo local_peer_info = 3;
+}
+
+// The engine has been deactivated
+message ConsensusNotifyEngineDeactivated {}
+
+// Confirm that the notification was received. The validator message
+// correlation id is used to determine which notification this is an ack for.
+message ConsensusNotifyAck {}
+
+// --== Services Provided ==--
+
+// The following are services provided by the validator to the consensus
+// engine. All service messages have at a minimum the following possible return
+// statuses:
+//
+//    STATUS_UNSET
+//        No status was set by the validator, this should never happen
+//    OK
+//        The request was completed successfully
+//    BAD_REQUEST
+//        The request was malformed in some way
+//    SERVICE_ERROR
+//        The validator failed to perform the request
+//    NOT_READY
+//        The validator is not accepting requests, usually because it is still
+//        starting up
+//    NOT_ACTIVE_ENGINE
+//        The consensus engine making the request is not the active engine
+//
+// Additionally, messages may have the following additional return statuses:
+//
+//    INVALID_STATE
+//        The request is not valid given the current state of the validator
+//    UNKNOWN_BLOCK
+//        No block with the given id could be found
+//    UNKNOWN_PEER
+//        No peer with the given id could be found
+
+// - P2P Messaging -
+
+// Send a consensus message to a specific, connected peer
+message ConsensusSendToRequest {
+  // Payload to send to peer
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 3;
+
+  // Peer that this message is destined for
+  bytes receiver_id = 2;
+}
+
+message ConsensusSendToResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_PEER = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+  Status status = 1;
+}
+
+// Broadcast a consensus message to all peers
+message ConsensusBroadcastRequest {
+  // Payload to broadcast peers
+  //
+  // NOTE: This payload will be wrapped up in a ConsensusPeerMessage struct,
+  // which includes computing its SHA-512 digest, inserting this engine's
+  // registration info, and the validator's public key, and signing everything
+  // with the validator's private key.
+  bytes content = 1;
+  string message_type = 2;
+}
+
+message ConsensusBroadcastResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+    NOT_ACTIVE_ENGINE = 5;
+  }
+  Status status = 1;
+}
+
+// - Block Creation -
+
+// Initialize a new block built on the block with the given previous id and
+// begin adding batches to it. If no previous id is specified, the current
+// head will be used.
+message ConsensusInitializeBlockRequest {
+  bytes previous_id = 1;
+}
+
+message ConsensusInitializeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    UNKNOWN_BLOCK = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+}
+
+// Stop adding batches to the current block and return a summary of its
+// contents.
+message ConsensusSummarizeBlockRequest {}
+
+message ConsensusSummarizeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+
+  // A summary of the block contents
+  bytes summary = 2;
+}
+
+// Insert the given consensus data into the block and sign it. If this call is
+// successful, the consensus engine will receive the block afterwards.
+message ConsensusFinalizeBlockRequest {
+  // The consensus data to include in the finalized block
+  bytes data = 1;
+}
+
+message ConsensusFinalizeBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+    BLOCK_NOT_READY = 6;
+
+    NOT_ACTIVE_ENGINE = 7;
+  }
+  Status status = 1;
+
+  // The block id of the newly created block
+  bytes block_id = 2;
+}
+
+// Stop adding batches to the current block and abandon it.
+message ConsensusCancelBlockRequest {}
+
+message ConsensusCancelBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    INVALID_STATE = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// - Block Directives -
+
+// Request that, for each block block in order, the block is checked to
+// determine whether the block can be committed successfully or not. Blocks
+// may be checked in parallel. If a new request arrives, it overrides the
+// previous request allowing the engine to reprioritize the list of blocks to
+// check.
+//
+// NOTE: OK does not mean the blocks will all commit successfully, only that
+// the directive was received successfully. The engine must listen for
+// notifications from the consuming component to learn if the blocks would
+// commit or not.
+message ConsensusCheckBlocksRequest {
+  repeated bytes block_ids = 1;
+}
+
+message ConsensusCheckBlocksResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Request that the block be committed. This request fails if the block has
+// not already been checked.
+//
+// NOTE: OK does not mean the block has been committed, only that the directive
+// was received successfully. The engine must listen for notifications from the
+// consuming component to learn when the block commits.
+message ConsensusCommitBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusCommitBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Inform the consuming component that this block is no longer being considered
+// and can be held or freed as needed.
+message ConsensusIgnoreBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusIgnoreBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// Fail this block and any of its descendants and purge them as needed.
+message ConsensusFailBlockRequest {
+  bytes block_id = 1;
+}
+
+message ConsensusFailBlockResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+}
+
+// - Queries -
+
+// Retrieve consensus-related information about blocks. If some blocks could
+// not be found, only the blocks that could be found will be returned.
+message ConsensusBlocksGetRequest {
+  repeated bytes block_ids = 1;
+}
+
+message ConsensusBlocksGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusBlock blocks = 2;
+}
+
+// Retrieve consensus-related information about the chain head.
+message ConsensusChainHeadGetRequest {}
+
+message ConsensusChainHeadGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    NO_CHAIN_HEAD = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  ConsensusBlock block = 2;
+}
+
+// Read the values of these settings from state as of the given block. If some
+// values settings keys cannot be found, the keys that were found will be
+// returned.
+message ConsensusSettingsGetRequest {
+  bytes block_id = 1;
+  repeated string keys = 2;
+}
+
+message ConsensusSettingsGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusSettingsEntry entries = 2;
+}
+
+// Read the data at these addresses from state as of the given block. If some
+// addresses cannot be found, state at the addresses that were found will be
+// returned.
+message ConsensusStateGetRequest {
+  bytes block_id = 1;
+  repeated string addresses = 2;
+}
+
+message ConsensusStateGetResponse {
+  enum Status {
+    STATUS_UNSET = 0;
+    OK = 1;
+    BAD_REQUEST = 2;
+    SERVICE_ERROR = 3;
+    NOT_READY = 4;
+
+    UNKNOWN_BLOCK = 5;
+
+    NOT_ACTIVE_ENGINE = 6;
+  }
+
+  Status status = 1;
+  repeated ConsensusStateEntry entries = 2;
+}

--- a/libsawtooth/protos/events.proto
+++ b/libsawtooth/protos/events.proto
@@ -1,0 +1,66 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "events_pb2";
+
+
+message Event {
+  // Used to subscribe to events and servers as a hint for how to deserialize
+  // event_data and what pairs to expect in attributes.
+  string event_type = 1;
+
+  // Transparent data defined by the event_type.
+  message Attribute {
+    string key = 1;
+    string value = 2;
+  }
+  repeated Attribute attributes = 2;
+
+  // Opaque data defined by the event_type.
+  bytes  data = 3;
+}
+
+message EventList {
+    repeated Event events = 1;
+}
+
+message EventFilter {
+    // EventFilter is used when subscribing to events to limit the events
+    // received within a given event type. See
+    // validator/server/events/subscription.py for further explanation.
+    string key = 1;
+    string match_string = 2;
+
+    enum FilterType {
+      FILTER_TYPE_UNSET = 0;
+      SIMPLE_ANY = 1;
+      SIMPLE_ALL = 2;
+      REGEX_ANY  = 3;
+      REGEX_ALL  = 4;
+    }
+    FilterType filter_type = 3;
+}
+
+message EventSubscription {
+    // EventSubscription is used when subscribing to events to specify the type
+    // of events being subscribed to, along with any additional filters. See
+    // validator/server/events/subscription.py for further explanation.
+    string event_type = 1;
+    repeated EventFilter filters = 2;
+}

--- a/libsawtooth/protos/setting.proto
+++ b/libsawtooth/protos/setting.proto
@@ -1,0 +1,32 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "setting_pb2";
+
+
+// Setting Container for on-chain configuration key/value pairs
+message Setting {
+    // Contains a setting entry (or entries, in the case of collisions).
+    message Entry {
+        string key = 1;
+        string value = 2;
+    }
+
+    // List of setting entries - more than one implies a state key collision
+    repeated Entry entries = 1;
+}

--- a/libsawtooth/protos/transaction.proto
+++ b/libsawtooth/protos/transaction.proto
@@ -1,0 +1,73 @@
+// Copyright 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "transaction_pb2";
+
+message TransactionHeader {
+    // Public key for the client who added this transaction to a batch
+    string batcher_public_key = 1;
+
+    // A list of transaction signatures that describe the transactions that
+    // must be processed before this transaction can be valid
+    repeated string dependencies = 2;
+
+    // The family name correlates to the transaction processor's family name
+    // that this transaction can be processed on, for example 'intkey'
+    string family_name = 3;
+
+    // The family version correlates to the transaction processor's family
+    // version that this transaction can be processed on, for example "1.0"
+    string family_version = 4;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to read from.
+    repeated string inputs = 5;
+
+    // A random string that provides uniqueness for transactions with
+    // otherwise identical fields.
+    string nonce = 6;
+
+    // A list of addresses that are given to the context manager and control
+    // what addresses the transaction processor is allowed to write to.
+    repeated string outputs = 7;
+
+    //The sha512 hash of the encoded payload
+    string payload_sha512 = 9;
+
+    // Public key for the client that signed the TransactionHeader
+    string signer_public_key = 10;
+}
+
+message Transaction {
+    // The serialized version of the TransactionHeader
+    bytes header = 1;
+
+    // The signature derived from signing the header
+    string header_signature = 2;
+
+    // The payload is the encoded family specific information of the
+    // transaction. Example cbor({'Verb': verb, 'Name': name,'Value': value})
+    bytes payload = 3;
+}
+
+// A simple list of transactions that needs to be serialized before
+// it can be transmitted to a batcher.
+message TransactionList {
+    repeated Transaction transactions = 1;
+}

--- a/libsawtooth/protos/transaction_receipt.proto
+++ b/libsawtooth/protos/transaction_receipt.proto
@@ -1,0 +1,53 @@
+// Copyright 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "txn_receipt_pb2";
+
+import "events.proto";
+
+
+message TransactionReceipt {
+  // State changes made by this transaction
+  // StateChange is defined in protos/transaction_receipt.proto
+  repeated StateChange state_changes = 1;
+  // Events fired by this transaction
+  repeated Event events = 2;
+  // Transaction family defined data
+  repeated bytes data = 3;
+
+  string transaction_id = 4;
+}
+
+//  StateChange objects have the type of SET, which is either an insert or
+//  update, or DELETE. Items marked as a DELETE will have no byte value.
+message StateChange {
+    enum Type {
+        TYPE_UNSET = 0;
+        SET = 1;
+        DELETE = 2;
+    }
+    string address = 1;
+    bytes value = 2;
+    Type type = 3;
+}
+
+// A collection of state changes.
+message StateChangeList {
+    repeated StateChange state_changes = 1;
+}

--- a/libsawtooth/protos/validator.proto
+++ b/libsawtooth/protos/validator.proto
@@ -1,0 +1,226 @@
+// Copyright 2016, 2017 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// -----------------------------------------------------------------------------
+
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "sawtooth.sdk.protobuf";
+option go_package = "validator_pb2";
+
+// A list of messages to be transmitted together.
+message MessageList {
+    repeated Message messages = 1;
+}
+
+// The message passed between the validator and client, containing the
+// header fields and content.
+message Message {
+
+    enum MessageType {
+        DEFAULT = 0;
+        // Registration request from the transaction processor to the validator
+        TP_REGISTER_REQUEST = 1;
+        // Registration response from the validator to the
+        // transaction processor
+        TP_REGISTER_RESPONSE = 2;
+        // Tell the validator that the transaction processor
+        // won't take any more transactions
+        TP_UNREGISTER_REQUEST = 3;
+        // Response from the validator to the tp that it won't
+        // send any more transactions
+        TP_UNREGISTER_RESPONSE = 4;
+        // Process Request from the validator/executor to the
+        // transaction processor
+        TP_PROCESS_REQUEST = 5;
+        // Process response from the transaction processor to the validator/executor
+        TP_PROCESS_RESPONSE = 6;
+        // State get request from the transaction processor to validator/context_manager
+        TP_STATE_GET_REQUEST = 7;
+        // State get response from the validator/context_manager to the transaction processor
+        TP_STATE_GET_RESPONSE = 8;
+        // State set request from the transaction processor to the validator/context_manager
+        TP_STATE_SET_REQUEST = 9;
+        // State set response from the validator/context_manager to the transaction processor
+        TP_STATE_SET_RESPONSE = 10;
+        // State delete request from the transaction processor to the validator/context_manager
+        TP_STATE_DELETE_REQUEST = 11;
+        // State delete response from the validator/context_manager to the transaction processor
+        TP_STATE_DELETE_RESPONSE = 12;
+        // Message to append data to a transaction receipt
+        TP_RECEIPT_ADD_DATA_REQUEST = 13;
+        // Response from validator to tell transaction processor that data has been appended
+        TP_RECEIPT_ADD_DATA_RESPONSE = 14;
+        // Message to add event
+        TP_EVENT_ADD_REQUEST = 15;
+        // Response from validator to tell transaction processor that event has been created
+        TP_EVENT_ADD_RESPONSE = 16;
+
+        // Submission of a batchlist from the web api or another client to the validator
+        CLIENT_BATCH_SUBMIT_REQUEST = 100;
+        // Response from the validator to the web api/client that the submission was accepted
+        CLIENT_BATCH_SUBMIT_RESPONSE = 101;
+        // A request to list blocks from the web api/client to the validator
+        CLIENT_BLOCK_LIST_REQUEST = 102;
+        CLIENT_BLOCK_LIST_RESPONSE = 103;
+        CLIENT_BLOCK_GET_BY_ID_REQUEST = 104;
+        CLIENT_BLOCK_GET_RESPONSE = 105;
+        CLIENT_BATCH_LIST_REQUEST = 106;
+        CLIENT_BATCH_LIST_RESPONSE = 107;
+        CLIENT_BATCH_GET_REQUEST = 108;
+        CLIENT_BATCH_GET_RESPONSE = 109;
+        CLIENT_TRANSACTION_LIST_REQUEST = 110;
+        CLIENT_TRANSACTION_LIST_RESPONSE = 111;
+        CLIENT_TRANSACTION_GET_REQUEST = 112;
+        CLIENT_TRANSACTION_GET_RESPONSE = 113;
+        // Client state request of the current state hash to be retrieved from the journal
+        CLIENT_STATE_CURRENT_REQUEST = 114;
+        // Response with the current state hash
+        CLIENT_STATE_CURRENT_RESPONSE = 115;
+        // A request of all the addresses under a particular prefix, for a state hash.
+        CLIENT_STATE_LIST_REQUEST = 116;
+        // The response of the addresses
+        CLIENT_STATE_LIST_RESPONSE = 117;
+        // Get the address:data entry at a particular address
+        CLIENT_STATE_GET_REQUEST = 118;
+        // The response with the entry
+        CLIENT_STATE_GET_RESPONSE = 119;
+        // A request for the status of a batch or batches
+        CLIENT_BATCH_STATUS_REQUEST = 120;
+        // A response with the batch statuses
+        CLIENT_BATCH_STATUS_RESPONSE = 121;
+        // A request for one or more transaction receipts
+        CLIENT_RECEIPT_GET_REQUEST = 122;
+        // A response with the receipts
+        CLIENT_RECEIPT_GET_RESPONSE = 123;
+        CLIENT_BLOCK_GET_BY_NUM_REQUEST = 124;
+        // A request for a validator's peers
+        CLIENT_PEERS_GET_REQUEST = 125;
+        // A response with the validator's peers
+        CLIENT_PEERS_GET_RESPONSE = 126;
+        CLIENT_BLOCK_GET_BY_TRANSACTION_ID_REQUEST = 127;
+        CLIENT_BLOCK_GET_BY_BATCH_ID_REQUEST = 128;
+        // A request for a validator's status
+        CLIENT_STATUS_GET_REQUEST = 129;
+        // A response with the validator's status
+        CLIENT_STATUS_GET_RESPONSE = 130;
+
+        // Message types for events
+        CLIENT_EVENTS_SUBSCRIBE_REQUEST = 500;
+        CLIENT_EVENTS_SUBSCRIBE_RESPONSE = 501;
+        CLIENT_EVENTS_UNSUBSCRIBE_REQUEST = 502;
+        CLIENT_EVENTS_UNSUBSCRIBE_RESPONSE = 503;
+        CLIENT_EVENTS = 504;
+        CLIENT_EVENTS_GET_REQUEST = 505;
+        CLIENT_EVENTS_GET_RESPONSE = 506;
+
+        // Temp message types until a discussion can be had about gossip msg
+        GOSSIP_MESSAGE = 200;
+        GOSSIP_REGISTER = 201;
+        GOSSIP_UNREGISTER = 202;
+        GOSSIP_BLOCK_REQUEST = 205;
+        GOSSIP_BLOCK_RESPONSE = 206;
+        GOSSIP_BATCH_BY_BATCH_ID_REQUEST = 207;
+        GOSSIP_BATCH_BY_TRANSACTION_ID_REQUEST = 208;
+        GOSSIP_BATCH_RESPONSE = 209;
+        GOSSIP_GET_PEERS_REQUEST = 210;
+        GOSSIP_GET_PEERS_RESPONSE = 211;
+        GOSSIP_CONSENSUS_MESSAGE = 212;
+
+        NETWORK_ACK = 300;
+        NETWORK_CONNECT = 301;
+        NETWORK_DISCONNECT = 302;
+
+        // Message types for Authorization Types
+        AUTHORIZATION_CONNECTION_RESPONSE = 600;
+        AUTHORIZATION_VIOLATION = 601;
+        AUTHORIZATION_TRUST_REQUEST = 602;
+        AUTHORIZATION_TRUST_RESPONSE = 603;
+        AUTHORIZATION_CHALLENGE_REQUEST = 604;
+        AUTHORIZATION_CHALLENGE_RESPONSE = 605;
+        AUTHORIZATION_CHALLENGE_SUBMIT = 606;
+        AUTHORIZATION_CHALLENGE_RESULT = 607;
+
+        PING_REQUEST = 700;
+        PING_RESPONSE = 701;
+
+        // Consensus service messages
+        CONSENSUS_REGISTER_REQUEST = 800;
+        CONSENSUS_REGISTER_RESPONSE = 801;
+
+        CONSENSUS_SEND_TO_REQUEST = 802;
+        CONSENSUS_SEND_TO_RESPONSE = 803;
+        CONSENSUS_BROADCAST_REQUEST = 804;
+        CONSENSUS_BROADCAST_RESPONSE = 805;
+
+        CONSENSUS_INITIALIZE_BLOCK_REQUEST = 806;
+        CONSENSUS_INITIALIZE_BLOCK_RESPONSE = 807;
+        CONSENSUS_FINALIZE_BLOCK_REQUEST = 808;
+        CONSENSUS_FINALIZE_BLOCK_RESPONSE = 809;
+        CONSENSUS_SUMMARIZE_BLOCK_REQUEST = 828;
+        CONSENSUS_SUMMARIZE_BLOCK_RESPONSE = 829;
+        CONSENSUS_CANCEL_BLOCK_REQUEST = 810;
+        CONSENSUS_CANCEL_BLOCK_RESPONSE = 811;
+
+        CONSENSUS_CHECK_BLOCKS_REQUEST = 812;
+        CONSENSUS_CHECK_BLOCKS_RESPONSE = 813;
+        CONSENSUS_COMMIT_BLOCK_REQUEST = 814;
+        CONSENSUS_COMMIT_BLOCK_RESPONSE = 815;
+        CONSENSUS_IGNORE_BLOCK_REQUEST = 816;
+        CONSENSUS_IGNORE_BLOCK_RESPONSE = 817;
+        CONSENSUS_FAIL_BLOCK_REQUEST = 818;
+        CONSENSUS_FAIL_BLOCK_RESPONSE = 819;
+
+        CONSENSUS_SETTINGS_GET_REQUEST = 820;
+        CONSENSUS_SETTINGS_GET_RESPONSE = 821;
+        CONSENSUS_STATE_GET_REQUEST = 822;
+        CONSENSUS_STATE_GET_RESPONSE = 823;
+        CONSENSUS_BLOCKS_GET_REQUEST = 824;
+        CONSENSUS_BLOCKS_GET_RESPONSE = 825;
+        CONSENSUS_CHAIN_HEAD_GET_REQUEST = 826;
+        CONSENSUS_CHAIN_HEAD_GET_RESPONSE = 827;
+
+        // Consensus notification messages
+        CONSENSUS_NOTIFY_PEER_CONNECTED = 900;
+        CONSENSUS_NOTIFY_PEER_DISCONNECTED = 901;
+        CONSENSUS_NOTIFY_PEER_MESSAGE = 902;
+
+        CONSENSUS_NOTIFY_BLOCK_NEW = 903;
+        CONSENSUS_NOTIFY_BLOCK_VALID = 904;
+        CONSENSUS_NOTIFY_BLOCK_INVALID = 905;
+        CONSENSUS_NOTIFY_BLOCK_COMMIT = 906;
+
+        CONSENSUS_NOTIFY_ENGINE_ACTIVATED = 907;
+        CONSENSUS_NOTIFY_ENGINE_DEACTIVATED = 908;
+
+        CONSENSUS_NOTIFY_ACK = 999;
+    }
+    // The type of message, used to determine how to 'route' the message
+    // to the appropriate handler as well as how to deserialize the
+    // content.
+    MessageType message_type = 1;
+
+    // The identifier used to correlate response messages to their related
+    // request messages.  correlation_id should be set to a random string
+    // for messages which are not responses to previously sent messages.  For
+    // response messages, correlation_id should be set to the same string as
+    // contained in the request message.
+    string correlation_id = 2;
+
+    // The content of the message, defined by message_type.  In many
+    // cases, this data has been serialized with Protocol Buffers or
+    // CBOR.
+    bytes content = 3;
+
+}

--- a/libsawtooth/src/protos/mod.rs
+++ b/libsawtooth/src/protos/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Cargill Incorporated
+// Copyright 2018 Bitwise IO, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "lmdb-store")]
-#[macro_use]
-extern crate log;
-
-#[cfg(feature = "validator-internals")]
-pub mod hashlib;
-#[cfg(feature = "validator-internals")]
-pub mod journal;
-#[cfg(feature = "stores")]
-pub mod store;
-pub mod protos;
+include!(concat!(env!("OUT_DIR"), "/protos/mod.rs"));


### PR DESCRIPTION
This PR starts moving protos to libsawtooth. The protos are currently copied into the libsawtooth/proto directory. This will be required when it is published and moved out to its own repo.

Currenlty the following protos files are included:
        batch
	block
	consensus
	events
	setting
	transaction
	transaction_receipt
        validator