### PR TITLE
Moves transaction and batch structs to libsawtooth

### DIFF
--- a/libsawtooth/src/batch.rs
+++ b/libsawtooth/src/batch.rs
@@ -15,20 +15,30 @@
  * ------------------------------------------------------------------------------
  */
 
-use proto;
 use protobuf;
 
-use sawtooth::batch::Batch;
-use sawtooth::transaction::Transaction;
+use crate::protos;
+use crate::transaction::Transaction;
 
-impl From<Batch> for proto::batch::Batch {
+#[derive(Clone, Debug, PartialEq)]
+pub struct Batch {
+    pub header_signature: String,
+    pub transactions: Vec<Transaction>,
+    pub signer_public_key: String,
+    pub transaction_ids: Vec<String>,
+    pub trace: bool,
+
+    pub header_bytes: Vec<u8>,
+}
+
+impl From<Batch> for protos::batch::Batch {
     fn from(batch: Batch) -> Self {
-        let mut proto_batch = proto::batch::Batch::new();
+        let mut proto_batch = protos::batch::Batch::new();
         proto_batch.set_transactions(protobuf::RepeatedField::from_vec(
             batch
                 .transactions
                 .into_iter()
-                .map(proto::transaction::Transaction::from)
+                .map(protos::transaction::Transaction::from)
                 .collect(),
         ));
         proto_batch.set_header_signature(batch.header_signature);
@@ -37,9 +47,9 @@ impl From<Batch> for proto::batch::Batch {
     }
 }
 
-impl From<proto::batch::Batch> for Batch {
-    fn from(mut proto_batch: proto::batch::Batch) -> Batch {
-        let mut batch_header: proto::batch::BatchHeader =
+impl From<protos::batch::Batch> for Batch {
+    fn from(mut proto_batch: protos::batch::Batch) -> Batch {
+        let mut batch_header: protos::batch::BatchHeader =
             protobuf::parse_from_bytes(proto_batch.get_header())
                 .expect("Unable to parse BatchHeader bytes");
 

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -24,6 +24,8 @@ pub mod execution;
 pub mod hashlib;
 #[cfg(feature = "validator-internals")]
 pub mod journal;
+pub mod protos;
 #[cfg(feature = "stores")]
 pub mod store;
-pub mod protos;
+#[cfg(feature = "validator-internals")]
+pub mod transaction;

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -21,6 +21,8 @@ pub mod consensus;
 #[cfg(feature = "validator-internals")]
 pub mod execution;
 #[cfg(feature = "validator-internals")]
+pub mod batch;
+#[cfg(feature = "validator-internals")]
 pub mod hashlib;
 #[cfg(feature = "validator-internals")]
 pub mod journal;

--- a/libsawtooth/src/transaction.rs
+++ b/libsawtooth/src/transaction.rs
@@ -15,13 +15,30 @@
  * ------------------------------------------------------------------------------
  */
 
-use sawtooth::transaction::Transaction;
+use protobuf;
 
-use proto;
+use crate::protos;
 
-impl From<Transaction> for proto::transaction::Transaction {
+#[derive(Clone, Debug, PartialEq)]
+pub struct Transaction {
+    pub header_signature: String,
+    pub payload: Vec<u8>,
+    pub batcher_public_key: String,
+    pub dependencies: Vec<String>,
+    pub family_name: String,
+    pub family_version: String,
+    pub inputs: Vec<String>,
+    pub outputs: Vec<String>,
+    pub nonce: String,
+    pub payload_sha512: String,
+    pub signer_public_key: String,
+
+    pub header_bytes: Vec<u8>,
+}
+
+impl From<Transaction> for protos::transaction::Transaction {
     fn from(other: Transaction) -> Self {
-        let mut proto_transaction = proto::transaction::Transaction::new();
+        let mut proto_transaction = protos::transaction::Transaction::new();
         proto_transaction.set_payload(other.payload);
         proto_transaction.set_header_signature(other.header_signature);
         proto_transaction.set_header(other.header_bytes);
@@ -29,9 +46,9 @@ impl From<Transaction> for proto::transaction::Transaction {
     }
 }
 
-impl From<proto::transaction::Transaction> for Transaction {
-    fn from(mut proto_txn: proto::transaction::Transaction) -> Self {
-        let mut txn_header: proto::transaction::TransactionHeader =
+impl From<protos::transaction::Transaction> for Transaction {
+    fn from(mut proto_txn: protos::transaction::Transaction) -> Self {
+        let mut txn_header: protos::transaction::TransactionHeader =
             protobuf::parse_from_bytes(proto_txn.get_header())
                 .expect("Unable to parse TransactionHeader bytes");
 

--- a/validator/src/batch.rs
+++ b/validator/src/batch.rs
@@ -18,7 +18,7 @@
 use proto;
 use protobuf;
 
-use transaction::Transaction;
+use sawtooth::transaction::Transaction;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Batch {

--- a/validator/src/batch_ffi.rs
+++ b/validator/src/batch_ffi.rs
@@ -15,44 +15,25 @@
  * ------------------------------------------------------------------------------
  */
 
-use cpython;
-use cpython::FromPyObject;
-use cpython::ObjectProtocol;
-use cpython::PythonObject;
-use cpython::ToPyObject;
+use cpython::{self, ObjectProtocol, Python, PythonObject, ToPyObject};
 use protobuf::Message;
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, protos, transaction::Transaction};
 
-use batch::Batch;
-use proto;
+use crate::py_object_wrapper::PyObjectWrapper;
 
-impl ToPyObject for Batch {
-    type ObjectType = cpython::PyObject;
+impl From<Batch> for PyObjectWrapper {
+    fn from(native_batch: Batch) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
 
-    fn to_py_object(&self, py: cpython::Python) -> Self::ObjectType {
-        let mut rust_batch = proto::batch::Batch::new();
-        rust_batch.set_header(self.header_bytes.clone());
-        let proto_txns = self
-            .transactions
-            .iter()
-            .map(|txn| {
-                let mut proto_txn = proto::transaction::Transaction::new();
-                proto_txn.set_header(txn.header_bytes.clone());
-                proto_txn.set_header_signature(txn.header_signature.clone());
-                proto_txn.set_payload(txn.payload.clone());
-                proto_txn
-            })
-            .collect::<Vec<_>>();
-        rust_batch.set_transactions(::protobuf::RepeatedField::from_vec(proto_txns));
-        rust_batch.set_trace(self.trace);
-        rust_batch.set_header_signature(self.header_signature.clone());
-
+        let batch_proto = protos::batch::Batch::from(native_batch);
         let batch_pb2 = py
             .import("sawtooth_validator.protobuf.batch_pb2")
             .expect("unable for python to import sawtooth_validator.protobuf.batch_pb2");
         let batch = batch_pb2
             .call(py, "Batch", cpython::NoArgs, None)
             .expect("No Batch in batch_pb2");
+
         batch
             .call_method(
                 py,
@@ -60,72 +41,60 @@ impl ToPyObject for Batch {
                 cpython::PyTuple::new(
                     py,
                     &[
-                        cpython::PyBytes::new(py, &rust_batch.write_to_bytes().unwrap())
+                        cpython::PyBytes::new(py, &batch_proto.write_to_bytes().unwrap())
                             .into_object(),
                     ],
                 ),
                 None,
             )
             .unwrap();
-        batch
+        PyObjectWrapper::new(batch)
     }
 }
 
-impl<'source> FromPyObject<'source> for Batch {
-    fn extract(py: cpython::Python, obj: &'source cpython::PyObject) -> cpython::PyResult<Self> {
-        let batch_bytes = obj
+impl From<PyObjectWrapper> for Batch {
+    fn from(py_object_wrapper: PyObjectWrapper) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let py_obj = py_object_wrapper.to_py_object(py);
+
+        let bytes: Vec<u8> = py_obj
             .call_method(py, "SerializeToString", cpython::NoArgs, None)
-            .unwrap()
-            .extract::<Vec<u8>>(py)
-            .unwrap();
-        let mut proto_batch: proto::batch::Batch =
-            ::protobuf::parse_from_bytes(batch_bytes.as_slice()).unwrap();
-        let mut proto_batch_header: proto::batch::BatchHeader =
-            ::protobuf::parse_from_bytes(proto_batch.get_header()).unwrap();
-        Ok(Batch {
+            .expect("Unable to serialize PyObject to string")
+            .extract(py)
+            .expect("Unable to extract bytes from PyObject string");
+
+        let mut proto_batch: protos::batch::Batch = protobuf::parse_from_bytes(&bytes)
+            .expect("Unable to parse protobuf bytes from python protobuf object");
+        let mut batch_header: protos::batch::BatchHeader =
+            protobuf::parse_from_bytes(proto_batch.get_header())
+                .expect("Unable to parse protobuf bytes from python protobuf object");
+
+        Batch {
             header_signature: proto_batch.take_header_signature(),
             header_bytes: proto_batch.take_header(),
-            transactions: proto_batch
-                .transactions
-                .iter_mut()
-                .map(|t| {
-                    let mut proto_header: proto::transaction::TransactionHeader =
-                        ::protobuf::parse_from_bytes(t.get_header()).unwrap();
-                    Ok(Transaction {
-                        header_signature: t.take_header_signature(),
-                        header_bytes: t.take_header(),
-                        payload: t.take_payload(),
-                        batcher_public_key: proto_header.take_batcher_public_key(),
-                        dependencies: proto_header.take_dependencies().to_vec(),
-                        family_name: proto_header.take_family_name(),
-                        family_version: proto_header.take_family_version(),
-                        inputs: proto_header.take_inputs().to_vec(),
-                        outputs: proto_header.take_outputs().to_vec(),
-                        nonce: proto_header.take_nonce(),
-                        payload_sha512: proto_header.take_payload_sha512(),
-                        signer_public_key: proto_header.take_signer_public_key(),
-                    })
-                })
-                .collect::<cpython::PyResult<Vec<_>>>()?,
-            signer_public_key: proto_batch_header.take_signer_public_key(),
-            transaction_ids: proto_batch_header.take_transaction_ids().to_vec(),
+            signer_public_key: batch_header.take_signer_public_key(),
+            transaction_ids: batch_header.take_transaction_ids().into_vec(),
             trace: proto_batch.get_trace(),
-        })
+
+            transactions: proto_batch
+                .take_transactions()
+                .into_iter()
+                .map(Transaction::from)
+                .collect(),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use super::Batch;
-    use cpython;
-    use cpython::ToPyObject;
-    use proto;
     use protobuf::Message;
-    use sawtooth::transaction::Transaction;
+    use py_object_wrapper::PyObjectWrapper;
+    use sawtooth::{batch::Batch, protos, transaction::Transaction};
 
     fn create_batch() -> Batch {
-        let mut batch_header = proto::batch::BatchHeader::new();
+        let mut batch_header = protos::batch::BatchHeader::new();
         batch_header.set_signer_public_key("C".into());
         batch_header.set_transaction_ids(::protobuf::RepeatedField::from_vec(vec!["B".into()]));
         Batch {
@@ -140,7 +109,7 @@ mod tests {
     }
 
     fn create_txn() -> Transaction {
-        let mut txn_header = proto::transaction::TransactionHeader::new();
+        let mut txn_header = protos::transaction::TransactionHeader::new();
         txn_header.set_batcher_public_key("C".into());
         txn_header.set_dependencies(::protobuf::RepeatedField::from_vec(vec!["D".into()]));
         txn_header.set_family_name("test".into());
@@ -170,11 +139,9 @@ mod tests {
 
     #[test]
     fn test_basic() {
-        let gil = cpython::Python::acquire_gil();
-        let py = gil.python();
-
         let batch = create_batch();
-        let resulting_batch = batch.to_py_object(py).extract::<Batch>(py).unwrap();
-        assert_eq!(batch, resulting_batch);
+        let py_obj_wrapper = PyObjectWrapper::from(batch.clone());
+        let extracted_batch = Batch::from(py_obj_wrapper);
+        assert_eq!(batch, extracted_batch);
     }
 }

--- a/validator/src/batch_ffi.rs
+++ b/validator/src/batch_ffi.rs
@@ -21,10 +21,10 @@ use cpython::ObjectProtocol;
 use cpython::PythonObject;
 use cpython::ToPyObject;
 use protobuf::Message;
+use sawtooth::transaction::Transaction;
 
 use batch::Batch;
 use proto;
-use transaction::Transaction;
 
 impl ToPyObject for Batch {
     type ObjectType = cpython::PyObject;
@@ -122,7 +122,7 @@ mod tests {
     use cpython::ToPyObject;
     use proto;
     use protobuf::Message;
-    use transaction::Transaction;
+    use sawtooth::transaction::Transaction;
 
     fn create_batch() -> Batch {
         let mut batch_header = proto::batch::BatchHeader::new();

--- a/validator/src/block.rs
+++ b/validator/src/block.rs
@@ -15,9 +15,9 @@
  * ------------------------------------------------------------------------------
  */
 
-use batch::Batch;
 use proto;
 use protobuf;
+use sawtooth::batch::Batch;
 use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Default)]

--- a/validator/src/block_ffi.rs
+++ b/validator/src/block_ffi.rs
@@ -15,9 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, transaction::Transaction};
 
-use batch::Batch;
 use block::Block;
 use cpython;
 use cpython::{FromPyObject, ObjectProtocol, PyObject, Python, PythonObject, ToPyObject};

--- a/validator/src/block_ffi.rs
+++ b/validator/src/block_ffi.rs
@@ -14,6 +14,9 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+
+use sawtooth::transaction::Transaction;
+
 use batch::Batch;
 use block::Block;
 use cpython;
@@ -26,7 +29,6 @@ use proto::transaction::Transaction as ProtoTxn;
 use proto::transaction::TransactionHeader;
 use protobuf;
 use protobuf::Message;
-use transaction::Transaction;
 
 impl<'source> FromPyObject<'source> for Block {
     fn extract(py: Python, obj: &'source PyObject) -> cpython::PyResult<Self> {

--- a/validator/src/gossip/permission_verifier.rs
+++ b/validator/src/gossip/permission_verifier.rs
@@ -16,8 +16,9 @@
  */
 
 use cpython::{self, ObjectProtocol, PyClone};
+use sawtooth::batch::Batch;
 
-use batch::Batch;
+use crate::py_object_wrapper::PyObjectWrapper;
 
 pub trait PermissionVerifier: Sync + Send {
     fn is_batch_signer_authorized(&self, batch: &Batch, state_root: &str) -> bool;
@@ -38,8 +39,15 @@ impl PermissionVerifier for PyPermissionVerifier {
         let gil = cpython::Python::acquire_gil();
         let py = gil.python();
 
+        let batch_wrapper = PyObjectWrapper::from(batch.clone());
+
         self.verifier
-            .call_method(py, "is_batch_signer_authorized", (batch, state_root), None)
+            .call_method(
+                py,
+                "is_batch_signer_authorized",
+                (batch_wrapper, state_root),
+                None,
+            )
             .expect("PermissionVerifier has no method `is_batch_signer_authorized`")
             .extract(py)
             .expect("Unable to extract bool from `is_batch_signer_authorized`")

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -25,10 +25,9 @@ use std::sync::{
 use std::thread;
 use std::time::Duration;
 
-use sawtooth::execution::execution_platform::NULL_STATE_HASH;
+use sawtooth::{batch::Batch, execution::execution_platform::NULL_STATE_HASH};
 use uluru;
 
-use batch::Batch;
 use block::Block;
 use execution::execution_platform::ExecutionPlatform;
 use gossip::permission_verifier::PermissionVerifier;

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -25,10 +25,10 @@ use cpython::PyClone;
 use cpython::Python;
 
 use sawtooth::hashlib::sha256_digest_strs;
+use sawtooth::transaction::Transaction;
 
 use batch::Batch;
 use block::Block;
-use transaction::Transaction;
 
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::commit_store::CommitStore;

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -36,6 +36,7 @@ use std::time::Duration;
 
 use protobuf;
 use sawtooth::{
+    batch::Batch,
     consensus::registry::ConsensusRegistry,
     journal::{
         chain::COMMIT_STORE, chain_id_manager::ChainIdManager, fork_cache::ForkCache,
@@ -43,7 +44,6 @@ use sawtooth::{
     },
 };
 
-use batch::Batch;
 use block::Block;
 use consensus::notifier::ConsensusNotifier;
 use execution::execution_platform::ExecutionPlatform;

--- a/validator/src/journal/chain_commit_state.rs
+++ b/validator/src/journal/chain_commit_state.rs
@@ -17,9 +17,8 @@
 
 use std::collections::HashSet;
 
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, transaction::Transaction};
 
-use batch::Batch;
 use journal::block_manager::BlockManager;
 use journal::commit_store::CommitStore;
 

--- a/validator/src/journal/chain_commit_state.rs
+++ b/validator/src/journal/chain_commit_state.rs
@@ -17,10 +17,11 @@
 
 use std::collections::HashSet;
 
+use sawtooth::transaction::Transaction;
+
 use batch::Batch;
 use journal::block_manager::BlockManager;
 use journal::commit_store::CommitStore;
-use transaction::Transaction;
 
 #[derive(Debug, PartialEq)]
 pub enum ChainCommitStateError {
@@ -173,7 +174,7 @@ mod test {
     use super::*;
     use block::Block;
     use journal::block_store::InMemoryBlockStore;
-    use transaction::Transaction;
+    use sawtooth::transaction::Transaction;
 
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;
 

--- a/validator/src/journal/chain_head_lock.rs
+++ b/validator/src/journal/chain_head_lock.rs
@@ -1,4 +1,5 @@
-use batch::Batch;
+use sawtooth::batch::Batch;
+
 use block::Block;
 use journal::publisher::{BlockPublisherState, SyncBlockPublisher};
 use std::sync::RwLockWriteGuard;

--- a/validator/src/journal/commit_store.rs
+++ b/validator/src/journal/commit_store.rs
@@ -18,6 +18,7 @@
 use proto::block::{Block as ProtoBlock, BlockHeader};
 use protobuf;
 use protobuf::Message;
+use sawtooth::transaction::Transaction;
 
 use batch::Batch;
 use block::Block;
@@ -29,7 +30,6 @@ use journal::block_store::{
     BatchIndex, BlockStore, BlockStoreError, IndexedBlockStore, TransactionIndex,
 };
 use journal::chain::{ChainReadError, ChainReader};
-use transaction::Transaction;
 
 /// Contains all committed blocks for the current chain
 #[derive(Clone)]

--- a/validator/src/journal/commit_store.rs
+++ b/validator/src/journal/commit_store.rs
@@ -18,9 +18,8 @@
 use proto::block::{Block as ProtoBlock, BlockHeader};
 use protobuf;
 use protobuf::Message;
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, transaction::Transaction};
 
-use batch::Batch;
 use block::Block;
 use database::error::DatabaseError;
 use database::lmdb::DatabaseReader;

--- a/validator/src/journal/commit_store_ffi.rs
+++ b/validator/src/journal/commit_store_ffi.rs
@@ -20,6 +20,7 @@ use std::os::raw::{c_char, c_void};
 use std::slice;
 
 use protobuf;
+use sawtooth::transaction::Transaction;
 
 use batch::Batch;
 use block::Block;
@@ -27,7 +28,6 @@ use database::error::DatabaseError;
 use database::lmdb::LmdbDatabase;
 use journal::commit_store::{ByHeightDirection, CommitStore, CommitStoreByHeightIterator};
 use proto;
-use transaction::Transaction;
 
 #[repr(u32)]
 #[derive(Debug)]

--- a/validator/src/journal/commit_store_ffi.rs
+++ b/validator/src/journal/commit_store_ffi.rs
@@ -20,9 +20,8 @@ use std::os::raw::{c_char, c_void};
 use std::slice;
 
 use protobuf;
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, transaction::Transaction};
 
-use batch::Batch;
 use block::Block;
 use database::error::DatabaseError;
 use database::lmdb::LmdbDatabase;

--- a/validator/src/journal/incoming_batch_queue_ffi.rs
+++ b/validator/src/journal/incoming_batch_queue_ffi.rs
@@ -19,8 +19,9 @@ use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 
 use cpython::{PyObject, Python};
+use sawtooth::batch::Batch;
 
-use batch::Batch;
+use crate::py_object_wrapper::PyObjectWrapper;
 use journal::publisher::IncomingBatchSender;
 
 macro_rules! check_null {
@@ -49,13 +50,8 @@ pub unsafe extern "C" fn incoming_batch_sender_send(
     let py = gil.python();
     let batch: Batch = {
         let pyobj = PyObject::from_borrowed_ptr(py, pyobj_ptr);
-
-        match pyobj.extract(py) {
-            Ok(batch) => batch,
-            Err(_) => {
-                return ErrorCode::InvalidInput;
-            }
-        }
+        let py_wrapper = PyObjectWrapper::new(pyobj);
+        Batch::from(py_wrapper)
     };
 
     let mut sender = (*(sender_ptr as *mut IncomingBatchSender)).clone();

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -17,7 +17,6 @@
 
 #![allow(unknown_lints)]
 
-use batch::Batch;
 use block::Block;
 
 use cpython::{NoArgs, ObjectProtocol, PyClone, PyDict, PyList, PyObject, Python};
@@ -30,6 +29,9 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::Duration;
 
+use sawtooth::batch::Batch;
+
+use crate::py_object_wrapper::PyObjectWrapper;
 use execution::execution_platform::ExecutionPlatform;
 use ffi::py_import_class;
 use journal::block_manager::{BlockManager, BlockRef};
@@ -461,8 +463,10 @@ impl SyncBlockPublisher {
             let gil = Python::acquire_gil();
             let py = gil.python();
 
+            let batch_wrapper = PyObjectWrapper::from(batch.clone());
+
             self.permission_verifier
-                .call_method(py, "is_batch_signer_authorized", (batch.clone(),), None)
+                .call_method(py, "is_batch_signer_authorized", (batch_wrapper,), None)
                 .expect("PermissionVerifier has no method is_batch_signer_authorized")
                 .extract(py)
                 .expect("PermissionVerifier.is_batch_signer_authorized did not return bool")

--- a/validator/src/journal/validation_rule_enforcer.rs
+++ b/validator/src/journal/validation_rule_enforcer.rs
@@ -15,9 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
-use sawtooth::transaction::Transaction;
+use sawtooth::{batch::Batch, transaction::Transaction};
 
-use batch::Batch;
 use state::settings_view::SettingsView;
 
 /// Retrieve the validation rules stored in state and check that the
@@ -231,8 +230,7 @@ fn parse_rule(rule: &str) -> Option<(&str, Vec<&str>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use batch::Batch;
-    use sawtooth::transaction::Transaction;
+    use sawtooth::{batch::Batch, transaction::Transaction};
 
     /// Test that if no validation rules are set, the block is valid.
     #[test]

--- a/validator/src/journal/validation_rule_enforcer.rs
+++ b/validator/src/journal/validation_rule_enforcer.rs
@@ -15,9 +15,10 @@
  * ------------------------------------------------------------------------------
  */
 
+use sawtooth::transaction::Transaction;
+
 use batch::Batch;
 use state::settings_view::SettingsView;
-use transaction::Transaction;
 
 /// Retrieve the validation rules stored in state and check that the
 /// given batches do not violate any of those rules. These rules include:
@@ -231,7 +232,7 @@ fn parse_rule(rule: &str) -> Option<(&str, Vec<&str>)> {
 mod tests {
     use super::*;
     use batch::Batch;
-    use transaction::Transaction;
+    use sawtooth::transaction::Transaction;
 
     /// Test that if no validation rules are set, the block is valid.
     #[test]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) mod gossip;
 pub(crate) mod journal;
 mod metrics;
 pub(crate) mod proto;
+pub(crate) mod py_object_wrapper;
 pub(crate) mod pylogger;
 pub(crate) mod scheduler;
 pub(crate) mod state;

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -42,11 +42,11 @@ pub(crate) mod proto;
 pub(crate) mod pylogger;
 pub(crate) mod scheduler;
 pub(crate) mod state;
+pub(crate) mod transaction;
 
 pub(crate) mod batch;
 mod batch_ffi;
 pub(crate) mod block;
 mod block_ffi;
-pub(crate) mod transaction;
 
 pub(crate) mod ffi;

--- a/validator/src/py_object_wrapper.rs
+++ b/validator/src/py_object_wrapper.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use cpython::{PyObject, Python, ToPyObject};
+
+pub struct PyObjectWrapper {
+    pub py_object: PyObject,
+}
+
+impl PyObjectWrapper {
+    pub fn new(py_object: PyObject) -> Self {
+        PyObjectWrapper { py_object }
+    }
+}
+
+impl ToPyObject for PyObjectWrapper {
+    type ObjectType = PyObject;
+
+    fn to_py_object(&self, py: Python) -> PyObject {
+        self.py_object
+            .extract::<PyObject>(py)
+            .expect("Unable to get PyObject")
+    }
+}

--- a/validator/src/scheduler/mod.rs
+++ b/validator/src/scheduler/mod.rs
@@ -15,11 +15,12 @@
  * ------------------------------------------------------------------------------
  */
 
+use sawtooth::batch::Batch;
+
 use proto::events::Event;
 use proto::transaction_receipt::StateChange;
 
 mod execution_result_ffi;
-use batch::Batch;
 
 pub mod py_scheduler;
 

--- a/validator/src/scheduler/py_scheduler.rs
+++ b/validator/src/scheduler/py_scheduler.rs
@@ -19,12 +19,13 @@ use cpython;
 use cpython::ObjectProtocol;
 use cpython::PyResult;
 
-use batch::Batch;
-
 use protobuf::ProtobufError;
+use sawtooth::batch::Batch;
 
 use scheduler::execution_result_ffi::{PyBatchExecutionResult, PyTxnExecutionResult};
 use scheduler::{ExecutionResults, Scheduler, SchedulerError};
+
+use crate::py_object_wrapper::PyObjectWrapper;
 
 impl From<ProtobufError> for SchedulerError {
     fn from(other: ProtobufError) -> SchedulerError {
@@ -81,11 +82,13 @@ impl Scheduler for PyScheduler {
         let gil = cpython::Python::acquire_gil();
         let py = gil.python();
 
+        let batch_wrapper = PyObjectWrapper::from(batch);
+
         self.py_scheduler
             .call_method(
                 py,
                 "add_batch",
-                (batch, expected_state_hash, required),
+                (batch_wrapper, expected_state_hash, required),
                 None,
             )
             .expect("No method add_batch on python scheduler");


### PR DESCRIPTION
Involves moving both the `Transaction` and `Batch` structs to libsawtooth, and makes the necessary changes to the validator to refer to this new location. Also creates a new `PyObjectWrapper` object which, appropriately, wraps a PyObject and implements the `ToPyObject` and `FromPyObject` traits in order to function as a go-between for the Batch struct defined in the libsawtooth module and the remaining validator code that still expects to translate this struct into a PyObject.