### PR TITLE
Move Block struct to libsawtooth

### DIFF
--- a/libsawtooth/src/block.rs
+++ b/libsawtooth/src/block.rs
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::fmt;
+
+use protobuf;
+
+use crate::batch::Batch;
+use crate::protos;
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Block {
+    pub header_signature: String,
+    pub batches: Vec<Batch>,
+    pub state_root_hash: String,
+    pub consensus: Vec<u8>,
+    pub batch_ids: Vec<String>,
+    pub signer_public_key: String,
+    pub previous_block_id: String,
+    pub block_num: u64,
+
+    pub header_bytes: Vec<u8>,
+}
+
+impl fmt::Display for Block {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "Block(id: {}, block_num: {}, state_root_hash: {}, previous_block_id: {})",
+            self.header_signature, self.block_num, self.state_root_hash, self.previous_block_id
+        )
+    }
+}
+
+impl From<Block> for protos::block::Block {
+    fn from(other: Block) -> Self {
+        let mut proto_block = protos::block::Block::new();
+        proto_block.set_batches(protobuf::RepeatedField::from_vec(
+            other
+                .batches
+                .into_iter()
+                .map(protos::batch::Batch::from)
+                .collect(),
+        ));
+        proto_block.set_header_signature(other.header_signature);
+        proto_block.set_header(other.header_bytes);
+        proto_block
+    }
+}
+
+impl From<protos::block::Block> for Block {
+    fn from(mut proto_block: protos::block::Block) -> Self {
+        let mut block_header: protos::block::BlockHeader =
+            protobuf::parse_from_bytes(proto_block.get_header())
+                .expect("Unable to parse BlockHeader bytes");
+
+        Block {
+            header_signature: proto_block.take_header_signature(),
+            header_bytes: proto_block.take_header(),
+            state_root_hash: block_header.take_state_root_hash(),
+            consensus: block_header.take_consensus(),
+            batch_ids: block_header.take_batch_ids().into_vec(),
+            signer_public_key: block_header.take_signer_public_key(),
+            previous_block_id: block_header.take_previous_block_id(),
+            block_num: block_header.get_block_num(),
+
+            batches: proto_block
+                .take_batches()
+                .into_iter()
+                .map(Batch::from)
+                .collect(),
+        }
+    }
+}

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -19,6 +19,8 @@ extern crate log;
 #[cfg(feature = "validator-internals")]
 pub mod batch;
 #[cfg(feature = "validator-internals")]
+pub mod block;
+#[cfg(feature = "validator-internals")]
 pub mod consensus;
 #[cfg(feature = "validator-internals")]
 pub mod execution;

--- a/validator/src/block.rs
+++ b/validator/src/block.rs
@@ -17,32 +17,8 @@
 
 use proto;
 use protobuf;
-use sawtooth::batch::Batch;
-use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, Default)]
-pub struct Block {
-    pub header_signature: String,
-    pub batches: Vec<Batch>,
-    pub state_root_hash: String,
-    pub consensus: Vec<u8>,
-    pub batch_ids: Vec<String>,
-    pub signer_public_key: String,
-    pub previous_block_id: String,
-    pub block_num: u64,
-
-    pub header_bytes: Vec<u8>,
-}
-
-impl fmt::Display for Block {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Block(id: {}, block_num: {}, state_root_hash: {}, previous_block_id: {})",
-            self.header_signature, self.block_num, self.state_root_hash, self.previous_block_id
-        )
-    }
-}
+use sawtooth::{batch::Batch, block::Block};
 
 impl From<Block> for proto::block::Block {
     fn from(other: Block) -> Self {

--- a/validator/src/block_ffi.rs
+++ b/validator/src/block_ffi.rs
@@ -14,26 +14,29 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-
-use sawtooth::{batch::Batch, transaction::Transaction};
-
-use block::Block;
+use crate::py_object_wrapper::PyObjectWrapper;
 use cpython;
-use cpython::{FromPyObject, ObjectProtocol, PyObject, Python, PythonObject, ToPyObject};
-use proto::batch::Batch as ProtoBatch;
-use proto::batch::BatchHeader;
-use proto::block::Block as ProtoBlock;
-use proto::block::BlockHeader;
-use proto::transaction::Transaction as ProtoTxn;
-use proto::transaction::TransactionHeader;
+use cpython::{ObjectProtocol, Python, PythonObject, ToPyObject};
 use protobuf;
 use protobuf::Message;
 
-impl<'source> FromPyObject<'source> for Block {
-    fn extract(py: Python, obj: &'source PyObject) -> cpython::PyResult<Self> {
-        let bytes: Vec<u8> = obj
-            .call_method(py, "SerializeToString", cpython::NoArgs, None)?
-            .extract(py)?;
+use sawtooth::{
+    batch::Batch,
+    block::Block,
+    protos::block::{Block as ProtoBlock, BlockHeader},
+};
+
+impl From<PyObjectWrapper> for Block {
+    fn from(py_object_wrapper: PyObjectWrapper) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let py_obj = py_object_wrapper.to_py_object(py);
+
+        let bytes: Vec<u8> = py_obj
+            .call_method(py, "SerializeToString", cpython::NoArgs, None)
+            .expect("Unable to serialize PyObject")
+            .extract(py)
+            .expect("Unable to extract bytes from PyObject");
 
         let mut proto_block: ProtoBlock = protobuf::parse_from_bytes(&bytes)
             .expect("Unable to parse protobuf bytes from python protobuf object");
@@ -52,107 +55,36 @@ impl<'source> FromPyObject<'source> for Block {
 
             batches: proto_block
                 .take_batches()
-                .iter_mut()
-                .map(proto_batch_to_batch)
+                .into_iter()
+                .map(Batch::from)
                 .collect(),
         };
 
-        Ok(block)
+        block
     }
 }
 
-fn proto_batch_to_batch(proto_batch: &mut ProtoBatch) -> Batch {
-    let mut batch_header: BatchHeader = protobuf::parse_from_bytes(proto_batch.get_header())
-        .expect("Unable to parse protobuf bytes from python protobuf object");
-    Batch {
-        header_signature: proto_batch.take_header_signature(),
-        header_bytes: proto_batch.take_header(),
-        signer_public_key: batch_header.take_signer_public_key(),
-        transaction_ids: batch_header.take_transaction_ids().into_vec(),
-        trace: proto_batch.get_trace(),
+impl From<Block> for PyObjectWrapper {
+    fn from(native_block: Block) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
 
-        transactions: proto_batch
-            .take_transactions()
-            .iter_mut()
-            .map(proto_txn_to_txn)
-            .collect(),
-    }
-}
-
-fn proto_txn_to_txn(proto_txn: &mut ProtoTxn) -> Transaction {
-    let mut txn_header: TransactionHeader = protobuf::parse_from_bytes(proto_txn.get_header())
-        .expect("Unable to parse protobuf bytes from python protobuf object");
-
-    Transaction {
-        header_signature: proto_txn.take_header_signature(),
-        header_bytes: proto_txn.take_header(),
-        payload: proto_txn.take_payload(),
-        batcher_public_key: txn_header.take_batcher_public_key(),
-        dependencies: txn_header.take_dependencies().into_vec(),
-        family_name: txn_header.take_family_name(),
-        family_version: txn_header.take_family_version(),
-        inputs: txn_header.take_inputs().into_vec(),
-        outputs: txn_header.take_outputs().into_vec(),
-        nonce: txn_header.take_nonce(),
-        payload_sha512: txn_header.take_payload_sha512(),
-        signer_public_key: txn_header.take_signer_public_key(),
-    }
-}
-
-impl ToPyObject for Block {
-    type ObjectType = PyObject;
-
-    fn to_py_object(&self, py: Python) -> PyObject {
-        let block_protobuf_mod = py
+        let block_proto = ProtoBlock::from(native_block);
+        let block_pb2 = py
             .import("sawtooth_validator.protobuf.block_pb2")
             .expect("Unable to import block_pb2");
-        let py_block = block_protobuf_mod
-            .get(py, "Block")
+        let block = block_pb2
+            .call(py, "Block", cpython::NoArgs, None)
             .expect("Unable to get Block");
 
-        let mut proto_block = ProtoBlock::new();
-        proto_block.set_header(self.header_bytes.clone());
-        proto_block.set_header_signature(self.header_signature.clone());
-
-        let proto_batches = self
-            .batches
-            .iter()
-            .map(|batch| {
-                let mut proto_batch = ProtoBatch::new();
-                proto_batch.set_header(batch.header_bytes.clone());
-                proto_batch.set_header_signature(batch.header_signature.clone());
-
-                let proto_txns = batch
-                    .transactions
-                    .iter()
-                    .map(|txn| {
-                        let mut proto_txn = ProtoTxn::new();
-                        proto_txn.set_header(txn.header_bytes.clone());
-                        proto_txn.set_header_signature(txn.header_signature.clone());
-                        proto_txn.set_payload(txn.payload.clone());
-                        proto_txn
-                    })
-                    .collect::<Vec<_>>();
-
-                proto_batch.set_transactions(protobuf::RepeatedField::from_vec(proto_txns));
-
-                proto_batch
-            })
-            .collect::<Vec<_>>();
-
-        proto_block.set_batches(protobuf::RepeatedField::from_vec(proto_batches));
-
-        let block = py_block
-            .call(py, cpython::NoArgs, None)
-            .expect("Unable to instantiate Block");
         block
             .call_method(
                 py,
                 "ParseFromString",
-                (cpython::PyBytes::new(py, &proto_block.write_to_bytes().unwrap()).into_object(),),
+                (cpython::PyBytes::new(py, &block_proto.write_to_bytes().unwrap()).into_object(),),
                 None,
             )
             .expect("Unable to ParseFromString");
-        block
+        PyObjectWrapper::new(block)
     }
 }

--- a/validator/src/consensus/notifier.rs
+++ b/validator/src/consensus/notifier.rs
@@ -19,11 +19,9 @@ use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use block::Block;
-
 use hex;
 use protobuf::{Message, RepeatedField};
-use sawtooth::hashlib::sha256_digest_strs;
+use sawtooth::{block::Block, hashlib::sha256_digest_strs};
 
 use proto::consensus::{
     ConsensusBlock, ConsensusNotifyBlockCommit, ConsensusNotifyBlockInvalid,

--- a/validator/src/consensus/notifier_ffi.rs
+++ b/validator/src/consensus/notifier_ffi.rs
@@ -22,8 +22,8 @@ use std::slice;
 use cpython::{NoArgs, ObjectProtocol, PyClone, PyObject, Python};
 use protobuf::{self, Message, ProtobufEnum};
 use py_ffi;
+use sawtooth::block::Block;
 
-use block::Block;
 use consensus::notifier::{
     BackgroundConsensusNotifier, ConsensusNotifier, NotifierService, NotifierServiceError,
 };

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -21,9 +21,8 @@ use std::collections::{HashMap, HashSet};
 use std::iter::{FromIterator, Peekable};
 use std::sync::{Arc, RwLock};
 
-use sawtooth::journal::NULL_BLOCK_IDENTIFIER;
+use sawtooth::{block::Block, journal::NULL_BLOCK_IDENTIFIER};
 
-use block::Block;
 use journal::block_store::{BatchIndex, BlockStoreError, IndexedBlockStore, TransactionIndex};
 use metrics;
 
@@ -1142,8 +1141,8 @@ impl Iterator for BranchDiffIterator {
 mod tests {
 
     use super::{BlockManager, BlockManagerError};
-    use block::Block;
     use journal::block_store::InMemoryBlockStore;
+    use sawtooth::block::Block;
 
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;
 

--- a/validator/src/journal/block_manager_ffi.rs
+++ b/validator/src/journal/block_manager_ffi.rs
@@ -20,7 +20,8 @@ use std::mem;
 use std::os::raw::{c_char, c_void};
 use std::slice;
 
-use block::Block;
+use sawtooth::block::Block;
+
 use journal::block_manager::{
     BlockManager, BlockManagerError, BranchDiffIterator, BranchIterator, GetBlockIterator,
 };
@@ -406,11 +407,11 @@ pub unsafe extern "C" fn block_manager_branch_diff_iterator_next(
 #[cfg(test)]
 mod test {
     use super::*;
-    use block::Block;
     use database::lmdb::{LmdbContext, LmdbDatabase};
     use journal::block_store::BlockStore;
     use journal::commit_store::CommitStore;
     use proto::block::BlockHeader;
+    use sawtooth::block::Block;
 
     use protobuf::Message;
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;

--- a/validator/src/journal/block_scheduler.rs
+++ b/validator/src/journal/block_scheduler.rs
@@ -18,9 +18,11 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
-use sawtooth::journal::{chain::COMMIT_STORE, NULL_BLOCK_IDENTIFIER};
+use sawtooth::{
+    block::Block,
+    journal::{chain::COMMIT_STORE, NULL_BLOCK_IDENTIFIER},
+};
 
-use block::Block;
 use journal::block_manager::BlockManager;
 use journal::block_validator::BlockStatusStore;
 use journal::block_wrapper::BlockStatus;

--- a/validator/src/journal/block_store.rs
+++ b/validator/src/journal/block_store.rs
@@ -15,11 +15,10 @@
  * ------------------------------------------------------------------------------
  */
 
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use std::collections::HashMap;
-
-use block::Block;
+use sawtooth::block::Block;
 
 #[derive(Debug)]
 pub enum BlockStoreError {
@@ -247,7 +246,7 @@ impl Iterator for InMemoryIter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use block::Block;
+    use sawtooth::block::Block;
 
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;
 

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -25,10 +25,9 @@ use std::sync::{
 use std::thread;
 use std::time::Duration;
 
-use sawtooth::{batch::Batch, execution::execution_platform::NULL_STATE_HASH};
+use sawtooth::{batch::Batch, block::Block, execution::execution_platform::NULL_STATE_HASH};
 use uluru;
 
-use block::Block;
 use execution::execution_platform::ExecutionPlatform;
 use gossip::permission_verifier::PermissionVerifier;
 use journal::block_scheduler::BlockScheduler;

--- a/validator/src/journal/block_wrapper.rs
+++ b/validator/src/journal/block_wrapper.rs
@@ -15,10 +15,12 @@
  * ------------------------------------------------------------------------------
  */
 
-use block::Block;
 use std::fmt;
 
 use cpython::{self, ObjectProtocol, PyClone, PyObject};
+use sawtooth::block::Block;
+
+use crate::py_object_wrapper::PyObjectWrapper;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockStatus {
@@ -55,11 +57,12 @@ impl BlockWrapper {
     pub fn block(&self) -> Block {
         let gil = cpython::Python::acquire_gil();
         let py = gil.python();
-        self.py_block_wrapper
+        let py_obj = self
+            .py_block_wrapper
             .getattr(py, "block")
-            .expect("Failed to get BlockWrapper.block")
-            .extract(py)
-            .expect("Failed to extract BlockWrapper.block")
+            .expect("Failed to get BlockWrapper.block");
+        let wrapper = PyObjectWrapper::new(py_obj);
+        Block::from(wrapper)
     }
 }
 

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -26,9 +26,7 @@ use cpython::PyList;
 use cpython::Python;
 
 use sawtooth::hashlib::sha256_digest_strs;
-use sawtooth::{batch::Batch, transaction::Transaction};
-
-use block::Block;
+use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
 
 use crate::py_object_wrapper::PyObjectWrapper;
 use journal::chain_commit_state::TransactionCommitCache;
@@ -241,7 +239,12 @@ impl CandidateBlock {
                     let gil = cpython::Python::acquire_gil();
                     let py = gil.python();
                     match injector
-                        .call_method(py, "block_start", (previous_block.clone(),), None)
+                        .call_method(
+                            py,
+                            "block_start",
+                            (PyObjectWrapper::from(previous_block.clone()),),
+                            None,
+                        )
                         .expect("BlockInjector.block_start failed")
                         .extract::<cpython::PyList>(py)
                     {

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -37,6 +37,7 @@ use std::time::Duration;
 use protobuf;
 use sawtooth::{
     batch::Batch,
+    block::Block,
     consensus::registry::ConsensusRegistry,
     journal::{
         chain::COMMIT_STORE, chain_id_manager::ChainIdManager, fork_cache::ForkCache,
@@ -44,7 +45,6 @@ use sawtooth::{
     },
 };
 
-use block::Block;
 use consensus::notifier::ConsensusNotifier;
 use execution::execution_platform::ExecutionPlatform;
 use gossip::permission_verifier::PermissionVerifier;

--- a/validator/src/journal/chain_commit_state.rs
+++ b/validator/src/journal/chain_commit_state.rs
@@ -171,8 +171,8 @@ impl TransactionCommitCache {
 #[cfg(test)]
 mod test {
     use super::*;
-    use block::Block;
     use journal::block_store::InMemoryBlockStore;
+    use sawtooth::block::Block;
     use sawtooth::transaction::Transaction;
 
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -17,7 +17,6 @@
 
 #![allow(unknown_lints)]
 
-use block::Block;
 use consensus::notifier::BackgroundConsensusNotifier;
 use consensus::registry_ffi::PyConsensusRegistry;
 use cpython::{self, ObjectProtocol, PyList, PyObject, Python, PythonObject, ToPyObject};
@@ -32,6 +31,7 @@ use journal::chain_head_lock::ChainHeadLock;
 use journal::commit_store::CommitStore;
 use py_ffi;
 use pylogger;
+use sawtooth::block::Block;
 use state::state_pruning_manager::StatePruningManager;
 use state::state_view_factory::StateViewFactory;
 use std::ffi::CStr;
@@ -45,6 +45,8 @@ use protobuf::{self, Message};
 
 use proto;
 use proto::transaction_receipt::TransactionReceipt;
+
+use py_object_wrapper::PyObjectWrapper;
 
 #[repr(u32)]
 #[derive(Debug)]
@@ -336,8 +338,10 @@ impl ChainObserver for PyChainObserver {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
 
+        let wrapped_block = PyObjectWrapper::from(block.clone());
+
         self.py_observer
-            .call_method(py, "chain_update", (block, receipts), None)
+            .call_method(py, "chain_update", (wrapped_block, receipts), None)
             .map(|_| ())
             .map_err(|py_err| {
                 pylogger::exception(py, "Unable to call observer.chain_update", py_err);

--- a/validator/src/journal/chain_head_lock.rs
+++ b/validator/src/journal/chain_head_lock.rs
@@ -1,6 +1,5 @@
-use sawtooth::batch::Batch;
+use sawtooth::{batch::Batch, block::Block};
 
-use block::Block;
 use journal::publisher::{BlockPublisherState, SyncBlockPublisher};
 use std::sync::RwLockWriteGuard;
 

--- a/validator/src/journal/commit_store.rs
+++ b/validator/src/journal/commit_store.rs
@@ -18,9 +18,8 @@
 use proto::block::{Block as ProtoBlock, BlockHeader};
 use protobuf;
 use protobuf::Message;
-use sawtooth::{batch::Batch, transaction::Transaction};
+use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
 
-use block::Block;
 use database::error::DatabaseError;
 use database::lmdb::DatabaseReader;
 use database::lmdb::LmdbDatabase;

--- a/validator/src/journal/commit_store_ffi.rs
+++ b/validator/src/journal/commit_store_ffi.rs
@@ -20,9 +20,8 @@ use std::os::raw::{c_char, c_void};
 use std::slice;
 
 use protobuf;
-use sawtooth::{batch::Batch, transaction::Transaction};
+use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
 
-use block::Block;
 use database::error::DatabaseError;
 use database::lmdb::LmdbDatabase;
 use journal::commit_store::{ByHeightDirection, CommitStore, CommitStoreByHeightIterator};


### PR DESCRIPTION
Moves the `Block` struct to libsawtooth, and changes all references to this struct within the validator to the moved struct. This also removes the `ToPyObject` and `FromPyObject` implementations for the `Block` struct, and replaces this with From impls for the struct and the `PyObjectWrapper`. 