### PR TITLE
Create traits for metrics module

### DIFF
--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -30,6 +30,8 @@ pub mod execution;
 pub mod hashlib;
 #[cfg(feature = "validator-internals")]
 pub mod journal;
+#[cfg(feature = "validator-internals")]
+pub mod metrics;
 pub mod protos;
 #[cfg(feature = "validator-internals")]
 pub mod scheduler;

--- a/libsawtooth/src/metrics/mod.rs
+++ b/libsawtooth/src/metrics/mod.rs
@@ -1,0 +1,53 @@
+// Copyright 2018 Intel Corporation
+// Copyright 2020 Walmart Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+#[derive(Copy, Clone)]
+pub enum Level {
+    Info,
+}
+
+impl Default for Level {
+    fn default() -> Self {
+        Level::Info
+    }
+}
+
+pub trait Counter: Send + Sync {
+    fn inc(&mut self);
+    fn inc_n(&mut self, value: usize);
+    fn dec_n(&mut self, value: usize);
+}
+
+pub trait Gauge<T>: Send + Sync {
+    fn set_value(&mut self, value: T);
+}
+
+pub trait MetricsCollectorHandle<S: AsRef<str>, T>: Send + Sync {
+    fn counter(
+        &self,
+        metric_name: S,
+        level: Option<Level>,
+        tags: Option<HashMap<String, String>>,
+    ) -> Box<dyn Counter>;
+
+    fn gauge(
+        &self,
+        metric_name: S,
+        level: Option<Level>,
+        tags: Option<HashMap<String, String>>,
+    ) -> Box<dyn Gauge<T>>;
+}

--- a/validator/src/journal/block_manager.rs
+++ b/validator/src/journal/block_manager.rs
@@ -25,9 +25,11 @@ use sawtooth::{block::Block, journal::NULL_BLOCK_IDENTIFIER};
 
 use journal::block_store::{BatchIndex, BlockStoreError, IndexedBlockStore, TransactionIndex};
 use metrics;
+use py_object_wrapper::PyObjectWrapper;
+use sawtooth::metrics::MetricsCollectorHandle;
 
 lazy_static! {
-    static ref COLLECTOR: metrics::MetricsCollectorHandle =
+    static ref COLLECTOR: Box<dyn MetricsCollectorHandle<&'static str, PyObjectWrapper>> =
         metrics::get_collector("sawtooth_validator.block_manager");
 }
 
@@ -290,7 +292,7 @@ impl BlockManagerState {
 
         COLLECTOR
             .gauge("BlockManager.pool_size", None, None)
-            .set_value(block_by_block_id.len());
+            .set_value(block_by_block_id.len().into());
 
         Ok(())
     }

--- a/validator/src/journal/block_scheduler.rs
+++ b/validator/src/journal/block_scheduler.rs
@@ -28,9 +28,11 @@ use sawtooth::{
 
 use journal::block_manager::BlockManager;
 use metrics;
+use py_object_wrapper::PyObjectWrapper;
+use sawtooth::metrics::MetricsCollectorHandle;
 
 lazy_static! {
-    static ref COLLECTOR: metrics::MetricsCollectorHandle =
+    static ref COLLECTOR: Box<dyn MetricsCollectorHandle<&'static str, PyObjectWrapper>> =
         metrics::get_collector("sawtooth_validator.block_validator");
 }
 
@@ -223,9 +225,9 @@ impl<B: BlockStatusStore> BlockSchedulerState<B> {
 
     fn update_gauges(&self) {
         let mut blocks_processing = COLLECTOR.gauge("BlockScheduler.blocks_processing", None, None);
-        blocks_processing.set_value(self.processing.len());
+        blocks_processing.set_value(self.processing.len().into());
         let mut blocks_pending = COLLECTOR.gauge("BlockScheduler.blocks_pending", None, None);
-        blocks_pending.set_value(self.pending.len())
+        blocks_pending.set_value(self.pending.len().into())
     }
 }
 

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -29,7 +29,6 @@ use std::time::Duration;
 
 use sawtooth::{batch::Batch, block::Block};
 
-use crate::py_object_wrapper::PyObjectWrapper;
 use execution::execution_platform::ExecutionPlatform;
 use ffi::py_import_class;
 use journal::block_manager::{BlockManager, BlockRef};
@@ -38,6 +37,8 @@ use journal::chain_commit_state::TransactionCommitCache;
 use journal::chain_head_lock::ChainHeadLock;
 use journal::commit_store::CommitStore;
 use metrics;
+use py_object_wrapper::PyObjectWrapper;
+use sawtooth::metrics::{Gauge, MetricsCollectorHandle};
 use state::settings_view::SettingsView;
 use state::state_view_factory::StateViewFactory;
 
@@ -45,7 +46,7 @@ const NUM_PUBLISH_COUNT_SAMPLES: usize = 5;
 const INITIAL_PUBLISH_COUNT: usize = 30;
 
 lazy_static! {
-    static ref COLLECTOR: metrics::MetricsCollectorHandle =
+    static ref COLLECTOR: Box<dyn MetricsCollectorHandle<&'static str, PyObjectWrapper>> =
         metrics::get_collector("sawtooth_validator.publisher");
 }
 
@@ -747,7 +748,7 @@ pub struct PendingBatchesPool {
     batches: Vec<Batch>,
     ids: HashSet<String>,
     limit: QueueLimit,
-    gauge: metrics::Gauge,
+    gauge: Box<dyn Gauge<PyObjectWrapper>>,
 }
 
 impl PendingBatchesPool {
@@ -824,7 +825,7 @@ impl PendingBatchesPool {
             }
         }
 
-        self.gauge.set_value(self.batches.len());
+        self.gauge.set_value(self.batches.len().into());
     }
 
     pub fn update(&mut self, mut still_pending: Vec<Batch>, last_sent: &Batch) {
@@ -850,7 +851,7 @@ impl PendingBatchesPool {
             self.append(batch);
         }
 
-        self.gauge.set_value(self.batches.len());
+        self.gauge.set_value(self.batches.len().into());
     }
 
     pub fn update_limit(&mut self, consumed: usize) {

--- a/validator/src/py_object_wrapper.rs
+++ b/validator/src/py_object_wrapper.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-use cpython::{PyObject, Python, ToPyObject};
+use cpython::{PyObject, Python, PythonObject, ToPyObject};
 
 pub struct PyObjectWrapper {
     pub py_object: PyObject,
@@ -34,5 +34,32 @@ impl ToPyObject for PyObjectWrapper {
         self.py_object
             .extract::<PyObject>(py)
             .expect("Unable to get PyObject")
+    }
+}
+
+impl From<usize> for PyObjectWrapper {
+    fn from(value: usize) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        PyObjectWrapper::new(value.to_py_object(py).into_object())
+    }
+}
+
+impl From<u64> for PyObjectWrapper {
+    fn from(value: u64) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        PyObjectWrapper::new(value.to_py_object(py).into_object())
+    }
+}
+
+impl From<&str> for PyObjectWrapper {
+    fn from(value: &str) -> Self {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        PyObjectWrapper::new(value.to_py_object(py).into_object())
     }
 }

--- a/validator/src/state/state_pruning_manager.rs
+++ b/validator/src/state/state_pruning_manager.rs
@@ -21,9 +21,11 @@ use sawtooth::database::lmdb::LmdbDatabase;
 use sawtooth::state::merkle::MerkleDatabase;
 
 use metrics;
+use py_object_wrapper::PyObjectWrapper;
+use sawtooth::metrics::MetricsCollectorHandle;
 
 lazy_static! {
-    static ref COLLECTOR: metrics::MetricsCollectorHandle =
+    static ref COLLECTOR: Box<dyn MetricsCollectorHandle<&'static str, PyObjectWrapper>> =
         metrics::get_collector("sawtooth_validator.state");
 }
 


### PR DESCRIPTION
1. Create a MetricsCollectorHandle trait that can generate
a counter and gauge objects.
2. Create traits for Counter and Gauge objects.
3. Abstract the Python implementation of MetricsCollectorHandle
and Counter/Gauge objects.
4. Use PyObjectWrapper as a generic parameter that gauge can take
in.
5. Implement PyObjectWrapper from usize, u64 and &str.

Signed-off-by: S m, Aruna <aruna.mohan@walmartlabs.com>