### PR TITLE
Move several modules from validator to libsawtooth

### DIFF
--- a/libsawtooth/src/gossip/mod.rs
+++ b/libsawtooth/src/gossip/mod.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+pub mod permission_verifier;

--- a/libsawtooth/src/gossip/permission_verifier.rs
+++ b/libsawtooth/src/gossip/permission_verifier.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use crate::batch::Batch;
+
+pub trait PermissionVerifier: Sync + Send {
+    fn is_batch_signer_authorized(&self, batch: &Batch, state_root: &str) -> bool;
+}

--- a/libsawtooth/src/journal/mod.rs
+++ b/libsawtooth/src/journal/mod.rs
@@ -21,3 +21,4 @@ pub mod chain;
 pub mod chain_id_manager;
 pub mod commit_store;
 pub mod fork_cache;
+pub mod validation_rule_enforcer;

--- a/libsawtooth/src/journal/validation_rule_enforcer.rs
+++ b/libsawtooth/src/journal/validation_rule_enforcer.rs
@@ -15,14 +15,16 @@
  * ------------------------------------------------------------------------------
  */
 
-use sawtooth::{batch::Batch, state::settings_view::SettingsView, transaction::Transaction};
+use crate::{batch::Batch, state::settings_view::SettingsView, transaction::Transaction};
 
 /// Retrieve the validation rules stored in state and check that the
 /// given batches do not violate any of those rules. These rules include:
 ///
+/// ```ignore
 ///     NofX: Only N of transaction type X may be included in a block.
 ///     XatY: A transaction of type X must be in the list at position Y.
 ///     local: A transaction must be signed by the given public key
+///```
 ///
 /// If any setting stored in state does not match the required format for
 /// that rule, the rule will be ignored.
@@ -228,7 +230,7 @@ fn parse_rule(rule: &str) -> Option<(&str, Vec<&str>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sawtooth::{batch::Batch, transaction::Transaction};
+    use crate::{batch::Batch, transaction::Transaction};
 
     /// Test that if no validation rules are set, the block is valid.
     #[test]

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -27,6 +27,8 @@ pub mod database;
 #[cfg(feature = "validator-internals")]
 pub mod execution;
 #[cfg(feature = "validator-internals")]
+pub mod gossip;
+#[cfg(feature = "validator-internals")]
 pub mod hashlib;
 #[cfg(feature = "validator-internals")]
 pub mod journal;

--- a/libsawtooth/src/state/mod.rs
+++ b/libsawtooth/src/state/mod.rs
@@ -18,6 +18,7 @@
 pub mod error;
 pub mod merkle;
 pub mod settings_view;
+pub mod state_view_factory;
 
 use self::error::StateDatabaseError;
 

--- a/libsawtooth/src/state/mod.rs
+++ b/libsawtooth/src/state/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod error;
 pub mod merkle;
+pub mod settings_view;
 
 use self::error::StateDatabaseError;
 

--- a/libsawtooth/src/state/settings_view.rs
+++ b/libsawtooth/src/state/settings_view.rs
@@ -14,17 +14,18 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::iter::repeat;
 use std::num::ParseIntError;
 
 use protobuf;
-use sawtooth::hashlib::sha256_digest_str;
-use sawtooth::state::error::StateDatabaseError;
-use sawtooth::state::StateReader;
 
-use proto::setting::Setting;
+use crate::hashlib::sha256_digest_str;
+use crate::protos::setting::Setting;
+use crate::state::error::StateDatabaseError;
+use crate::state::StateReader;
 
 const CONFIG_STATE_NAMESPACE: &str = "000000";
 const MAX_KEY_PARTS: usize = 4;
@@ -173,8 +174,8 @@ fn short_hash(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proto::setting::Setting;
-    use proto::setting::Setting_Entry;
+    use crate::protos::setting::Setting;
+    use crate::protos::setting::Setting_Entry;
     use protobuf;
     use protobuf::Message;
     use std::collections::HashMap;

--- a/libsawtooth/src/state/state_view_factory.rs
+++ b/libsawtooth/src/state/state_view_factory.rs
@@ -14,10 +14,12 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-use sawtooth::database::lmdb::LmdbDatabase;
-use sawtooth::state::error::StateDatabaseError;
-use sawtooth::state::merkle::{DecodedMerkleStateReader, MerkleDatabase};
-use sawtooth::state::StateReader;
+use crate::database::lmdb::LmdbDatabase;
+use crate::state::{
+    error::StateDatabaseError,
+    merkle::{DecodedMerkleStateReader, MerkleDatabase},
+    StateReader,
+};
 
 /// The StateViewFactory produces StateViews for a particular merkle root.
 ///

--- a/validator/src/gossip/permission_verifier.rs
+++ b/validator/src/gossip/permission_verifier.rs
@@ -17,12 +17,9 @@
 
 use cpython::{self, ObjectProtocol, PyClone};
 use sawtooth::batch::Batch;
+use sawtooth::gossip::permission_verifier::PermissionVerifier;
 
 use crate::py_object_wrapper::PyObjectWrapper;
-
-pub trait PermissionVerifier: Sync + Send {
-    fn is_batch_signer_authorized(&self, batch: &Batch, state_root: &str) -> bool;
-}
 
 pub struct PyPermissionVerifier {
     verifier: cpython::PyObject,

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -29,6 +29,7 @@ use sawtooth::{
     batch::Batch,
     block::Block,
     execution::execution_platform::NULL_STATE_HASH,
+    gossip::permission_verifier::PermissionVerifier,
     journal::{
         block_validator::BlockStatusStore, block_wrapper::BlockStatus,
         validation_rule_enforcer::enforce_validation_rules,
@@ -39,7 +40,6 @@ use sawtooth::{
 use uluru;
 
 use execution::execution_platform::ExecutionPlatform;
-use gossip::permission_verifier::PermissionVerifier;
 use journal::block_manager::BlockManager;
 use journal::block_scheduler::BlockScheduler;
 use journal::chain_commit_state::{

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -31,7 +31,7 @@ use sawtooth::{
     execution::execution_platform::NULL_STATE_HASH,
     journal::{block_validator::BlockStatusStore, block_wrapper::BlockStatus},
     scheduler::TxnExecutionResult,
-    state::settings_view::SettingsView,
+    state::{settings_view::SettingsView, state_view_factory::StateViewFactory},
 };
 use uluru;
 
@@ -44,7 +44,6 @@ use journal::chain_commit_state::{
     validate_transaction_dependencies, ChainCommitStateError,
 };
 use journal::validation_rule_enforcer::enforce_validation_rules;
-use state::state_view_factory::StateViewFactory;
 
 const BLOCKVALIDATION_QUEUE_RECV_TIMEOUT: u64 = 100;
 

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -31,6 +31,7 @@ use sawtooth::{
     execution::execution_platform::NULL_STATE_HASH,
     journal::{block_validator::BlockStatusStore, block_wrapper::BlockStatus},
     scheduler::TxnExecutionResult,
+    state::settings_view::SettingsView,
 };
 use uluru;
 
@@ -43,7 +44,7 @@ use journal::chain_commit_state::{
     validate_transaction_dependencies, ChainCommitStateError,
 };
 use journal::validation_rule_enforcer::enforce_validation_rules;
-use state::{settings_view::SettingsView, state_view_factory::StateViewFactory};
+use state::state_view_factory::StateViewFactory;
 
 const BLOCKVALIDATION_QUEUE_RECV_TIMEOUT: u64 = 100;
 

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -29,7 +29,10 @@ use sawtooth::{
     batch::Batch,
     block::Block,
     execution::execution_platform::NULL_STATE_HASH,
-    journal::{block_validator::BlockStatusStore, block_wrapper::BlockStatus},
+    journal::{
+        block_validator::BlockStatusStore, block_wrapper::BlockStatus,
+        validation_rule_enforcer::enforce_validation_rules,
+    },
     scheduler::TxnExecutionResult,
     state::{settings_view::SettingsView, state_view_factory::StateViewFactory},
 };
@@ -43,7 +46,6 @@ use journal::chain_commit_state::{
     validate_no_duplicate_batches, validate_no_duplicate_transactions,
     validate_transaction_dependencies, ChainCommitStateError,
 };
-use journal::validation_rule_enforcer::enforce_validation_rules;
 
 const BLOCKVALIDATION_QUEUE_RECV_TIMEOUT: u64 = 100;
 

--- a/validator/src/journal/block_validator_ffi.rs
+++ b/validator/src/journal/block_validator_ffi.rs
@@ -23,8 +23,9 @@ use journal::{
     block_validator::{BlockValidationResultStore, BlockValidator},
 };
 use py_ffi;
-use state::state_view_factory::StateViewFactory;
 use std::os::raw::c_void;
+
+use sawtooth::state::state_view_factory::StateViewFactory;
 
 #[repr(u32)]
 #[derive(Debug)]

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -27,12 +27,12 @@ use cpython::Python;
 
 use sawtooth::hashlib::sha256_digest_strs;
 use sawtooth::journal::commit_store::CommitStore;
+use sawtooth::journal::validation_rule_enforcer;
 use sawtooth::state::settings_view::SettingsView;
 use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
 
 use crate::py_object_wrapper::PyObjectWrapper;
 use journal::chain_commit_state::TransactionCommitCache;
-use journal::validation_rule_enforcer;
 
 use pylogger;
 

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -27,12 +27,12 @@ use cpython::Python;
 
 use sawtooth::hashlib::sha256_digest_strs;
 use sawtooth::journal::commit_store::CommitStore;
+use sawtooth::state::settings_view::SettingsView;
 use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
 
 use crate::py_object_wrapper::PyObjectWrapper;
 use journal::chain_commit_state::TransactionCommitCache;
 use journal::validation_rule_enforcer;
-use state::settings_view::SettingsView;
 
 use pylogger;
 

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -39,6 +39,7 @@ use sawtooth::{
     batch::Batch,
     block::Block,
     consensus::registry::ConsensusRegistry,
+    gossip::permission_verifier::PermissionVerifier,
     journal::{
         block_wrapper::BlockStatus,
         chain::{ChainReadError, ChainReader, COMMIT_STORE},
@@ -52,7 +53,6 @@ use sawtooth::{
 
 use consensus::notifier::ConsensusNotifier;
 use execution::execution_platform::ExecutionPlatform;
-use gossip::permission_verifier::PermissionVerifier;
 use journal::block_manager::{BlockManager, BlockManagerError, BlockRef};
 use journal::block_validator::{
     BlockValidationResult, BlockValidationResultStore, BlockValidator, ValidationError,

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -47,6 +47,7 @@ use sawtooth::{
         NULL_BLOCK_IDENTIFIER,
     },
     scheduler::TxnExecutionResult,
+    state::state_view_factory::StateViewFactory,
 };
 
 use consensus::notifier::ConsensusNotifier;
@@ -59,7 +60,6 @@ use journal::block_validator::{
 use journal::chain_head_lock::ChainHeadLock;
 use metrics;
 use state::state_pruning_manager::StatePruningManager;
-use state::state_view_factory::StateViewFactory;
 
 use proto::transaction_receipt::TransactionReceipt;
 use py_object_wrapper::PyObjectWrapper;

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -32,7 +32,6 @@ use sawtooth::block::Block;
 use sawtooth::database::lmdb::LmdbDatabase;
 use sawtooth::journal::commit_store::CommitStore;
 use state::state_pruning_manager::StatePruningManager;
-use state::state_view_factory::StateViewFactory;
 use std::ffi::CStr;
 use std::mem;
 use std::os::raw::{c_char, c_void};
@@ -42,6 +41,7 @@ use std::time::Duration;
 
 use protobuf::{self, Message};
 use sawtooth::journal::block_wrapper::BlockStatus;
+use sawtooth::state::state_view_factory::StateViewFactory;
 
 use proto;
 use proto::transaction_receipt::TransactionReceipt;

--- a/validator/src/journal/mod.rs
+++ b/validator/src/journal/mod.rs
@@ -32,4 +32,3 @@ pub mod commit_store_ffi;
 pub mod incoming_batch_queue_ffi;
 pub mod publisher;
 pub mod publisher_ffi;
-mod validation_rule_enforcer;

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -28,7 +28,7 @@ use std::thread;
 use std::time::Duration;
 
 use sawtooth::journal::commit_store::CommitStore;
-use sawtooth::state::settings_view::SettingsView;
+use sawtooth::state::{settings_view::SettingsView, state_view_factory::StateViewFactory};
 use sawtooth::{batch::Batch, block::Block};
 
 use execution::execution_platform::ExecutionPlatform;
@@ -40,7 +40,6 @@ use journal::chain_head_lock::ChainHeadLock;
 use metrics;
 use py_object_wrapper::PyObjectWrapper;
 use sawtooth::metrics::{Gauge, MetricsCollectorHandle};
-use state::state_view_factory::StateViewFactory;
 
 const NUM_PUBLISH_COUNT_SAMPLES: usize = 5;
 const INITIAL_PUBLISH_COUNT: usize = 30;

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -28,6 +28,7 @@ use std::thread;
 use std::time::Duration;
 
 use sawtooth::journal::commit_store::CommitStore;
+use sawtooth::state::settings_view::SettingsView;
 use sawtooth::{batch::Batch, block::Block};
 
 use execution::execution_platform::ExecutionPlatform;
@@ -39,7 +40,6 @@ use journal::chain_head_lock::ChainHeadLock;
 use metrics;
 use py_object_wrapper::PyObjectWrapper;
 use sawtooth::metrics::{Gauge, MetricsCollectorHandle};
-use state::settings_view::SettingsView;
 use state::state_view_factory::StateViewFactory;
 
 const NUM_PUBLISH_COUNT_SAMPLES: usize = 5;

--- a/validator/src/journal/publisher_ffi.rs
+++ b/validator/src/journal/publisher_ffi.rs
@@ -22,6 +22,7 @@ use std::slice;
 
 use cpython::{ObjectProtocol, PyClone, PyList, PyObject, Python};
 use sawtooth::journal::commit_store::CommitStore;
+use sawtooth::state::state_view_factory::StateViewFactory;
 use sawtooth::{batch::Batch, block::Block};
 
 use crate::py_object_wrapper::PyObjectWrapper;
@@ -31,8 +32,6 @@ use journal::block_manager::BlockManager;
 use journal::publisher::{
     BatchObserver, BlockPublisher, FinalizeBlockError, IncomingBatchSender, InitializeBlockError,
 };
-
-use state::state_view_factory::StateViewFactory;
 
 lazy_static! {
     static ref PY_BATCH_PUBLISHER_CLASS: PyObject = py_import_class(

--- a/validator/src/journal/validation_rule_enforcer.rs
+++ b/validator/src/journal/validation_rule_enforcer.rs
@@ -15,9 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-use sawtooth::{batch::Batch, transaction::Transaction};
-
-use state::settings_view::SettingsView;
+use sawtooth::{batch::Batch, state::settings_view::SettingsView, transaction::Transaction};
 
 /// Retrieve the validation rules stored in state and check that the
 /// given batches do not violate any of those rules. These rules include:

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -17,7 +17,6 @@
 
 pub mod identity_view;
 pub mod merkle_ffi;
-pub mod settings_view;
 pub mod state_pruning_manager;
 pub mod state_view_factory;
 pub mod state_view_ffi;

--- a/validator/src/state/mod.rs
+++ b/validator/src/state/mod.rs
@@ -18,5 +18,4 @@
 pub mod identity_view;
 pub mod merkle_ffi;
 pub mod state_pruning_manager;
-pub mod state_view_factory;
 pub mod state_view_ffi;

--- a/validator/src/state/state_view_ffi.rs
+++ b/validator/src/state/state_view_ffi.rs
@@ -17,8 +17,7 @@
 use std::os::raw::c_void;
 
 use sawtooth::database::lmdb::LmdbDatabase;
-
-use state::state_view_factory::StateViewFactory;
+use sawtooth::state::state_view_factory::StateViewFactory;
 
 #[repr(u32)]
 #[derive(Debug)]


### PR DESCRIPTION
This moves a few modules over to libsawtooth, including:

* `SettingsView`
* `StateViewFactory`
* `enforce_validation_rules` function
* `PermissionVerifier` trait