### PR TITLE
WIP - Replace libsawtooth state/database with Hyperledger Transact

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -13,7 +13,7 @@ libc = ">=0.2.35"
 metrics = { version = "0.12", features = ["std"] }
 protobuf = "2.0"
 python3-sys = "0.2"
-sawtooth = { version = "0.3", features = ["validator-internals"] }
+sawtooth = {git = "https://github.com/Cargill/sawtooth-lib", branch="agunde406-transact-state", features = ["validator-internals"]}
 
 [build-dependencies]
 protoc-rust = "2.0"

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -14,6 +14,7 @@ metrics = { version = "0.12", features = ["std"] }
 protobuf = "2.0"
 python3-sys = "0.2"
 sawtooth = {git = "https://github.com/Cargill/sawtooth-lib", branch="agunde406-transact-state", features = ["validator-internals"]}
+transact = "0.2"
 
 [build-dependencies]
 protoc-rust = "2.0"

--- a/validator/src/database/lmdb_ffi.rs
+++ b/validator/src/database/lmdb_ffi.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
-use sawtooth::database::lmdb::*;
+use transact::database::lmdb::*;
 
 use cpython::{PyList, PyObject, Python};
 use py_ffi;

--- a/validator/src/journal/block_manager_ffi.rs
+++ b/validator/src/journal/block_manager_ffi.rs
@@ -412,9 +412,9 @@ mod test {
 
     use protobuf::Message;
     use sawtooth::block::Block;
-    use sawtooth::database::lmdb::{LmdbContext, LmdbDatabase};
     use sawtooth::journal::block_store::BlockStore;
     use sawtooth::journal::NULL_BLOCK_IDENTIFIER;
+    use transact::database::lmdb::{LmdbContext, LmdbDatabase};
 
     use std::env;
     use std::fs::remove_file;

--- a/validator/src/journal/chain_ffi.rs
+++ b/validator/src/journal/chain_ffi.rs
@@ -24,7 +24,6 @@ use gossip::permission_verifier::PyPermissionVerifier;
 use py_ffi;
 use pylogger;
 use sawtooth::block::Block;
-use sawtooth::database::lmdb::LmdbDatabase;
 use sawtooth::journal::commit_store::CommitStore;
 use std::ffi::CStr;
 use std::mem;
@@ -32,6 +31,7 @@ use std::os::raw::{c_char, c_void};
 use std::ptr;
 use std::slice;
 use std::time::Duration;
+use transact::database::lmdb::LmdbDatabase;
 
 use protobuf::{self, Message};
 use sawtooth::{
@@ -46,7 +46,6 @@ use sawtooth::{
     state::{state_pruning_manager::StatePruningManager, state_view_factory::StateViewFactory},
 };
 
-use proto;
 use proto::events::{Event, Event_Attribute};
 use proto::transaction_receipt::{StateChange, StateChange_Type, TransactionReceipt};
 

--- a/validator/src/journal/commit_store_ffi.rs
+++ b/validator/src/journal/commit_store_ffi.rs
@@ -20,12 +20,12 @@ use std::os::raw::{c_char, c_void};
 use std::slice;
 
 use protobuf;
-use sawtooth::database::error::DatabaseError;
-use sawtooth::database::lmdb::LmdbDatabase;
 use sawtooth::journal::commit_store::{
     ByHeightDirection, CommitStore, CommitStoreByHeightIterator,
 };
 use sawtooth::{batch::Batch, block::Block, transaction::Transaction};
+use transact::database::error::DatabaseError;
+use transact::database::lmdb::LmdbDatabase;
 
 #[repr(u32)]
 #[derive(Debug)]

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -27,6 +27,7 @@ extern crate log;
 #[macro_use]
 extern crate metrics;
 extern crate sawtooth;
+extern crate transact;
 
 // exported modules
 pub(crate) mod consensus;

--- a/validator/src/state/state_view_ffi.rs
+++ b/validator/src/state/state_view_ffi.rs
@@ -16,8 +16,8 @@
  */
 use std::os::raw::c_void;
 
-use sawtooth::database::lmdb::LmdbDatabase;
 use sawtooth::state::state_view_factory::StateViewFactory;
+use transact::database::lmdb::LmdbDatabase;
 
 #[repr(u32)]
 #[derive(Debug)]


### PR DESCRIPTION
This is the first step in replacing the existing transaction
execution platform in the validator with transact.


This is a work in progress and currently points to a PR branch off of libsawtooth and should not be merged.