### PR TITLE
Update validator library crate type to cdylib

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -21,7 +21,7 @@ protoc-rust = "2.0"
 glob = "0.2"
 
 [lib]
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [[bin]]
 name = "sawtooth-validator"


### PR DESCRIPTION
The validator needs to be available as a dynamic library because
of the FFI integration with the python code. However, using dylib
caused linker issues when pulling in the sawtooth-sabre
transaction handler, a requirement for the integration with transact.

Changing to a cdylib fixes this issue.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>