### PR TITLE
Check if check_connections is None before calling

### DIFF
--- a/validator/sawtooth_validator/networking/interconnect.py
+++ b/validator/sawtooth_validator/networking/interconnect.py
@@ -658,7 +658,8 @@ class _SendReceive:
         while True:
             try:
                 yield from self._monitor_sock.recv_multipart()
-                self._check_connections()
+                if self._check_connections is not None:
+                    self._check_connections()
             except CancelledError:  # pylint: disable=try-except-raise
                 # The concurrent.futures.CancelledError is caught by asyncio
                 # when the Task associated with the coroutine is cancelled.


### PR DESCRIPTION
This check was called when the monitor thread was notified
of a disconnection and would check all existing external
transaction processors. With the transact integration and
removal of the python executor, the check_connection
function was never set.

This commit adds a check to skip calling check_connections
if it is none.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>