### PR TITLE
Fix bug in batch tracker's chain_update method

### DIFF
--- a/validator/sawtooth_validator/state/batch_tracker.py
+++ b/validator/sawtooth_validator/state/batch_tracker.py
@@ -15,6 +15,7 @@
 
 import abc
 from threading import RLock
+from sawtooth_validator.journal.block_wrapper import BlockWrapper
 from sawtooth_validator.journal.timed_cache import TimedCache
 from sawtooth_validator.journal.chain import ChainObserver
 from sawtooth_validator.journal.publisher import InvalidTransactionObserver
@@ -61,9 +62,10 @@ class BatchTracker(ChainObserver,
         """Removes batches from the pending cache if found in the block store,
         and notifies any observers.
         """
+        block = BlockWrapper.wrap(block)
         with self._lock:
-            for batch_id in self._pending.copy():
-                if self._batch_committed(batch_id):
+            for batch_id in block.header.batch_ids:
+                if batch_id in self._pending:
                     self._pending.remove(batch_id)
                     self._update_observers(batch_id,
                                            ClientBatchStatus.COMMITTED)

--- a/validator/tests/test_client_request_handlers/mocks.py
+++ b/validator/tests/test_client_request_handlers/mocks.py
@@ -98,7 +98,7 @@ class MockBlockStore(BlockStore):
     def clear(self):
         self.__init__(size=0)
 
-    def add_block(self, base_id, root=b'merkle_root'.hex()):
+    def make_mock_block(self, base_id, root=b'merkle_root'.hex()):
         block_id = 'b' * (128 - len(base_id)) + base_id
         head = self.chain_head
         if head:
@@ -110,20 +110,25 @@ class MockBlockStore(BlockStore):
 
         signer_public_key = b'public_key' + bytes(base_id, 'utf-8')
 
+        batch = make_mock_batch(base_id)
+
         header = BlockHeader(
             block_num=num,
             previous_block_id=previous_id,
             signer_public_key=signer_public_key.hex(),
-            batch_ids=[block_id],
+            batch_ids=[batch.header_signature],
             consensus=b'consensus',
             state_root_hash=root)
 
         block = Block(
             header=header.SerializeToString(),
             header_signature=block_id,
-            batches=[make_mock_batch(base_id)])
+            batches=[batch])
 
-        self.put_blocks([block])
+        return block
+
+    def add_block(self, base_id, root=b'merkle_root'.hex()):
+        self.put_blocks([self.make_mock_block(base_id, root)])
 
 
 def make_db_and_store(base_dir, size=3):

--- a/validator/tests/test_client_request_handlers/test_submit_handlers.py
+++ b/validator/tests/test_client_request_handlers/test_submit_handlers.py
@@ -262,8 +262,9 @@ class TestBatchStatusRequests(ClientHandlerTestCase):
 
         def delayed_add():
             sleep(1)
+            block = self._store.make_mock_block('e')
             self._store.add_block('e')
-            self._tracker.chain_update(None, [])
+            self._tracker.chain_update(block, [])
 
         Thread(target=delayed_add).start()
 


### PR DESCRIPTION
Updates the `chain_update` method for the batch tracker to use the
provided block for notifying of committed batches rather than checking
the commit store. This fixes a bug that was created by a recent change
to the chain controller; the chain controller now notifies of committed
batches before persisting the committed block to the commit store. This
resulted in the batch tracker not properly notifying of committed
batches.

The fix is to not check the commit store in `chain_update`, but rather
just use the batch IDs in the provided block. In addition to fixing the
bug, this avoids an unnecessary database call.

Signed-off-by: Logan Seeley <seeley@bitwise.io>