### PR TITLE
Fix typo in _create_identifier method

### DIFF
--- a/validator/sawtooth_validator/metrics/metrics.py
+++ b/validator/sawtooth_validator/metrics/metrics.py
@@ -198,7 +198,7 @@ class MetricsCollectorHandle:
             identifier.insert(0, instance.__class__.__name__)
         if self._module_name is not None:
             identifier.insert(0, self._module_name)
-        return instance
+        return identifier
 
 
 class NoOpMetricsRegistry:


### PR DESCRIPTION
Fixes a typo in the `MetricsCollectorHandle._create_identifier` method.
The wrong thing was being returned from this function.

Signed-off-by: Logan Seeley <seeley@bitwise.io>