### PR TITLE
Fix admin tools build versioning

### DIFF
--- a/adm/Dockerfile-installed-bionic
+++ b/adm/Dockerfile-installed-bionic
@@ -44,7 +44,7 @@ COPY . /project
 WORKDIR /project/adm
 
 RUN export VERSION=$(../bin/get_version) \
- && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
  && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== admin tools docker build ===-------------

--- a/adm/Dockerfile-installed-xenial
+++ b/adm/Dockerfile-installed-xenial
@@ -44,7 +44,7 @@ COPY . /project
 WORKDIR /project/adm
 
 RUN export VERSION=$(../bin/get_version) \
- && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && sed -i -e "0,/version.*$/ s/version.*$/version\ =\ \"${VERSION}\"/" Cargo.toml \
  && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== admin tools docker build ===-------------


### PR DESCRIPTION
Change command to only substitute first occurrence of version when building `admin tools`.