### PR TITLE
Pin pylint to fix CI builds

### DIFF
--- a/docker/lint
+++ b/docker/lint
@@ -44,7 +44,7 @@ RUN apt-get install -y -q \
     python3-yaml \
     python3-zmq \
  && pip3 install \
-    pylint \
+    pylint==2.6.2 \
     pycodestyle \
     bandit \
     coverage --upgrade


### PR DESCRIPTION
Since the release of version 2.7.0 pylint has been segfaulting during the
linting step of CI builds. This can be researched more comprehensively once
active development continues on Sawtooth.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>