### PR TITLE
Pin docutils version

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -101,6 +101,7 @@ RUN apt-get update && apt-get install -y -q \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install \
+    docutils==0.16 \
     sphinx \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \


### PR DESCRIPTION
v0.17 causes builds to fail with a UnicodeDecodeError.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>