### PR TITLE
Fix panic w/non-static String compiler warning

### DIFF
--- a/perf/smallbank_workload/src/playlist.rs
+++ b/perf/smallbank_workload/src/playlist.rs
@@ -483,7 +483,7 @@ impl<'a> From<&'a Yaml> for SmallbankTransactionPayload {
                     );
                     payload.set_amalgamate(data);
                 }
-                Some(txn_type) => panic!(format!("unknown transaction_type: {}", txn_type)),
+                Some(txn_type) => panic!("unknown transaction_type: {}", txn_type),
                 None => panic!("No transaction_type specified"),
             }
             payload


### PR DESCRIPTION
The solution here is to reduce it a simple string, which isn't ideal
since it will no longer print the missing transaciton type. However,
this code is unrefined anyway since it panics at all, and the solution
of rewriting it with proper error handling can happen in a future change
aimed at removing the panics.