### PR TITLE
Pin sphinx to 4.0 to fix build issues

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -102,7 +102,7 @@ RUN apt-get update && apt-get install -y -q \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install \
     docutils==0.16 \
-    sphinx \
+    sphinx==4.0 \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \
     sphinx_rtd_theme


### PR DESCRIPTION
The following error was being returned when using the latest
version of sphinx:

<openapi>:1:Problem in http domain: field is supposed to use role 'obj',
but that role is not in the domain.

This is caused by an incompatibility with the current version of
sphinxcontrib-httpdomain. The issues does not exist in sphinx 0.4.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>