### PR TITLE
Pin Coverage to version 5.5

### DIFF
--- a/cli/tests/cli-tests.dockerfile
+++ b/cli/tests/cli-tests.dockerfile
@@ -40,7 +40,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/docker/bandit
+++ b/docker/bandit
@@ -24,6 +24,6 @@ RUN apt-get install -y -q \
     python3-pip \
  && pip3 install \
     bandit \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin

--- a/docker/lint
+++ b/docker/lint
@@ -44,7 +44,7 @@ RUN apt-get install -y -q \
     pylint==2.3.1 \
     pycodestyle \
     bandit \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN apt-get install -y -q --allow-downgrades \
     build-essential \

--- a/docker/sawtooth-debug-python
+++ b/docker/sawtooth-debug-python
@@ -81,7 +81,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci xenial universe" >>
     pylint \
     pycodestyle \
     bandit \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
  && add-apt-repository \

--- a/families/battleship/tests/battleship-tests.dockerfile
+++ b/families/battleship/tests/battleship-tests.dockerfile
@@ -40,7 +40,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/families/block_info/tests/block-info-tests.dockerfile
+++ b/families/block_info/tests/block-info-tests.dockerfile
@@ -41,7 +41,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/families/identity/tests/identity-tests.dockerfile
+++ b/families/identity/tests/identity-tests.dockerfile
@@ -40,7 +40,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/families/settings/tests/settings.dockerfile
+++ b/families/settings/tests/settings.dockerfile
@@ -39,7 +39,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/integration/sawtooth_integration/docker/integration-tests.dockerfile
+++ b/integration/sawtooth_integration/docker/integration-tests.dockerfile
@@ -42,7 +42,7 @@ RUN apt-get install -y -q \
     software-properties-common
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
  && add-apt-repository \

--- a/rest_api/tests/rest-api-tests.dockerfile
+++ b/rest_api/tests/rest-api-tests.dockerfile
@@ -41,7 +41,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/sdk/python/tests/python-sdk-tests.dockerfile
+++ b/sdk/python/tests/python-sdk-tests.dockerfile
@@ -44,7 +44,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN mkdir -p /var/log/sawtooth
 

--- a/signing/tests/signing-tests.dockerfile
+++ b/signing/tests/signing-tests.dockerfile
@@ -37,7 +37,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin
 

--- a/validator/tests/validator-tests.dockerfile
+++ b/validator/tests/validator-tests.dockerfile
@@ -54,7 +54,7 @@ RUN apt-get install -y -q \
     python3-pip
 
 RUN pip3 install \
-    coverage --upgrade
+    coverage==5.5 --upgrade
 
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \


### PR DESCRIPTION
The 6.0 release of Coverage dropped support for python 3.5, which is the last
supported version on Xenial.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>