### PR TITLE
Fix doc build

### DIFF
--- a/bin/make_templated_docs
+++ b/bin/make_templated_docs
@@ -42,7 +42,7 @@ comments = {
     'default': {'line': '//'}}
 
 # Build globals
-conf = yaml.load(open(template_abs + '/template_config.yaml', 'r'))
+conf = yaml.safe_load(open(template_abs + '/template_config.yaml', 'r'))
 env = Environment(
     loader=FileSystemLoader(template_abs),
     trim_blocks=True,


### PR DESCRIPTION
The 6.0 release of PyYAML (a bandit dependency) introduced a change that
requires the `Loader=` argument when using `yaml.load()`. Because we don't need
any of the additional funcationality available in `yaml.load()`, this function
was switched to `yaml.safe_load()` instead.

https://github.com/yaml/pyyaml/pull/561

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>