### PR TITLE
Pin bandit version

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -82,7 +82,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
     pylint \
-    bandit
+    bandit==1.7.1
 
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/bandit
+++ b/docker/bandit
@@ -26,7 +26,7 @@ RUN apt-get install -y -q \
     python3-dev \
     python3-pip \
  && pip3 install \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-core/bin

--- a/docker/lint
+++ b/docker/lint
@@ -46,7 +46,7 @@ RUN apt-get install -y -q \
  && pip3 install \
     pylint==2.6.2 \
     pycodestyle \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 RUN apt-get install -y -q \


### PR DESCRIPTION
The 1.7.2 release of Bandit drops support for python 3.6, which is the latest
available for ubuntu bionic.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>