### PR TITLE
fixed outdated deployment configs

### DIFF
--- a/docker/kubernetes/sawtooth-kubernetes-default.yaml
+++ b/docker/kubernetes/sawtooth-kubernetes-default.yaml
@@ -4,12 +4,15 @@ kind: List
 
 items:
 
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: sawtooth-0
   spec:
     replicas: 1
+    selector:
+      matchLabels:
+        name: sawtooth-0
     template:
       metadata:
         labels:


### PR DESCRIPTION
In deploying a Sawtooth single node with the latest minikube release, encountered issues involving outdated API version and missing deployment selector labels. 