### PR TITLE
Fix dependencies to build on ARM

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -33,10 +33,7 @@ setup(
     author='Hyperledger Sawtooth',
     url='https://github.com/hyperledger/sawtooth-core',
     packages=find_packages(),
-    install_requires=[
-        'colorlog', 'protobuf', 'sawtooth-sdk', 'toml', 'PyYAML',
-        'requests'
-    ],
+    install_requires=[],
     data_files=data_files,
     entry_points={
         'console_scripts': [

--- a/cli/stdeb.cfg
+++ b/cli/stdeb.cfg
@@ -1,2 +1,1 @@
 [DEFAULT]
-Depends3: python3-sawtooth-sdk

--- a/validator/Dockerfile-installed-bionic
+++ b/validator/Dockerfile-installed-bionic
@@ -31,18 +31,26 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/ap
     libssl-dev \
     openssl \
     pkg-config \
+    protobuf-compiler \
     python3 \
-    python3-cachetools \
     python3-dev \
-    python3-grpcio \
-    python3-grpcio-tools \
-    python3-protobuf \
-    python3-pyformance \
-    python3-sawtooth-sdk \
-    python3-secp256k1 \
+    python3-pip \
+    python3-cachetools \
     python3-stdeb \
-    python3-toml \
     unzip
+
+RUN python3 -m pip install pip --upgrade
+
+RUN python3 -m pip install --ignore-installed setuptools protobuf==3.6.1 lmdb colorlog toml
+
+RUN python3 -m pip install --ignore-installed \
+    secp256k1
+
+RUN python3 -m pip install --ignore-installed \
+    grpcio==1.15.0 \
+    grpcio-tools==1.15.0
+
+RUN python3 -m pip install --ignore-installed sawtooth-sdk pyformance==0.4
 
 RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
@@ -90,13 +98,22 @@ RUN echo "deb http://repo.sawtooth.me/ubuntu/nightly bionic universe" >> /etc/ap
  && apt-get update \
  && apt-get install -y -q \
     git \
-    python3 \
-    python3-protobuf \
-    python3-stdeb \
-    python3-toml \
-    python3-grpcio-tools \
-    python3-grpcio \
-    python3-sawtooth-sdk
+    pkg-config \
+    python3.6 \
+    python3.6-dev \
+    python3-pip \
+    python3-stdeb
+
+RUN python3 -m pip install pip --upgrade
+
+RUN python3 -m pip install --ignore-installed \
+    setuptools==50.1.0 \
+    protobuf==3.6.1 \
+    grpcio==1.15.0 \
+    grpcio-tools==1.15.0 \
+    toml
+
+RUN python3 -m pip install --ignore-installed sawtooth-sdk
 
 COPY . /project
 
@@ -113,8 +130,30 @@ FROM ubuntu:bionic
 
 RUN apt-get update \
  && apt-get install -y \
- gnupg \
- systemd
+    pkg-config \
+    python3.6 \
+    python3.6-dev \
+    python3-pip \
+    gnupg \
+    systemd
+RUN python3 -m pip install pip --upgrade
+
+RUN python3 -m pip install --ignore-installed setuptools protobuf==3.6.1 lmdb colorlog toml
+
+RUN python3 -m pip install --ignore-installed \
+    secp256k1
+
+RUN python3 -m pip install --ignore-installed \
+    grpcio==1.15.0 \
+    grpcio-tools==1.15.0
+
+RUN python3 -m pip install --ignore-installed \
+    netifaces \
+    cbor \
+    cachetools \
+    requests
+
+RUN python3 -m pip install --ignore-installed sawtooth-sdk pyformance==0.4
 
 COPY --from=sawtooth-cli-builder /project/python3-sawtooth-cli*.deb /tmp
 

--- a/validator/setup.py
+++ b/validator/setup.py
@@ -52,19 +52,6 @@ setup(
     author='Hyperledger Sawtooth',
     url='https://github.com/hyperledger/sawtooth-core',
     packages=find_packages(),
-    install_requires=[
-        "cachetools",
-        "cbor>=0.1.23",
-        "colorlog",
-        "protobuf",
-        "lmdb",
-        "requests",
-        "sawtooth-sdk",
-        "toml",
-        "PyYAML",
-        "pyzmq",
-        "netifaces",
-        "pyformance"
-    ],
+    install_requires=[],
     data_files=data_files,
     entry_points={})

--- a/validator/stdeb.cfg
+++ b/validator/stdeb.cfg
@@ -1,2 +1,1 @@
 [DEFAULT]
-Depends3: libpython3-dev, openssl, libssl-dev, python3-cachetools


### PR DESCRIPTION
Updates many dependencies to enable sawtooth validator to build and
run on ARM. Fixes a memory leak that occurs when using the currently
published image on ARM.

Some packages that were pulled in via apt install (ex.
python3-pyformance, python3-grpcio, etc.) aren't published for ARM, so
we need to install them via pip. To install them via pip, we need to
lock versions for some of the packages to continue to use python3.6 and
be compatible with Grid. Some packages need to be up-to-date and not
version-locked. Installing packages via pip is done in steps, as some
packages need to be finished installing before calling `pip install ...`
for others.

This also removes the dependency declarations in `setup.py` and
`stdeb.cfg` files, as these mostly refer to packages without
compatible ARM versions published. They are also silent failures in the
build process.

I suspect that using an updated version of lmdb resolved the memory
leak.

Signed-off-by: Chris Eckhardt <eckhardt@bitwise.io>