### PR TITLE
change TransactionCommitCache to LRU

### DIFF
--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -15,7 +15,7 @@ cbor-codec = "0.7"
 openssl = "0.10"
 protobuf = "2.0"
 python3-sys = "0.2"
-uluru = "0.2.0"
+uluru = "3.0.0"
 
 [dev-dependencies]
 rand = "0.4"

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -57,7 +57,7 @@ pub enum ValidationError {
 }
 
 type BlockValidationResultCache =
-    uluru::LRUCache<[uluru::Entry<BlockValidationResult>; BLOCK_VALIDATION_RESULT_CACHE_SIZE]>;
+    uluru::LRUCache<BlockValidationResult, BLOCK_VALIDATION_RESULT_CACHE_SIZE>;
 
 #[derive(Clone, Default)]
 pub struct BlockValidationResultStore {
@@ -73,7 +73,7 @@ impl BlockValidationResultStore {
         self.validation_result_cache
             .lock()
             .expect("The mutex is poisoned")
-            .insert(result)
+            .insert(result);
     }
 
     pub fn get(&self, block_id: &str) -> Option<BlockValidationResult> {


### PR DESCRIPTION
TransactionCommitCache is currently based on a HashSet which depends on its clients to properly clean up their items in a timely fashion. However, under high load circumstances, this can be too long resulting in quiet OOM issues and in practice freezing the whole network.

This changes the TransactionCommitCache to an uluru LRU. This is safe since the commit cache is based on data that cannot change and the worst that happens on a miss is a refetch from the store.

uluru is also updated to 3.0.0 which requires a minor change to `block_validator.rs` to account for the changed construction