### PR TITLE
use 'chime' instead of 'nightly' images for sawtooth-default-poet.yaml

### DIFF
--- a/docker/compose/sawtooth-default-poet.yaml
+++ b/docker/compose/sawtooth-default-poet.yaml
@@ -20,7 +20,7 @@ volumes:
 
 services:
   shell:
-    image: hyperledger/sawtooth-shell:nightly
+    image: hyperledger/sawtooth-shell:chime
     container_name: sawtooth-shell-default
     entrypoint: "bash -c \"\
         sawtooth keygen && \
@@ -28,7 +28,7 @@ services:
         \""
 
   validator-0:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:chime
     container_name: sawtooth-validator-default-0
     expose:
       - 4004
@@ -80,7 +80,7 @@ services:
     stop_signal: SIGKILL
 
   validator-1:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:chime
     container_name: sawtooth-validator-default-1
     expose:
       - 4004
@@ -110,7 +110,7 @@ services:
     stop_signal: SIGKILL
 
   validator-2:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:chime
     container_name: sawtooth-validator-default-2
     expose:
       - 4004
@@ -140,7 +140,7 @@ services:
     stop_signal: SIGKILL
 
   validator-3:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:chime
     container_name: sawtooth-validator-default-3
     expose:
       - 4004
@@ -170,7 +170,7 @@ services:
     stop_signal: SIGKILL
 
   validator-4:
-    image: hyperledger/sawtooth-validator:nightly
+    image: hyperledger/sawtooth-validator:chime
     container_name: sawtooth-validator-default-4
     expose:
       - 4004
@@ -200,7 +200,7 @@ services:
     stop_signal: SIGKILL
 
   rest-api-0:
-    image: hyperledger/sawtooth-rest-api:nightly
+    image: hyperledger/sawtooth-rest-api:chime
     container_name: sawtooth-rest-api-default-0
     expose:
       - 8008
@@ -213,7 +213,7 @@ services:
     stop_signal: SIGKILL
 
   rest-api-1:
-    image: hyperledger/sawtooth-rest-api:nightly
+    image: hyperledger/sawtooth-rest-api:chime
     container_name: sawtooth-rest-api-default-1
     expose:
       - 8008
@@ -226,7 +226,7 @@ services:
     stop_signal: SIGKILL
 
   rest-api-2:
-    image: hyperledger/sawtooth-rest-api:nightly
+    image: hyperledger/sawtooth-rest-api:chime
     container_name: sawtooth-rest-api-default-2
     expose:
       - 8008
@@ -239,7 +239,7 @@ services:
     stop_signal: SIGKILL
 
   rest-api-3:
-    image: hyperledger/sawtooth-rest-api:nightly
+    image: hyperledger/sawtooth-rest-api:chime
     container_name: sawtooth-rest-api-default-3
     expose:
       - 8008
@@ -252,7 +252,7 @@ services:
     stop_signal: SIGKILL
 
   rest-api-4:
-    image: hyperledger/sawtooth-rest-api:nightly
+    image: hyperledger/sawtooth-rest-api:chime
     container_name: sawtooth-rest-api-default-4
     expose:
       - 8008
@@ -265,7 +265,7 @@ services:
     stop_signal: SIGKILL
 
   intkey-tp-0:
-    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    image: hyperledger/sawtooth-intkey-tp-python:chime
     container_name: sawtooth-intkey-tp-python-default-0
     expose:
       - 4004
@@ -273,7 +273,7 @@ services:
     stop_signal: SIGKILL
 
   intkey-tp-1:
-    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    image: hyperledger/sawtooth-intkey-tp-python:chime
     container_name: sawtooth-intkey-tp-python-default-1
     expose:
       - 4004
@@ -281,7 +281,7 @@ services:
     stop_signal: SIGKILL
 
   intkey-tp-2:
-    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    image: hyperledger/sawtooth-intkey-tp-python:chime
     container_name: sawtooth-intkey-tp-python-default-2
     expose:
       - 4004
@@ -289,7 +289,7 @@ services:
     stop_signal: SIGKILL
 
   intkey-tp-3:
-    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    image: hyperledger/sawtooth-intkey-tp-python:chime
     container_name: sawtooth-intkey-tp-python-default-3
     expose:
       - 4004
@@ -297,7 +297,7 @@ services:
     stop_signal: SIGKILL
 
   intkey-tp-4:
-    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    image: hyperledger/sawtooth-intkey-tp-python:chime
     container_name: sawtooth-intkey-tp-python-default-4
     expose:
       - 4004
@@ -305,7 +305,7 @@ services:
     stop_signal: SIGKILL
 
   xo-tp-0:
-    image: hyperledger/sawtooth-xo-tp-python:nightly
+    image: hyperledger/sawtooth-xo-tp-python:chime
     container_name: sawtooth-xo-tp-python-default-0
     expose:
       - 4004
@@ -313,7 +313,7 @@ services:
     stop_signal: SIGKILL
 
   xo-tp-1:
-    image: hyperledger/sawtooth-xo-tp-python:nightly
+    image: hyperledger/sawtooth-xo-tp-python:chime
     container_name: sawtooth-xo-tp-python-default-1
     expose:
       - 4004
@@ -321,7 +321,7 @@ services:
     stop_signal: SIGKILL
 
   xo-tp-2:
-    image: hyperledger/sawtooth-xo-tp-python:nightly
+    image: hyperledger/sawtooth-xo-tp-python:chime
     container_name: sawtooth-xo-tp-python-default-2
     expose:
       - 4004
@@ -329,7 +329,7 @@ services:
     stop_signal: SIGKILL
 
   xo-tp-3:
-    image: hyperledger/sawtooth-xo-tp-python:nightly
+    image: hyperledger/sawtooth-xo-tp-python:chime
     container_name: sawtooth-xo-tp-python-default-3
     expose:
       - 4004
@@ -337,7 +337,7 @@ services:
     stop_signal: SIGKILL
 
   xo-tp-4:
-    image: hyperledger/sawtooth-xo-tp-python:nightly
+    image: hyperledger/sawtooth-xo-tp-python:chime
     container_name: sawtooth-xo-tp-python-default-4
     expose:
       - 4004
@@ -345,7 +345,7 @@ services:
     stop_signal: SIGKILL
 
   settings-tp-0:
-    image: hyperledger/sawtooth-settings-tp:nightly
+    image: hyperledger/sawtooth-settings-tp:chime
     container_name: sawtooth-settings-tp-default-0
     expose:
       - 4004
@@ -353,7 +353,7 @@ services:
     stop_signal: SIGKILL
 
   settings-tp-1:
-    image: hyperledger/sawtooth-settings-tp:nightly
+    image: hyperledger/sawtooth-settings-tp:chime
     container_name: sawtooth-settings-tp-default-1
     expose:
       - 4004
@@ -361,7 +361,7 @@ services:
     stop_signal: SIGKILL
 
   settings-tp-2:
-    image: hyperledger/sawtooth-settings-tp:nightly
+    image: hyperledger/sawtooth-settings-tp:chime
     container_name: sawtooth-settings-tp-default-2
     expose:
       - 4004
@@ -369,7 +369,7 @@ services:
     stop_signal: SIGKILL
 
   settings-tp-3:
-    image: hyperledger/sawtooth-settings-tp:nightly
+    image: hyperledger/sawtooth-settings-tp:chime
     container_name: sawtooth-settings-tp-default-3
     expose:
       - 4004
@@ -377,7 +377,7 @@ services:
     stop_signal: SIGKILL
 
   settings-tp-4:
-    image: hyperledger/sawtooth-settings-tp:nightly
+    image: hyperledger/sawtooth-settings-tp:chime
     container_name: sawtooth-settings-tp-default-4
     expose:
       - 4004
@@ -385,7 +385,7 @@ services:
     stop_signal: SIGKILL
 
   poet-engine-0:
-    image: hyperledger/sawtooth-poet-engine:nightly
+    image: hyperledger/sawtooth-poet-engine:chime
     container_name: sawtooth-poet-engine-0
     volumes:
       - poet-shared:/poet-shared
@@ -406,7 +406,7 @@ services:
     \""
 
   poet-engine-1:
-    image: hyperledger/sawtooth-poet-engine:nightly
+    image: hyperledger/sawtooth-poet-engine:chime
     container_name: sawtooth-poet-engine-1
     volumes:
       - poet-shared:/poet-shared
@@ -417,7 +417,7 @@ services:
     \""
 
   poet-engine-2:
-    image: hyperledger/sawtooth-poet-engine:nightly
+    image: hyperledger/sawtooth-poet-engine:chime
     container_name: sawtooth-poet-engine-2
     volumes:
       - poet-shared:/poet-shared
@@ -428,7 +428,7 @@ services:
     \""
 
   poet-engine-3:
-    image: hyperledger/sawtooth-poet-engine:nightly
+    image: hyperledger/sawtooth-poet-engine:chime
     container_name: sawtooth-poet-engine-3
     volumes:
       - poet-shared:/poet-shared
@@ -439,7 +439,7 @@ services:
     \""
 
   poet-engine-4:
-    image: hyperledger/sawtooth-poet-engine:nightly
+    image: hyperledger/sawtooth-poet-engine:chime
     container_name: sawtooth-poet-engine-4
     volumes:
       - poet-shared:/poet-shared
@@ -450,7 +450,7 @@ services:
     \""
 
   poet-validator-registry-tp-0:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:nightly
+    image: hyperledger/sawtooth-poet-validator-registry-tp:chime
     container_name: sawtooth-poet-validator-registry-tp-0
     expose:
       - 4004
@@ -460,7 +460,7 @@ services:
     stop_signal: SIGKILL
 
   poet-validator-registry-tp-1:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:nightly
+    image: hyperledger/sawtooth-poet-validator-registry-tp:chime
     container_name: sawtooth-poet-validator-registry-tp-1
     expose:
       - 4004
@@ -470,7 +470,7 @@ services:
     stop_signal: SIGKILL
 
   poet-validator-registry-tp-2:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:nightly
+    image: hyperledger/sawtooth-poet-validator-registry-tp:chime
     container_name: sawtooth-poet-validator-registry-tp-2
     expose:
       - 4004
@@ -480,7 +480,7 @@ services:
     stop_signal: SIGKILL
 
   poet-validator-registry-tp-3:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:nightly
+    image: hyperledger/sawtooth-poet-validator-registry-tp:chime
     container_name: sawtooth-poet-validator-registry-tp-3
     expose:
       - 4004
@@ -490,7 +490,7 @@ services:
     stop_signal: SIGKILL
 
   poet-validator-registry-tp-4:
-    image: hyperledger/sawtooth-poet-validator-registry-tp:nightly
+    image: hyperledger/sawtooth-poet-validator-registry-tp:chime
     container_name: sawtooth-poet-validator-registry-tp-4
     expose:
       - 4004


### PR DESCRIPTION
This responds to difficulties experienced by users of the [Creating a Sawtooth Test Network](https://sawtooth.hyperledger.org/docs/1.2/app_developers_guide/creating_sawtooth_network.html) tutorial. Switching the configured images from `nightly` to `chime` allows me to complete the tutorial successfully.

---
[SAW-14](https://blockchaintp.atlassian.net/browse/SAW-14)
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)