### PR TITLE
fix REST API URL in intro xo transaction family docs

### DIFF
--- a/docs/source/app_developers_guide/intro_xo_transaction_family.rst
+++ b/docs/source/app_developers_guide/intro_xo_transaction_family.rst
@@ -107,13 +107,13 @@ If the REST API's URL is not ``http://127.0.0.1:8008``, you must add the
 
   .. important::
 
-     In the Docker environment, the REST API is at ``http://rest-api:8008``.
-     You must add ``--url http://rest-api:8008`` to all ``xo`` commands in this
+     In the Docker environment, the REST API is at ``http://rest-api-1:8008``.
+     You must add ``--url http://rest-api-1:8008`` to all ``xo`` commands in this
      procedure. For example:
 
         .. code-block:: console
 
-           $ xo create my-game --username jack --url http://rest-api:8008
+           $ xo create my-game --username jack --url http://rest-api-1:8008
 
 * Kubernetes: See :ref:`confirming-connectivity-k8s-label`
 


### PR DESCRIPTION
This intends to fix a step of the [XO transaction family tutorial](https://sawtooth.hyperledger.org/docs/1.2/app_developers_guide/intro_xo_transaction_family.html).

---
[SAW-14](https://blockchaintp.atlassian.net/browse/SAW-14)
Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)