### PR TITLE
Fix PartialOrd implementation for prune candidate

### DIFF
--- a/validator/src/state/state_pruning_manager.rs
+++ b/validator/src/state/state_pruning_manager.rs
@@ -49,7 +49,7 @@ impl Ord for PruneCandidate {
 
 impl PartialOrd for PruneCandidate {
     fn partial_cmp(&self, other: &PruneCandidate) -> Option<Ordering> {
-        Some(Ordering::reverse(self.0.cmp(&other.0)))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
In the previous code, the line `Some(Ordering::reverse(self.0.cmp(&other.0)))` was incorrect because it would return the opposite of what you intended, potentially leading to incorrect ordering of elements.

Signed-off-by: Joseph Livesey [jlivesey@gmail.com](mailto:jlivesey@gmail.com)